### PR TITLE
Hotfix: Added map initialisation when the map is made visible

### DIFF
--- a/angular/shared/form/field-map.component.ts
+++ b/angular/shared/form/field-map.component.ts
@@ -258,6 +258,13 @@ export class MapField extends FieldBase<any> {
     });
   }
 
+  public setVisibility(data, eventConf:any = {}) {
+    let that = this;
+    super.setVisibility(data,eventConf);
+    setTimeout(function() {
+      that.initMap(that.map,that);
+    })
+  }
 
   postInit(value: any) {
     if (!_.isEmpty(value)) {


### PR DESCRIPTION
Fixes issue where the map does not render correctly when it is initialised as not visible and is later made visible via setVisibility