### PR TITLE
Hotfix: Emails for pending access were not being lower cased

### DIFF
--- a/typescript/api/services/RDMPService.ts
+++ b/typescript/api/services/RDMPService.ts
@@ -298,7 +298,7 @@ export module Services {
       return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
     }
 
-    protected addEmailToList(contributor, emailProperty, emailList) {
+    protected addEmailToList(contributor, emailProperty, emailList, lowerCaseEmailAddresses:boolean = true) {
       let contributorEmailAddress = _.get(contributor, emailProperty, null);
       if (!contributorEmailAddress) {
         if (!contributor) {
@@ -312,6 +312,9 @@ export module Services {
         }
         if (_.isString(contributorEmailAddress)) {
           sails.log.verbose(`Pushing contrib email address ${contributorEmailAddress}`);
+          if(lowerCaseEmailAddresses) {
+            contributorEmailAddress = contributorEmailAddress.toLowerCase()
+          }
           emailList.push(contributorEmailAddress);
         }
       }


### PR DESCRIPTION
Email Addresses are being made lowercase when stored in the user database but this was not happening for the email addresses stored in the pending access arrays on the record (i.e. editPending and viewPending) so potentially records were not being matched on login for these users.

This fix sets the pending email addresses to lower case