### PR TITLE
Improve tree node component to toggle expand collapse by click on the name/description of items 

### DIFF
--- a/angular-legacy/shared/form/field-andsvocab.component.ts
+++ b/angular-legacy/shared/form/field-andsvocab.component.ts
@@ -46,6 +46,7 @@ export class ANDSVocabField extends FieldBase<any> {
   public disableCheckboxRegexPattern:string;
   public disableCheckboxRegexTestValue:string;
   public disableCheckboxRegexCaseSensitive: boolean;
+  public disableExpandCollapseToggleByName: boolean;
   public component:any;
 
   constructor(options: any, injector: any) {
@@ -56,6 +57,7 @@ export class ANDSVocabField extends FieldBase<any> {
     this.disableCheckboxRegexPattern = options['disableCheckboxRegexPattern'] || "";
     this.disableCheckboxRegexTestValue = options['disableCheckboxRegexTestValue'] || "";
     this.disableCheckboxRegexCaseSensitive = options['disableCheckboxRegexCaseSensitive'] || true;
+    this.disableExpandCollapseToggleByName = options['disableExpandCollapseToggleByName'] || false;
 
     this.andsService = this.getFromInjector(ANDSService);
   }
@@ -300,7 +302,9 @@ export class ANDSVocabComponent extends SimpleComponent {
         break;
     }
 
-    this.expandCollapseNode(event.node);
+    if(!this.field.disableExpandCollapseToggleByName) {
+      this.expandCollapseNode(event.node);
+    }
   }
 
   protected updateSingleNodeSelectedState(node, state) {

--- a/angular-legacy/shared/form/field-andsvocab.component.ts
+++ b/angular-legacy/shared/form/field-andsvocab.component.ts
@@ -335,18 +335,6 @@ export class ANDSVocabComponent extends SimpleComponent {
     that.andsTree.treeModel.setState(state);
     that.andsTree.treeModel.update();
     that.expandNodeIds = _.sortBy(that.expandNodeIds, (o) => { return _.isString(o) ? o.length : 0 });
-
-    //Populate a list of expanded node ids on first load based of expandNodeIds 
-    for(let i = 0; i < that.expandNodeIds.length; i++) {
-      let nodeId = that.expandNodeIds[i];
-
-      //Ignore child nodes with 6 digit codes
-      if(nodeId.length > 4) {
-        continue;
-      }
-
-      that.treeNodeLiveStatusIDs.push({nodeId: nodeId, nodeStatus: 'exapanded'});
-    }
   }
 
   //Takes the first entry in expandNodeIds list and expands the node and the removed the id from the list 
@@ -365,25 +353,16 @@ export class ANDSVocabComponent extends SimpleComponent {
     const nodeId = _.get(nodeEvent,'id','');
 
     //Ignore child nodes with 6 digit codes
-    if(nodeId.length > 4) {
+    if(nodeId == '' || nodeId.length > 4) {
       return;
     }
 
-    let nodeStatusObject = _.find(this.treeNodeLiveStatusIDs, (o: any) => { return o.nodeId == nodeId });
-    let nodeStatus = 'collapsed';
-    if(!_.isUndefined(nodeStatusObject)) {
-      nodeStatus = _.get(nodeStatusObject, 'nodeStatus', 'collapsed');
-    }
     const node = this.andsTree.treeModel.getNodeById(nodeId);
     if (node) {
-      if(nodeStatus == 'collapsed') {
+      if(_.get(node, 'isCollapsed', false)) {
         node.expand();
-        _.remove(this.treeNodeLiveStatusIDs, (o: any) => { return o.nodeId == nodeId });
-        this.treeNodeLiveStatusIDs.push({nodeId: nodeId, nodeStatus: 'exapanded'});
       } else {
         node.collapse();
-        _.remove(this.treeNodeLiveStatusIDs, (o: any) => { return o.nodeId == nodeId });
-        this.treeNodeLiveStatusIDs.push({nodeId: nodeId, nodeStatus: 'collapsed'});
       }
     }
   }

--- a/angular-legacy/shared/form/field-andsvocab.component.ts
+++ b/angular-legacy/shared/form/field-andsvocab.component.ts
@@ -47,6 +47,7 @@ export class ANDSVocabField extends FieldBase<any> {
   public disableCheckboxRegexTestValue:string;
   public disableCheckboxRegexCaseSensitive: boolean;
   public disableExpandCollapseToggleByName: boolean;
+  public skipLeafNodeExpandCollapseProcessing: number;
   public component:any;
 
   constructor(options: any, injector: any) {
@@ -58,6 +59,7 @@ export class ANDSVocabField extends FieldBase<any> {
     this.disableCheckboxRegexTestValue = options['disableCheckboxRegexTestValue'] || "";
     this.disableCheckboxRegexCaseSensitive = options['disableCheckboxRegexCaseSensitive'] || true;
     this.disableExpandCollapseToggleByName = options['disableExpandCollapseToggleByName'] || false;
+    this.skipLeafNodeExpandCollapseProcessing = options['skipLeafNodeExpandCollapseProcessing'] || 4;
 
     this.andsService = this.getFromInjector(ANDSService);
   }
@@ -179,7 +181,6 @@ export class ANDSVocabComponent extends SimpleComponent {
   readonly STATUS_EXPANDED = 4;
   loadState: any;
   initialised:boolean = false;
-  treeNodeLiveStatusIDs: any = []; 
 
   constructor(@Inject(ElementRef) elementRef: ElementRef) {
     super();
@@ -356,8 +357,8 @@ export class ANDSVocabComponent extends SimpleComponent {
   protected expandCollapseNode(nodeEvent: any) {
     const nodeId = _.get(nodeEvent,'id','');
 
-    //Ignore child nodes with 6 digit codes
-    if(nodeId == '' || nodeId.length > 4) {
+    //Ignore expand collapse processing if id string value has length that exceeds default
+    if(nodeId == '' || nodeId.length > this.field.skipLeafNodeExpandCollapseProcessing) {
       return;
     }
 

--- a/angular-legacy/shared/form/field-andsvocab.component.ts
+++ b/angular-legacy/shared/form/field-andsvocab.component.ts
@@ -339,6 +339,12 @@ export class ANDSVocabComponent extends SimpleComponent {
     //Populate a list of expanded node ids on first load based of expandNodeIds 
     for(let i = 0; i < that.expandNodeIds.length; i++) {
       let nodeId = that.expandNodeIds[i];
+
+      //Ignore child nodes with 6 digit codes
+      if(nodeId.length > 4) {
+        continue;
+      }
+
       that.treeNodeLiveStatusIDs.push({nodeId: nodeId, nodeStatus: 'exapanded'});
     }
   }
@@ -357,6 +363,12 @@ export class ANDSVocabComponent extends SimpleComponent {
 
   protected expandCollapseNode(nodeEvent: any) {
     const nodeId = _.get(nodeEvent,'id','');
+
+    //Ignore child nodes with 6 digit codes
+    if(nodeId.length > 4) {
+      return;
+    }
+
     let nodeStatusObject = _.find(this.treeNodeLiveStatusIDs, (o: any) => { return o.nodeId == nodeId });
     let nodeStatus = 'collapsed';
     if(!_.isUndefined(nodeStatusObject)) {


### PR DESCRIPTION
Currently the tree node component is not handling click event on the name/description of items but only handling expand collapse through click on the arrow next to each item. This enhancement allows to toggle expand collapse by click directly on the name/description of each item   