### PR TITLE
Added user filtering to AAF authentication to prevent unwanted users access. 

### DIFF
--- a/typescript/api/services/UsersService.ts
+++ b/typescript/api/services/UsersService.ts
@@ -252,6 +252,21 @@ export module Services {
               lastLogin: new Date()
             };
             sails.log.verbose(userToCreate);
+            if (authorizedEmailExceptions.length > 0 || authorizedEmailDomains > 0) {
+              let emailParts = userToCreate.email.split('@');
+              if (emailParts.length != 2) {
+                sails.log.error(`Unexpected email format: ${userToCreate.email}`);
+                return done(`Unexpected email format: ${userToCreate.email}`, false);
+              }
+
+              let emailDomain = emailParts[1];
+              if (authorizedEmailDomains.indexOf(emailDomain) == -1) {
+                if (authorizedEmailExceptions.indexOf(userToCreate.email) == -1) {
+                  sails.log.error(`User is not authorized to login: ${userToCreate.email}`);
+                  return done(`User is not authorized to login: ${userToCreate.email}`, false);
+                }
+              }
+            }
             User.create(userToCreate).exec(function (err, newUser) {
               if (err) {
                 sails.log.error("Error creating new user:");


### PR DESCRIPTION
You can now define a list of ser email domains to accept for authentication (e.g. jcu.edu.au) as well as a list of explicit email addresses to allow as exceptions to this rule (e.g. user1@institution.edu.au)

Example usage:
```aaf: {
        loginUrl: "https://rapid.aaf.edu.au/jwt/authnrequest/research/xxxxxx",
        defaultRole: 'Researcher',
        authorizedEmailDomains: ['institution.edu.au','student.institution.edu.au'],
        authorizedEmailExceptions: ['another.user@example.edu.au'],```