### PR TITLE
Feature: Added option to not attempt sign out from Authentication server for OIDC users

### DIFF
--- a/typescript/api/controllers/UserController.ts
+++ b/typescript/api/controllers/UserController.ts
@@ -24,7 +24,7 @@ declare var _;
 declare var BrandingService, UsersService, ConfigService;
 import * as uuidv4 from 'uuid/v4';
 
-import { Controllers as controllers, RequestDetails} from '@researchdatabox/redbox-core-types';
+import { Controllers as controllers, RequestDetails } from '@researchdatabox/redbox-core-types';
 
 
 export module Controllers {
@@ -132,7 +132,7 @@ export module Controllers {
       });
       // instead of destroying the session, as per M$ directions, we only unset the user, so branding, etc. is retained in the session
       _.unset(req.session, 'user');
-      res.redirect(redirUrl); 
+      res.redirect(redirUrl);
     }
 
     public info(req, res) {
@@ -258,8 +258,8 @@ export module Controllers {
 
     public openidConnectLogin(req, res) {
       let passportIdentifier = 'oidc'
-      if(!_.isEmpty(req.param('id'))) {
-        passportIdentifier= `oidc-${req.param('id')}`
+      if (!_.isEmpty(req.param('id'))) {
+        passportIdentifier = `oidc-${req.param('id')}`
       }
       sails.config.passport.authenticate(passportIdentifier, function (err, user, info) {
         sails.log.verbose("At openIdConnectAuth Controller, verify...");
@@ -287,7 +287,7 @@ export module Controllers {
           if (_.startsWith(err, "Error: did not find expected authorization request details in session")) {
             // letting the user try again seems to 'refresh' the session
             req.session['data'] = `oidc-login-session-destroyed`;
-            return res.serverError();  
+            return res.serverError();
           }
 
           if (_.isEmpty(err)) {
@@ -298,15 +298,15 @@ export module Controllers {
           // "The specified data will be excluded from the JSON response and view locals if the app is running in the "production" environment (i.e. process.env.NODE_ENV === 'production')."
           // so storing the data in session
           if (_.isEmpty(req.session.data)) {
-            req.session['data'] = { 
+            req.session['data'] = {
               "message": 'error-auth',
               "detailedMessager": `${err}${info}`
             };
           }
 
           const url = `${BrandingService.getFullPath(req)}/home`;
-          return res.redirect(url); 
-        }       
+          return res.redirect(url);
+        }
         let requestDetails = new RequestDetails(req);
         UsersService.addUserAuditEvent(user, "login", requestDetails).then(response => {
           sails.log.debug(`User login audit event created for OIDC login: ${_.isEmpty(user) ? '' : user.id}`)
@@ -326,8 +326,8 @@ export module Controllers {
     public beginOidc(req, res) {
       sails.log.verbose(`At OIDC begin flow, redirecting...`);
       let passportIdentifier = 'oidc'
-      if(!_.isEmpty(req.param('id'))) {
-        passportIdentifier= `oidc-${req.param('id')}`
+      if (!_.isEmpty(req.param('id'))) {
+        passportIdentifier = `oidc-${req.param('id')}`
       }
       sails.config.passport.authenticate(passportIdentifier)(req, res);
     }
@@ -344,17 +344,17 @@ export module Controllers {
         sails.log.verbose(user);
         if ((err) || (!user)) {
           sails.log.error(err)
-            // means the provider has authenticated the user, but has been rejected, redirect to catch-all
-            // from https://sailsjs.com/documentation/reference/response-res/res-server-error
-            // "The specified data will be excluded from the JSON response and view locals if the app is running in the "production" environment (i.e. process.env.NODE_ENV === 'production')."
-            // so storing the data in session
-            if (_.isEmpty(req.session.data)) {
-              req.session['data'] = { 
-                "message": 'error-auth',
-                "detailedMessager": `${err}${info}`
-              };
-            }
-            return res.serverError();
+          // means the provider has authenticated the user, but has been rejected, redirect to catch-all
+          // from https://sailsjs.com/documentation/reference/response-res/res-server-error
+          // "The specified data will be excluded from the JSON response and view locals if the app is running in the "production" environment (i.e. process.env.NODE_ENV === 'production')."
+          // so storing the data in session
+          if (_.isEmpty(req.session.data)) {
+            req.session['data'] = {
+              "message": 'error-auth',
+              "detailedMessager": `${err}${info}`
+            };
+          }
+          return res.serverError();
         }
 
         let requestDetails = new RequestDetails(req);

--- a/typescript/api/services/UsersService.ts
+++ b/typescript/api/services/UsersService.ts
@@ -359,10 +359,15 @@ export module Services {
 
     protected openIdConnectAuthVerifyCallback(oidcConfig, issuer, req, tokenSet, userinfo = undefined, done) {
       const that = this;
-      req.session.logoutUrl = issuer.end_session_endpoint;
-      const postLogoutUris = _.get(oidcConfig.opts, 'client.post_logout_redirect_uris');
-      if (!_.isEmpty(postLogoutUris)) {
-        req.session.logoutUrl = `${req.session.logoutUrl}?post_logout_redirect_uri=${postLogoutUris[0]}`;
+      const logoutFromAuthServer = _.get(oidcConfig,'logoutFromAuthServer', true);
+      if(logoutFromAuthServer) {
+       req.session.logoutUrl = issuer.end_session_endpoint;
+        const postLogoutUris = _.get(oidcConfig.opts, 'client.post_logout_redirect_uris');
+        if (!_.isEmpty(postLogoutUris)) {
+          req.session.logoutUrl = `${req.session.logoutUrl}?post_logout_redirect_uri=${postLogoutUris[0]}`;
+        }
+      } else {
+        req.session.logoutUrl = sails.config.auth.postLogoutRedir
       }
       sails.log.verbose(`OIDC login success, tokenset: `);
       sails.log.verbose(JSON.stringify(tokenSet));


### PR DESCRIPTION
Some implementations prefer to sign the user out of ReDBox only and not the authentication server at the same time. An option in the oidc config named logoutFromAuthServer has been added to enable/disable the feature. Defaults to true for backwards compatibility.

Example Usage
```
oidc: {
     logoutFromAuthServer: false,
     ....
}
```
