### PR TITLE
Feature - customisable required field indicator

### DIFF
--- a/angular/shared/form/field-andsvocab.html
+++ b/angular/shared/form/field-andsvocab.html
@@ -7,7 +7,7 @@
 </div>
 <div *ngIf="field.editMode" [formGroup]='form' [ngClass]="getGroupClass()">
   <span class="label-font">
-    {{field.label}} {{getRequiredLabelStr()}}
+   <span [outerHTML]="field.label"></span><span class="form-field-required-indicator" [innerHTML]="getRequiredLabelStr()"></span>
     <button type="button" class="btn btn-default" *ngIf="field.help" (click)="toggleHelp()" [attr.aria-label]="'help' | translate "><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></button>
   </span>
   <span id="{{ 'helpBlock_' + field.name }}" class="help-block" *ngIf="this.helpShow" [innerHtml]="field.help">{{field.help}}</span>

--- a/angular/shared/form/field-base.ts
+++ b/angular/shared/form/field-base.ts
@@ -74,6 +74,7 @@ export class FieldBase<T> {
   defaultSelect: string;
   parentField: any;
   setParentField:boolean;
+  requiredFieldIndicator:string = `(*)`
   /**
    * Flag to indicate there is a potential configuration issue for this field
    */
@@ -112,6 +113,7 @@ export class FieldBase<T> {
     defaultValue?: any,
     selectFor?: string,
     defaultSelect?: string,
+    requiredFieldIndicator?: string
   } = {}) {
     this.value = this.getTranslated(options.value, undefined);
     this.name = options.name || '';
@@ -148,6 +150,9 @@ export class FieldBase<T> {
     }
     this.options = options;
     this.hasControl = true;
+    if(options.requiredFieldIndicator) {
+      this.requiredFieldIndicator = options.requiredFieldIndicator;
+    }
     this.validationMessages = {};
     _.forOwn(options['validationMessages'] || {}, (messageKey, messageName) => {
       this.validationMessages[messageName] = this.getTranslated(messageKey, messageKey);

--- a/angular/shared/form/field-contributor.component.html
+++ b/angular/shared/form/field-contributor.component.html
@@ -3,7 +3,7 @@
   <div class="row" *ngIf="field.label && field.showHeader">
     <div class="col-xs-12">
       <span class="label-font">
-        {{field.label}} {{getRequiredLabelStr()}}
+       <span [outerHTML]="field.label"></span><span class="form-field-required-indicator" [innerHTML]="getRequiredLabelStr()"></span>
         <button type="button" class="btn btn-default" *ngIf="field.help" (click)="toggleHelp()" [attr.aria-label]="'help' | translate "><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></button>
       </span>
     </div>

--- a/angular/shared/form/field-group.component.ts
+++ b/angular/shared/form/field-group.component.ts
@@ -84,7 +84,7 @@ Generic component for grouping components together. The resulting JSON will have
     <ng-container *ngIf="field.editMode">
       <div *ngIf="field.label">
         <label>
-          {{field.label}} {{getRequiredLabelStr()}}
+         <span [outerHTML]="field.label"></span><span class="form-field-required-indicator" [innerHTML]="getRequiredLabelStr()"></span>
           <button type="button" class="btn btn-default" *ngIf="field.help" (click)="toggleHelp()" [attr.aria-label]="'help' | translate "><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></button>
         </label>
         <span id="{{ 'helpBlock_' + field.name }}" class="help-block" *ngIf="this.helpShow" [innerHtml]="field.help">{{field.help}}</span>
@@ -197,7 +197,7 @@ export class GenericGroupComponent extends EmbeddableComponent {
     <div *ngIf="field.editMode">
       <div *ngIf="field.label">
         <span class="label-font">
-          {{field.label}} {{getRequiredLabelStr()}}
+         <span [outerHTML]="field.label"></span><span class="form-field-required-indicator" [innerHTML]="getRequiredLabelStr()"></span>
           <button type="button" class="btn btn-default" *ngIf="field.help" (click)="toggleHelp()" [attr.aria-label]="'help' | translate "><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></button>
         </span>
         <span id="{{ 'helpBlock_' + field.name }}" class="help-block" *ngIf="this.helpShow" [innerHtml]="field.help">{{field.help}}</span>

--- a/angular/shared/form/field-simple.component.ts
+++ b/angular/shared/form/field-simple.component.ts
@@ -184,7 +184,7 @@ export class SimpleComponent {
    * @return {string}
    */
   getRequiredLabelStr(): string {
-    return this.field.required ? '(*)' : '';
+    return this.field.required ? this.field.requiredFieldIndicator : '';
   }
   /**
    * Returns the NG2 root injector
@@ -221,7 +221,7 @@ export class SelectionComponent extends SimpleComponent {
   template: `
   <div [formGroup]='form' *ngIf="field.editMode && field.visible" [ngClass]="getGroupClass()">
      <label [attr.for]="field.name">
-      {{field.label}} {{ getRequiredLabelStr()}}
+     <span [outerHTML]="field.label"></span><span class="form-field-required-indicator" [innerHTML]="getRequiredLabelStr()"></span>
       <button type="button" class="btn btn-default" *ngIf="field.help" (click)="toggleHelp()" [attr.aria-label]="'help' | translate "><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></button>
      </label><br/>
      <span id="{{ 'helpBlock_' + field.name }}" class="help-block" *ngIf="this.helpShow" [innerHtml]="field.help"></span>
@@ -257,7 +257,7 @@ export class DropdownFieldComponent extends SelectionComponent {
   template: `
   <div [formGroup]='getFormGroup()' *ngIf="field.editMode && field.visible" class="form-group">
      <span class="label-font">
-      {{field.label}} {{ getRequiredLabelStr()}}
+     <span [outerHTML]="field.label"></span><span class="form-field-required-indicator" [innerHTML]="getRequiredLabelStr()"></span>
       <button type="button" class="btn btn-default" *ngIf="field.help" (click)="toggleHelp()" [attr.aria-label]="'help' | translate "><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></button>
      </span><br/>
      <span id="{{ 'helpBlock_' + field.name }}" class="help-block" *ngIf="this.helpShow" [innerHtml]="field.help"></span>
@@ -810,7 +810,7 @@ Based on: https://bootstrap-datepicker.readthedocs.io/en/stable/
   <ng-container *ngIf="field.visible">
   <div *ngIf="field.editMode" [formGroup]='form' class="form-group">
     <span class="label-font">
-      {{field.label}} {{ getRequiredLabelStr()}}
+     <span [outerHTML]="field.label"></span><span class="form-field-required-indicator" [innerHTML]="getRequiredLabelStr()"></span>
       <button type="button" class="btn btn-default" *ngIf="field.help" (click)="toggleHelp()" [attr.aria-label]="'help' | translate "><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></button>
     </span><br/>
     <span id="{{ 'helpBlock_' + field.name }}" class="help-block" *ngIf="this.helpShow" [innerHtml]="field.help"></span>

--- a/angular/shared/form/field-textfield.component.ts
+++ b/angular/shared/form/field-textfield.component.ts
@@ -137,7 +137,7 @@ export class TextArea extends FieldBase<string> {
   <div *ngIf="field.editMode && field.visible" [ngClass]="getGroupClass()">
     <div *ngIf="!isEmbedded" >
       <label [attr.for]="field.name">
-        {{field.label}} {{ getRequiredLabelStr() }}
+       <span [outerHTML]="field.label"></span><span class="form-field-required-indicator" [innerHTML]="getRequiredLabelStr()"></span>
         <button type="button" class="btn btn-default" *ngIf="field.help" (click)="toggleHelp()" [attr.aria-label]="'help' | translate "><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></button>
       </label>
         <span id="{{ 'helpBlock_' + field.name }}" class="help-block" *ngIf="this.helpShow" [innerHtml]="field.help"></span>
@@ -173,7 +173,7 @@ export class TextFieldComponent extends EmbeddableComponent {
     <div class="row">
       <div class="col-xs-12">
       <span class="label-font" [id]="field.name">
-        {{field.label}} {{ getRequiredLabelStr() }}
+       <span [outerHTML]="field.label"></span><span class="form-field-required-indicator" [innerHTML]="getRequiredLabelStr()"></span>
         <button type="button" class="btn btn-default" *ngIf="field.help" (click)="toggleHelp()" [attr.aria-label]="'help' | translate "><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></button>
       </span>
       <span id="{{ 'helpBlock_' + field.name }}" class="help-block" *ngIf="this.helpShow" [innerHtml]="field.help"></span>
@@ -233,7 +233,7 @@ export class RepeatableTextfieldComponent extends RepeatableComponent {
   template: `
   <div *ngIf="field.editMode && field.visible" [formGroup]='form' [ngClass]="getGroupClass()">
     <label [attr.for]="field.name">
-      {{field.label}} {{ getRequiredLabelStr()}}
+     <span [outerHTML]="field.label"></span><span class="form-field-required-indicator" [innerHTML]="getRequiredLabelStr()"></span>
       <button type="button" class="btn btn-default" *ngIf="field.help" (click)="toggleHelp()" [attr.aria-label]="'help' | translate "><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></button>
     </label>
     <!-- Normal version -->
@@ -279,7 +279,7 @@ export class TextAreaComponent extends EmbeddableComponent implements OnInit {
   template: `
   <div *ngIf="field.editMode" [formGroup]='form' class="form-group">
     <label [attr.for]="field.name">
-      {{field.label}} {{ getRequiredLabelStr()}}
+     <span [outerHTML]="field.label"></span><span class="form-field-required-indicator" [innerHTML]="getRequiredLabelStr()"></span>
       <button type="button" class="btn btn-default" *ngIf="field.help" (click)="toggleHelp()" [attr.aria-label]="'help' | translate "><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></button>
     </label><br/>
     <span id="{{ 'helpBlock_' + field.name }}" class="help-block" *ngIf="this.helpShow" [innerHtml]="field.help"></span>

--- a/angular/shared/form/field-vocab.component.ts
+++ b/angular/shared/form/field-vocab.component.ts
@@ -519,7 +519,7 @@ export class VocabFieldLookupService extends BaseService {
   <ng-container *ngIf="field.visible">
   <div *ngIf="field.editMode && !isEmbedded" [formGroup]='form' [ngClass]="getGroupClass()">
     <label [attr.for]="field.name" *ngIf="field.label">
-      {{field.label}} {{getRequiredLabelStr()}}
+     <span [outerHTML]="field.label"></span><span class="form-field-required-indicator" [innerHTML]="getRequiredLabelStr()"></span>
       <button type="button" class="btn btn-default" *ngIf="field.help" (click)="toggleHelp()" [attr.aria-label]="'help' | translate "><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></button>
     </label>
     <span id="{{ 'helpBlock_' + field.name }}" class="help-block" *ngIf="this.helpShow" [innerHtml]="field.help">{{field.help}}</span>

--- a/angular/shared/form/workspace-selector.component.ts
+++ b/angular/shared/form/workspace-selector.component.ts
@@ -29,7 +29,7 @@ export class WorkspaceSelectorComponent extends SimpleComponent {
   template: `
   <div [formGroup]='form' *ngIf="field.editMode" [ngClass]="getGroupClass()">
     <label [attr.for]="field.name">
-      {{field.label}} {{ getRequiredLabelStr()}}
+     <span [outerHTML]="field.label"></span><span class="form-field-required-indicator" [innerHTML]="getRequiredLabelStr()"></span>
       <button type="button" class="btn btn-default" *ngIf="field.help" (click)="toggleHelp()" [attr.aria-label]="'help' | translate "><span
         class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></button>
     </label>

--- a/api/models/Form.js
+++ b/api/models/Form.js
@@ -27,6 +27,9 @@ module.exports = {
     messages: {
       type: 'json'
     },
+    requiredFieldIndicator: {
+      type: 'string'
+    },
     viewCssClasses: {
       type: 'string'
     },

--- a/assets/styles/theme.scss
+++ b/assets/styles/theme.scss
@@ -492,3 +492,7 @@ tree-internal > ul.rootless > li > tree-internal > ul {
   overflow-x: auto;
   max-height: 400px;
 }
+
+span.form-field-required-indicator {
+  margin-left: 5px;
+}

--- a/config/http.js
+++ b/config/http.js
@@ -168,7 +168,7 @@ module.exports.http = {
     },
 
     cacheControl: function(req, res, next) {
-      let sessionTimeoutSeconds = (_.isUndefined(sails.config.session.cookie) || _.isUndefined(sails.config.session.cookie.maxAge) ? 0 : sails.config.session.cookie.maxAge / 1000 );
+      let sessionTimeoutSeconds = (_.isUndefined(sails.config.session.cookie) || _.isUndefined(sails.config.session.cookie.maxAge) ? 31536000 : sails.config.session.cookie.maxAge / 1000 );
       let cacheControlHeaderVal = null;
       let expiresHeaderVal = null;
       if (sessionTimeoutSeconds > 0) {

--- a/typescript/api/controllers/RecordController.ts
+++ b/typescript/api/controllers/RecordController.ts
@@ -947,13 +947,8 @@ export module Controllers {
       const fieldsToDelete = [];
       const metadata = currentRec.metadata;
       const metaMetadata = currentRec.metaMetadata;
-      _.forEach(fields, (field: any) => {
-        sails.log.error(`_.isEmpty(field.definition.requiredFieldIndicator): ${_.isEmpty(field.definition.requiredFieldIndicator)}`)
-        sails.log.error(`!_.isUndefined(requiredFieldIndicator): ${!_.isUndefined(requiredFieldIndicator)}`)
-        sails.log.error(`_.isUndefined(field.definition.requiredFieldIndicator): ${_.isUndefined(field.definition.requiredFieldIndicator)}`)
+      _.forEach(fields, (field: any) => {   
         if (!_.isUndefined(requiredFieldIndicator) && _.isEmpty(field.definition.requiredFieldIndicator) && _.isUndefined(field.definition.requiredFieldIndicator)) {
-          sails.log.error("REQUIRED FIELD INDICATOR")
-          sails.log.error(requiredFieldIndicator)
           _.set(field,'definition.requiredFieldIndicator',requiredFieldIndicator)
         }
         if (!_.isEmpty(field.definition.name) && !_.isUndefined(field.definition.name)) {

--- a/typescript/api/controllers/RecordController.ts
+++ b/typescript/api/controllers/RecordController.ts
@@ -398,7 +398,7 @@ export module Controllers {
       let obs = null;
       if (_.isEmpty(oid)) {
         obs = FormsService.getForm(brand.id, name, editMode, true).flatMap(form => {
-          let mergedForm = this.mergeFields(req, res, form.fields, name, {}).then(fields => {
+          let mergedForm = this.mergeFields(req, res, form.fields, form.requiredFieldIndicator, name, {}).then(fields => {
             form.fields = fields;
             return form;
           });
@@ -422,7 +422,7 @@ export module Controllers {
                   if (_.isEmpty(form)) {
                     return Observable.throw(new Error(`Error, getting form ${formName} for OID: ${oid}`));
                   }
-                  let mergedForm = this.mergeFields(req, res, form.fields, currentRec.metaMetadata.type, currentRec).then(fields => {
+                  let mergedForm = this.mergeFields(req, res, form.fields, form.requiredFieldIndicator, currentRec.metaMetadata.type, currentRec).then(fields => {
                     form.fields = fields;
 
                     return form;
@@ -444,7 +444,7 @@ export module Controllers {
                     return Observable.throw(new Error(`Error, getting form ${formName} for OID: ${oid}`));
                   }
                   FormsService.filterFieldsHasEditAccess(form.fields, hasEditAccess);
-                  return this.mergeFields(req, res, form.fields, currentRec.metaMetadata.type, currentRec).then(fields => {
+                  return this.mergeFields(req, res, form.fields, form.requiredFieldIndicator, currentRec.metaMetadata.type, currentRec).then(fields => {
                     form.fields = fields;
 
                     return form;
@@ -935,19 +935,27 @@ export module Controllers {
         });
     }
 
-    protected async mergeFields(req, res, fields, type, currentRec) {
+    protected async mergeFields(req, res, fields, requiredFieldIndicator, type, currentRec) {
 
       let recordType = await RecordTypesService.get(BrandingService.getBrand(req.session.branding), type).toPromise();
       let workflowSteps = await WorkflowStepsService.getAllForRecordType(recordType).toPromise();
-      this.mergeFieldsSync(req, res, fields, currentRec, workflowSteps);
+      this.mergeFieldsSync(req, res, fields,requiredFieldIndicator, currentRec, workflowSteps);
       return fields;
     }
 
-    protected mergeFieldsSync(req, res, fields, currentRec, workflowSteps) {
+    protected mergeFieldsSync(req, res, fields,requiredFieldIndicator, currentRec, workflowSteps) {
       const fieldsToDelete = [];
       const metadata = currentRec.metadata;
       const metaMetadata = currentRec.metaMetadata;
       _.forEach(fields, (field: any) => {
+        sails.log.error(`_.isEmpty(field.definition.requiredFieldIndicator): ${_.isEmpty(field.definition.requiredFieldIndicator)}`)
+        sails.log.error(`!_.isUndefined(requiredFieldIndicator): ${!_.isUndefined(requiredFieldIndicator)}`)
+        sails.log.error(`_.isUndefined(field.definition.requiredFieldIndicator): ${_.isUndefined(field.definition.requiredFieldIndicator)}`)
+        if (!_.isUndefined(requiredFieldIndicator) && _.isEmpty(field.definition.requiredFieldIndicator) && _.isUndefined(field.definition.requiredFieldIndicator)) {
+          sails.log.error("REQUIRED FIELD INDICATOR")
+          sails.log.error(requiredFieldIndicator)
+          _.set(field,'definition.requiredFieldIndicator',requiredFieldIndicator)
+        }
         if (!_.isEmpty(field.definition.name) && !_.isUndefined(field.definition.name)) {
           if (_.has(metaMetadata, field.definition.name)) {
             field.definition.value = metaMetadata[field.definition.name];
@@ -997,7 +1005,7 @@ export module Controllers {
           });
         } else
           if (field.definition.fields) {
-            this.mergeFieldsSync(req, res, field.definition.fields, currentRec, workflowSteps);
+            this.mergeFieldsSync(req, res, field.definition.fields, requiredFieldIndicator, currentRec, workflowSteps);
           }
       });
       _.remove(fields, (f) => {

--- a/typescript/api/controllers/webservice/ReportController.ts
+++ b/typescript/api/controllers/webservice/ReportController.ts
@@ -207,7 +207,9 @@ export module Controllers {
           responseRecords.push({
             oid: record.redboxOid,
             title: record.metadata.title,
-            metadata: record.metadata
+            metadata: record.metadata,
+            lastSaveDate: record.lastSaveDate,
+            dateCreated: record.dateCreated
           })
         }
         let response = new ListAPIResponse();

--- a/typescript/api/services/FormsService.ts
+++ b/typescript/api/services/FormsService.ts
@@ -116,6 +116,7 @@ export module Services {
               type: sails.config.form.forms[formName].type,
               messages: sails.config.form.forms[formName].messages,
               viewCssClasses: sails.config.form.forms[formName].viewCssClasses,
+              requiredFieldIndicator: sails.config.form.forms[formName].requiredFieldIndicator,
               editCssClasses: sails.config.form.forms[formName].editCssClasses,
               skipValidationOnSave: sails.config.form.forms[formName].skipValidationOnSave,
               attachmentFields: sails.config.form.forms[formName].attachmentFields,


### PR DESCRIPTION
Allows the required field indicator to be customisable.

The default indicator now is wrapped in span with class name form-field-required-indicator so that it can now be targeted in CSS for styling.

Additionally, the form can configure a custom required field indicator which can be HTML. This allows for using an icon or image instead of the default (*). The value can be set at the form config level
```
  name: 'default-1.0-draft',
  type: 'rdmp',
  requiredFieldIndicator: '<i class="fa fa-star" aria-hidden="true"></i>'
```
  or can set at a specific field level if required
```
{
    class: 'TextField',
    editOnly: true,
    definition: {
        name: 'title',
        label: '@dmpt-project-title',
        help: '@dmpt-project-title-help',
        type: 'text',
        required: true,
        requiredFieldIndicator: '(^^^)'
    }
}
```
  