### PR TITLE
Feature to make add datastream synchronous on create and on update and after pre save triggers 

### DIFF
--- a/angular/shared/form/field-datalocation.component.ts
+++ b/angular/shared/form/field-datalocation.component.ts
@@ -268,6 +268,7 @@ export class DataLocationComponent extends SimpleComponent {
     console.log(this.uppy);
     let fieldVal: any = null;
     // attach event handers...
+    let that = this;
     this.uppy.on('upload-success', (file, resp, uploadURL) => {
       console.debug("File info:");
       console.debug(file);
@@ -277,7 +278,9 @@ export class DataLocationComponent extends SimpleComponent {
       // add to form control on each upload...
       const urlParts = uploadURL.split('/');
       const fileId = urlParts[urlParts.length - 1];
-      const oidUrlPosition = _.indexOf(urlParts, oid);
+      let oidGlobal = that.field.fieldMap[that.field.name].instance.oid;
+      console.debug(`oid:${oidGlobal}`);
+      const oidUrlPosition = _.indexOf(urlParts, oidGlobal);
       const choppedUrl = urlParts.slice(oidUrlPosition, urlParts.length).join('/');
       const newLoc = { type: "attachment", pending: true, location: choppedUrl, notes: file.meta.notes, mimeType: file.type, name: file.meta.name, fileId: fileId, uploadUrl: uploadURL, size: file.size };
       console.debug(`Adding new location:`);

--- a/typescript/api/controllers/RecordController.ts
+++ b/typescript/api/controllers/RecordController.ts
@@ -706,7 +706,7 @@ export module Controllers {
       currentRec.metaMetadata.attachmentFields = form.attachmentFields;
       try {
         sails.log.verbose(`RecordController - updateInternal - before this.updateMetadata`);
-        let resposeDatastream = await this.handleUpdateDataStream(oid, origRecord, metadata).toPromise();
+        let resposeDatastream = await this.handleUpdateDataStream(oid, currentRec, metadata).toPromise();
         sails.log.verbose(`RecordController - updateInternal - Done with updating streams and returning response...`);
         let response = await this.recordsService.updateMeta(brand, oid, currentRec, user, false, false);
 

--- a/typescript/api/controllers/RecordController.ts
+++ b/typescript/api/controllers/RecordController.ts
@@ -849,7 +849,6 @@ export module Controllers {
       sails.log.verbose(`RecordController - updateMetadataWithTriggerSelector - Calling record service...`);
       sails.log.verbose(`RecordController - updateMetadataWithTriggerSelector - triggerPreSaveTriggers ${triggerPreSaveTriggers}`);
       sails.log.verbose(`RecordController - updateMetadataWithTriggerSelector - triggerPostSaveTriggers ${triggerPostSaveTriggers}`);
-      sails.log.verbose(currentRec);
       return Observable.fromPromise(this.recordsService.updateMeta(brand, oid, currentRec, user, triggerPreSaveTriggers, triggerPostSaveTriggers));
     }
 

--- a/typescript/api/controllers/RecordController.ts
+++ b/typescript/api/controllers/RecordController.ts
@@ -706,9 +706,9 @@ export module Controllers {
       currentRec.metaMetadata.attachmentFields = form.attachmentFields;
       try {
         sails.log.verbose(`RecordController - updateInternal - before this.updateMetadata`);
-        let resposeDatastream = await this.handleUpdateDataStream(oid, currentRec, metadata).toPromise();
+        let resposeDatastream = await this.handleUpdateDataStream(oid, origRecord, metadata).toPromise();
         sails.log.verbose(`RecordController - updateInternal - Done with updating streams and returning response...`);
-        let response = await this.recordsService.updateMeta(brand, oid, currentRec, user, false, false);
+        let response = await this.updateMetadata(brand, oid, currentRec, user).toPromise();
 
         if (response && response.isSuccessful()) {
           response.success = true;


### PR DESCRIPTION
This feature is required because there is the possibility to integrate redbox with figshare that includes the feature to upload files from redbox to figshare. The upload files feature created the necessity to refactor the create and update processes so these happen in the below order:
1- pre save triggers
2- add datastream to gridfs
3- update metadata
4- post triggers (that may included a call to an upload files to figshare process)

The file upload process has been designed to be called as a post save triggers and it will extract the file from gridfs and will save it in a temp folder and will upload file in chunks in the background 