### PR TITLE
Feature max total file upload append alternative process message

### DIFF
--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -726,6 +726,6 @@
   "@dmp-associated-rdmp-link": "View Associated RDMP",
   "not-enough-disk-space": "There is not enough free space on disk to upload file",
   "attachment-upload-error": "There is an error uploading files",
-  "max-1GB-total-files-upload": "Max upload total size is 1GB adding all files associated to the record.",
-  "max-1GB-total-files-upload-alternative": "For bigger files please follow the following alternative process"
+  "max-total-files-upload-size-validation-error": "Max upload total size is {{maxUploadSize}} per record.",
+  "max-total-files-upload-size-alternative-validation-error": ""
 }

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -725,5 +725,7 @@
   "@status-label": "Status",
   "@dmp-associated-rdmp-link": "View Associated RDMP",
   "not-enough-disk-space": "There is not enough free space on disk to upload file",
-  "attachment-upload-error": "There is an error uploading files"
+  "attachment-upload-error": "There is an error uploading files",
+  "max-1GB-total-files-upload": "Max upload total size is 1GB adding all files associated to the record.",
+  "max-1GB-total-files-upload-alternative": "For bigger files please follow the following alternative process"
 }

--- a/config/recordtype.js
+++ b/config/recordtype.js
@@ -56,7 +56,7 @@ module.exports.recordtype = {
           function: 'sails.services.rdmpservice.checkTotalSizeOfFilesInRecord',
           options: {
               triggerCondition: '<%= _.isEqual(record.workflow.stage, "draft") || _.isEqual(record.workflow.stage, "queued") || _.isEqual(record.workflow.stage, "published") %>',
-              maxUploadSizeMessageCode: 'max-1GB-total-files-upload-alternative',
+              maxUploadSizeMessageCode: 'max-total-files-upload-size-alternative-validation-error',
               replaceOrAppend:'append'
               }
           }

--- a/config/recordtype.js
+++ b/config/recordtype.js
@@ -51,7 +51,17 @@ module.exports.recordtype = {
             ],
             "recordCreatorPermissions" : "view&edit"
           }
-        }],
+        },
+        {
+          function: 'sails.services.rdmpservice.checkTotalSizeOfFilesInRecord',
+          options: {
+              triggerCondition: '<%= _.isEqual(record.workflow.stage, "draft") || _.isEqual(record.workflow.stage, "queued") || _.isEqual(record.workflow.stage, "published") %>',
+              maxUploadSizeMessageCode: 'max-1GB-total-files-upload-alternative',
+              replaceOrAppend:'append'
+              }
+          }
+      
+      ],
         // Requires the PDF Gen hook to be installed https://www.npmjs.com/package/@researchdatabox/sails-hook-redbox-pdfgen
         // post: [{
         //   function: 'sails.services.pdfservice.createPDF',

--- a/typescript/api/services/RDMPService.ts
+++ b/typescript/api/services/RDMPService.ts
@@ -255,7 +255,7 @@ export module Services {
           sails.log[functionLogLevel]('checkTotalSizeOfFilesInRecord - totalSizeOfFilesInRecord '+totalSizeOfFilesInRecord);
           if(totalSizeOfFilesInRecord > sails.config.record.maxUploadSize) {
             
-            let maxUploadSizeMessage = TranslationService.t('max-1GB-total-files-upload');
+            let maxUploadSizeMessage = TranslationService.t('max-total-files-upload-size-validation-error');
             let alternativeMessageCode = options['maxUploadSizeMessageCode'];
             
             if(!_.isUndefined(alternativeMessageCode)) {
@@ -270,6 +270,9 @@ export module Services {
                 maxUploadSizeMessage = tmpMaxUploadSizeMessage;
               }
             }
+            let maxSizeFormatted = this.formatBytes(sails.config.record.maxUploadSize);
+            let interMessage = TranslationService.tInter(maxUploadSizeMessage,{maxUploadSize: maxSizeFormatted});
+            maxUploadSizeMessage = interMessage;
             let customError: RBValidationError = new RBValidationError(maxUploadSizeMessage);
             throw customError;
           }
@@ -278,6 +281,21 @@ export module Services {
 
       sails.log[functionLogLevel]('checkTotalSizeOfFilesInRecord - end');
       return record;
+    }
+
+    //Fixed version, unminified and ES6'ed 
+    //taken from SO
+    //https://stackoverflow.com/questions/15900485/correct-way-to-convert-size-in-bytes-to-kb-mb-gb-in-javascript
+    private formatBytes(bytes, decimals = 2) {
+      if (bytes === 0) return '0 Bytes';
+  
+      const k = 1024;
+      const dm = decimals < 0 ? 0 : decimals;
+      const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+  
+      const i = Math.floor(Math.log(bytes) / Math.log(k));
+  
+      return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
     }
 
     protected addEmailToList(contributor, emailProperty, emailList) {

--- a/typescript/api/services/RDMPService.ts
+++ b/typescript/api/services/RDMPService.ts
@@ -254,7 +254,23 @@ export module Services {
           
           sails.log[functionLogLevel]('checkTotalSizeOfFilesInRecord - totalSizeOfFilesInRecord '+totalSizeOfFilesInRecord);
           if(totalSizeOfFilesInRecord > sails.config.record.maxUploadSize) {
-            let customError: RBValidationError = new RBValidationError('Max upload total size is 1GB adding all files associated to the record');
+            
+            let maxUploadSizeMessage = TranslationService.t('max-1GB-total-files-upload');
+            let alternativeMessageCode = options['maxUploadSizeMessageCode'];
+            
+            if(!_.isUndefined(alternativeMessageCode)) {
+              let replaceOrAppend = options['replaceOrAppend'];
+              if(_.isUndefined(replaceOrAppend)) {
+                replaceOrAppend = 'append';
+              }
+              if(replaceOrAppend == 'replace'){
+                maxUploadSizeMessage = TranslationService.t(alternativeMessageCode);
+              } else if (replaceOrAppend == 'append') {
+                let tmpMaxUploadSizeMessage = maxUploadSizeMessage + ' ' + TranslationService.t(alternativeMessageCode);
+                maxUploadSizeMessage = tmpMaxUploadSizeMessage;
+              }
+            }
+            let customError: RBValidationError = new RBValidationError(maxUploadSizeMessage);
             throw customError;
           }
         }

--- a/typescript/api/services/TranslationService.ts
+++ b/typescript/api/services/TranslationService.ts
@@ -38,7 +38,8 @@ export module Services {
     protected _exportedMethods: any = [
       'bootstrap',
       't',
-      'reloadResources'
+      'reloadResources',
+      'tInter'
     ];
     /** Warning this is synch... */
     public bootstrap() {
@@ -53,6 +54,7 @@ export module Services {
           lng: 'en',
           fallbackLng: 'en',
           initImmediate: false,
+          skipOnVariables: false,
           backend: {
             loadPath: `${sails.config.appPath}/assets/locales/{{lng}}/{{ns}}.json`
           }
@@ -66,7 +68,11 @@ export module Services {
     public t(key, context = null) {
       //@ts-ignore
       return i18next.t(key);
+    }
 
+    public tInter(key, context = null) {
+      //@ts-ignore
+      return i18next.t(key, context);
     }
 
     public reloadResources() {


### PR DESCRIPTION
If a data location widget is added to a form there is the ability to enforce the max total files upload size for a given record. The validation message is a standard message given that indicates the to user what is the max constraint defined and it will not add much value to allow the institution admins to modify this message given it can lead to confusion about what is the real constraint however adding additional information to the existing standard message can be useful therefore this feature adds the ability to add additional info to the standard message