### PR TITLE
Upgrade base image to Node v14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 jobs:
   build:
     docker:
-      - image: 'cimg/node:16.15'
+      - image: 'node:14.19.0-buster'
     steps:
       - checkout
       - run: (cd core && npm install && node_modules/.bin/tsc)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 jobs:
   build:
     docker:
-      - image: 'cimg/node:12.22.6'
+      - image: 'cimg/node:16.15'
     steps:
       - checkout
       - run: (cd core && npm install && node_modules/.bin/tsc)
@@ -15,7 +15,7 @@ jobs:
             - .
   build_without_angular:
     docker:
-      - image: 'cimg/node:12.22.6'
+      - image: 'cimg/node:16.15'
     steps:
       - checkout
       - run: (cd core && npm install && node_modules/.bin/tsc)
@@ -38,7 +38,7 @@ jobs:
       - run: node_modules/.bin/tsc
   deploy:
     docker:
-      - image: 'cimg/node:12.22.6'
+      - image: 'cimg/node:16.15'
     steps:
       - setup_remote_docker
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
             - .
   deploy:
     docker:
-      - image: 'node:14.19.0-buster'
+      - image: 'cimg/node:14.19'
     steps:
       - setup_remote_docker
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 jobs:
   build:
     docker:
-      - image: 'node:14.19.0-buster'
+      - image: 'cimg/node:14.19'
     steps:
       - checkout
       - run: (cd core && npm install && node_modules/.bin/tsc)
@@ -15,7 +15,7 @@ jobs:
             - .
   build_without_angular:
     docker:
-      - image: 'node:14.19.0-buster'
+      - image: 'cimg/node:14.19'
     steps:
       - checkout
       - run: (cd core && npm install && node_modules/.bin/tsc)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,16 +33,16 @@ jobs:
       - attach_workspace:
            at: /home/circleci/project
       # Make a copy of original project state as it gets modified for integration testing and code coverage reasons
-      - run: (mkdir -p /tmp/original && cp -Rf /home/circleci/project/* /tmp/original
+      # - run: (mkdir -p /tmp/original && cp -Rf /home/circleci/project/* /tmp/original
       - run: node_modules/.bin/tsc -p tsconfig-codecov.json
       - run: (sudo chmod -R 777 . && cd support/integration-testing && sudo mkdir -p .tmp/attachments/staging && sudo chmod -R 777 . && docker-compose -f docker-compose.newman.yml up --abort-on-container-exit --exit-code-from redboxportal && docker-compose -f docker-compose.mocha.yml up --abort-on-container-exit --exit-code-from redboxportal)
       - run: npm i -g codecov && codecov -t $CODECOV_TOKEN
       # Restore original project state before persiting to workspace
-      - run: (sudo rm -Rf /home/circleci/project/* && cp -Rf /tmp/original/* /home/circleci/project/)
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .
+      # - run: (sudo rm -Rf /home/circleci/project/* && cp -Rf /tmp/original/* /home/circleci/project/)
+      # - persist_to_workspace:
+      #     root: .
+      #     paths:
+      #       - .
   deploy:
     docker:
       - image: 'cimg/node:14.19'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,10 +32,17 @@ jobs:
       # - docker/install-docker-compose
       - attach_workspace:
            at: /home/circleci/project
+      # Make a copy of original project state as it gets modified for integration testing and code coverage reasons
+      - run: (mkdir -p /tmp/original && cp -Rf /home/circleci/project/* /tmp/original
       - run: node_modules/.bin/tsc -p tsconfig-codecov.json
       - run: (sudo chmod -R 777 . && cd support/integration-testing && sudo mkdir -p .tmp/attachments/staging && sudo chmod -R 777 . && docker-compose -f docker-compose.newman.yml up --abort-on-container-exit --exit-code-from redboxportal && docker-compose -f docker-compose.mocha.yml up --abort-on-container-exit --exit-code-from redboxportal)
       - run: npm i -g codecov && codecov -t $CODECOV_TOKEN
-      - run: node_modules/.bin/tsc
+      # Restore original project state before persiting to workspace
+      - run: (sudo rm -Rf /home/circleci/project/* && cp -Rf /tmp/original/* /home/circleci/project/)
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
   deploy:
     docker:
       - image: 'node:14.19.0-buster'
@@ -75,7 +82,6 @@ jobs:
 orbs:
   node: circleci/node@4.0.0
   docker: circleci/docker@1.4.0
-  python: circleci/python@2.0.3
 version: 2.1
 workflows:
   build_test_gendocs_and_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,20 +29,12 @@ jobs:
     machine:
       image: ubuntu-2004:202201-02
     steps:
-      # - docker/install-docker-compose
       - attach_workspace:
            at: /home/circleci/project
-      # Make a copy of original project state as it gets modified for integration testing and code coverage reasons
-      # - run: (mkdir -p /tmp/original && cp -Rf /home/circleci/project/* /tmp/original
       - run: node_modules/.bin/tsc -p tsconfig-codecov.json
       - run: (sudo chmod -R 777 . && cd support/integration-testing && sudo mkdir -p .tmp/attachments/staging && sudo chmod -R 777 . && docker-compose -f docker-compose.newman.yml up --abort-on-container-exit --exit-code-from redboxportal && docker-compose -f docker-compose.mocha.yml up --abort-on-container-exit --exit-code-from redboxportal)
       - run: npm i -g codecov && codecov -t $CODECOV_TOKEN
-      # Restore original project state before persiting to workspace
-      # - run: (sudo rm -Rf /home/circleci/project/* && cp -Rf /tmp/original/* /home/circleci/project/)
-      # - persist_to_workspace:
-      #     root: .
-      #     paths:
-      #       - .
+      - run: npm i
   deploy:
     docker:
       - image: 'cimg/node:14.19'
@@ -50,7 +42,6 @@ jobs:
       - setup_remote_docker
       - attach_workspace:
             at: /home/circleci/project
-      # - docker/install-docker-compose
       - run: (chmod +x dockerhub_deploy.sh && ./dockerhub_deploy.sh)
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,7 @@ jobs:
 orbs:
   node: circleci/node@4.0.0
   docker: circleci/docker@1.4.0
+  python: circleci/python@2.0.3
 version: 2.1
 workflows:
   build_test_gendocs_and_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
             - .
   build_without_angular:
     docker:
-      - image: 'cimg/node:16.15'
+      - image: 'node:14.19.0-buster'
     steps:
       - checkout
       - run: (cd core && npm install && node_modules/.bin/tsc)
@@ -38,7 +38,7 @@ jobs:
       - run: node_modules/.bin/tsc
   deploy:
     docker:
-      - image: 'cimg/node:16.15'
+      - image: 'node:14.19.0-buster'
     steps:
       - setup_remote_docker
       - attach_workspace:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.15.0-buster
+FROM node:14.19.0-buster
 ENV node_env production
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH=$PATH:/home/node/.npm-global/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,7 @@
-FROM node:12.22.6
+FROM node:16.15.0-buster
 ENV node_env production
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH=$PATH:/home/node/.npm-global/bin
-RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
-RUN apt-get update \
-     && apt-get install -y wget gnupg ca-certificates procps libxss1 \
-     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-     && apt-get update \
-     # We install Chrome to get all the OS level dependencies, but Chrome itself
-     # is not actually used as it's packaged in the node puppeteer library.
-     # Alternatively, we could could include the entire dep list ourselves
-     # (https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#chrome-headless-doesnt-launch-on-unix)
-     # but that seems too easy to get out of date.
-     && apt-get install -y google-chrome-stable \
-&& apt-get install --no-install-recommends -yq gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
-libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
-libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
-ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget && rm -rf /var/lib/apt/lists/*
 RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64
 RUN chmod +x /usr/local/bin/dumb-init
 RUN echo "Australia/Brisbane" > /etc/timezone && dpkg-reconfigure -f noninteractive tzdata

--- a/angular/shared/form/field-base.ts
+++ b/angular/shared/form/field-base.ts
@@ -556,7 +556,6 @@ export class FieldBase<T> {
    */
   public publishProcessedValueLoaded(curValue) {
     this.onValueLoaded.emit(curValue);
-    return curValue;
   }
 
   /**
@@ -601,7 +600,6 @@ export class FieldBase<T> {
    */
   public publishProcessedValueUpdated(curValue) {
     this.onValueUpdate.emit(curValue);
-    return curValue;
   }  
 
   setRequiredAndClearValueOnFalse(flag) {

--- a/angular/shared/form/field-base.ts
+++ b/angular/shared/form/field-base.ts
@@ -556,6 +556,7 @@ export class FieldBase<T> {
    */
   public publishProcessedValueLoaded(curValue) {
     this.onValueLoaded.emit(curValue);
+    return curValue;
   }
 
   /**
@@ -600,6 +601,7 @@ export class FieldBase<T> {
    */
   public publishProcessedValueUpdated(curValue) {
     this.onValueUpdate.emit(curValue);
+    return curValue;
   }  
 
   setRequiredAndClearValueOnFalse(flag) {

--- a/support/development/docker-compose.yml
+++ b/support/development/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   redboxportal:
     # uncomment this if you are making changes to the Dockerfile
     # build: .
-    image: qcifengineering/redbox-portal:master
+    image: rbnode16
     ports:
       - "1500:1500"
     user: node

--- a/support/integration-testing/docker-compose.mocha.yml
+++ b/support/integration-testing/docker-compose.mocha.yml
@@ -3,7 +3,7 @@ networks:
   main:
 services:
   redboxportal:
-    image: qcifengineering/redbox-portal:feature-node14
+    image: qcifengineering/redbox-portal:feature-node-14
     ports:
        - "1500:1500"
     volumes:

--- a/support/integration-testing/docker-compose.mocha.yml
+++ b/support/integration-testing/docker-compose.mocha.yml
@@ -3,7 +3,7 @@ networks:
   main:
 services:
   redboxportal:
-    image: qcifengineering/redbox-portal:master
+    image: qcifengineering/redbox-portal:feature-node14
     ports:
        - "1500:1500"
     volumes:

--- a/support/integration-testing/docker-compose.newman.yml
+++ b/support/integration-testing/docker-compose.newman.yml
@@ -3,7 +3,7 @@ networks:
   main:
 services:
   redboxportal:
-    image: qcifengineering/redbox-portal:feature-node14
+    image: qcifengineering/redbox-portal:feature-node-14
     ports:
        - "1500:1500"
     volumes:

--- a/support/integration-testing/docker-compose.newman.yml
+++ b/support/integration-testing/docker-compose.newman.yml
@@ -3,7 +3,7 @@ networks:
   main:
 services:
   redboxportal:
-    image: qcifengineering/redbox-portal:master
+    image: qcifengineering/redbox-portal:feature-node14
     ports:
        - "1500:1500"
     volumes:


### PR DESCRIPTION
Upgrade to the Docker base image to Node v14.19.0.
As part of this update, the apt installation of Google Chrome has been removed from the base image build. If you need Chrome for PDF generation then you will need to install it as part of the [sails-hook-redbox-pdfgen](https://github.com/redbox-mint/sails-hook-redbox-pdfgen) installation