### PR TITLE
Fix: Contributor component does not function with the setVisibility function

### DIFF
--- a/angular/shared/form/custom-validation-handler.ts
+++ b/angular/shared/form/custom-validation-handler.ts
@@ -1,0 +1,6 @@
+export interface CustomValidationHandlerField {
+
+    enableValidators();
+
+    disableValidators();
+}

--- a/angular/shared/form/field-base.ts
+++ b/angular/shared/form/field-base.ts
@@ -509,8 +509,7 @@ export class FieldBase<T> {
       } else {
         if (!that.visible) {
           // restore validators
-          if (that.formModel) {
-            if (that.formModel) {
+          if (that.formModel) {       
               if(that['enableValidators'] != null && typeof(that['enableValidators']) == 'function') {
                 that['enableValidators']();
               } else {

--- a/angular/shared/form/field-base.ts
+++ b/angular/shared/form/field-base.ts
@@ -510,8 +510,13 @@ export class FieldBase<T> {
         if (!that.visible) {
           // restore validators
           if (that.formModel) {
-            that.formModel.setValidators(that.validators);
-            that.formModel.updateValueAndValidity();
+            if (that.formModel) {
+              if(that['enableValidators'] != null && typeof(that['enableValidators']) == 'function') {
+                that['enableValidators']();
+              } else {
+                that.formModel.setValidators(that.validators);
+              }
+              that.formModel.updateValueAndValidity();
           }
         }
       }

--- a/angular/shared/form/field-contributor.component.ts
+++ b/angular/shared/form/field-contributor.component.ts
@@ -24,7 +24,7 @@ import {FormControl, FormGroup, Validators} from '@angular/forms';
 import * as _ from "lodash";
 import { VocabField } from './field-vocab.component';
 import { Observable} from 'rxjs/Rx';
-import { CustomValidationHandler } from './custom-validation-handler';
+import { CustomValidationHandlerField } from './custom-validation-handler';
 
 /**
  * Contributor Model
@@ -38,7 +38,7 @@ const KEY_EN = 13;
 const KEY_LEFT = 37;
 const KEY_RIGHT = 39;
 
-export class ContributorField extends FieldBase<any> implements CustomValidationHandler {
+export class ContributorField extends FieldBase<any> implements CustomValidationHandlerField {
   nameColHdr: string;
   emailColHdr: string;
   roleColHdr: string;

--- a/angular/shared/form/field-contributor.component.ts
+++ b/angular/shared/form/field-contributor.component.ts
@@ -24,6 +24,8 @@ import {FormControl, FormGroup, Validators} from '@angular/forms';
 import * as _ from "lodash";
 import { VocabField } from './field-vocab.component';
 import { Observable} from 'rxjs/Rx';
+import { CustomValidationHandler } from './custom-validation-handler';
+
 /**
  * Contributor Model
  *
@@ -36,7 +38,7 @@ const KEY_EN = 13;
 const KEY_LEFT = 37;
 const KEY_RIGHT = 39;
 
-export class ContributorField extends FieldBase<any> {
+export class ContributorField extends FieldBase<any> implements CustomValidationHandler {
   nameColHdr: string;
   emailColHdr: string;
   roleColHdr: string;

--- a/dockerhub_deploy.sh
+++ b/dockerhub_deploy.sh
@@ -9,10 +9,12 @@ if [ -z "$CIRCLE_BRANCH" ]; then
         export TAG="$CIRCLE_TAG";
 fi;
 
+export DEPLOY_TAG=${TAG/\//-}
+
 docker build -f Dockerfile -t $REPO:$CIRCLE_SHA1 .
-docker tag $REPO:$CIRCLE_SHA1 $REPO:$TAG
+docker tag $REPO:$CIRCLE_SHA1 $REPO:$DEPLOY_TAG
 docker tag $REPO:$CIRCLE_SHA1 $REPO:circleci-$CIRCLE_BUILD_NUM
-docker push $REPO:$TAG
+docker push $REPO:$DEPLOY_TAG
 docker push $REPO:$CIRCLE_SHA1
 docker push $REPO:circleci-$CIRCLE_BUILD_NUM
 


### PR DESCRIPTION
The Contributor component has custom validation logic due the multi sub-field setup for name, email address and ORCID. 
As setVisibility removes and re-adds validation to the field depending on the visibility state, the contributor field breaks when it is made visible again due to the custom validation logic.

This PR adds an interface for fields that need custom validation logic (which the contributor field implements) and the setVisibility function has been updated to detect fields that use it.