### PR TITLE
Fix: Static links don't render properly when there isnt a link value present in the RelatedObjectData Field

### DIFF
--- a/angular/shared/form/field-relatedobjectdata.html
+++ b/angular/shared/form/field-relatedobjectdata.html
@@ -55,7 +55,7 @@
                     <!-- Disabled link retained for backwards compat -->
                     <ng-template #disableLinkBlock>
                       <span>
-                        {{ field.getPropertyValue(item, column) }}
+                        {{ field.getPropertyLabel(item, column) }}
                       </span>
                     </ng-template>
                   </div>


### PR DESCRIPTION
Issue occurs when the related object's link metadata is as follows
```
"location" : {
      "label" : "sample location",
      "description" : "sample description",
      "link" : null
},
```
and column config is
```
{
       "label": "Location",
       "property": "location",
       "link": {
            "type": "static"
       }
}
```

Renders the column value as [Object object]. This PR fixes the output to display the label