### PR TITLE
Use the description field to the ng2-completer in the vocab-comp, expand dropdown-holder

### DIFF
--- a/angular/shared/form/field-vocab.component.ts
+++ b/angular/shared/form/field-vocab.component.ts
@@ -48,6 +48,7 @@ export class VocabField extends FieldBase<any> {
   public titleFieldName: string;
   public titleFieldArr: string[];
   public titleFieldDelim: any;
+  public titleCompleterDescription: string;
   public searchFields: string;
   public fieldNames: any[];
   public sourceType: string;
@@ -73,6 +74,7 @@ export class VocabField extends FieldBase<any> {
     this.titleFieldArr = options['titleFieldArr'] || [];
     this.searchFields = options['searchFields'] || '';
     this.titleFieldDelim = options['titleFieldDelim'] || ' - ';
+    this.titleCompleterDescription = options['titleCompleterDescription'] || '';
     this.fieldNames = options['fieldNames'] || [];
     this.sourceType = options['sourceType'] || 'vocab';
     this.placeHolder = options['placeHolder'] || 'Select a valid value';
@@ -173,6 +175,7 @@ export class VocabField extends FieldBase<any> {
         this.titleFieldName,
         this.titleFieldArr,
         this.titleFieldDelim,
+        this.titleCompleterDescription,
         this.searchFields);
     } else if (this.sourceType == "external") {
       const url = this.lookupService.getExternalServiceUrl(this.provider);
@@ -339,6 +342,7 @@ class MintLookupDataService extends Subject<CompleterItem[]> implements Complete
     private compositeTitleName: string,
     private titleFieldArr: string[],
     private titleFieldDelim: any[],
+    private titleCompleterDescription: string,
     searchFieldStr: any) {
     super();
     this.searchFields = searchFieldStr.split(',');
@@ -388,8 +392,21 @@ class MintLookupDataService extends Subject<CompleterItem[]> implements Complete
     // build the title,
     let completerItem = {};
     completerItem[this.compositeTitleName] = this.getTitle(data);
+    completerItem['description'] = this.getCompleterDescription(data);
     completerItem['originalObject'] = item;
     return completerItem as CompleterItem;
+  }
+
+  getCompleterDescription(data: any): string {
+    let description = '';
+    const fieldDesc = this.titleCompleterDescription;
+    if(data) {
+      if (_.isString(fieldDesc)) {
+        const ele = data[fieldDesc];
+        description = _.toString(_.head(ele)) || '';
+      }
+    }
+    return description;
   }
 
   getTitle(data: any): string {

--- a/assets/styles/theme.scss
+++ b/assets/styles/theme.scss
@@ -484,3 +484,11 @@ tree-internal > ul.rootless > li > tree-internal > ul {
     word-break: break-all;
     white-space: normal;
 }
+
+.completer-dropdown {
+  /*This worked because shadow dom did not!*/
+  width: auto !important;
+  overflow-y: scroll;
+  overflow-x: auto;
+  max-height: 400px;
+}


### PR DESCRIPTION
Hi!

What do you think about this?

I wanted to add information to the ng2-completer component, it had the "description" field so I used it.

To use it i the VocabField add:

```
titleCompleterDescription: 'Email'
```
![Screen Shot 2019-04-16 at 10 43 56 am](https://user-images.githubusercontent.com/2850269/56174258-07172000-6035-11e9-8ca0-375be6f3a63e.png)

or
```
titleCompleterDescription : 'dc_identifier',
```
![Screen Shot 2019-04-16 at 10 46 52 am](https://user-images.githubusercontent.com/2850269/56174282-1d24e080-6035-11e9-975e-3bc30fea349e.png)

It will get the first element it finds on the mint search. 

Also, I have expanded the dropdown-holder.