### PR TITLE
Feature storage mongo 1.1.5 alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1790,15 +1790,10 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "@researchdatabox/redbox-core-types": {
-      "version": "1.0.6-beta",
-      "resolved": "https://registry.npmjs.org/@researchdatabox/redbox-core-types/-/redbox-core-types-1.0.6-beta.tgz",
-      "integrity": "sha512-VISl3X3ldolUwt7dHjx1qHnf9SJVc+mCbAob6nvzurDBtnlcgqGX4uur6VQpwItJEOSI9SaxUlngZpb+/wA6Hw=="
-    },
     "@researchdatabox/sails-hook-redbox-storage-mongo": {
-      "version": "1.1.4-alpha",
-      "resolved": "https://registry.npmjs.org/@researchdatabox/sails-hook-redbox-storage-mongo/-/sails-hook-redbox-storage-mongo-1.1.4-alpha.tgz",
-      "integrity": "sha512-zsk8FswSGY88qeq0eTJiIp8UuS/NoyDkXzxtsuhRpbrOdsMsDYYvmugWLdmIEvFzAT0reRYRP5em4R3vy36bKQ==",
+      "version": "1.1.5-alpha",
+      "resolved": "https://registry.npmjs.org/@researchdatabox/sails-hook-redbox-storage-mongo/-/sails-hook-redbox-storage-mongo-1.1.5-alpha.tgz",
+      "integrity": "sha512-5QBA2HMBQDVOtIBtZt/9hHWvtneDT42X2iIc/1zclL6talvzWrHG5U+ium7WtJGTiEYruNKPKB7mc8nubA+cmQ==",
       "requires": {
         "json2csv": "^5.0.3",
         "lodash": "^4.17.20",
@@ -7916,9 +7911,9 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json2csv": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-5.0.6.tgz",
-      "integrity": "sha512-0/4Lv6IenJV0qj2oBdgPIAmFiKKnh8qh7bmLFJ+/ZZHLjSeiL3fKKGX3UryvKPbxFbhV+JcYo9KUC19GJ/Z/4A==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-5.0.7.tgz",
+      "integrity": "sha512-YRZbUnyaJZLZUJSRi2G/MqahCyRv9n/ds+4oIetjDF3jWQA7AG7iSeKTiZiCNqtMZM7HDyt0e/W6lEnoGEmMGA==",
       "requires": {
         "commander": "^6.1.0",
         "jsonparse": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": [],
   "dependencies": {
     "@researchdatabox/redbox-core-types": "1.0.8",
-    "@researchdatabox/sails-hook-redbox-storage-mongo": "^1.1.4-alpha",
+    "@researchdatabox/sails-hook-redbox-storage-mongo": "^1.1.5-alpha",
     "@sailshq/upgrade": "^1.0.9",
     "@uppy/core": "^1.18.0",
     "@uppy/dashboard": "^1.19.0",


### PR DESCRIPTION
Updates @researchdatabox/sails-hook-redbox-storage-mongo to version 1.1.5
[Release Notes](https://github.com/redbox-mint/sails-hook-redbox-storage-mongo/releases/tag/v1.1.5-alpha)