### PR TITLE
Harvest API 

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -242,6 +242,11 @@ module.exports.routes = {
     action: 'updateMeta',
     csrf: false
   },
+  'post /:branding/:portal/api/records/harvest/:recordType': {
+    controller: 'webservice/RecordController',
+    action: 'harvest',
+    csrf: false
+  },
   'put /:branding/:portal/api/records/objectmetadata/:oid': {
     controller: 'webservice/RecordController',
     action: 'updateObjectMeta',

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@researchdatabox/redbox-core-types",
-  "version": "1.0.5-beta",
+  "version": "1.0.6-beta",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/core/src/model/APIHarvestResponse.ts
+++ b/core/src/model/APIHarvestResponse.ts
@@ -1,0 +1,15 @@
+export class APIHarvestResponse{
+    harvestId:string;
+    oid:string;
+    message:string;
+    details:string;
+    status:boolean;
+
+    constructor(harvestId:string, oid:string, status:boolean = true, message:string ='Harvested successfully',details:string = '') {
+        this.harvestId = harvestId;
+        this.message = message;
+        this.details = details;
+        this.oid = oid;
+        this.status = status;
+    }
+}

--- a/core/src/model/index.ts
+++ b/core/src/model/index.ts
@@ -1,7 +1,7 @@
 export {APIActionResponse} from "./APIActionResponse";
 export {APIErrorResponse} from "./APIErrorResponse";
 export {APIObjectActionResponse} from "./APIObjectActionResponse";
-
+export {APIHarvestResponse} from "./APIHarvestResponse";
 export {ListAPIResponse}from "./ListAPIResponse";
 export {ListAPISummary}from "./ListAPISummary";
 export {RecordAuditModel} from "./RecordAuditModel";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1796,9 +1796,9 @@
       }
     },
     "@researchdatabox/redbox-core-types": {
-      "version": "1.0.5-beta",
-      "resolved": "https://registry.npmjs.org/@researchdatabox/redbox-core-types/-/redbox-core-types-1.0.5-beta.tgz",
-      "integrity": "sha512-Ab4qT03r4fQRBXKA6K7C5t7N5AX1c/sD2WoHg58V4foQ26eZZ7gvsqz/j5w0Qlne7gPCMVxM2oOd5NOMFwBZQg=="
+      "version": "1.0.6-beta",
+      "resolved": "https://registry.npmjs.org/@researchdatabox/redbox-core-types/-/redbox-core-types-1.0.6-beta.tgz",
+      "integrity": "sha512-VISl3X3ldolUwt7dHjx1qHnf9SJVc+mCbAob6nvzurDBtnlcgqGX4uur6VQpwItJEOSI9SaxUlngZpb+/wA6Hw=="
     },
     "@researchdatabox/sails-hook-redbox-storage-mongo": {
       "version": "1.1.4-alpha",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "ReDBox 2 Portal",
   "keywords": [],
   "dependencies": {
-    "@researchdatabox/redbox-core-types": "^1.0.5-beta",
+    "@researchdatabox/redbox-core-types": "^1.0.6-beta",
     "@researchdatabox/sails-hook-redbox-storage-mongo": "^1.1.4-alpha",
     "@sailshq/upgrade": "^1.0.9",
     "@uppy/core": "^1.18.0",

--- a/test/postman/test-collection.json
+++ b/test/postman/test-collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "76c707fc-5b0f-4957-8d14-7384c1eb408f",
+		"_postman_id": "f372b319-3be3-460f-9326-440747f84bf2",
 		"name": "Redbox Portal API - With tests",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -865,6 +865,158 @@
 										"step",
 										"queued",
 										"{{tempDataPubOid}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Harvest RDMPs",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Result array is length 1\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.length).to.equal(1);",
+											"});",
+											"",
+											"",
+											"pm.test(\"First result shows successful creation\", function () {",
+											"    var jsonData = pm.response.json()[0];",
+											"    pm.expect(jsonData.status).to.equal(true);",
+											"    pm.expect(jsonData.message).to.equal(\"Record created successfully\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"records\": [\n    {\n        \"harvestId\": \"redbox1\",\n      \"recordRequest\": {\n        \"metadata\": {\n          \"title\": \"Andrew's Postman test\",\n          \"dc:identifier\": \"http://purl.org/au-research/grants/nhmrc/566728\",\n          \"description\": \"Movement of molecules within cells by a process known as membrane transport is critical for normal cell function and also exploited by bacteria to promote infection. The pathway that connects the import pathway to the export pathway is essential for the function of a large number of proteins, however this connecting pathway is poorly characterised. This study will define the machinery of this trafficking pathway, which will provide the ability to modulate biological processes and cytotoxicity.\",\n          \"finalKeywords\": [\n            \"270199\",\n            \"Golgi apparatus\",\n            \"endocytosis\",\n            \"membrane transport\",\n            \"protein trafficking\",\n            \"secretion\",\n            \"HIV-AIDS\",\n            \"bacterial pathogen\",\n            \"hormone secretion\",\n            \"immune development\",\n            \"lysosomal storage disorder\"\n          ],\n          \"contributor_ci\": {\n            \"text_full_name\": \"Prof Paul Gleeson\",\n            \"email\": \"notAReal@email.edu.au\",\n            \"orcid\": \"http://orcid.org/0000-0000-0000-000\"\n          },\n          \"contributor_data_manager\": {\n            \"text_full_name\": \"Prof Paul Gleeson\",\n            \"email\": \"notAReal@email.edu.au\",\n            \"orcid\": \"http://orcid.org/0000-0000-0000-000\"\n          },\n          \"contributors\": [\n            {\n              \"text_full_name\": \"Prof Paul Gleeson\",\n              \"email\": \"notAReal@email.edu.au\",\n              \"orcid\": \"http://orcid.org/0000-0000-0000-000\"\n            }\n          ],\n          \"vivo:Dataset_redbox:DataCollectionMethodology\": \"The data collection methodology\",\n          \"vivo:Dataset_dc_format\": \"xls\",\n          \"vivo:Dataset_dc:location_rdf:PlainLiteral\": \"eResearch Store network drive\",\n          \"vivo:Dataset_dc:source_dc:location_rdf:PlainLiteral\": \"shared university network drive (e.g. G, H, etc)\",\n          \"vivo:Dataset_dc:extent\": \"100GB - 2TB\",\n          \"redbox:retentionPeriod_dc:date\": \"1year\",\n          \"dc:rightsHolder_dc:name\": \"myUni\",\n          \"dc:accessRights\": \"permission from the data manager\",\n          \"authorization\": []\n        }\n      }\n    }\n  ]\n}"
+								},
+								"url": {
+									"raw": "{{host}}/default/rdmp/api/records/harvest/rdmp",
+									"host": [
+										"{{host}}"
+									],
+									"path": [
+										"default",
+										"rdmp",
+										"api",
+										"records",
+										"harvest",
+										"rdmp"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Harvest RDMPs - Ignore update",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Result array is length 1\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.length).to.equal(1);",
+											"});",
+											"",
+											"pm.test(\"First result shows successful ignored update\", function () {",
+											"    var jsonData = pm.response.json()[0];",
+											"    pm.expect(jsonData.status).to.equal(true);",
+											"    var oid = jsonData['oid']",
+											"    pm.expect(jsonData.message).to.equal(\"Record ignored as the record already exists. oid: \"+oid);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"records\": [\n    {\n        \"harvestId\": \"redbox1\",\n      \"recordRequest\": {\n        \"metadata\": {\n          \"title\": \"Andrew's Postman test\",\n          \"dc:identifier\": \"http://purl.org/au-research/grants/nhmrc/566728\",\n          \"description\": \"Movement of molecules within cells by a process known as membrane transport is critical for normal cell function and also exploited by bacteria to promote infection. The pathway that connects the import pathway to the export pathway is essential for the function of a large number of proteins, however this connecting pathway is poorly characterised. This study will define the machinery of this trafficking pathway, which will provide the ability to modulate biological processes and cytotoxicity.\",\n          \"finalKeywords\": [\n            \"270199\",\n            \"Golgi apparatus\",\n            \"endocytosis\",\n            \"membrane transport\",\n            \"protein trafficking\",\n            \"secretion\",\n            \"HIV-AIDS\",\n            \"bacterial pathogen\",\n            \"hormone secretion\",\n            \"immune development\",\n            \"lysosomal storage disorder\"\n          ],\n          \"contributor_ci\": {\n            \"text_full_name\": \"Prof Paul Gleeson\",\n            \"email\": \"notAReal@email.edu.au\",\n            \"orcid\": \"http://orcid.org/0000-0000-0000-000\"\n          },\n          \"contributor_data_manager\": {\n            \"text_full_name\": \"Prof Paul Gleeson\",\n            \"email\": \"notAReal@email.edu.au\",\n            \"orcid\": \"http://orcid.org/0000-0000-0000-000\"\n          },\n          \"contributors\": [\n            {\n              \"text_full_name\": \"Prof Paul Gleeson\",\n              \"email\": \"notAReal@email.edu.au\",\n              \"orcid\": \"http://orcid.org/0000-0000-0000-000\"\n            }\n          ],\n          \"vivo:Dataset_redbox:DataCollectionMethodology\": \"The data collection methodology\",\n          \"vivo:Dataset_dc_format\": \"xls\",\n          \"vivo:Dataset_dc:location_rdf:PlainLiteral\": \"eResearch Store network drive\",\n          \"vivo:Dataset_dc:source_dc:location_rdf:PlainLiteral\": \"shared university network drive (e.g. G, H, etc)\",\n          \"vivo:Dataset_dc:extent\": \"100GB - 2TB\",\n          \"redbox:retentionPeriod_dc:date\": \"1year\",\n          \"dc:rightsHolder_dc:name\": \"myUni\",\n          \"dc:accessRights\": \"permission from the data manager\",\n          \"authorization\": []\n        }\n      }\n    }\n  ]\n}"
+								},
+								"url": {
+									"raw": "{{host}}/default/rdmp/api/records/harvest/rdmp?updateMode=ignore",
+									"host": [
+										"{{host}}"
+									],
+									"path": [
+										"default",
+										"rdmp",
+										"api",
+										"records",
+										"harvest",
+										"rdmp"
+									],
+									"query": [
+										{
+											"key": "updateMode",
+											"value": "ignore"
+										}
 									]
 								}
 							},

--- a/typescript/api/controllers/webservice/RecordController.ts
+++ b/typescript/api/controllers/webservice/RecordController.ts
@@ -27,14 +27,15 @@ declare var UsersService;
 declare var FormsService;
 declare var RecordTypesService;
 declare var WorkflowStepsService;
+declare var Record;
 declare var _;
 declare var User;
 /**
  * Package that contains all Controllers.
  */
-import {Observable} from 'rxjs/Rx';
+import { Observable } from 'rxjs/Rx';
 import * as path from "path";
-import {APIErrorResponse, Controllers as controllers, Datastream, DatastreamService, DatastreamServiceResponse, RecordsService, SearchService} from '@researchdatabox/redbox-core-types';
+import { APIErrorResponse, APIHarvestResponse, Controllers as controllers, Datastream, DatastreamService, DatastreamServiceResponse, RecordsService, SearchService } from '@researchdatabox/redbox-core-types';
 import { ListAPIResponse } from '@researchdatabox/redbox-core-types';
 
 
@@ -46,7 +47,7 @@ export module Controllers {
    *
    * @author <a target='_' href='https://github.com/andrewbrazzatti'>Andrew Brazzatti</a>
    */
-  export class Record extends controllers.Core.Controller {
+  export class RecordWeb extends controllers.Core.Controller {
 
     RecordsService: RecordsService = sails.services.recordsservice;
     SearchService: SearchService;
@@ -74,7 +75,8 @@ export module Controllers {
       'addRoleEdit',
       'removeRoleEdit',
       'addRoleView',
-      'removeRoleView'
+      'removeRoleView',
+      'harvest'
     ];
 
     constructor() {
@@ -103,7 +105,7 @@ export module Controllers {
       const brand = BrandingService.getBrand(req.session.branding);
       var oid = req.param('oid');
 
-     Observable.fromPromise(this.RecordsService.getMeta(oid)).subscribe(record => {
+      Observable.fromPromise(this.RecordsService.getMeta(oid)).subscribe(record => {
         return res.json(record["authorization"]);
       });
 
@@ -127,19 +129,19 @@ export module Controllers {
           record["authorization"]["editPending"] = _.union(record["authorization"]["editPending"], pendingUsers);
         }
 
-        var obs = Observable.fromPromise(this.RecordsService.updateMeta(brand, oid, record,req.user));
+        var obs = Observable.fromPromise(this.RecordsService.updateMeta(brand, oid, record, req.user));
         obs.subscribe(result => {
           if (result.isSuccessful()) {
             Observable.fromPromise(this.RecordsService.getMeta(result.oid)).subscribe(record => {
               return res.json(record["authorization"]);
-            }, error=> {
+            }, error => {
               sails.log.error(error);
               return this.apiFail(req, res, 500, new APIErrorResponse('Failed adding an editor, check server logs.'));
             });
           } else {
             return res.json(result);
           }
-        }, error=> {
+        }, error => {
           sails.log.error(error);
           return this.apiFail(req, res, 500, new APIErrorResponse('Failed adding an editor, check server logs.'));
         });
@@ -194,7 +196,7 @@ export module Controllers {
           record["authorization"]["editPending"] = _.difference(record["authorization"]["editPending"], pendingUsers);
         }
 
-        var obs = Observable.fromPromise(this.RecordsService.updateMeta(brand, oid, record,req.user));
+        var obs = Observable.fromPromise(this.RecordsService.updateMeta(brand, oid, record, req.user));
         obs.subscribe(result => {
           if (result.isSuccessful()) {
             Observable.fromPromise(this.RecordsService.getMeta(result["oid"])).subscribe(record => {
@@ -248,10 +250,10 @@ export module Controllers {
         }
         return res.json(record["metadata"]);
       },
-      error=> {
-        sails.log.error("Get metadata failed, failed to retrieve existing record.", error);
-        return this.apiFail(req, res, 500, new APIErrorResponse("Get Metadata failed, failed to retrieve existing record. "));
-      });
+        error => {
+          sails.log.error("Get metadata failed, failed to retrieve existing record.", error);
+          return this.apiFail(req, res, 500, new APIErrorResponse("Get Metadata failed, failed to retrieve existing record. "));
+        });
     }
 
     public getObjectMeta(req, res) {
@@ -292,22 +294,22 @@ export module Controllers {
             sails.log.verbose(`Processing datastreams of: ${oid}`);
             for (let attField of record.metaMetadata.attachmentFields) {
               // TODO: add support for removing datastreams
-              const result:DatastreamServiceResponse = await this.DatastreamService.addDatastreams(oid, _.get(record['metadata'], attField, []));  
+              const result: DatastreamServiceResponse = await this.DatastreamService.addDatastreams(oid, _.get(record['metadata'], attField, []));
             }
             return res.json(result);
           } else {
             // not processing datastreams... 
             return res.json(result);
           }
-        }, error=> {
+        }, error => {
           sails.log.error("Update metadata failed", error);
           return this.apiFail(req, res, 500, new APIErrorResponse("Update Metadata failed"));
         });
       },
-      error=> {
-        sails.log.error("Update metadata failed, failed to retrieve existing record.", error);
-        return this.apiFail(req, res, 400, new APIErrorResponse("Update Metadata failed, failed to retrieve existing record. "));
-      });
+        error => {
+          sails.log.error("Update metadata failed, failed to retrieve existing record.", error);
+          return this.apiFail(req, res, 400, new APIErrorResponse("Update Metadata failed, failed to retrieve existing record. "));
+        });
     }
 
     public updateObjectMeta(req, res) {
@@ -357,7 +359,7 @@ export module Controllers {
             metaMetadata["type"] = recordTypeModel.name;
             metaMetadata["packageName"] = recordTypeModel.packageName;
             metaMetadata["packageType"] = recordTypeModel.packageType;
-            
+
             // Resolves #723: removed hardcoded value
             metaMetadata["createdBy"] = req.user.username;
             request["metaMetadata"] = metaMetadata;
@@ -376,7 +378,7 @@ export module Controllers {
             var workflowStepsObs = WorkflowStepsService.getAllForRecordType(recordTypeModel);
 
             workflowStepsObs.subscribe(workflowSteps => {
-              _.each(workflowSteps, function(workflowStep) {
+              _.each(workflowSteps, function (workflowStep) {
                 // If no workflowStage set, find the starting step
                 if (workflowStage == null) {
                   if (workflowStep["starting"] == true) {
@@ -411,7 +413,7 @@ export module Controllers {
                   sails.log.error("Create Record failed");
                   return this.apiFail(req, res, 500, new APIErrorResponse("Create failed"));
                 }
-              }, error=> {
+              }, error => {
                 sails.log.error("Create Record failed", error);
                 return this.apiFail(req, res, 500, new APIErrorResponse("Create failed"));
               });
@@ -431,25 +433,25 @@ export module Controllers {
       const datastreamId = req.param('datastreamId');
       sails.log.info(`getDataStream ${oid} ${datastreamId}`);
       return Observable.fromPromise(this.RecordsService.getMeta(oid)).flatMap(currentRec => {
-            const fileName = req.param('fileName') ? req.param('fileName') : datastreamId;
-            res.set('Content-Type', 'application/octet-stream');
-            sails.log.verbose("fileName "+fileName);
-            res.attachment(fileName);
-            sails.log.info(`Returning datastream observable of ${oid}: ${fileName}, datastreamId: ${datastreamId}`);
-            return this.DatastreamService.getDatastream(oid, datastreamId).flatMap((response) => {
-              if (response.readstream) {
-                response.readstream.pipe(res);
-              } else {
-                res.end(Buffer.from(response.body), 'binary');
-              }
-              return Observable.of(oid);
-            });
+        const fileName = req.param('fileName') ? req.param('fileName') : datastreamId;
+        res.set('Content-Type', 'application/octet-stream');
+        sails.log.verbose("fileName " + fileName);
+        res.attachment(fileName);
+        sails.log.info(`Returning datastream observable of ${oid}: ${fileName}, datastreamId: ${datastreamId}`);
+        return this.DatastreamService.getDatastream(oid, datastreamId).flatMap((response) => {
+          if (response.readstream) {
+            response.readstream.pipe(res);
+          } else {
+            res.end(Buffer.from(response.body), 'binary');
+          }
+          return Observable.of(oid);
+        });
       }).subscribe(whatever => {
         // ignore...
-          sails.log.verbose(`Done with updating streams and returning response...`);
+        sails.log.verbose(`Done with updating streams and returning response...`);
       }, error => {
-          return this.customErrorMessageHandlingOnUpstreamResult(error, res);
-        }
+        return this.customErrorMessageHandlingOnUpstreamResult(error, res);
+      }
       );
     }
 
@@ -475,31 +477,31 @@ export module Controllers {
         if (error) {
           const errorMessage = `There was a problem adding datastream(s) to: ${sails.config.record.attachments.stageDir}.`;
           sails.log.error(errorMessage, error);
-          return res.status(500).json({message: errorMessage});
+          return res.status(500).json({ message: errorMessage });
         }
         sails.log.verbose(UploadedFileMetadata);
         sails.log.verbose('Succesfully uploaded all file metadata. Sending locations downstream....');
         const fileIds = _.map(UploadedFileMetadata, function (nextDescriptor) {
-          return new Datastream({fileId: path.relative(sails.config.record.attachments.stageDir, nextDescriptor.fd), name: nextDescriptor.filename, mimeType: nextDescriptor.type, size: nextDescriptor.size });
+          return new Datastream({ fileId: path.relative(sails.config.record.attachments.stageDir, nextDescriptor.fd), name: nextDescriptor.filename, mimeType: nextDescriptor.type, size: nextDescriptor.size });
         });
         sails.log.verbose('files to send upstream are:');
         sails.log.verbose(_.toString(fileIds));
         const defaultErrorMessage = 'Error sending datastreams upstream.';
         try {
-          const result:DatastreamServiceResponse = await self.DatastreamService.addDatastreams(oid, fileIds);
-    
+          const result: DatastreamServiceResponse = await self.DatastreamService.addDatastreams(oid, fileIds);
+
           sails.log.verbose(`Done with updating streams and returning response...`);
           if (result.isSuccessful()) {
             sails.log.verbose("Presuming success...");
-            _.merge(result, {fileIds: fileIds});
-            return res.json({message: result});
+            _.merge(result, { fileIds: fileIds });
+            return res.json({ message: result });
           } else {
-            return res.status(500).json({message: result.message});
+            return res.status(500).json({ message: result.message });
           }
 
         } catch (error) {
           sails.log.error(defaultErrorMessage, error);
-          return res.status(500).json({message: defaultErrorMessage});
+          return res.status(500).json({ message: defaultErrorMessage });
         }
       });
     }
@@ -522,7 +524,7 @@ export module Controllers {
       sails.log.verbose(error);
       res.set('Content-Type', 'application/json');
       _.unset(res, 'Content-Disposition');
-      return res.status(error.statusCode || 500).json({message: errorMessage});
+      return res.status(error.statusCode || 500).json({ message: errorMessage });
     }
 
 
@@ -533,109 +535,109 @@ export module Controllers {
      */
 
 
-     /* Ad-hoc methods for listing records via api
-     * Using DashboardService for getRecords similar (copied from
-     * DashboardController) to DashboardService
-     * Can be used for building reports or SPAs for redbox
-     * TODO: Refactor DashboardController to use this and move DashboardService.getRecords
-     * to RecordsService
-     */
+    /* Ad-hoc methods for listing records via api
+    * Using DashboardService for getRecords similar (copied from
+    * DashboardController) to DashboardService
+    * Can be used for building reports or SPAs for redbox
+    * TODO: Refactor DashboardController to use this and move DashboardService.getRecords
+    * to RecordsService
+    */
 
-     private getDocMetadata(doc) {
-       var metadata = {};
-       for(var key in doc){
-         if(key.indexOf('authorization_') != 0 && key.indexOf('metaMetadata_') != 0) {
-           metadata[key] = doc[key];
-         }
-         if(key == 'authorization_editRoles') {
-           metadata[key] = doc[key];
-         }
-       }
-       return metadata;
-     }
+    private getDocMetadata(doc) {
+      var metadata = {};
+      for (var key in doc) {
+        if (key.indexOf('authorization_') != 0 && key.indexOf('metaMetadata_') != 0) {
+          metadata[key] = doc[key];
+        }
+        if (key == 'authorization_editRoles') {
+          metadata[key] = doc[key];
+        }
+      }
+      return metadata;
+    }
 
-     protected async getRecords(workflowState, recordType, start, rows, user, roles, brand, editAccessOnly=undefined, packageType = undefined, sort=undefined, fieldNames=undefined, filterString=undefined) {
-       const username = user.username;
-       if (!_.isUndefined(recordType) && !_.isEmpty(recordType)) {
-         recordType = recordType.split(',');
-       }
-       if (!_.isUndefined(packageType) && !_.isEmpty(packageType)) {
-         packageType = packageType.split(',');
-       }
-       if(start == null) {
-         start = 0;
-       }
-       if(rows == undefined) {
-         rows = 10;
-       }
-       var results = await this.RecordsService.getRecords(workflowState, recordType, start, rows, username, roles, brand, editAccessOnly, packageType, sort,fieldNames, filterString);
-       sails.log.debug(    results);  
-       let apiReponse: ListAPIResponse<any> = new ListAPIResponse();       
-          var totalItems = results.totalItems
-          var startIndex = start;
-          var noItems = rows;
-          var pageNumber = Math.floor((startIndex / noItems) + 1);
- 
-          apiReponse.summary.numFound = totalItems;
-          apiReponse.summary.start = startIndex;
-          apiReponse.summary.page = pageNumber;
- 
- 
-          var items = [];
-          var docs = results["items"];
- 
-          for (var i = 0; i < docs.length; i++) {
-            var doc = docs[i];
-            var item = {};
-            item["oid"] = doc["redboxOid"];
-            item["title"] = doc["metadata"]["title"];
-            item["metadata"]= doc["metadata"];
-            item["dateCreated"] =  doc["dateCreated"];
-            item["dateModified"] = doc["lastSaveDate"];
-            item["hasEditAccess"] = this.RecordsService.hasEditAccess(brand, user, roles, doc);
-            items.push(item);
-          }
-          apiReponse.records = items;
-          return apiReponse;
-      
-     }
+    protected async getRecords(workflowState, recordType, start, rows, user, roles, brand, editAccessOnly = undefined, packageType = undefined, sort = undefined, fieldNames = undefined, filterString = undefined) {
+      const username = user.username;
+      if (!_.isUndefined(recordType) && !_.isEmpty(recordType)) {
+        recordType = recordType.split(',');
+      }
+      if (!_.isUndefined(packageType) && !_.isEmpty(packageType)) {
+        packageType = packageType.split(',');
+      }
+      if (start == null) {
+        start = 0;
+      }
+      if (rows == undefined) {
+        rows = 10;
+      }
+      var results = await this.RecordsService.getRecords(workflowState, recordType, start, rows, username, roles, brand, editAccessOnly, packageType, sort, fieldNames, filterString);
+      sails.log.debug(results);
+      let apiReponse: ListAPIResponse<any> = new ListAPIResponse();
+      var totalItems = results.totalItems
+      var startIndex = start;
+      var noItems = rows;
+      var pageNumber = Math.floor((startIndex / noItems) + 1);
 
-     public listRecords(req, res) {
-       //sails.log.debug('api-list-records');
-       const brand = BrandingService.getBrand(req.session.branding);
-       const editAccessOnly = req.query.editOnly;
+      apiReponse.summary.numFound = totalItems;
+      apiReponse.summary.start = startIndex;
+      apiReponse.summary.page = pageNumber;
 
-       var roles = [];
-       var username = "guest";
-       let user = {};
-       if (req.isAuthenticated()) {
-         roles = req.user.roles;
-         user = req.user;
-         username = req.user.username;
-       } else {
-         // assign default role if needed...
-         user = {username: username};
-         roles = [];
-         roles.push(RolesService.getDefUnathenticatedRole(brand));
-       }
-       const recordType = req.param('recordType');
-       const workflowState = req.param('state');
-       const start = req.param('start');
-       const rows = req.param('rows');
-       const packageType = req.param('packageType');
-       const sort = req.param('sort');
-       const filterFieldString = req.param('filterFields');
-       let filterString = req.param('filter');
-       let filterFields = undefined;
 
-       if(!_.isEmpty(filterFieldString)) {
-         filterFields = filterString.split(',')
-       } else {
-         filterString = undefined;
-       }
+      var items = [];
+      var docs = results["items"];
 
-       if(rows > parseInt(sails.config.api.max_requests)){
-         var error = {
+      for (var i = 0; i < docs.length; i++) {
+        var doc = docs[i];
+        var item = {};
+        item["oid"] = doc["redboxOid"];
+        item["title"] = doc["metadata"]["title"];
+        item["metadata"] = doc["metadata"];
+        item["dateCreated"] = doc["dateCreated"];
+        item["dateModified"] = doc["lastSaveDate"];
+        item["hasEditAccess"] = this.RecordsService.hasEditAccess(brand, user, roles, doc);
+        items.push(item);
+      }
+      apiReponse.records = items;
+      return apiReponse;
+
+    }
+
+    public listRecords(req, res) {
+      //sails.log.debug('api-list-records');
+      const brand = BrandingService.getBrand(req.session.branding);
+      const editAccessOnly = req.query.editOnly;
+
+      var roles = [];
+      var username = "guest";
+      let user = {};
+      if (req.isAuthenticated()) {
+        roles = req.user.roles;
+        user = req.user;
+        username = req.user.username;
+      } else {
+        // assign default role if needed...
+        user = { username: username };
+        roles = [];
+        roles.push(RolesService.getDefUnathenticatedRole(brand));
+      }
+      const recordType = req.param('recordType');
+      const workflowState = req.param('state');
+      const start = req.param('start');
+      const rows = req.param('rows');
+      const packageType = req.param('packageType');
+      const sort = req.param('sort');
+      const filterFieldString = req.param('filterFields');
+      let filterString = req.param('filter');
+      let filterFields = undefined;
+
+      if (!_.isEmpty(filterFieldString)) {
+        filterFields = filterString.split(',')
+      } else {
+        filterString = undefined;
+      }
+
+      if (rows > parseInt(sails.config.api.max_requests)) {
+        var error = {
           "code": 400,
           "contactEmail": null,
           "description": "You have reached the maximum of request available; Max rows per request " + sails.config.api.max_requests,
@@ -645,192 +647,376 @@ export module Controllers {
         };
         res.status(400);
         res.json(error);
-       } else {
-         // sails.log.debug(`getRecords: ${recordType} ${workflowState} ${start}`);
-         // sails.log.debug(`${rows} ${packageType} ${sort}`);
-         this.getRecords(workflowState, recordType, start, rows, user, roles, brand, editAccessOnly, packageType, sort, filterFields, filterString).then(response => {
-             res.json(response);
-           }).catch( error => {
-             sails.log.error("Error:");
-             sails.log.error(error);
-             var err = error['error'];
-             res.json(err);
-           });
-       }
-     }
+      } else {
+        // sails.log.debug(`getRecords: ${recordType} ${workflowState} ${start}`);
+        // sails.log.debug(`${rows} ${packageType} ${sort}`);
+        this.getRecords(workflowState, recordType, start, rows, user, roles, brand, editAccessOnly, packageType, sort, filterFields, filterString).then(response => {
+          res.json(response);
+        }).catch(error => {
+          sails.log.error("Error:");
+          sails.log.error(error);
+          var err = error['error'];
+          res.json(err);
+        });
+      }
+    }
 
-     public async deleteRecord(req, res) {
-       const oid = req.param('oid');
-       if (_.isEmpty(oid)) {
-         return this.apiFail(req, res, 400, new APIErrorResponse("Missing ID of record."));
-       }
-       const response = await this.RecordsService.delete(oid);
-       if (response.isSuccessful()) {
-         this.apiRespond(req, res, response);
-       } else {
-         sails.log.verbose(`Delete attempt failed for OID: ${oid}`);
-         sails.log.verbose(JSON.stringify(response));
-         this.apiFail(req, res, 500, new APIErrorResponse(response.message, response.details));
-       }
-     }
+    public async deleteRecord(req, res) {
+      const oid = req.param('oid');
+      if (_.isEmpty(oid)) {
+        return this.apiFail(req, res, 400, new APIErrorResponse("Missing ID of record."));
+      }
+      const response = await this.RecordsService.delete(oid);
+      if (response.isSuccessful()) {
+        this.apiRespond(req, res, response);
+      } else {
+        sails.log.verbose(`Delete attempt failed for OID: ${oid}`);
+        sails.log.verbose(JSON.stringify(response));
+        this.apiFail(req, res, 500, new APIErrorResponse(response.message, response.details));
+      }
+    }
 
-     public async transitionWorkflow(req, res) {
-       const oid = req.param('oid');
-       const targetStepName = req.param('targetStep');
-       try {
-         if (_.isEmpty(oid)) {
-           return this.apiFail(req, res, 400, new APIErrorResponse("Missing ID of record."));
-         }
-         const brand = BrandingService.getBrand(req.session.branding);
-         const record = await this.RecordsService.getMeta(oid);
-         if (_.isEmpty(record)) {
-           this.apiFail(req, res, 500, new APIErrorResponse(`Missing OID: ${oid}`));
-           return;
-         }
-         if (!this.RecordsService.hasEditAccess(brand, req.user, req.user.roles, record)) {
-           this.apiFail(req, res, 500, new APIErrorResponse(`User has no edit permissions for :${oid}`));
-           return;
-         }
-         const recType = await RecordTypesService.get(brand, record.metaMetadata.type).toPromise();
-         const nextStep = await WorkflowStepsService.get(recType, targetStepName).toPromise();
-         this.RecordsService.updateWorkflowStep(record, nextStep);
-         const response = await this.RecordsService.updateMeta(brand, oid, record, req.user);
-         this.apiRespond(req, res, response);
-       } catch (err) {
-         sails.log.error(`Failed to transitionWorkflow: ${oid} to ${targetStepName}`);
-         sails.log.error(JSON.stringify(err));
-         this.apiFail(req, res, 500, new APIErrorResponse(`Failed to transition workflow, please check server logs.`));
-       }
-     }
+    public async transitionWorkflow(req, res) {
+      const oid = req.param('oid');
+      const targetStepName = req.param('targetStep');
+      try {
+        if (_.isEmpty(oid)) {
+          return this.apiFail(req, res, 400, new APIErrorResponse("Missing ID of record."));
+        }
+        const brand = BrandingService.getBrand(req.session.branding);
+        const record = await this.RecordsService.getMeta(oid);
+        if (_.isEmpty(record)) {
+          this.apiFail(req, res, 500, new APIErrorResponse(`Missing OID: ${oid}`));
+          return;
+        }
+        if (!this.RecordsService.hasEditAccess(brand, req.user, req.user.roles, record)) {
+          this.apiFail(req, res, 500, new APIErrorResponse(`User has no edit permissions for :${oid}`));
+          return;
+        }
+        const recType = await RecordTypesService.get(brand, record.metaMetadata.type).toPromise();
+        const nextStep = await WorkflowStepsService.get(recType, targetStepName).toPromise();
+        this.RecordsService.updateWorkflowStep(record, nextStep);
+        const response = await this.RecordsService.updateMeta(brand, oid, record, req.user);
+        this.apiRespond(req, res, response);
+      } catch (err) {
+        sails.log.error(`Failed to transitionWorkflow: ${oid} to ${targetStepName}`);
+        sails.log.error(JSON.stringify(err));
+        this.apiFail(req, res, 500, new APIErrorResponse(`Failed to transition workflow, please check server logs.`));
+      }
+    }
 
-     public async listDatastreams(req, res) {
-       const oid = req.param('oid');
-       if (_.isEmpty(oid)) {
-         return this.apiFail(req, res, 400, new APIErrorResponse("Missing ID of record."));
-       }
-       try {
-         const attachments = await this.RecordsService.getAttachments(oid);
-         sails.log.verbose(JSON.stringify(attachments));
-         let response: ListAPIResponse < any > = new ListAPIResponse < any > ();
-         response.summary.numFound = _.size(attachments);
-         response.summary.page = 1;
-         response.records = attachments;
-         this.apiRespond(req, res, response);
-       } catch (err) {
-         sails.log.error(`Failed to list attachments: ${oid}`);
-         sails.log.error(JSON.stringify(err));
-         this.apiFail(req, res, 500, new APIErrorResponse(`Failed to list attachments, please check server logs.`));
-       }
-     }
+    public async listDatastreams(req, res) {
+      const oid = req.param('oid');
+      if (_.isEmpty(oid)) {
+        return this.apiFail(req, res, 400, new APIErrorResponse("Missing ID of record."));
+      }
+      try {
+        const attachments = await this.RecordsService.getAttachments(oid);
+        sails.log.verbose(JSON.stringify(attachments));
+        let response: ListAPIResponse<any> = new ListAPIResponse<any>();
+        response.summary.numFound = _.size(attachments);
+        response.summary.page = 1;
+        response.records = attachments;
+        this.apiRespond(req, res, response);
+      } catch (err) {
+        sails.log.error(`Failed to list attachments: ${oid}`);
+        sails.log.error(JSON.stringify(err));
+        this.apiFail(req, res, 500, new APIErrorResponse(`Failed to list attachments, please check server logs.`));
+      }
+    }
 
-     public addRoleEdit(req, res) {
-       const brand = BrandingService.getBrand(req.session.branding);
-
-
-       var oid = req.param('oid');
-       var body = req.body;
-       var roles = body["roles"];
-       Observable.fromPromise(this.RecordsService.getMeta(oid)).subscribe(record => {
-
-         if (roles != null && roles.length > 0) {
-           record["authorization"]["editRoles"] = _.union(record["authorization"]["editRoles"], roles);
-         }
-
-         var obs = Observable.fromPromise(this.RecordsService.updateMeta(brand, oid, record, req.user));
-         obs.subscribe(result => {
-           if (result.isSuccessful()) {
-             Observable.fromPromise(this.RecordsService.getMeta(result.oid)).subscribe(record => {
-               return res.json(record["authorization"]);
-             }, error=> {
-               sails.log.error(error);
-               return this.apiFail(req, res, 500, new APIErrorResponse('Failed adding an editor role, check server logs.'));
-             });
-           } else {
-             return res.json(result);
-           }
-         }, error=> {
-           sails.log.error(error);
-           return this.apiFail(req, res, 500, new APIErrorResponse('Failed adding an editor role, check server logs.'));
-         });
-       });
-     }
-
-     public addRoleView(req, res) {
-       const brand = BrandingService.getBrand(req.session.branding);
+    public addRoleEdit(req, res) {
+      const brand = BrandingService.getBrand(req.session.branding);
 
 
-       var oid = req.param('oid');
-       var body = req.body;
-       var roles = body["roles"];
-       Observable.fromPromise(this.RecordsService.getMeta(oid)).subscribe(record => {
+      var oid = req.param('oid');
+      var body = req.body;
+      var roles = body["roles"];
+      Observable.fromPromise(this.RecordsService.getMeta(oid)).subscribe(record => {
 
-         if (roles != null && roles.length > 0) {
-           record["authorization"]["viewRoles"] = _.union(record["authorization"]["viewRoles"], roles);
-         }
+        if (roles != null && roles.length > 0) {
+          record["authorization"]["editRoles"] = _.union(record["authorization"]["editRoles"], roles);
+        }
 
-         var obs = Observable.fromPromise(this.RecordsService.updateMeta(brand, oid, record, req.user));
-         obs.subscribe(result => {
-           if (result.isSuccessful()) {
-             Observable.fromPromise(this.RecordsService.getMeta(result["oid"])).subscribe(record => {
-               return res.json(record["authorization"]);
-             });
-           } else {
-             return res.json(result);
-           }
-         });
-       });
-     }
+        var obs = Observable.fromPromise(this.RecordsService.updateMeta(brand, oid, record, req.user));
+        obs.subscribe(result => {
+          if (result.isSuccessful()) {
+            Observable.fromPromise(this.RecordsService.getMeta(result.oid)).subscribe(record => {
+              return res.json(record["authorization"]);
+            }, error => {
+              sails.log.error(error);
+              return this.apiFail(req, res, 500, new APIErrorResponse('Failed adding an editor role, check server logs.'));
+            });
+          } else {
+            return res.json(result);
+          }
+        }, error => {
+          sails.log.error(error);
+          return this.apiFail(req, res, 500, new APIErrorResponse('Failed adding an editor role, check server logs.'));
+        });
+      });
+    }
 
-     public removeRoleEdit(req, res) {
-       const brand = BrandingService.getBrand(req.session.branding);
-       var oid = req.param('oid');
+    public addRoleView(req, res) {
+      const brand = BrandingService.getBrand(req.session.branding);
 
-       var body = req.body;
-       var roles = body["roles"];
-       Observable.fromPromise(this.RecordsService.getMeta(oid)).subscribe(record => {
 
-         if (roles != null && roles.length > 0) {
-           record["authorization"]["editRoles"] = _.difference(record["authorization"]["editRoles"], roles);
-         }
+      var oid = req.param('oid');
+      var body = req.body;
+      var roles = body["roles"];
+      Observable.fromPromise(this.RecordsService.getMeta(oid)).subscribe(record => {
 
-         var obs = Observable.fromPromise(this.RecordsService.updateMeta(brand, oid, record,req.user));
-         obs.subscribe(result => {
-           if (result.isSuccessful()) {
-             Observable.fromPromise(this.RecordsService.getMeta(result["oid"])).subscribe(record => {
-               return res.json(record["authorization"]);
-             });
-           } else {
-             return res.json(result);
-           }
-         });
-       });
-     }
+        if (roles != null && roles.length > 0) {
+          record["authorization"]["viewRoles"] = _.union(record["authorization"]["viewRoles"], roles);
+        }
 
-     public removeRoleView(req, res) {
-       const brand = BrandingService.getBrand(req.session.branding);
-       var oid = req.param('oid');
+        var obs = Observable.fromPromise(this.RecordsService.updateMeta(brand, oid, record, req.user));
+        obs.subscribe(result => {
+          if (result.isSuccessful()) {
+            Observable.fromPromise(this.RecordsService.getMeta(result["oid"])).subscribe(record => {
+              return res.json(record["authorization"]);
+            });
+          } else {
+            return res.json(result);
+          }
+        });
+      });
+    }
 
-       var body = req.body;
-       var users = body["roles"];
-       Observable.fromPromise(this.RecordsService.getMeta(oid)).subscribe(record => {
+    public removeRoleEdit(req, res) {
+      const brand = BrandingService.getBrand(req.session.branding);
+      var oid = req.param('oid');
 
-         if (users != null && users.length > 0) {
-           record["authorization"]["viewRoles"] = _.difference(record["authorization"]["viewRoles"], users);
-         }
+      var body = req.body;
+      var roles = body["roles"];
+      Observable.fromPromise(this.RecordsService.getMeta(oid)).subscribe(record => {
 
-         var obs = Observable.fromPromise(this.RecordsService.updateMeta(brand, oid, record, req.user));
-         obs.subscribe(result => {
-           if (result.isSuccessful()) {
-             Observable.fromPromise(this.RecordsService.getMeta(result["oid"])).subscribe(record => {
-               return res.json(record["authorization"]);
-             });
-           } else {
-             return res.json(result);
-           }
-         });
-       });
-     }
+        if (roles != null && roles.length > 0) {
+          record["authorization"]["editRoles"] = _.difference(record["authorization"]["editRoles"], roles);
+        }
+
+        var obs = Observable.fromPromise(this.RecordsService.updateMeta(brand, oid, record, req.user));
+        obs.subscribe(result => {
+          if (result.isSuccessful()) {
+            Observable.fromPromise(this.RecordsService.getMeta(result["oid"])).subscribe(record => {
+              return res.json(record["authorization"]);
+            });
+          } else {
+            return res.json(result);
+          }
+        });
+      });
+    }
+
+    public removeRoleView(req, res) {
+      const brand = BrandingService.getBrand(req.session.branding);
+      var oid = req.param('oid');
+
+      var body = req.body;
+      var users = body["roles"];
+      Observable.fromPromise(this.RecordsService.getMeta(oid)).subscribe(record => {
+
+        if (users != null && users.length > 0) {
+          record["authorization"]["viewRoles"] = _.difference(record["authorization"]["viewRoles"], users);
+        }
+
+        var obs = Observable.fromPromise(this.RecordsService.updateMeta(brand, oid, record, req.user));
+        obs.subscribe(result => {
+          if (result.isSuccessful()) {
+            Observable.fromPromise(this.RecordsService.getMeta(result["oid"])).subscribe(record => {
+              return res.json(record["authorization"]);
+            });
+          } else {
+            return res.json(result);
+          }
+        });
+      });
+    }
+
+
+    public async harvest(req, res) {
+      const brand = BrandingService.getBrand(req.session.branding);
+      let updateModes = ["merge", "override", "create"]
+
+      let updateMode = req.param('updateMode')
+      if (_.isEmpty(updateMode)) {
+        updateMode = "override"
+      }
+
+      var recordType = req.param('recordType');
+      var recordTypeModel = await RecordTypesService.get(brand, recordType).toPromise();
+
+
+      if (recordTypeModel == null) {
+        return this.apiFail(req, res, 400, new APIErrorResponse("Record Type provided is not valid"));
+      }
+      var user = req.user;
+      var body = req.body;
+      if (body != null) {
+
+        if (_.isEmpty(body["records"])) {
+          return this.apiFail(req, res, 400, new APIErrorResponse("Invalid request body"));
+        }
+        let recordResponses = [];
+        let records = body['records'];
+        for (let record of records) {
+          let harvestId = record["harvestId"]
+          if (_.isEmpty(harvestId)) {
+            recordResponses.push(new APIHarvestResponse(harvestId, null, false,"HarvestId was not specified"))
+          } else {
+            let existingRecord = await this.findExistingRecord(harvestId, recordType)
+            if (existingRecord.length == 0 || updateMode == "create") {
+              recordResponses.push(await this.createHarvestRecord(brand, recordTypeModel, record['recordRequest'], harvestId, updateMode, user));
+            } else {
+              let oid = existingRecord[0].redboxOid;
+              if(updateMode != "ignore") {
+               recordResponses.push(await this.updateHarvestRecord(brand, recordTypeModel, updateMode, record['recordRequest']['metadata'], oid, harvestId, user));
+              } else {
+                recordResponses.push(new APIHarvestResponse(harvestId, oid, true,`Record ignored as the record already exists. oid: ${oid}`))
+              }
+            }
+          }
+        }
+        return res.json(recordResponses);
+      }
+      return this.apiFail(req, res, 400, new APIErrorResponse("Invalid request"));
+    }
+
+    private async updateHarvestRecord(brand: any, recordTypeModel: any, updateMode: any, body: any, oid: any, harvestId: any, user: any) {
+
+      const shouldMerge = updateMode == "merge" ? true : false;
+      try {
+        let record = await this.RecordsService.getMeta(oid)
+        if (_.isEmpty(record)) {
+          return new APIHarvestResponse(harvestId,oid, false, `Failed to update meta, cannot find existing record with oid: ${oid}`)
+        }
+        try {
+          if (shouldMerge) {
+            // behavior modified from replacing arrays to appending to arrays:
+            record["metadata"] = _.mergeWith(record.metadata, body, (objValue, srcValue) => {
+              if (_.isArray(objValue)) {
+                return objValue.concat(srcValue);
+              }
+            });
+          } else {
+            record["metadata"] = body;
+          }
+          let result = await this.RecordsService.updateMeta(brand, oid, record, user);
+
+          return new APIHarvestResponse(harvestId,oid, true, `Record updated successfully`)
+
+        } catch (error) {
+          return new APIHarvestResponse(harvestId,oid, false, `Failed to update meta`)
+        }
+      } catch (error) {
+        return new APIHarvestResponse(harvestId,oid, false, `Failed to retrieve record metadata before update`)
+      }
+    }
+
+
+    private async findExistingRecord(harvestId: any, recordType: any) {
+      let results = await Record.find({
+        'harvestId': harvestId,
+        'metaMetadata.type': recordType
+      }).meta({
+        enableExperimentalDeepTargets: true
+      })
+      return results;
+    }
+
+    private async createHarvestRecord(brand, recordTypeModel, body, harvestId, updateMode, user) {
+      let authorizationEdit, authorizationView, authorizationEditPending, authorizationViewPending;
+      if (body["authorization"] != null) {
+        authorizationEdit = body["authorization"]["edit"];
+        authorizationView = body["authorization"]["view"];
+        authorizationEditPending = body["authorization"]["editPending"];
+        authorizationViewPending = body["authorization"]["viewPending"];
+      } else {
+        // If no authorization block set to user
+        body["authorization"] = [];
+        authorizationEdit = [];
+        authorizationView = [];
+        authorizationEdit.push(user.username);
+        authorizationView.push(user.username);
+      }
+
+      var metadata = body["metadata"];
+      var workflowStage = body["workflowStage"];
+      var request = {};
+      if(updateMode != "create") {
+       // Only set harvestId if not in create mode
+       request["harvestId"] = harvestId;
+      }
+      var metaMetadata = {};
+      metaMetadata["brandId"] = brand.id;
+      metaMetadata["type"] = recordTypeModel.name;
+      metaMetadata["packageName"] = recordTypeModel.packageName;
+      metaMetadata["packageType"] = recordTypeModel.packageType;
+
+      // Resolves #723: removed hardcoded value
+      metaMetadata["createdBy"] = user.username;
+      request["metaMetadata"] = metaMetadata;
+      //if no metadata field, no authorization
+      if (metadata == null) {
+        request["metadata"] = body;
+      } else {
+        request["metadata"] = metadata;
+        // Adding custom metaMetadata values when specifying the metadata block
+        if (!_.isEmpty(body["metaMetadata"])) {
+          _.merge(metaMetadata, body["metaMetadata"]);
+        }
+      }
+
+      // FormsService
+      let workflowSteps = await WorkflowStepsService.getAllForRecordType(recordTypeModel).toPromise();
+
+
+      for (let workflowStep of workflowSteps) {
+        // If no workflowStage set, find the starting step
+        if (workflowStage == null) {
+          if (workflowStep["starting"] == true) {
+            request["workflow"] = workflowStep["config"]["workflow"];
+            request["authorization"] = workflowStep["config"]["authorization"];
+            request["authorization"]["view"] = authorizationView;
+            request["authorization"]["edit"] = authorizationEdit;
+            request["authorization"]["viewPending"] = authorizationViewPending;
+            request["authorization"]["editPending"] = authorizationEditPending;
+            metaMetadata["form"] = workflowStep["config"]["form"];
+          }
+        } else {
+          if (workflowStep["name"] == workflowStage) {
+            request["workflow"] = workflowStep["config"]["workflow"];
+            request["authorization"] = workflowStep["config"]["authorization"];
+            request["authorization"]["view"] = authorizationView;
+            request["authorization"]["edit"] = authorizationEdit;
+            request["authorization"]["viewPending"] = authorizationViewPending;
+            request["authorization"]["editPending"] = authorizationEditPending;
+            metaMetadata["form"] = workflowStep["config"]["form"];
+          }
+        }
+
+      }
+      try {
+        let response = await this.RecordsService.create(brand, request, recordTypeModel, user)
+
+        if (response.isSuccessful()) {
+           return new APIHarvestResponse(harvestId,response.oid, true, `Record created successfully`);
+        } else {
+          
+          return new APIHarvestResponse(harvestId, null, false, `Record creation failed`);
+
+        }
+      } catch (error) {
+        return new APIHarvestResponse(harvestId, null, false, error.toString());
+      }
+
+
+
+
+    }
+
   }
 }
 
-module.exports = new Controllers.Record().exports();
+
+module.exports = new Controllers.RecordWeb().exports();


### PR DESCRIPTION
New API endpoint on post /:branding/:portal/api/records/harvest to support batch harvesting records.
Supports creating/updating records based on a source system's Id (the harvestId parameter is essentially an alternate key for the record for the purposes of harvesting).
Multiple update modes supported:
* override: replace the record's metadata completely with the posted metadata provided via the API
* merge: performs a JSON merge of the stored metadata overriding only the keys present in the posted metadata
* create: create's a new record regardless of a record existing with the provided harvestId
* ignore: will not attempt to update the existing record

Supports optionally storing a copy of the source system's metadata for auditing purposes