### PR TITLE
Fix to interpret html in err msg from sails in dmp form

### DIFF
--- a/angular/dmp/app/dmp-form.html
+++ b/angular/dmp/app/dmp-form.html
@@ -8,12 +8,13 @@
             <div *ngIf="editMode" class="form-row">
               <div class="form-status-message pull-right col-md-10 margin-15">
                 <p class="bg-info text-16 text-info padding-10" *ngIf="status.saving">{{status.saving.msg}}<i class="fa fa-spinner fa-pulse fa-1x fa-fw"></i></p>
-                <p class="bg-danger text-16 text-danger padding-10" *ngIf="status.error">
+                <p class="bg-danger text-16 text-danger padding-10" *ngIf="status.error && failedValidationLink != undefined">
                   {{status.error.msg}}
                   <a style="cursor:pointer" *ngFor="let failedValidationLink of failedValidationLinks" (click)="gotoTab(failedValidationLink.parentId)">
                       {{failedValidationLink.label}}
                   </a>
                 </p>
+                <p class="bg-danger text-16 text-danger padding-10" [innerHTML]="status.error.msg" *ngIf="status.error && failedValidationLink == undefined"></p>
                 <p class="bg-success text-16 text-success padding-10" *ngIf="status.success">{{status.success.msg}}</p>
               </div>
             </div>


### PR DESCRIPTION
Fix to interpret html in error messages thrown from sails in dmp form