### PR TITLE
Feature: Improved styling capabilities of Selection Field Component in edit mode

### DIFF
--- a/angular/shared/form/field-simple.component.ts
+++ b/angular/shared/form/field-simple.component.ts
@@ -321,16 +321,16 @@ export class DropdownFieldComponent extends SelectionComponent {
       <button type="button" class="btn btn-default" *ngIf="field.help" (click)="toggleHelp()" [attr.aria-label]="'help' | translate "><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></button>
      </span><br/>
      <span id="{{ 'helpBlock_' + field.name }}" class="help-block" *ngIf="this.helpShow" [innerHtml]="field.help"></span>
-     <fieldset>
-      <legend [hidden]="true"><span></span></legend>
-        <span *ngFor="let opt of findAvailableOptions(field.value)">
+     <fieldset [ngClass]="field.fieldSetCssClasses">
+      
+        <div *ngFor="let opt of findAvailableOptions(field.value)" [ngClass]="field.controlGroupCssClasses">
           <!-- radio type hard-coded otherwise accessor directive will not work! -->
           <!-- the ID and associated label->for property is now delegated to a Fn rather than inline-templated here, to make it optional, e.g. if it is nested -->
-          <input *ngIf="isRadio()" type="radio" [id]="getInputId(opt)" [formControlName]="field.name" [value]="opt.value" [attr.disabled]="field.readOnly ? '' : null ">
-          <input *ngIf="!isRadio()" type="{{field.controlType}}" name="{{field.name}}" [id]="getInputId(opt)" [value]="opt.value" (change)="onChange(opt, $event)" [attr.selected]="getCheckedFromOption(opt)" [checked]="getCheckedFromOption(opt)" [attr.disabled]="field.readOnly ? '' : null ">
-          <label [attr.for]="getInputId(opt)" class="radio-label"  [innerHtml]="opt.label"></label>
-          <br/>
-        </span>
+          <input *ngIf="isRadio()" type="radio" [id]="getInputId(opt)" [formControlName]="field.name" [value]="opt.value" [attr.disabled]="field.readOnly ? '' : null " [ngClass]="field.controlInputCssClasses">
+          <input *ngIf="!isRadio()" type="{{field.controlType}}" name="{{field.name}}" [id]="getInputId(opt)" [value]="opt.value" (change)="onChange(opt, $event)" [ngClass]="field.controlInputCssClasses" [attr.selected]="getCheckedFromOption(opt)" [checked]="getCheckedFromOption(opt)" [attr.disabled]="field.readOnly ? '' : null ">
+          <label [attr.for]="getInputId(opt)" class="radio-label" [ngClass]="field.controlLabelCssClasses" [innerHtml]="opt.label"></label>
+          
+        </div>
      </fieldset>
      <div class="text-danger" *ngIf="hasRequiredError() && !field.validationMessages?.required">{{field.label}} is required</div>
      <div class="text-danger" *ngIf="hasRequiredError() && field.validationMessages?.required">{{field.validationMessages.required}}</div>

--- a/angular/shared/form/field-simple.ts
+++ b/angular/shared/form/field-simple.ts
@@ -95,10 +95,10 @@ export class SelectionField extends FieldBase<any>  {
     }
     this.disableOptionLabelsFor = options['disableOptionLabelsFor'];
     this.useFormGroup = options['useFormGroup'];
-    this.controlGroupCssClasses = options['controlGroupCssClasses']?? this.controlGroupCssClasses;
-    this.fieldSetCssClasses = options['fieldSetCssClasses']?? this.fieldSetCssClasses;
-    this.controlInputCssClasses = options['controlInputCssClasses']?? this.controlInputCssClasses;
-    this.controlLabelCssClasses = options['controlLabelCssClasses']?? this.controlLabelCssClasses;
+    this.controlGroupCssClasses = options['controlGroupCssClasses'] == undefined ? this.controlGroupCssClasses : options['controlGroupCssClasses'];
+    this.fieldSetCssClasses = options['fieldSetCssClasses'] == undefined ? this.fieldSetCssClasses : options['fieldSetCssClasses'];
+    this.controlInputCssClasses = options['controlInputCssClasses'] == undefined ? this.controlInputCssClasses : options['controlInputCssClasses'];
+    this.controlLabelCssClasses = options['controlLabelCssClasses'] == undefined ? this.controlLabelCssClasses : options['controlLabelCssClasses'];
   }
 
 

--- a/angular/shared/form/field-simple.ts
+++ b/angular/shared/form/field-simple.ts
@@ -49,6 +49,10 @@ export class SelectionField extends FieldBase<any>  {
   compare: any;
   disableOptionLabelsFor: boolean = false;
   useFormGroup: string;
+  controlGroupCssClasses: string = 'selection-control-group';
+  fieldSetCssClasses: string = 'selection-field-set';
+  controlInputCssClasses:string = 'selection-control-input';
+  controlLabelCssClasses:string = 'selection-control-label';
   
   constructor(options: any, injector: any) {
     super(options, injector);
@@ -91,6 +95,10 @@ export class SelectionField extends FieldBase<any>  {
     }
     this.disableOptionLabelsFor = options['disableOptionLabelsFor'];
     this.useFormGroup = options['useFormGroup'];
+    this.controlGroupCssClasses = options['controlGroupCssClasses']?? this.controlGroupCssClasses;
+    this.fieldSetCssClasses = options['fieldSetCssClasses']?? this.fieldSetCssClasses;
+    this.controlInputCssClasses = options['controlInputCssClasses']?? this.controlInputCssClasses;
+    this.controlLabelCssClasses = options['controlLabelCssClasses']?? this.controlLabelCssClasses;
   }
 
 


### PR DESCRIPTION
Improved the ability to style the selection field component in edit mode.

It is now possible to add classes for custom styling using the following options:

- fieldSetCssClasses: String that defines the set of classes for the entire set of selection controls. Default value: 'selection-field-set'
- controlGroupCssClasses: String that defines the set of classes for group div containing an individual input control and label. Default value: 'selection-control-group'
- controlLabelCssClasses: String that defines the set of classes for an individual control. Default value: 'selection-control-label'