### PR TITLE
Fix for attachments bug

### DIFF
--- a/typescript/api/services/RecordsService.ts
+++ b/typescript/api/services/RecordsService.ts
@@ -166,7 +166,7 @@ export module Services {
         opts.json = false;
         opts.headers['Content-Type'] = 'application/octet-stream';
       }
-      if (_.size(addIds) > 0 && _.size(removeIds) > 0) {
+      if (_.size(addIds) > 0 || _.size(removeIds) > 0) {
         return request[apiConfig.method](opts);
       }
     }


### PR DESCRIPTION
Wrong boolean operator was stopping attachments - they were only updating if there were some additions and some deletions (not or)