### PR TITLE
Feature to handle historic values in dropdown, radio and checkbox 

### DIFF
--- a/angular/shared/form/field-simple.ts
+++ b/angular/shared/form/field-simple.ts
@@ -65,6 +65,16 @@ export class SelectionField extends FieldBase<any>  {
     this.selectOptions = _.map(options['options'] || [], (option)=> {
       option['label'] = this.getTranslated(option['label'], option['label']);
       option['value'] = this.getTranslated(option['value'], option['value']);
+
+      let histOnly = _.get(option, 'historicalOnly');
+      //Check if historicalOnly attribute is present and set to true  
+      if(!_.isUndefined(histOnly) && histOnly == true) {
+        _.set(option, 'historicalOnly', true);
+      } else {
+          //By default if historicalOnly attribute is not present it will set to false
+        _.set(option, 'historicalOnly', false);
+      }
+
       return option;
     });
 


### PR DESCRIPTION
Feature to handle historic values in dropdown, radio and checkbox. Now besides label and value the list items in options block in the form config can accept a new attribute historicalOnly. If not present it will default to false and standard functionality applies to the list items. If present and set to true it will enable the following behavior. The historical only option will be hidden from the list for new records and it will only be seen on the list if an existing record has the historical option value already selected. This will allow to open a record and see the historical value had been selected on the list and will allow to leave the record unchanged or change the historical only option to a different option and save. Once saved to a different value the historical only option will disappear from the list for that particular record.  

