### PR TITLE
Feature: Add configurable triggers on login

### DIFF
--- a/config/auth.js
+++ b/config/auth.js
@@ -212,10 +212,7 @@ module.exports.auth = {
             failureMode: 'continue', //options continue or stop processing
             options: {
               sourceType: 'Parties AND repository_name:People',
-              queryString: 'autocomplete_given_name:{{{name}}}* OR autocomplete_family_name:{{{name}}}* OR autocomplete_full_name:{{{name}}}*',
-              userAttribute: 'name',
-              placeholderLeftSeparator: '{{{',
-              placeholderRightSeparator: '}}}',
+              queryString: 'autocomplete_given_name:<%= user.name%>* OR autocomplete_family_name:<%= user.name%>* OR autocomplete_full_name:<%= user.name%>*',
               fieldsToMap: ['text_full_name', 'dc_identifier']
             }
           }

--- a/config/auth.js
+++ b/config/auth.js
@@ -200,6 +200,29 @@ module.exports.auth = {
       },
       templatePath: 'local.ejs',
       postLoginRedir: 'researcher/home',
+      hooks: {
+        onCreate: {
+          pre: [],
+          post: []
+        },
+        onUpdate: {
+          pre: [
+          {
+            function: 'sails.services.vocabservice.findInMintTriggerWrapper',
+            failureMode: 'continue', //options continue or stop processing
+            options: {
+              sourceType: 'Parties AND repository_name:People',
+              queryString: 'autocomplete_given_name:{{{name}}}* OR autocomplete_family_name:{{{name}}}* OR autocomplete_full_name:{{{name}}}*',
+              userAttribute: 'name',
+              placeholderLeftSeparator: '{{{',
+              placeholderRightSeparator: '}}}',
+              fieldsToMap: ['text_full_name', 'dc_identifier']
+            }
+          }
+        ],
+        post: []
+      }
+      }
     },
     aaf: {
       defaultRole: 'Researcher',

--- a/typescript/api/services/UsersService.ts
+++ b/typescript/api/services/UsersService.ts
@@ -238,11 +238,6 @@ export module Services {
       sails.log.verbose(`hooks.${mode}.pre`);
       sails.log.verbose(JSON.stringify(config));
       let preSaveUpdateHooks = _.get(config, `hooks.${mode}.pre`, null);
-      let failureMode = _.get(preSaveUpdateHooks, 'failureMode');
-      if(_.isUndefined(failureMode) || (failureMode != 'continue' && failureMode != 'stop')) {
-        failureMode = 'continue';
-      }
-      sails.log.verbose(`hooks.${mode}.pre failureMode ${failureMode}`);
       sails.log.debug(preSaveUpdateHooks);
 
       if (_.isArray(preSaveUpdateHooks)) {
@@ -254,7 +249,11 @@ export module Services {
             try {
               let preSaveUpdateHookFunction = eval(preSaveUpdateHookFunctionString);
               let options = _.get(preSaveUpdateHook, 'options', {});
-              sails.log.verbose(`Triggering pre save triggers: ${preSaveUpdateHookFunctionString}`);
+              let failureMode = _.get(preSaveUpdateHook, 'failureMode');
+              if(_.isUndefined(failureMode) || (failureMode != 'continue' && failureMode != 'stop')) {
+                failureMode = 'continue';
+              }
+              sails.log.verbose(`Triggering pre save triggers: ${preSaveUpdateHookFunctionString} failureMode ${failureMode}`);
               let hookResponse = preSaveUpdateHookFunction(user, options, failureMode);
               user = await this.resolveHookResponse(hookResponse);
               sails.log.debug(`${preSaveUpdateHookFunctionString} response now is:`);

--- a/typescript/api/services/UsersService.ts
+++ b/typescript/api/services/UsersService.ts
@@ -162,6 +162,14 @@ export module Services {
                           sails.log.verbose(user);
                           return;
                       });
+
+                      if(that.hasPostSaveTriggerConfigured(configLocal, 'onUpdate')){
+                        that.triggerPostSaveTriggers(foundUser, configLocal);
+                      }
+
+                      if(that.hasPostSaveSyncTriggerConfigured(configLocal, 'onUpdate')){
+                        that.triggerPostSaveSyncTriggers(foundUser, configLocal);
+                      }
                       
                       return done(null, userAdditionalInfo, {
                         message: 'Logged In Successfully'
@@ -195,18 +203,18 @@ export module Services {
                     sails.log.verbose(user);
                     return;
                 });
+                
+                if(that.hasPostSaveTriggerConfigured(configLocal, 'onUpdate')){
+                  that.triggerPostSaveTriggers(foundUser, configLocal);
+                }
+
+                if(that.hasPostSaveSyncTriggerConfigured(configLocal, 'onUpdate')){
+                  that.triggerPostSaveSyncTriggers(foundUser, configLocal);
+                }
 
                 return done(null, foundUser, {
                   message: 'Logged In Successfully'
                 });
-              }
-
-              if(that.hasPostSaveTriggerConfigured(configLocal, 'onUpdate')){
-                that.triggerPostSaveTriggers(foundUser, configLocal);
-              }
-
-              if(that.hasPostSaveSyncTriggerConfigured(configLocal, 'onUpdate')){
-                that.triggerPostSaveSyncTriggers(foundUser, configLocal);
               }
 
             });
@@ -472,6 +480,14 @@ export module Services {
                         return done("No user found", false, {message: "No user found"});
                       }
               
+                      if(that.hasPostSaveTriggerConfigured(configAAF, 'onUpdate')){
+                        that.triggerPostSaveTriggers(user, configAAF);
+                      }
+        
+                      if(that.hasPostSaveSyncTriggerConfigured(configAAF, 'onUpdate')){
+                        that.triggerPostSaveSyncTriggers(user, configAAF);
+                      }
+                      
                       sails.log.verbose("Done, returning updated user:");
                       sails.log.verbose(user);
                       return done(null, user[0],{
@@ -500,6 +516,14 @@ export module Services {
                     return done("No user found", false, {message: "No user found"});
                   }
           
+                  if(that.hasPostSaveTriggerConfigured(configAAF, 'onUpdate')){
+                    that.triggerPostSaveTriggers(user, configAAF);
+                  }
+    
+                  if(that.hasPostSaveSyncTriggerConfigured(configAAF, 'onUpdate')){
+                    that.triggerPostSaveSyncTriggers(user, configAAF);
+                  }
+
                   sails.log.verbose("Done, returning updated user:");
                   sails.log.verbose(user);
                   return done(null, user[0],{
@@ -551,13 +575,22 @@ export module Services {
                   
                   let success = that.checkAllTriggersSuccessOrFailure(userAdditionalInfo);
                   if(success) {
-                    User.create(userAdditionalInfo).exec(function (err, newUser) {
+                    userToCreate = userAdditionalInfo;
+                    User.create(userToCreate).exec(function (err, newUser) {
                       if (err) {
                         sails.log.error("Error creating new user:");
                         sails.log.error(err);
                         return done(err, false);
                       }
       
+                      if(that.hasPostSaveTriggerConfigured(configAAF, 'onCreate')){
+                        that.triggerPostSaveTriggers(newUser, configAAF);
+                      }
+    
+                      if(that.hasPostSaveSyncTriggerConfigured(configAAF, 'onCreate')){
+                        that.triggerPostSaveSyncTriggers(newUser, configAAF);
+                      }
+
                       sails.log.verbose("Done, returning new user:");
                       sails.log.verbose(newUser);
                       return done(null, newUser);
@@ -566,6 +599,7 @@ export module Services {
                     return done(`All required conditions for login not met ${userAdditionalInfo.email}`, false);
                   }
                 });
+
 
               } else {
 
@@ -576,6 +610,14 @@ export module Services {
                     return done(err, false);
                   }
   
+                  if(that.hasPostSaveTriggerConfigured(configAAF, 'onCreate')){
+                    that.triggerPostSaveTriggers(newUser, configAAF);
+                  }
+
+                  if(that.hasPostSaveSyncTriggerConfigured(configAAF, 'onCreate')){
+                    that.triggerPostSaveSyncTriggers(newUser, configAAF);
+                  }
+
                   sails.log.verbose("Done, returning new user:");
                   sails.log.verbose(newUser);
                   return done(null, newUser);

--- a/typescript/api/services/UsersService.ts
+++ b/typescript/api/services/UsersService.ts
@@ -800,6 +800,14 @@ export module Services {
                     sails.log.error("No user found");
                     return done("No user found", false);
                   }
+
+                  if(that.hasPostSaveTriggerConfigured(oidcConfig, 'onUpdate')){
+                    that.triggerPostSaveTriggers(user, oidcConfig);
+                  }
+    
+                  if(that.hasPostSaveSyncTriggerConfigured(oidcConfig, 'onUpdate')){
+                    that.triggerPostSaveSyncTriggers(user, oidcConfig);
+                  }
           
                   sails.log.verbose("Done, returning updated user:");
                   sails.log.verbose(user);
@@ -824,6 +832,14 @@ export module Services {
               if (_.isEmpty(user)) {
                 sails.log.error("No user found");
                 return done("No user found", false);
+              }
+
+              if(that.hasPostSaveTriggerConfigured(oidcConfig, 'onUpdate')){
+                that.triggerPostSaveTriggers(user, oidcConfig);
+              }
+
+              if(that.hasPostSaveSyncTriggerConfigured(oidcConfig, 'onUpdate')){
+                that.triggerPostSaveSyncTriggers(user, oidcConfig);
               }
       
               sails.log.verbose("Done, returning updated user:");
@@ -871,12 +887,20 @@ export module Services {
                     sails.log.error(err);
                     return done(err, false);
                   }
+
+                  if(that.hasPostSaveTriggerConfigured(oidcConfig, 'onCreate')){
+                    that.triggerPostSaveTriggers(newUser, oidcConfig);
+                  }
+
+                  if(that.hasPostSaveSyncTriggerConfigured(oidcConfig, 'onCreate')){
+                    that.triggerPostSaveSyncTriggers(newUser, oidcConfig);
+                  }
       
                   sails.log.verbose("Done, returning new user:");
                   sails.log.verbose(newUser);
                   return done(null, newUser);
                 });
-                
+
               } else {
                 return done('All required conditions for login not met', false);
               } 
@@ -889,6 +913,14 @@ export module Services {
                 sails.log.error("Error creating new user:");
                 sails.log.error(err);
                 return done(err, false);
+              }
+
+              if(that.hasPostSaveTriggerConfigured(oidcConfig, 'onCreate')){
+                that.triggerPostSaveTriggers(newUser, oidcConfig);
+              }
+
+              if(that.hasPostSaveSyncTriggerConfigured(oidcConfig, 'onCreate')){
+                that.triggerPostSaveSyncTriggers(newUser, oidcConfig);
               }
   
               sails.log.verbose("Done, returning new user:");

--- a/typescript/api/services/VocabService.ts
+++ b/typescript/api/services/VocabService.ts
@@ -85,7 +85,7 @@ export module Services {
               _.set(user, 'additionalAttributes.'+fieldName, sourceField);
             }
           }
-          this.setSuccessOrFailure(user, additionalInfoFound, failureMode, true);
+          this.setSuccessOrFailure(user, additionalInfoFound, '', true);
 
         } else {
           

--- a/typescript/api/services/VocabService.ts
+++ b/typescript/api/services/VocabService.ts
@@ -68,13 +68,10 @@ export module Services {
       try {
         let sourceType = _.get(options, 'sourceType');
         let queryStringTmp = _.get(options, 'queryString');
-        let userAttribute = _.get(options, 'userAttribute');
-        let placeholderLeftSeparator = _.get(options, 'placeholderLeftSeparator');
-        let placeholderRightSeparator = _.get(options, 'placeholderRightSeparator');
+        let compiledTemplate = _.template(queryStringTmp, {});
         let fieldsToMap = _.get(options, 'fieldsToMap');
-        let placeholder = placeholderLeftSeparator + userAttribute + placeholderRightSeparator;
-        let attributeValue = _.get(user, userAttribute);
-        let queryString = queryStringTmp.replaceAll(placeholder,attributeValue);
+        
+        let queryString = compiledTemplate({user: user});
         let mintResponse = await this.findInMint(sourceType, queryString).toPromise();
         let responseDocs = _.get(mintResponse, 'response.docs');
         if(_.isArray(responseDocs) && responseDocs.length > 0) {


### PR DESCRIPTION
This PR adds support for configurable triggers on login.
This can be useful for populating additional user metadata on login from another source (such as Mint, trigger included to support queries to mint) or sending event information off to different sources.