### PR TITLE
new api method records/list ; reuse dashboard service as api

### DIFF
--- a/config/api.js
+++ b/config/api.js
@@ -1,0 +1,3 @@
+module.exports.api = {
+  max_requests: 20
+}

--- a/config/routes.js
+++ b/config/routes.js
@@ -249,6 +249,7 @@ module.exports.routes = {
     csrf: false
   },
   'get /:branding/:portal/api/records/metadata/:oid': 'webservice/RecordController.getMeta',
+  'get /:branding/:portal/api/records/list': 'webservice/RecordController.listRecords',  
   'get /:branding/:portal/api/records/objectmetadata/:oid': 'webservice/RecordController.getObjectMeta',
   'post /:branding/:portal/api/records/permissions/edit/:oid': {
     controller: 'webservice/RecordController',

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "start": "node app.js",
     "test": "node ./node_modules/mocha/bin/mocha test/bootstrap.test.js test/unit/**/*.test.js",
     "api-test": "node test/postman/runNewmanTests.js",
-    "doc-ng2": "npm -g install @compodoc/compodoc; npm -g install ejs-cli; compodoc -p angular/tsconfig.json -d support/docs/generated/ng2 -n \"ReDBox Portal - NG2 Apps\" --theme postmark --includes support/docs; ejs-cli views/default/default/apidocsapib.ejs -O '{\"portal\":\"rdmp\",\"branding\":\"default\"}' > apidocs.apib; docker run -it --rm -v $PWD:/doc quay.io/bukalapak/snowboard html -o rest-api.html apidocs.apib; mv -f rest-api.html support/docs/generated/ng2/additional-documentation"
+    "doc-ng2": "npm -g install @compodoc/compodoc; npm -g install ejs-cli; compodoc -p angular/tsconfig.json -d support/docs/generated/ng2 -n \"ReDBox Portal - NG2 Apps\" --theme postmark --includes support/docs; ejs-cli views/default/default/apidocsapib.ejs -O '{\"portal\":\"rdmp\",\"branding\":\"default\"}' > apidocs.apib; docker run -it --rm -v $PWD:/doc quay.io/bukalapak/snowboard html -o rest-api.html apidocs.apib; mv -f rest-api.html support/docs/generated/ng2/additional-documentation",
+    "compile": "./node_modules/.bin/tsc --project tsconfig.json"
   },
   "main": "app.js",
   "repository": {

--- a/views/default/default/apidocsapib.ejs
+++ b/views/default/default/apidocsapib.ejs
@@ -8,6 +8,42 @@ The ReDBox Portal API provides authorized access to manage functions.
 
 ## Record Collection
 
+### List records in the system [GET /<%= branding %>/<%= portal %>/api/records/list]
++ Parameters
+    + packageType (string) ... The type of package
+    + recordType (string) ... The type of record
+    + sort (object) ... Sort by object Example: date_object_modified:-1
+    + start (number) ... The number to start the records
+    + rows (number) ... The number of records per request
+
++ Request Get Records (application/json)
+  + Headers
+    Authorization: Bearer abcabcab-abca-abca-abca-abcabcabcabc
+  + Body
+  {
+    "totalItems": 3,
+    "currentPage": 1,
+    "noItems": 3,
+    "items": [
+      {
+        "oid": "946a62900e045873b0318f44e775d7da",
+        "title": "test3",
+        "metadata": {
+          ...
+        },
+        "dateCreated": "2020-05-20T06:22:56.113Z",
+        "dateModified": "2020-05-20T06:22:56.121Z",
+        "hasEditAccess": true
+      },
+      {
+        ...
+      },
+      {
+        ...
+      }
+    ]
+  }
+
 ### Create Record [POST /<%= branding %>/<%= portal %>/api/records/metadata/{recordType}]
 + Parameters
   + recordType (string) ... The type of record to create


### PR DESCRIPTION
Example:

Get:
```
http://localhost:1500/default/rdmp/api/records/list?packageType=rdmp&sort=date_object_modified:-1&start=0&rows=10
```

configure:

config/api.js
- max_requests: 20

result:
```
{
  "totalItems": 3,
  "currentPage": 1,
  "noItems": 3,
  "items": [
     ...
  ]
}
```