### PR TITLE
Enable autocomplete a Contributor with Mint Data, SelectionField display different values and Toggle depending on configuration variables

### DIFF
--- a/angular/shared/form/field-base.ts
+++ b/angular/shared/form/field-base.ts
@@ -51,7 +51,7 @@ export class FieldBase<T> {
   validationMessages: any;
   editMode: boolean;
   readOnly: boolean;
-  help: string;
+  help: any;
   translationService: TranslationService;
   defaultValue: any;
   marginTop: string;
@@ -68,6 +68,8 @@ export class FieldBase<T> {
   visibilityCriteria: any;
   validators: any;
   requiredIfHasValue: any[];
+  selectFor: string;
+  defaultSelect: string;
 
   @Output() public onValueUpdate: EventEmitter<any> = new EventEmitter<any>();
   @Output() public onValueLoaded: EventEmitter<any> = new EventEmitter<any>();
@@ -96,13 +98,24 @@ export class FieldBase<T> {
     groupName?: string,
     editMode? : boolean,
     readOnly?: boolean,
-    help?: string,
-    defaultValue?: any
+    help?: any,
+    defaultValue?: any,
+    selectFor?: string,
+    defaultSelect?: string,
   } = {}) {
     this.value = this.getTranslated(options.value, undefined);
     this.name = options.name || '';
     this.id = options.id || '';
     this.label = this.getTranslated(options.label, '');
+    if(options.selectFor && options.defaultSelect) {
+      if(_.isArray(options.help)) {
+        const newHelp = _.defaultTo(
+          _.find(options.help, f => f.key === options.selectFor),
+          _.find(options.help, f => f.key === options.defaultSelect)
+        );
+        options.help = newHelp.value;
+      }
+    }
     this.help = this.getTranslated(options.help, undefined);
     this.required = !!options.required;
     this.controlType = options.controlType || '';

--- a/angular/shared/form/field-simple.ts
+++ b/angular/shared/form/field-simple.ts
@@ -49,6 +49,13 @@ export class SelectionField extends FieldBase<any>  {
 
 
     // this.options = options['options'] || [];
+    if(options.selectFor && options.defaultSelect) {
+      const newOptions = _.defaultTo(
+        _.find(options['options'], f => f.key === options.selectFor),
+        _.find(options['options'], f => f.key === options.defaultSelect)
+      );
+      options['options'] = newOptions.value;
+    }
     this.selectOptions = _.map(options['options'] || [], (option)=> {
       option['label'] = this.getTranslated(option['label'], option['label']);
       option['value'] = this.getTranslated(option['value'], option['value']);
@@ -415,7 +422,15 @@ export class Toggle extends FieldBase<boolean> {
   constructor(options: any, injector: any) {
     super(options, injector);
     this.type = options['type'] || 'checkbox';
-    this.value = options['value'] || false;
+    this.value = this.setToggle();
+  }
+
+  setToggle() {
+    if(this.options.valueCheck && this.options['checkedWhen'] && this.editMode) {
+      return this.options.valueCheck === this.options['checkedWhen'];
+    } else {
+      return this.options['value'] || false;
+    }
   }
 }
 


### PR DESCRIPTION
This example form-config for ContributorField will autocomplete the supervisor of the logged in user to the FNCI field

```JS
{
  class: 'ContributorField',
  showHeader: true,
  showRole: false,
  definition: {
    name: 'contributor_ci',
    required: true,
    label: '@dmpt-people-tab-ci',
    help: '@dmpt-people-tab-ci-help',
    role: "@dmpt-people-tab-ci-role",
    freeText: false,
    forceLookupOnly: true,
    vocabId: 'Parties AND repository_name:People',
    sourceType: 'mint',
    disabledExpression: '<%= !_.isEmpty(oid) %>',
    fieldNames: [{
      'text_full_name': 'text_full_name'
    }, {
      'full_name_honorific': 'text_full_name_honorific'
    }, {
      'email': 'Email[0]'
    }, {
      'given_name': 'Given_Name[0]'
    }, {
      'family_name': 'Family_Name[0]'
    }, {
      'honorific': 'Honorific[0]'
    }, {
      'full_name_family_name_first': 'dc_title'
    }
    ],
    searchFields: 'autocomplete_given_name,autocomplete_family_name,autocomplete_full_name',
    titleFieldArr: ['text_full_name'],
    titleFieldDelim: '',
    titleCompleterDescription: 'Email',
    nameColHdr: '@dmpt-people-tab-name-hdr',
    emailColHdr: '@dmpt-people-tab-email-hdr',
    orcidColHdr: '@dmpt-people-tab-orcid-hdr',
    validation_required_name: '@dmpt-people-tab-validation-name-required',
    validation_required_email: '@dmpt-people-tab-validation-email-required',
    validation_invalid_email: '@dmpt-people-tab-validation-email-invalid',
    publish: {
      onValueUpdate: {
        modelEventSource: 'valueChanges'
      }
    },
    // For who to enable findRelationshipFor for:
    findRelationshipFor: 'student@uts.edu.au',
    // Example use case:
    // Find a user with RelateWith and Autocomplete this field
    // findRelationship will autocomplete the first element found in the search
    // if relatedWith cosmo.costanza@example.edu.au has a dc_supervisor 1111
    // do a second mint lookup and find a relationship for 1111
    findRelationship: {
      relationship: 'dc_supervisor',
      relateWith: 'userEmail',
      role: 'Chief Investigator',
      searchField: 'dc_email',// Optional search Fields to find a relationship object /?search=[searchFields]:cosmo.costanza@example.edu.au
      searchFieldLower: false, // Search in lowercase or not
      searchRelation: 'dc_utsId',// Optional search Relationship field /?search=[searchRelation]:1111
      searchRelationLower: false, //Search in lowercase or not
      title: 'text_full_name',
      fullNameHonorific: 'text_full_name_honorific',
      honorific: 'honorific',
      email: 'dc_email',
      givenName: 'autocomplete_given_name',
      familyName: 'autocomplete_family_name'
    },
    // Using custom fields from config/record.js
    userEmail: '@user_email',
    relationshipFor: '@user_edupersonscopedaffiliation',
  },
  variableSubstitutionFields: ['userEmail', 'relationshipFor']
}
```

and add a customField in config/record.js for @user_edupersonscopedaffiliation

```JS
'@user_edupersonscopedaffiliation': {
      source: 'request',
      type: 'user',
      field: 'edupersonscopedaffiliation'
    }
```