### PR TITLE
Feature: System Message Support

### DIFF
--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -755,7 +755,7 @@
   "oidc-user-doesnt-exist-in-tenant-detail": "For email {{-email}} and url {{-url}} and tenant {{-name}}",
   "lang-en": "English",
   "lang-mri": "Māori",
-  "system-message-enabled": "true",
+  "system-message-enabled": "false",
   "system-message-title": "System Notification",
   "system-message-description": "ReDBox will be unavailable from 9am to 12pm on October 20 for system upgrades. Please contact support for any help"
   

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -754,5 +754,9 @@
   "oidc-user-doesnt-exist-in-tenant": "User account from identity provider does not exist in tenant. The account needs to be added as an external user in the tenant first.",
   "oidc-user-doesnt-exist-in-tenant-detail": "For email {{-email}} and url {{-url}} and tenant {{-name}}",
   "lang-en": "English",
-  "lang-mri": "Māori"
+  "lang-mri": "Māori",
+  "system-message-enabled": "true",
+  "system-message-title": "System Notification",
+  "system-message-description": "ReDBox will be unavailable from 9am to 12pm on October 20 for system upgrades. Please contact support for any help"
+  
 }

--- a/assets/styles/default-theme.scss
+++ b/assets/styles/default-theme.scss
@@ -192,6 +192,11 @@ z-index: 999;
   padding: 80px 0 130px;
 }
 
+#system-message-area {
+    padding-top: 80px;
+    display: none;
+  }
+
 .site-branding-area {
   background-color: $site-branding-area-background;
 }

--- a/views/default/default/layout.ejs
+++ b/views/default/default/layout.ejs
@@ -188,7 +188,7 @@
     const currentEpochMillis = Date.now();
 
     localStorage.setItem('systemMessageDismissalTime', currentEpochMillis.toString());
-    $//remove the system message area as it takes up space even when hidden
+    //remove the system message area as it takes up space even when hidden
     const systemMessageArea = document.getElementById('system-message-area');
       systemMessageArea.parentNode.removeChild(systemMessageArea)
   })

--- a/views/default/default/layout.ejs
+++ b/views/default/default/layout.ejs
@@ -115,6 +115,16 @@
 <% if (typeof title!== 'undefined') { %>
 <% } %>
 
+<% if (TranslationService.t('system-message-enabled') == 'true') { %>
+  <div id="system-message-area" class="container">
+  <div id="system-message" class="alert alert-primary alert-dismissible fade show" role="alert">
+    <h4><%- TranslationService.t('system-message-title') %></h4>
+    <div><%- TranslationService.t('system-message-description') %></div>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+  </div>
+</div>
+ <% } %>
+
   <div class="maincontent-body">
     <%- body %>
   </div>
@@ -155,6 +165,33 @@
         curHref.closest('li').addClass('active').closest('.dropdown').addClass('site-branding-area');
       }
     }
+
+    const storedsystemMessageDismissalTime = parseInt(localStorage.getItem('systemMessageDismissalTime'), 10);
+
+   if (storedsystemMessageDismissalTime) {
+    const currentsystemMessageDismissalTime = Date.now();
+    const eightHoursInMillis = 8 * 60 * 60 * 1000; // 8 hours in milliseconds
+    if (currentsystemMessageDismissalTime - storedsystemMessageDismissalTime > eightHoursInMillis) {
+     //Already been dismissed in the past 8 hours so close it
+      $('#system-message-area').show()
+    }  else {
+      //remove the system message area as it takes up space even when hidden
+      const systemMessageArea = document.getElementById('system-message-area');
+      systemMessageArea.parentNode.removeChild(systemMessageArea)
+    }
+  }  else {
+    $('#system-message-area').show()
+  }
+
+    $('#system-message').on('closed.bs.alert', function () {
+
+    const currentEpochMillis = Date.now();
+
+    localStorage.setItem('systemMessageDismissalTime', currentEpochMillis.toString());
+    $//remove the system message area as it takes up space even when hidden
+    const systemMessageArea = document.getElementById('system-message-area');
+      systemMessageArea.parentNode.removeChild(systemMessageArea)
+  })
   });
   </script>
 </body>


### PR DESCRIPTION
Basic support for displaying a system message in the app to allow administrators to notify of upcoming maintenance.

Message is enabled by setting the language code "system-message-enabled" to the value "true". The title of the system message can then be set via "system-message-title" and the description can be set via "system-message-description".

To avoid persistent nagging of users, the message can be dismissed and won't show again on the same browser for a period of 8 hours.

Future versions may move enabling to brand specific configuration and support multiple system message.