### PR TITLE
run as node user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,4 @@ typescript/api/controllers/**/*.js
 typescript/api/services/**/*.js
 assets/angular
 api/core/*.js
+dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:12.16.0
 ENV node_env production
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+ENV PATH=$PATH:/home/node/.npm-global/bin
+VOLUME ["/opt/redbox-portal/","/attachments","/publication","/opt/hooks"]
 RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
 RUN apt-get update && \
 apt-get install --no-install-recommends -yq gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
@@ -7,7 +10,7 @@ libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 li
 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget && rm -rf /var/lib/apt/lists/*
-
-COPY . /opt/redbox-portal/
 RUN echo "Australia/Brisbane" > /etc/timezone && dpkg-reconfigure -f noninteractive tzdata
+COPY --chown=node:node . /opt/redbox-portal/
+USER node
 CMD NODE_ENV=$node_env node app.js

--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@ The [Queensland Cyber Infrastructure Foundation](http://www.qcif.edu.au) (QCIF) 
 ## Development
 Requirements:
 
-- Node 8.11.0
+- Docker
 
-Development requires Docker. Run `./runForDev.sh install jit` at least once.
+Run `./runForDev.sh install jit`
+
+It will 
+   - Pull qcifengineering/redbox-portal from docker hub (If a local copy does not exist)
+   - Compile backend
+   - Compile frontend
+   - Then start docker-compose
+   
+Open http://localhost:1500 to start browsing
+
+### Build local docker image
+
+Run `./dockerlocal_dev.sh`
+
+It will
+   - Build a local docker image of qcifengineering/redbox-portal:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,24 +6,25 @@ services:
     build: .
     image: qcifengineering/redbox-portal:latest
     ports:
-       - "1500:1500"
+      - "1500:1500"
+    user: node
     volumes:
-       - ".:/opt/redbox-portal"
-       - "/mnt/data/attachments:/attachments"
-       - "/mnt/data/publication:/publication"
-       - "/opt/hooks:/opt/hooks"
+      - ".:/opt/redbox-portal:delegated"
+      - "./dev/attachments:/attachments:delegated"
+      - "./dev/publication:/publication:delegated"
+      - "./dev/hooks:/opt/hooks:delegated"
     expose:
-       - "1500"
+      - "1500"
     environment:
       - NODE_ENV=docker
       - PORT=1500
       - sails_redbox__apiKey=c8e844fc-8550-497f-b970-7900ec8741ca
-      - sails_record__baseUrl_redbox=http://redbox:9000/redbox
-      - sails_record__baseUrl_mint=https://demo.redboxresearchdata.com.au/mint
+      - sails_record__baseUrl__redbox=http://redbox:9000/redbox
+      - sails_record__baseUrl__mint=https://demo.redboxresearchdata.com.au/mint
     networks:
-     main:
-       aliases:
-         - rbportal
+      main:
+        aliases:
+          - rbportal
     entrypoint: /bin/bash -c "cd /opt/redbox-portal && node app.js"
 
   nginx:
@@ -32,37 +33,20 @@ services:
       - "8080:8080"
     restart: always
     volumes:
-      - "/mnt/data/publication:/usr/share/nginx/html"
-      - "/mnt/nginx.conf:/etc/nginx/conf.d"
+      - "./dev/publication:/usr/share/nginx/html:delegated"
+      - "./dev/nginx.conf:/etc/nginx/conf.d:delegated"
     expose:
       - "8080"
-
-
-  redbox:
-    image: qcifengineering/redbox:2.x
-    expose:
-       - "9000"
-    environment:
-      - RB_API_KEY=c8e844fc-8550-497f-b970-7900ec8741ca
-    volumes:
-        - "/mnt/data/redbox:/opt/redbox/data"
-        - "/var/log/redbox:/opt/redbox/home/logs"
-    networks:
-      main:
-        aliases:
-          - redbox
-    ports:
-       - "9000:9000"
 
   mongodb:
     image: mvertes/alpine-mongo:latest
     volumes:
-      - "./devdata:/devdata"
-      - "/mnt/data/mongo/data/db:/data/db"
-      - "/var/log/mongo:/var/log/mongo"
+      - "./devdata:/devdata:delegated"
+      - "./dev/mongo/data/db:/data/db:delegated"
+      - "./dev/log/mongo:/var/log/mongo:delegated"
     networks:
       main:
         aliases:
           - mongodb
     ports:
-       - "27017:27017"
+      - "27017:27017"

--- a/dockerlocal_dev.sh
+++ b/dockerlocal_dev.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Simple docker build for local development
+REPO=qcifengineering/redbox-portal
+TAG=latest
+
+docker build -f Dockerfile -t $REPO:$TAG .

--- a/runForDev.sh
+++ b/runForDev.sh
@@ -4,29 +4,29 @@
 PORTAL_DIR=/opt/redbox-portal
 PORTAL_IMAGE=qcifengineering/redbox-portal:latest
 source dev_build/buildFns.sh
-sudo chown -R vagrant:vagrant *
+
 watch="false"
 # Not really needed but I'm putting this in a for loop in case we want to add more arguments later
 WATCH_COUNT=0
 for var in "$@"
 do
     if [ $var = "install" ]; then
-        docker run -it --rm -v $PWD:$PORTAL_DIR $PORTAL_IMAGE /bin/bash -c "cd $PORTAL_DIR; npm -g i typings && npm install"
+        docker run -it --rm -u "node" -v $PWD:$PORTAL_DIR $PORTAL_IMAGE /bin/bash -c "cd $PORTAL_DIR; npm -g i typings && npm install"
     fi
     if [ $var = "jit" ]; then
       #linkNodeLib "lodash" "lodash-lib"
       # Build targets are different for assets/angular, clearing all .js files from .ts files
       cleanUpAllJs
       export ENV=development
-      docker run -it --rm -v $PWD:$PORTAL_DIR $PORTAL_IMAGE /bin/bash -c "cd $PORTAL_DIR; npm install -g @angular/cli@1.7.1;  npm i --save-dev; node_modules/.bin/tsc --project tsconfig.json; cd angular; npm i; make build-frontend"
+      docker run -it --rm -u "node" -v $PWD:$PORTAL_DIR $PORTAL_IMAGE /bin/bash -c "cd $PORTAL_DIR; npm install -g @angular/cli@1.7.1;  npm i --save-dev; node_modules/.bin/tsc --project tsconfig.json; cd angular; npm i; make build-frontend"
     fi
     if [ $var = "jit-skip-frontend" ]; then
       #linkNodeLib "lodash" "lodash-lib"
       export ENV=development
-      docker run -it --rm -v $PWD:$PORTAL_DIR $PORTAL_IMAGE /bin/bash -c "cd $PORTAL_DIR; npm install -g @angular/cli@1.7.1;  npm i --save-dev; node_modules/.bin/tsc --project tsconfig.json;"
+      docker run -it --rm -u "node" -v $PWD:$PORTAL_DIR $PORTAL_IMAGE /bin/bash -c "cd $PORTAL_DIR; npm install -g @angular/cli@1.7.1;  npm i --save-dev; node_modules/.bin/tsc --project tsconfig.json;"
     fi
     if [ $var == "aot" ]; then
-      docker run -it --rm -v $PWD:$PORTAL_DIR $PORTAL_IMAGE /bin/bash -c "cd $PORTAL_DIR; export buildTarget=\"${buildTarget}\"; ./runForDev.sh aotCompile"
+      docker run -it --rm -u "node" -v $PWD:$PORTAL_DIR $PORTAL_IMAGE /bin/bash -c "cd $PORTAL_DIR; export buildTarget=\"${buildTarget}\"; ./runForDev.sh aotCompile"
       export ENV=development
       export FORCE_BUNDLE=1
     fi
@@ -45,7 +45,7 @@ do
         RBPORTAL_PS=$(docker ps -f name=redbox-portal_redboxportal_1 -q)
         echo "redbox container is \"${RBPORTAL_PS}\""
         echo "ng2App is \"${ng2App}\""
-        docker exec --detach $RBPORTAL_PS /bin/bash -c "cd /opt/redbox-portal/angular; npm install -g @angular/cli@1.7.1; npm i; ng build --app=${ng2App} --watch --verbose > ${ng2App}-build.log" || exit
+        docker exec -u "node" --detach $RBPORTAL_PS /bin/bash -c "cd /opt/redbox-portal/angular; npm install -g @angular/cli@1.7.1; npm i; ng build --app=${ng2App} --watch --verbose > ${ng2App}-build.log" || exit
         let WATCH_COUNT++
     fi
 done

--- a/runForProd.sh
+++ b/runForProd.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 export buildTarget="PROD"
 source dev_build/buildFns.sh
-sudo chown -R vagrant:vagrant *
 cleanUpAllJs
-docker run -it --rm -v $PWD:/opt/rds-rdmp-portal qcifengineering/dlcf-portal:latest /bin/bash -c "cd /opt/rds-rdmp-portal; npm install;"
+docker run -it --rm -u "node" -v $PWD:/opt/rds-rdmp-portal qcifengineering/dlcf-portal:latest /bin/bash -c "cd /opt/rds-rdmp-portal; npm install;"
 linkNodeLib "lodash-es" "lodash-lib"
 compileAoT
 export ENV=production


### PR DESCRIPTION
This will allow it to run only on docker. 

To test you can build a local "qcifengineering/redbox-portal" image with `./dockerlocal_dev.sh`

Details:
run as node user, remove vagrant user, fixed sails env vars, changed docker-compose volumes to be relative to installation, added delegated to docker-compose volumes to make it faster