### PR TITLE
Add ability to autocomplete vocab if subscribed value needs conversion

### DIFF
--- a/angular/shared/form/field-simple.ts
+++ b/angular/shared/form/field-simple.ts
@@ -249,6 +249,12 @@ export class DateTime extends FieldBase<any> {
     }
   }
 
+  setValue(value:any) {
+      this.value = value;
+      this.formModel.patchValue(value, {emitEvent: true, emitModelToViewChange:true });
+      this.formModel.markAsTouched();
+    }
+
   formatValue(value: any) {
     // assume local date
     console.log(`Formatting value: ${value}`)
@@ -274,6 +280,9 @@ export class DateTime extends FieldBase<any> {
       const newOpts = _.cloneDeep(this.datePickerOpts);
       newOpts.startDate = eventData;
       this.datePickerOpts = newOpts;
+    } else {
+      const value = this.parseToDate(eventData);
+      this.setValue(value);
     }
   }
 }

--- a/angular/shared/util-service.ts
+++ b/angular/shared/util-service.ts
@@ -196,6 +196,28 @@ export class UtilityService {
     return _.first(value);
   }
 
+  /**
+   * Format date with moment from origin to target
+   *
+   * Author: <a href='https://github.com/moisbo' target='_blank'>Moises Sacal Bonequi</a>
+   * @param {any} data
+   * @param  {any} config - field, formatOrigin, formatTarget
+   * @return {array}
+   */
+  public convertToDateFormat(data:any, config:any) {
+    let field = config.field;
+    let formatOrigin = config.formatOrigin || 'DD-MMM-YY';
+    let formatTarget = config.formatTarget || 'YYYY-MM-DD';
+    let value = data;
+
+    if(field) {
+      value = _.get(data,field);
+    }
+    const converted = moment(value, formatOrigin).format(formatTarget);
+    console.log(`convertToDateFormat ${converted}`);
+    return converted;
+  }
+
   public joinArray(data: any, config: any, fieldName: string = null, fieldSeparator: string = null) {
     return _.join(_.get(data, fieldName ? fieldName : config.field), fieldSeparator ? fieldSeparator : config.separator);
   }


### PR DESCRIPTION
Usage example:

Subscribe a DateTime component to a `title` field for example and if the value published needs conversion add action:
`utilityService.convertToDateFormat'`  


```
subscribe: {
  title: {
    onItemSelect: [
      {
        action: 'reset'
      },
      {
        action: 'utilityService.convertToDateFormat',
        field: 'startDate',
        formatOrigin: 'DD-MMM-YY',
        formatTarget: 'YYYY-MM-DD'
      }
    ]
  }
}
```
the field corresponds to the value on the VocabField, example:

```
fieldNames: ['dc_title', 'folio', 'description', 'summary', 'refId', 'keyword', 'startDate', 'endDate', 'organization', 'fundingSource', 'rmId'],
```

where `startDate` is the field to get from title Vocab return.

![autocomplete-datetime-convert](https://user-images.githubusercontent.com/2850269/84101023-6f526d80-aa50-11ea-8944-8605e2be3e0d.gif)
