### PR TITLE
Provided an option to return the provided data object for setVisibilility

### DIFF
--- a/angular/shared/form/field-base.ts
+++ b/angular/shared/form/field-base.ts
@@ -496,6 +496,10 @@ export class FieldBase<T> {
       }
       that.visible = newVisible;
     });
+    if(eventConf.returnData == true) {
+      return data;
+    }
+    
   }
 
   public replaceValWithConfig(val) {

--- a/angular/shared/form/field-repeatable.component.ts
+++ b/angular/shared/form/field-repeatable.component.ts
@@ -312,6 +312,9 @@ export class RepeatableContainer extends Container {
       }
       that.visible = newVisible;
     });
+    if(eventConf.returnData == true) {
+      return data;
+    }
   }
 }
 


### PR DESCRIPTION
This can be used when the setVisibility call is not at the end of the chain where you need that data for further processing. Defaults to not returning the data. Fixes #1065