### PR TITLE
Add configurable regex validation to exclude selected checkboxes in andsvocab component 

### DIFF
--- a/angular/shared/form/field-andsvocab.component.ts
+++ b/angular/shared/form/field-andsvocab.component.ts
@@ -42,11 +42,17 @@ export class ANDSVocabField extends FieldBase<any> {
 
   public andsService:ANDSService;
   public vocabId:string;
+  public disableCheckboxRegexEnabled:boolean;
+  public disableCheckboxRegexPattern:string;
+  public disableCheckboxRegexTestValue:string;
 
   constructor(options: any, injector: any) {
     super(options, injector);
     this.value = options['value'] || this.setEmptyValue();
     this.vocabId  = options['vocabId'] || 'anzsrc-for';
+    this.disableCheckboxRegexEnabled = options['disableCheckboxRegexEnabled'] || false;
+    this.disableCheckboxRegexPattern = options['disableCheckboxRegexPattern'] || "";
+    this.disableCheckboxRegexTestValue = options['disableCheckboxRegexTestValue'] || "";
 
     this.andsService = this.getFromInjector(ANDSService);
   }
@@ -174,6 +180,9 @@ export class ANDSVocabComponent extends SimpleComponent {
   public onEvent(event) {
     switch(event.eventName) {
       case "select":
+        if(!this.isSelectionValid(event.node)){
+          break;
+        }
         this.field.setSelected(this.getValueFromChildData(event.node), true);
         break;
       case "deselect":
@@ -191,7 +200,11 @@ export class ANDSVocabComponent extends SimpleComponent {
     switch(event.eventName) {
       case "nodeActivate":
         if (currentState == undefined) {
-          currentState = true;
+          if(!this.isSelectionValid(event.node)){
+            currentState = false;
+          } else {
+            currentState = true;
+          }
         } else {
           currentState = false;
         }
@@ -291,6 +304,23 @@ export class ANDSVocabComponent extends SimpleComponent {
     const val = { name: `${data.notation} - ${data.label}`,  label: data.label, notation: data.notation };
     this.setParentTree(val, childNode);
     return val;
+  }
+
+  public isSelectionValid(childNode: any) {
+    let valid = true;
+    if(this.field.disableCheckboxRegexEnabled) {
+      const data = childNode.data;
+      let nodeId = _.get(data,this.field.disableCheckboxRegexTestValue);
+      let re = new RegExp(this.field.disableCheckboxRegexPattern,'i');
+      if(!_.isUndefined(nodeId)) {
+        let reTest = re.test(nodeId.toString());
+        console.log(nodeId + ' ' + this.field.disableCheckboxRegexTestValue + ' ' + reTest);
+        if(!reTest) {
+          valid = false;
+        } 
+      }
+    }
+    return valid;
   }
 
   public setParentTree(val:any, childNode: any) {


### PR DESCRIPTION
This feature will allow to exclude selected checkboxes from being saved in the database based on a regex validation pattern. This validation can be set at form config level. An example configuration of how to use this feature is as below:

```
    {
        class: 'ANDSVocab',
        compClass: 'ANDSVocabComponent',
        definition: {
            label: "@dmpt-project-anzsrcFor",
            help: "@dmpt-project-anzsrcFor-help",
            name: "anzsrcFor",
            required: true,
            vocabId: 'anzsrc-2020-for',
            disableCheckboxRegexEnabled: true,
            disableCheckboxRegexPattern: "^[0-9]{6,6}$",
            disableCheckboxRegexTestValue: "id"
        }
    }
```