### PR TITLE
Added trigger function that will only allow the specified role or user modify the specified metadata fields

### DIFF
--- a/typescript/api/services/TriggerService.ts
+++ b/typescript/api/services/TriggerService.ts
@@ -21,7 +21,7 @@ import { Observable } from 'rxjs/Rx';
 import {
   Services as services,
   RBValidationError
-}   from '@researchdatabox/redbox-core-types';
+} from '@researchdatabox/redbox-core-types';
 import { Sails, Model } from "sails";
 
 declare var sails: Sails;
@@ -44,7 +44,8 @@ export module Services {
     protected _exportedMethods: any = [
       'transitionWorkflow',
       'runHooksSync',
-      'validateFieldUsingRegex'
+      'validateFieldUsingRegex',
+      'applyFieldLevelPermissions'
     ];
 
     /**
@@ -59,17 +60,17 @@ export module Services {
     public transitionWorkflow(oid, record, options) {
       const triggerCondition = _.get(options, "triggerCondition", "");
 
-      var variables= {};
+      var variables = {};
       variables['imports'] = record;
       var compiled = _.template(triggerCondition, variables);
       const compileResult = compiled();
       sails.log.verbose(`Trigger condition for ${oid} ==> "${triggerCondition}", has result: '${compileResult}'`);
-      if(_.isEqual(compileResult, "true")) {
+      if (_.isEqual(compileResult, "true")) {
         const workflowStageTarget = _.get(options, "targetWorkflowStageName", _.get(record, 'workflow.stage'));
         const workflowStageLabel = _.get(options, "targetWorkflowStageLabel", _.get(record, 'workflow.stageLabel'));
         sails.log.verbose(`Trigger condition met for ${oid}, transitioning to: ${workflowStageTarget}`);
-        _.set(record,"workflow.stage",workflowStageTarget);
-        _.set(record,"workflow.stageLabel",workflowStageLabel);
+        _.set(record, "workflow.stage", workflowStageTarget);
+        _.set(record, "workflow.stageLabel", workflowStageLabel);
         // we need to update the form too!!!!
         _.set(record, "metaMetadata.form", _.get(options, "targetForm", record.metaMetadata.form));
       }
@@ -103,7 +104,7 @@ export module Services {
           const hookOpt = _.get(hookFnDef, "options");
           if (_.isFunction(hookFn)) {
             sails.log.debug(`runHooksSync, adding: ${hookFnStr}`);
-            hookFnDefArray.push({hookFn:hookFn, hookOpt:hookOpt});
+            hookFnDefArray.push({ hookFn: hookFn, hookOpt: hookOpt });
           } else {
             sails.log.error(`runHooksSync, this is not a valid function: ${hookFnStr}`);
             sails.log.error(hookFnDef);
@@ -116,10 +117,10 @@ export module Services {
       if (!_.isEmpty(hookFnDefArray)) {
         sails.log.debug(`runHooksSync, running..`);
         return Observable.from(hookFnDefArray)
-        .concatMap(hookDef => {
-          return hookDef.hookFn(oid, record, hookDef.hookOpt, user);
-        })
-        .last();
+          .concatMap(hookDef => {
+            return hookDef.hookFn(oid, record, hookDef.hookOpt, user);
+          })
+          .last();
       } else {
         sails.log.debug(`runHooksSync, no observables to run`);
         return Observable.of(record);
@@ -128,20 +129,20 @@ export module Services {
 
     private validateRegex(data, regexPattern, fieldLanguageCode, errorMessageCode, caseSensitive) {
       let re;
-      if(caseSensitive) {
+      if (caseSensitive) {
         re = new RegExp(regexPattern);
       } else {
-        re = new RegExp(regexPattern,'i');
+        re = new RegExp(regexPattern, 'i');
       }
-      sails.log.verbose('validateFieldUsingRegex data.toString() '+data.toString());
+      sails.log.verbose('validateFieldUsingRegex data.toString() ' + data.toString());
       let reTest = re.test(data.toString());
-      sails.log.verbose('validateFieldUsingRegex caseSensitive '+caseSensitive+' reTest '+reTest);
-      if(!reTest) {
+      sails.log.verbose('validateFieldUsingRegex caseSensitive ' + caseSensitive + ' reTest ' + reTest);
+      if (!reTest) {
         let customError: RBValidationError;
-        if(!_.isUndefined(fieldLanguageCode)) {
+        if (!_.isUndefined(fieldLanguageCode)) {
           let fieldName = TranslationService.t(fieldLanguageCode);
           let baseErrorMessage = TranslationService.t(errorMessageCode);
-          customError = new RBValidationError(fieldName + ' '+ baseErrorMessage);
+          customError = new RBValidationError(fieldName + ' ' + baseErrorMessage);
         } else {
           let baseErrorMessage = TranslationService.t(errorMessageCode);
           customError = new RBValidationError(baseErrorMessage);
@@ -150,30 +151,64 @@ export module Services {
       }
     }
 
+    public async applyFieldLevelPermissions(oid, record, options, user) {
+      // mandatory
+      let fieldDBNames = _.get(options, 'fieldDBNames', []);
+      // Allow a certain user to edit
+      let userWithPermissionToEdit = _.get(options, 'userWithPermissionToEdit')
+      let roleEditPermission = _.get(options, 'roleEditPermission')
+      user.role
+
+      if (user.username != userWithPermissionToEdit && !this.userHasRoleEditPermission(user, roleEditPermission)) {
+        let previousRecord = await RecordsService.getMeta(oid)
+        for (let fieldDBName of fieldDBNames) {
+          let data = _.get(record, fieldDBName);
+          sails.log.debug(`field name ${fieldDBName} value is ${data}`)
+          let previousData = _.get(previousRecord, fieldDBName);
+          sails.log.debug(`previous field name ${fieldDBName} value is ${previousData}`)
+          if (previousData != null && previousData.trim() != '') {
+            _.set(record, fieldDBName, previousData);
+            sails.log.info(`Setting field name ${fieldDBName} of record with OID ${oid} to ${previousData}`)
+          }
+        }
+      }
+
+      return record;
+    }
+
+    private userHasRoleEditPermission(user, roleEditPermission) {
+      for (let role of user.roles) {
+        if (role.name === roleEditPermission) {
+          return true;
+        }
+      }
+      return false
+    }
+
     public validateFieldUsingRegex(oid, record, options) {
       //mandatory
-      let fieldDBName = _.get(options,'fieldDBName');
-      let errorMessageCode = _.get(options,'errorLanguageCode');
-      let regexPattern = _.get(options,'regexPattern');
+      let fieldDBName = _.get(options, 'fieldDBName');
+      let errorMessageCode = _.get(options, 'errorLanguageCode');
+      let regexPattern = _.get(options, 'regexPattern');
       //optional
-      let fieldLanguageCode = _.get(options,'fieldLanguageCode');
-      let arrayObjFieldDBName = _.get(options,'arrayObjFieldDBName');
+      let fieldLanguageCode = _.get(options, 'fieldLanguageCode');
+      let arrayObjFieldDBName = _.get(options, 'arrayObjFieldDBName');
       //Set false by default if not present this option will remove leading and trailing spaces from a none array value
       //then it will modify the value in the record if the the regex validation is passed therefore handle with care
-      let trimLeadingAndTrailingSpacesBeforeValidation = _.get(options,'trimLeadingAndTrailingSpacesBeforeValidation') || false;
-      let caseSensitive = _.get(options,'caseSensitive') || true;
-      
+      let trimLeadingAndTrailingSpacesBeforeValidation = _.get(options, 'trimLeadingAndTrailingSpacesBeforeValidation') || false;
+      let caseSensitive = _.get(options, 'caseSensitive') || true;
+
       let data = _.get(record, fieldDBName);
 
-      if(_.isArray(data) && !_.isUndefined(arrayObjFieldDBName)) {  
+      if (_.isArray(data) && !_.isUndefined(arrayObjFieldDBName)) {
 
-        sails.log.verbose(`validateFieldUsingRegex is array ${fieldDBName} `+JSON.stringify(data));
-        sails.log.verbose('validateFieldUsingRegex is array regexPattern '+regexPattern);
-        for(let row of data) {
+        sails.log.verbose(`validateFieldUsingRegex is array ${fieldDBName} ` + JSON.stringify(data));
+        sails.log.verbose('validateFieldUsingRegex is array regexPattern ' + regexPattern);
+        for (let row of data) {
 
           let objField = _.get(row, arrayObjFieldDBName);
 
-          if(!_.isUndefined(objField) && objField != null && objField != '' && !_.isUndefined(regexPattern) && !_.isUndefined(errorMessageCode) ) {
+          if (!_.isUndefined(objField) && objField != null && objField != '' && !_.isUndefined(regexPattern) && !_.isUndefined(errorMessageCode)) {
 
             this.validateRegex(objField, regexPattern, fieldLanguageCode, errorMessageCode, caseSensitive);
           }
@@ -181,19 +216,19 @@ export module Services {
 
       } else {
 
-        sails.log.verbose(`validateFieldUsingRegex ${fieldDBName} `+data);
-        sails.log.verbose('validateFieldUsingRegex regexPattern '+regexPattern);
-        if(!_.isUndefined(data) && data != null && data != '' &&  !_.isUndefined(regexPattern) && !_.isUndefined(errorMessageCode) ) {
+        sails.log.verbose(`validateFieldUsingRegex ${fieldDBName} ` + data);
+        sails.log.verbose('validateFieldUsingRegex regexPattern ' + regexPattern);
+        if (!_.isUndefined(data) && data != null && data != '' && !_.isUndefined(regexPattern) && !_.isUndefined(errorMessageCode)) {
 
-          if(trimLeadingAndTrailingSpacesBeforeValidation) {
+          if (trimLeadingAndTrailingSpacesBeforeValidation) {
             let trimData = _.trim(data);
             data = trimData;
           }
 
           this.validateRegex(data, regexPattern, fieldLanguageCode, errorMessageCode, caseSensitive);
-          
-          if(trimLeadingAndTrailingSpacesBeforeValidation) {
-            _.set(record,fieldDBName,data);
+
+          if (trimLeadingAndTrailingSpacesBeforeValidation) {
+            _.set(record, fieldDBName, data);
           }
         }
       }

--- a/typescript/api/services/TriggerService.ts
+++ b/typescript/api/services/TriggerService.ts
@@ -155,20 +155,19 @@ export module Services {
       // mandatory
       let fieldDBNames = _.get(options, 'fieldDBNames', []);
       // Allow a certain user to edit
-      let userWithPermissionToEdit = _.get(options, 'userWithPermissionToEdit')
-      let roleEditPermission = _.get(options, 'roleEditPermission')
-      user.role
+      let userWithPermissionToEdit = _.get(options, 'userWithPermissionToEdit');
+      let roleEditPermission = _.get(options, 'roleEditPermission');
 
       if (user.username != userWithPermissionToEdit && !this.userHasRoleEditPermission(user, roleEditPermission)) {
-        let previousRecord = await RecordsService.getMeta(oid)
+        let previousRecord = await RecordsService.getMeta(oid);
         for (let fieldDBName of fieldDBNames) {
           let data = _.get(record, fieldDBName);
           sails.log.debug(`field name ${fieldDBName} value is ${data}`)
           let previousData = _.get(previousRecord, fieldDBName);
-          sails.log.debug(`previous field name ${fieldDBName} value is ${previousData}`)
+          sails.log.debug(`previous field name ${fieldDBName} value is ${previousData}`);
           if (previousData != null && previousData.trim() != '') {
             _.set(record, fieldDBName, previousData);
-            sails.log.info(`Setting field name ${fieldDBName} of record with OID ${oid} to ${previousData}`)
+            sails.log.info(`Setting field name ${fieldDBName} of record with OID ${oid} to ${previousData}`);
           }
         }
       }
@@ -182,7 +181,7 @@ export module Services {
           return true;
         }
       }
-      return false
+      return false;
     }
 
     public validateFieldUsingRegex(oid, record, options) {


### PR DESCRIPTION
Trigger function that prevents metadata fields from being modified by users with insufficient privileges.

Function checks whether the user has the appropriate system role or user name and if the user is unauthorized, fetches the existing metadata from the database and sets the values of the metadata to the previously saved version. No errors are thrown as the front end forms are unable to strictly enforce field level permissions so there are times where values may be inadvertently overwritten.

Example trigger configuration
To prevent the description field from being edited by anyone but the user with the username "redbox_user"
```{
          function: 'sails.services.triggerservice.applyFieldLevelPermissions',
          options: {
              fieldDBNames: ['metadata.description'],
              userWithPermissionToEdit: 'redbox_user'
          }          
        }
```
To prevent the description field from being edited by anyone but the users with the "Admin" system role
```{
          function: 'sails.services.triggerservice.applyFieldLevelPermissions',
          options: {
              fieldDBNames: ['metadata.description'],
              roleEditPermission: 'Admin'
          }          
        }
```