### PR TITLE
Removed export data button/link

### DIFF
--- a/views/default/default/layout.ejs
+++ b/views/default/default/layout.ejs
@@ -106,7 +106,6 @@
                 <ul class="dropdown-menu">
                   <li><a href="<%= BrandingService.getBrandAndPortalPath(req) %>/workspaces/list"><%= TranslationService.t('workspaces-dashboard')%></a></li>
                   <li><a href="<%= BrandingService.getBrandAndPortalPath(req) %>/availableServicesList"><%= TranslationService.t('workspace-services-list') %></a></li>
-                  <li><a href="#"><%= TranslationService.t('workspace-export-data') %></a></li>
                 </ul>
               </li>
             <li class="dropdown">

--- a/views/default/default/researcher/home.ejs
+++ b/views/default/default/researcher/home.ejs
@@ -26,7 +26,6 @@
         <div class="panel-body">
           <div><a href="<%= BrandingService.getBrandAndPortalPath(req) %>/workspaces/list"><%= TranslationService.t('workspaces-dashboard')%></a></div>
           <div><a href="<%= BrandingService.getBrandAndPortalPath(req) %>/availableServicesList"><%= TranslationService.t('workspace-services-list') %></a></div>
-          <div><a href="#"><%= TranslationService.t('workspace-export-data') %></a></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Hi all,

I removed the button from the menu and the researcher-home. I think this should be on each workspace list element as an action.

Or what do you think?
