### PR TITLE
Fix User Audit Persistence

### DIFF
--- a/typescript/api/services/UsersService.ts
+++ b/typescript/api/services/UsersService.ts
@@ -47,7 +47,7 @@ export module Services {
    *
    */
   export class Users extends services.Core.Service {
-
+    
     protected _exportedMethods: any = [
       'bootstrap',
       'updateUserRoles',
@@ -586,12 +586,23 @@ export module Services {
       if (!_.isEmpty(user.password)) {
         delete user.password;
       }
-      auditEvent['user'] = user;
+      user.additionalAttributes = this.stringifyObject(user.additionalAttributes)
+      auditEvent['user'] = user
       auditEvent['action'] = action;
-      auditEvent['additionalContext'] = additionalContext;
+      auditEvent['additionalContext'] = this.stringifyObject(additionalContext);
       sails.log.verbose('Adding user audit event');
       sails.log.verbose(auditEvent);
       return super.getObservable(UserAudit.create(auditEvent)).toPromise();
+    }
+
+    stringifyObject(object: any): any {
+      return JSON.stringify(object, function(key, value) {
+        if (typeof value === 'function') {
+          return 'function-property-not-exported'
+        } else {
+          return value;
+        }
+      })
     }
 
     /**


### PR DESCRIPTION
Keys with "." don't persist correctly in mongo, as these occasionally appear in the additionalContext object, to ensure the audit records save correctly, we will stringify the object before saving it to the DB.