### PR TITLE
user was not being passed through to a post-save trigger function

### DIFF
--- a/typescript/api/services/RecordsService.ts
+++ b/typescript/api/services/RecordsService.ts
@@ -809,7 +809,7 @@ export module Services {
             let postSaveCreateHookFunction = eval(postSaveCreateHookFunctionString);
             let options = _.get(postSaveCreateHook, "options", {});
             if (_.isFunction(postSaveCreateHookFunction)) {
-              postSaveCreateHookFunction(oid, record, options).subscribe(result => {
+              postSaveCreateHookFunction(oid, record, options, user).subscribe(result => {
                 sails.log.debug(`post-save trigger ${postSaveCreateHookFunctionString} completed for ${oid}`)
               });
             } else {


### PR DESCRIPTION
Came across this while trying to get the email of the logged-in user written to a DataCrate in the publication workflow (so the metadata can record the approver) - the user wasn't being passed through to the post-save hook in RecordsService.triggerPostSaveTriggers