### PR TITLE
Solr Preindex support for setting properties as JSON strings and evaluating lodash templates

### DIFF
--- a/support/integration-testing/docker-compose.mocha.yml
+++ b/support/integration-testing/docker-compose.mocha.yml
@@ -3,7 +3,7 @@ networks:
   main:
 services:
   redboxportal:
-    image: qcifengineering/redbox-portal:feature-node-14
+    image: qcifengineering/redbox-portal:master
     ports:
        - "1500:1500"
     volumes:

--- a/test/unit/services/SolrSearchService.test.js
+++ b/test/unit/services/SolrSearchService.test.js
@@ -7,21 +7,21 @@ describe('The Solr Indexing Service', function () {
     done()
   })
 
- let createdIndex = null
+  let createdIndex = null
   it("Should start Indexing", function (done) {
     this.timeout(5000)
     let oid = "xxxxxxxxx"
     let record = {}
-    SolrSearchService.index(oid,record)
+    SolrSearchService.index(oid, record)
     SolrSearchService.searchAdvanced('test').then(result => {
       sails.log.debug("Index result: ")
       sails.log.debug(result)
       expect(result).to.not.be.null &&
-      expect(result).to.have.property('responseHeader')
-        .and.to.have.property('status')
+        expect(result).to.have.property('responseHeader')
+          .and.to.have.property('status')
           .and.equal(0) &&
-      expect(result).to.have.property('response')
-        .and.to.have.property('numFound')
+        expect(result).to.have.property('response')
+          .and.to.have.property('numFound')
           .and.equal(0)
       createdIndex = result
       done()
@@ -30,5 +30,79 @@ describe('The Solr Indexing Service', function () {
       sails.log.error(error);
       done()
     })
+
+  })
+
+  it("Should produce a transformed document", function (done) {
+    let originalPreIndexConfig = _.cloneDeep(sails.config.solr.preIndex)
+    let testPreIndexConfig = {
+      move: [
+        {
+          source: 'movedPropertyOriginalPosition',
+          dest: 'movedPropertyNewPosition'
+        }
+      ],
+      copy: [
+        {
+          source: 'copiedPropertyOriginalPosition',
+          dest: 'copiedPropertyNewPosition'
+        }
+      ],
+      flatten: {
+        special: [
+          {
+            source: 'specialFlattenObject',
+            options: {
+              safe: false,
+              delimiter: '_'
+            }
+          }
+        ]
+      },
+      jsonString: [{
+        source: 'specialFlattenObject',
+        dest: 'jsonStringifiedObject'
+      }],
+      template: [
+        {
+          template: '<%= data.specialFlattenObject.property1 + data.specialFlattenObject.property2 %>',
+          dest: "templatespecialFlattenObjectProperty1AndProperty2"
+        }
+      ]
+    }
+
+    let testObject = {
+      movedPropertyOriginalPosition: "movedValue",
+      copiedPropertyOriginalPosition: "copiedValue",
+      specialFlattenObject: {
+        property1: "value1",
+        property2: "value2"
+      }
+    }
+
+    sails.config.solr.preIndex = testPreIndexConfig;
+
+    let result = SolrSearchService.preIndex(testObject)
+    
+    // Test move function
+    expect(result, 'movedPropertyOriginalPosition does not exist').to.not.have.property('movedPropertyOriginalPosition');
+    expect(result, 'movedPropertyNewPosition exists and has correct value').to.have.property('movedPropertyNewPosition').and.equal("movedValue");
+
+    // Test copy function
+    expect(result, 'copiedPropertyOriginalPosition exists and has correct value').to.have.property('copiedPropertyOriginalPosition').and.equal("copiedValue");
+    expect(result, 'copiedPropertyNewPosition exists and has correct value').to.have.property('copiedPropertyNewPosition').and.equal("copiedValue");
+
+    // Test special flatten function
+    expect(result, 'specialFlattenObject_property1 exists and has correct value').to.have.property('specialFlattenObject_property1').and.equal("value1");
+    expect(result, 'specialFlattenObject_property2 exists and has correct value').to.have.property('specialFlattenObject_property2').and.equal("value2");
+
+    // Test jsonString function
+    expect(result, 'stringified version of specialFlattenObject exists on property jsonStringifiedObject').to.have.property('jsonStringifiedObject').and.equal(JSON.stringify(testObject.specialFlattenObject));
+
+    // Test template function
+    expect(result, 'template evaluated correctly and stored into property templatespecialFlattenObjectProperty1AndProperty2').to.have.property('templatespecialFlattenObjectProperty1AndProperty2').and.equal('value1value2');
+          
+    sails.config.solr.preIndex = originalPreIndexConfig;
+    done()
   })
 })

--- a/typescript/api/services/SolrSearchService.ts
+++ b/typescript/api/services/SolrSearchService.ts
@@ -47,8 +47,9 @@ export module Services {
       'searchFuzzy',
       'solrAddOrUpdate',
       'solrDelete',
-      'searchAdvanced'
-    ];
+      'searchAdvanced',
+      'preIndex'
+    ]
 
     protected queueService: QueueService;
     private client: any;
@@ -251,7 +252,7 @@ export module Services {
 
     public async solrAddOrUpdate(job: any) {
       try {
-        let data = job.attrs.data;
+        let data:any = job.attrs.data;
         sails.log.verbose(`${this.logHeader} adding document: ${data.id} to index`);
         // flatten the JSON
         const processedData = this.preIndex(data);
@@ -267,48 +268,78 @@ export module Services {
       }
     }
 
-    private preIndex(data: any) {
-      let processedData = _.cloneDeep(data);
+    // TODO: This method shouldn't need to be public 
+    // but can't unit test it easily if it isn't
+    public preIndex(data: any) {
+      let processedData:any = _.cloneDeep(data);
       // moving
-      _.each(sails.config.solr.preIndex.move, (moveConfig) => {
-        const source = moveConfig.source;
-        const dest = moveConfig.dest;
+      _.each(sails.config.solr.preIndex.move, (moveConfig:any) => {
+        const source:string = moveConfig.source;
+        const dest:string = moveConfig.dest;
         // the data used will always be the original object
-        const moveData = _.get(data, source);
+        const moveData:any = _.get(data, source);
         if (!_.isEmpty(moveData)) {
           _.unset(processedData, source);
           if (_.isEmpty(dest)) {
             // empty destination means the root object
             _.merge(processedData, moveData);
           } else {
-            _.set(processedData, dest);
+            _.set(processedData, dest, moveData);
           }
         } else {
           sails.log.verbose(`${this.logHeader} no data to move from: ${moveConfig.source}, ignoring.`);
         }
       });
       // copying
-      _.each(sails.config.solr.preIndex.copy, (copyConfig) => {
+      _.each(sails.config.solr.preIndex.copy, (copyConfig:any) => {
         _.set(processedData, copyConfig.dest, _.get(data, copyConfig.source));
       });
       // flattening...
       // first remove those with special flattening options
-      _.each(sails.config.solr.preIndex.flatten.special, (specialFlattenConfig) => {
+      _.each(sails.config.solr.preIndex.flatten.special, (specialFlattenConfig:any) => {
         _.unset(processedData, specialFlattenConfig.field);
       });
       processedData = flat.flatten(processedData, sails.config.solr.preIndex.flatten.options);
-      _.each(sails.config.solr.preIndex.flatten.special, (specialFlattenConfig) => {
-        const dataToFlatten = {};
+      _.each(sails.config.solr.preIndex.flatten.special, (specialFlattenConfig:any) => {
+        const dataToFlatten:any = {};
         if (specialFlattenConfig.dest) {
           _.set(dataToFlatten, specialFlattenConfig.dest, _.get(data, specialFlattenConfig.source));
         } else {
           _.set(dataToFlatten, specialFlattenConfig.source, _.get(data, specialFlattenConfig.source));
         }
-        let flattened = flat.flatten(dataToFlatten, specialFlattenConfig.options);
+        let flattened:any = flat.flatten(dataToFlatten, specialFlattenConfig.options);
         _.merge(processedData, flattened);
       });
+
+      _.each(sails.config.solr.preIndex.jsonString, (jsonStringConfig:any) => {
+        let setProperty:string = jsonStringConfig.source;
+        if (jsonStringConfig.dest != null) {
+          setProperty = jsonStringConfig.dest;
+        }
+          _.set(processedData, setProperty, JSON.stringify(_.get(data, jsonStringConfig.source, undefined)));
+      });
+
+      //Evaluate a template to generate a value for the solr document
+      _.each(sails.config.solr.preIndex.template, (templateConfig:any) => {
+        let setProperty:string = templateConfig.source;
+        if (templateConfig.dest != null) {
+          setProperty = templateConfig.dest;
+        }
+
+        // If no source property set, use the whole data object
+        let templateData:any;
+        if(templateConfig.source != null) {
+          templateData = _.get(data, templateConfig.source)
+        } else {
+          templateData = _.cloneDeep(data);
+        }
+
+        let template:any = _.template(templateConfig.template)
+        _.set(processedData, setProperty, template({data: templateData}) );
+      });
+
       // sanitise any empty keys so SOLR doesn't complain
-      _.forOwn(processedData, (v, k) => {
+      _.forOwn(processedData, (v:any, k:any) => {
         if (_.isEmpty(k)) {
           _.unset(processedData, k);
         }

--- a/typescript/api/services/SolrSearchService.ts
+++ b/typescript/api/services/SolrSearchService.ts
@@ -294,22 +294,6 @@ export module Services {
       _.each(sails.config.solr.preIndex.copy, (copyConfig:any) => {
         _.set(processedData, copyConfig.dest, _.get(data, copyConfig.source));
       });
-      // flattening...
-      // first remove those with special flattening options
-      _.each(sails.config.solr.preIndex.flatten.special, (specialFlattenConfig:any) => {
-        _.unset(processedData, specialFlattenConfig.field);
-      });
-      processedData = flat.flatten(processedData, sails.config.solr.preIndex.flatten.options);
-      _.each(sails.config.solr.preIndex.flatten.special, (specialFlattenConfig:any) => {
-        const dataToFlatten:any = {};
-        if (specialFlattenConfig.dest) {
-          _.set(dataToFlatten, specialFlattenConfig.dest, _.get(data, specialFlattenConfig.source));
-        } else {
-          _.set(dataToFlatten, specialFlattenConfig.source, _.get(data, specialFlattenConfig.source));
-        }
-        let flattened:any = flat.flatten(dataToFlatten, specialFlattenConfig.options);
-        _.merge(processedData, flattened);
-      });
 
       _.each(sails.config.solr.preIndex.jsonString, (jsonStringConfig:any) => {
         let setProperty:string = jsonStringConfig.source;
@@ -336,6 +320,23 @@ export module Services {
 
         let template:any = _.template(templateConfig.template)
         _.set(processedData, setProperty, template({data: templateData}) );
+      });
+
+      // flattening...
+      // first remove those with special flattening options
+      _.each(sails.config.solr.preIndex.flatten.special, (specialFlattenConfig:any) => {
+        _.unset(processedData, specialFlattenConfig.field);
+      });
+      processedData = flat.flatten(processedData, sails.config.solr.preIndex.flatten.options);
+      _.each(sails.config.solr.preIndex.flatten.special, (specialFlattenConfig:any) => {
+        const dataToFlatten:any = {};
+        if (specialFlattenConfig.dest) {
+          _.set(dataToFlatten, specialFlattenConfig.dest, _.get(data, specialFlattenConfig.source));
+        } else {
+          _.set(dataToFlatten, specialFlattenConfig.source, _.get(data, specialFlattenConfig.source));
+        }
+        let flattened:any = flat.flatten(dataToFlatten, specialFlattenConfig.options);
+        _.merge(processedData, flattened);
       });
 
       // sanitise any empty keys so SOLR doesn't complain


### PR DESCRIPTION
Adds support for setting a solr property as a JSON string representation of the original metadata document as well as transforming properties from the original document using lodash templates