### PR TITLE
Soft delete functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,7 +178,9 @@ dev
 core/dist
 api/models/Record.js
 api/models/RecordAudit.js
+api/models/DeletedRecord.js
 support/raido/src
 support/raido/dist
 support/raido/*.tgz
 angular/.angular/cache/
+

--- a/config/routes.js
+++ b/config/routes.js
@@ -283,6 +283,21 @@ module.exports.routes = {
     action: 'listRecords',
     csrf: false
   },
+  'get /:branding/:portal/api/deletedrecords/list': {
+    controller: 'webservice/RecordController',
+    action: 'listDeletedRecords',
+    csrf: false
+  },
+  'put /:branding/:portal/api/deletedrecords/:oid': {
+    controller: 'webservice/RecordController',
+    action: 'restoreRecord',
+    csrf: false
+  },
+  'delete /:branding/:portal/api/deletedrecords/:oid': {
+    controller: 'webservice/RecordController',
+    action: 'destroyDeletedRecord',
+    csrf: false
+  },
   'get /:branding/:portal/api/records/objectmetadata/:oid': {
     controller: 'webservice/RecordController',
     action: 'getObjectMeta',

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@researchdatabox/redbox-core-types",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@researchdatabox/redbox-core-types",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "ISC",
       "dependencies": {
         "@tsconfig/node18": "^18.2.0"

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@researchdatabox/redbox-core-types",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/core/src/Attachment.ts
+++ b/core/src/Attachment.ts
@@ -29,7 +29,7 @@ export class Attachment {
   dateCreated: any;
   body: any; // bad idea to load everything in-memory
   readstream: any; // strongly suggest services stream rather than load everything in-mem
-
+  size: number; // the number of bytes the attachment is
   constructor() {
   }
 }

--- a/core/src/RecordsService.ts
+++ b/core/src/RecordsService.ts
@@ -1,6 +1,6 @@
 import { StorageService } from "./StorageService";
 
-export interface RecordsService extends StorageService {
+export interface RecordsService {
 
   triggerPreSaveTriggers(oid: string, record: any, recordType: object, mode: string, user): Promise<any>;
   triggerPostSaveTriggers(oid: string, record: any, recordType: object, mode: string, user): void;
@@ -10,7 +10,16 @@ export interface RecordsService extends StorageService {
   appendToRecord(targetRecordOid: string, linkData: any, fieldName: string, fieldType: string, targetRecord: any): Promise<any>
   updateWorkflowStep(currentRec, nextStep): void;
   getAttachments(oid: string, labelFilterStr?: string): Promise<any>;
+  getDeletedRecords(workflowState, recordType, start, rows, username, roles, brand, editAccessOnly, packageType, sort, fieldNames?, filterString?, filterMode?): Promise<any>;
+  getRecords(workflowState, recordType, start, rows, username, roles, brand, editAccessOnly, packageType, sort, fieldNames?, filterString?, filterMode?): Promise<any>;
+  create(brand, record, recordType, user?):Promise<any>;
   updateMeta(brand, oid, record, user?, triggerPreSaveTriggers?, triggerPostSaveTriggers?): Promise<any>;
+  delete(oid, permanentlyDelete, user): Promise<any>;
+  destroyDeletedRecord(oid: any, user:any): Promise<any>;
+  getMeta(oid): Promise<any>;
+  restoreRecord(oid,user): Promise<any>;
+  getRecordAudit(params): Promise<any>;
+  getRelatedRecords(oid, brand): Promise<any>;
   // Probably to be retired or reimplemented in a different service
   checkRedboxRunning(): Promise<any>;
 

--- a/core/src/StorageService.ts
+++ b/core/src/StorageService.ts
@@ -8,10 +8,14 @@ export interface StorageService{
   createBatch(type, data, harvestIdFldName): Promise<any>;
   provideUserAccessAndRemovePendingAccess(oid, userid, pendingValue): void;
   getRelatedRecords(oid, brand): Promise<any>;
-  delete(oid): Promise<any>;
+  delete(oid, permanentlyDelete): Promise<any>;
   updateNotificationLog(oid, record, options): Promise<any>;
 
+  restoreRecord(oid): Promise<any>;
+  destroyDeletedRecord(oid): Promise<any>;
+
   getRecords(workflowState, recordType, start, rows, username, roles, brand, editAccessOnly, packageType, sort, fieldNames?, filterString?, filterMode?): Promise<any>;
+  getDeletedRecords(workflowState, recordType, start, rows, username, roles, brand, editAccessOnly, packageType, sort, fieldNames?, filterString?, filterMode?): Promise<any>;
   exportAllPlans(username, roles, brand, format, modBefore, modAfter, recType): Readable;
 
   createRecordAudit?(record):Promise<any>;

--- a/core/src/model/RecordAuditModel.ts
+++ b/core/src/model/RecordAuditModel.ts
@@ -1,15 +1,17 @@
 declare var _:any;
 export class RecordAuditModel {
     redboxOid: string;
+    action:string;
     user: any;
     record: any;
 
-    constructor(oid, record,user) {
+    constructor(oid, record, user, action:string = 'update') {
         if (user!= null && !_.isEmpty(user.password)) {
             delete user.password;
         }
         this.redboxOid = oid;
         this.record = record;
         this.user = user;
+        this.action = action;
     }
 }

--- a/core/src/model/RecordAuditModel.ts
+++ b/core/src/model/RecordAuditModel.ts
@@ -1,11 +1,11 @@
 declare var _:any;
 export class RecordAuditModel {
     redboxOid: string;
-    action:string;
+    action:RecordAuditActionType;
     user: any;
     record: any;
 
-    constructor(oid, record, user, action:string = 'update') {
+    constructor(oid, record, user, action:RecordAuditActionType = RecordAuditActionType.updated) {
         if (user!= null && !_.isEmpty(user.password)) {
             delete user.password;
         }
@@ -14,4 +14,12 @@ export class RecordAuditModel {
         this.user = user;
         this.action = action;
     }
+}
+
+export enum RecordAuditActionType {
+    created = 'created',
+    updated = 'updated',
+    deleted = 'deleted',
+    permanentlyDeleted = 'perm_deleted',
+    restored = 'restored'
 }

--- a/core/src/model/RecordAuditModel.ts
+++ b/core/src/model/RecordAuditModel.ts
@@ -20,6 +20,6 @@ export enum RecordAuditActionType {
     created = 'created',
     updated = 'updated',
     deleted = 'deleted',
-    permanentlyDeleted = 'perm_deleted',
+    destroyed = 'destroyed',
     restored = 'restored'
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@researchdatabox/raido-openapi-generated-node": "^0.0.2",
         "@researchdatabox/redbox-core-types": "^1.4.3",
-        "@researchdatabox/sails-hook-redbox-storage-mongo": "^1.4.3",
+        "@researchdatabox/sails-hook-redbox-storage-mongo": "^1.4.4",
         "@researchdatabox/sails-ng-common": "^0.1.0",
         "@tsconfig/node18": "^18.2.2",
         "agenda": "github:redbox-mint-contrib/agenda#dist",
@@ -442,9 +442,9 @@
       }
     },
     "node_modules/@researchdatabox/sails-hook-redbox-storage-mongo": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@researchdatabox/sails-hook-redbox-storage-mongo/-/sails-hook-redbox-storage-mongo-1.4.3.tgz",
-      "integrity": "sha512-hqe7HgAaL2vriwHtVBBkoBkI3/hZjDZwTdz6Qn4lC44+27iSX0+hwEka6ry0LnYTQckvubCAdYvfaP9mqasPHQ==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@researchdatabox/sails-hook-redbox-storage-mongo/-/sails-hook-redbox-storage-mongo-1.4.4.tgz",
+      "integrity": "sha512-auhOHmTvJXXFpMs7PWDQzY4uTRSAbf0a7u2dLV/+woCv11ajkemI++qSc/4LHXTFd5BVW2u9YmO1ygErI9RkjQ==",
       "dependencies": {
         "json2csv": "^5.0.3",
         "lodash": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL2",
       "dependencies": {
         "@researchdatabox/raido-openapi-generated-node": "^0.0.2",
-        "@researchdatabox/redbox-core-types": "^1.4.2",
+        "@researchdatabox/redbox-core-types": "^1.4.3",
         "@researchdatabox/sails-hook-redbox-storage-mongo": "^1.4.3",
         "@researchdatabox/sails-ng-common": "^0.1.0",
         "@tsconfig/node18": "^18.2.2",
@@ -434,9 +434,9 @@
       "integrity": "sha512-Q9h0PYZZBWSELCkBSwGqG//ynOUSAYEwieFM5lfi27A2k1C86ayHoDThbRq7XqGmSbaE+EhmX3lxdiAhkkPNig=="
     },
     "node_modules/@researchdatabox/redbox-core-types": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@researchdatabox/redbox-core-types/-/redbox-core-types-1.4.2.tgz",
-      "integrity": "sha512-npuaYjnbS2Ed8khDCGYJBiXnu6U3Vkd40b2/KArKCB2XD1xGwtp93ZpncueMVrbgPAUk8IuEEWtdmEGCK+4NKQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@researchdatabox/redbox-core-types/-/redbox-core-types-1.4.3.tgz",
+      "integrity": "sha512-Krxi2jxUUH+pl/XmZ5ze7Ko22S5ZLjX0cMLWNsyymavw1/gsXxdaJUgtXUQyFpEMmDlOrDYLn08/1v7Ojctauw==",
       "dependencies": {
         "@tsconfig/node18": "^18.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@researchdatabox/raido-openapi-generated-node": "^0.0.2",
     "@researchdatabox/redbox-core-types": "^1.4.3",
-    "@researchdatabox/sails-hook-redbox-storage-mongo": "^1.4.3",
+    "@researchdatabox/sails-hook-redbox-storage-mongo": "^1.4.4",
     "@researchdatabox/sails-ng-common": "^0.1.0",
     "@tsconfig/node18": "^18.2.2",
     "agenda": "github:redbox-mint-contrib/agenda#dist",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": [],
   "dependencies": {
     "@researchdatabox/raido-openapi-generated-node": "^0.0.2",
-    "@researchdatabox/redbox-core-types": "^1.4.2",
+    "@researchdatabox/redbox-core-types": "^1.4.3",
     "@researchdatabox/sails-hook-redbox-storage-mongo": "^1.4.3",
     "@researchdatabox/sails-ng-common": "^0.1.0",
     "@tsconfig/node18": "^18.2.2",

--- a/test/postman/test-collection.json
+++ b/test/postman/test-collection.json
@@ -6566,7 +6566,7 @@
 									"});",
 									"",
 									"pm.test(\"Has valid content\", function () {",
-									"    pm.expect(pm.response.stream.toString()).to.match(/^@charset \"UTF-8\"/)",
+									"    pm.expect(pm.response.stream.toString()).to.match(/^.*@charset \"UTF-8\"/)",
 									"});",
 									""
 								],

--- a/test/postman/test-collection.json
+++ b/test/postman/test-collection.json
@@ -1,8 +1,9 @@
 {
 	"info": {
-		"_postman_id": "816374e1-fedf-4203-ad54-8bab7ab2a6fd",
+		"_postman_id": "e8c23941-c2d8-4537-810f-031a881dd33d",
 		"name": "Redbox Portal API - With tests",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "6438809"
 	},
 	"item": [
 		{
@@ -728,6 +729,213 @@
 									]
 								},
 								"description": "Delete Record"
+							},
+							"response": []
+						},
+						{
+							"name": "List Deleted RDMPs",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"There is more than 1 RDMP record in the records\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.records.length).to.be.greaterThan(0);",
+											"});",
+											"",
+											"pm.test(\"Check record has oid and metadata properties\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.records[0]).to.have.property(\"oid\")",
+											"    pm.expect(jsonData.records[0]).to.have.property(\"deletedRecord\")",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}",
+										"type": "text"
+									},
+									{
+										"key": "",
+										"value": "",
+										"type": "text",
+										"disabled": true
+									}
+								],
+								"url": {
+									"raw": "{{host}}/default/rdmp/api/deletedrecords/list?recordType=rdmp",
+									"host": [
+										"{{host}}"
+									],
+									"path": [
+										"default",
+										"rdmp",
+										"api",
+										"deletedrecords",
+										"list"
+									],
+									"query": [
+										{
+											"key": "recordType",
+											"value": "rdmp"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Restore Deleted Record",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}",
+										"type": "text"
+									},
+									{
+										"key": "",
+										"value": "",
+										"type": "text",
+										"disabled": true
+									}
+								],
+								"url": {
+									"raw": "{{host}}/default/rdmp/api/deletedrecords/{{dmpOidToDelete}}",
+									"host": [
+										"{{host}}"
+									],
+									"path": [
+										"default",
+										"rdmp",
+										"api",
+										"deletedrecords",
+										"{{dmpOidToDelete}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete Record Again",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Success is set and is true\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData).to.have.property('success');",
+											"    pm.expect(jsonData.success).to.eql(true);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{token}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{host}}/default/rdmp/api/records/metadata/{{dmpOidToDelete}}",
+									"host": [
+										"{{host}}"
+									],
+									"path": [
+										"default",
+										"rdmp",
+										"api",
+										"records",
+										"metadata",
+										"{{dmpOidToDelete}}"
+									]
+								},
+								"description": "Delete Record"
+							},
+							"response": []
+						},
+						{
+							"name": "Destroy Deleted Record",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}",
+										"type": "text"
+									},
+									{
+										"key": "",
+										"value": "",
+										"type": "text",
+										"disabled": true
+									}
+								],
+								"url": {
+									"raw": "{{host}}/default/rdmp/api/deletedrecords/{{dmpOidToDelete}}",
+									"host": [
+										"{{host}}"
+									],
+									"path": [
+										"default",
+										"rdmp",
+										"api",
+										"deletedrecords",
+										"{{dmpOidToDelete}}"
+									]
+								}
 							},
 							"response": []
 						},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "compilerOptions": {
       "outDir": "./",
       "rootDir": "./typescript",
-      "strict": false
+      "strict": false,
+      "inlineSourceMap": true
     },
     "exclude": [
       "node_modules/**",

--- a/typescript/api/controllers/RecordController.ts
+++ b/typescript/api/controllers/RecordController.ts
@@ -633,7 +633,7 @@ export module Controllers {
       })
         .flatMap(hasEditAccess => {
           if (hasEditAccess) {
-            return Observable.fromPromise(this.recordsService.delete(oid, false));
+            return Observable.fromPromise(this.recordsService.delete(oid, false, user));
           }
           message = TranslationService.t('edit-error-no-permissions');
           return Observable.throw(new Error(TranslationService.t('edit-error-no-permissions')));
@@ -729,7 +729,7 @@ export module Controllers {
 
       try {
         if (metadata.delete) {
-          let response = await this.recordsService.delete(oid, false);
+          let response = await this.recordsService.delete(oid, false, user);
           if (response && response.isSuccessful()) {
             response.success = true;
             sails.log.verbose(`Successfully deleted: ${oid}`);

--- a/typescript/api/controllers/RecordController.ts
+++ b/typescript/api/controllers/RecordController.ts
@@ -633,7 +633,7 @@ export module Controllers {
       })
         .flatMap(hasEditAccess => {
           if (hasEditAccess) {
-            return Observable.fromPromise(this.recordsService.delete(oid));
+            return Observable.fromPromise(this.recordsService.delete(oid, false));
           }
           message = TranslationService.t('edit-error-no-permissions');
           return Observable.throw(new Error(TranslationService.t('edit-error-no-permissions')));
@@ -729,7 +729,7 @@ export module Controllers {
 
       try {
         if (metadata.delete) {
-          let response = await this.recordsService.delete(oid);
+          let response = await this.recordsService.delete(oid, false);
           if (response && response.isSuccessful()) {
             response.success = true;
             sails.log.verbose(`Successfully deleted: ${oid}`);

--- a/typescript/api/controllers/webservice/RecordController.ts
+++ b/typescript/api/controllers/webservice/RecordController.ts
@@ -70,7 +70,10 @@ export module Controllers {
       'getDataStream',
       'addDataStreams',
       'listRecords',
+      'listDeletedRecords',
       'deleteRecord',
+      'destroyDeletedRecord',
+      'restoreRecord',
       'transitionWorkflow',
       'listDatastreams',
       'addRoleEdit',
@@ -668,6 +671,52 @@ export module Controllers {
 
     }
 
+    protected async getDeletedRecords(workflowState, recordType, start, rows, user, roles, brand, editAccessOnly = undefined, packageType = undefined, sort = undefined, fieldNames = undefined, filterString = undefined) {
+      const username = user.username;
+      if (!_.isUndefined(recordType) && !_.isEmpty(recordType)) {
+        recordType = recordType.split(',');
+      }
+      if (!_.isUndefined(packageType) && !_.isEmpty(packageType)) {
+        packageType = packageType.split(',');
+      }
+      if (start == null) {
+        start = 0;
+      }
+      if (rows == undefined) {
+        rows = 10;
+      }
+      var results = await this.RecordsService.getDeletedRecords(workflowState, recordType, start, rows, username, roles, brand, editAccessOnly, packageType, sort, fieldNames, filterString);
+      sails.log.debug(results);
+      let apiReponse: ListAPIResponse<any> = new ListAPIResponse();
+      var totalItems = results.totalItems
+      var startIndex = start;
+      var noItems = rows;
+      var pageNumber = Math.floor((startIndex / noItems) + 1);
+
+      apiReponse.summary.numFound = totalItems;
+      apiReponse.summary.start = startIndex;
+      apiReponse.summary.page = pageNumber;
+
+
+      var items = [];
+      var docs = results["items"];
+
+      for (var i = 0; i < docs.length; i++) {
+        var doc = docs[i];
+        var item = {};
+        item["oid"] = doc["redboxOid"];
+        item["title"] = doc["deletedRecordMetadata"]["metadata"]["title"];
+        item["deletedRecord"] = doc["deletedRecordMetadata"];
+        item["dateCreated"] = doc["dateCreated"];
+        item["dateModified"] = doc["lastSaveDate"];
+        item["dateDeleted"]  = doc["dateDeleted"];
+        items.push(item);
+      }
+      apiReponse.records = items;
+      return apiReponse;
+
+    }
+
     public listRecords(req, res) {
       //sails.log.debug('api-list-records');
       const brand = BrandingService.getBrand(req.session.branding);
@@ -727,18 +776,51 @@ export module Controllers {
       }
     }
 
-    public async deleteRecord(req, res) {
+    public async restoreRecord(req, res) {
       const oid = req.param('oid');
-      const permanentlyDelete = _.isEmpty(req.param('permanent')) ? req.param('permanent') : false ;
+      var user = req.user;
       if (_.isEmpty(oid)) {
         return this.apiFail(req, res, 400, new APIErrorResponse("Missing ID of record."));
       }
 
-      const response = await this.RecordsService.delete(oid, permanentlyDelete);
+      const response = await this.RecordsService.restoreRecord(oid,user);
       if (response.isSuccessful()) {
         this.apiRespond(req, res, response);
       } else {
         sails.log.verbose(`Delete attempt failed for OID: ${oid}`);
+        sails.log.verbose(JSON.stringify(response));
+        this.apiFail(req, res, 500, new APIErrorResponse(response.message, response.details));
+      }
+    }
+
+    public async deleteRecord(req, res) {
+      const oid = req.param('oid');
+      const permanentlyDelete = req.param('permanent') === 'true' ? true : false ;
+      const user = req.user;
+      if (_.isEmpty(oid)) {
+        return this.apiFail(req, res, 400, new APIErrorResponse("Missing ID of record."));
+      }
+      const response = await this.RecordsService.delete(oid, permanentlyDelete, user);
+      if (response.isSuccessful()) {
+        this.apiRespond(req, res, response);
+      } else {
+        sails.log.verbose(`Delete attempt failed for OID: ${oid}`);
+        sails.log.verbose(JSON.stringify(response));
+        this.apiFail(req, res, 500, new APIErrorResponse(response.message, response.details));
+      }
+    }
+
+    public async destroyDeletedRecord(req, res) {
+      const oid = req.param('oid');
+      const user = req.user;
+      if (_.isEmpty(oid)) {
+        return this.apiFail(req, res, 400, new APIErrorResponse("Missing ID of record."));
+      }
+      const response = await this.RecordsService.destroyDeletedRecord(oid, user);
+      if (response.isSuccessful()) {
+        this.apiRespond(req, res, response);
+      } else {
+        sails.log.verbose(`Destroy attempt failed for OID: ${oid}`);
         sails.log.verbose(JSON.stringify(response));
         this.apiFail(req, res, 500, new APIErrorResponse(response.message, response.details));
       }
@@ -1092,6 +1174,66 @@ export module Controllers {
 
 
 
+    }
+
+
+    public listDeletedRecords(req, res) {
+      //sails.log.debug('api-list-records');
+      const brand = BrandingService.getBrand(req.session.branding);
+      const editAccessOnly = req.query.editOnly;
+
+      var roles = [];
+      var username = "guest";
+      let user = {};
+      if (req.isAuthenticated()) {
+        roles = req.user.roles;
+        user = req.user;
+        username = req.user.username;
+      } else {
+        // assign default role if needed...
+        user = { username: username };
+        roles = [];
+        roles.push(RolesService.getDefUnathenticatedRole(brand));
+      }
+      const recordType = req.param('recordType');
+      const workflowState = req.param('state');
+      const start = req.param('start');
+      const rows = req.param('rows');
+      const packageType = req.param('packageType');
+      const sort = req.param('sort');
+      const filterFieldString = req.param('filterFields');
+      let filterString = req.param('filter');
+      let filterFields = undefined;
+
+      if (!_.isEmpty(filterFieldString)) {
+        filterFields = filterString.split(',')
+      } else {
+        filterString = undefined;
+      }
+
+      if (rows > parseInt(sails.config.api.max_requests)) {
+        var error = {
+          "code": 400,
+          "contactEmail": null,
+          "description": "You have reached the maximum of request available; Max rows per request " + sails.config.api.max_requests,
+          "homeRef": "/",
+          "reasonPhrase": "Bad Request",
+          "uri": "http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1"
+        };
+        res.status(400);
+        res.json(error);
+      } else {
+        // sails.log.debug(`getRecords: ${recordType} ${workflowState} ${start}`);
+        // sails.log.debug(`${rows} ${packageType} ${sort}`);
+        this.getDeletedRecords(workflowState, recordType, start, rows, user, roles, brand, editAccessOnly, packageType, sort, filterFields, filterString).then(response => {
+          res.json(response);
+        }).catch(error => {
+          sails.log.error("Error:");
+          sails.log.error(error);
+          var err = error['error'];
+          res.json(err);
+        });
+      }
     }
 
   }

--- a/typescript/api/controllers/webservice/RecordController.ts
+++ b/typescript/api/controllers/webservice/RecordController.ts
@@ -729,10 +729,12 @@ export module Controllers {
 
     public async deleteRecord(req, res) {
       const oid = req.param('oid');
+      const permanentlyDelete = _.isEmpty(req.param('permanent')) ? req.param('permanent') : false ;
       if (_.isEmpty(oid)) {
         return this.apiFail(req, res, 400, new APIErrorResponse("Missing ID of record."));
       }
-      const response = await this.RecordsService.delete(oid);
+
+      const response = await this.RecordsService.delete(oid, permanentlyDelete);
       if (response.isSuccessful()) {
         this.apiRespond(req, res, response);
       } else {

--- a/typescript/api/services/RecordsService.ts
+++ b/typescript/api/services/RecordsService.ts
@@ -127,6 +127,9 @@ export module Services {
       'deleteFilesFromStageDir',
       'getRelatedRecords',
       'delete',
+      'restoreRecord',
+      'destroyDeletedRecord',
+      'getDeletedRecords',
       'updateNotificationLog',
       'updateWorkflowStep',
       'triggerPreSaveTriggers',
@@ -299,8 +302,8 @@ export module Services {
       return this.storageService.getRelatedRecords(oid, brand);
     }
 
-    async delete(oid: any) {
-      const response = await this.storageService.delete(oid);
+    async delete(oid: any, permanentlyDelete:boolean) {
+      const response = await this.storageService.delete(oid, permanentlyDelete);
       if (response.isSuccessful()) {
         this.searchService.remove(oid);
       }
@@ -688,6 +691,23 @@ export module Services {
       //   return Observable.of(record);
       // });
     }
+
+    async restoreRecord(oid: any): Promise<any> {
+      return await this.storageService.restoreRecord(oid);
+    }
+
+    async destroyDeletedRecord(oid: any): Promise<any> {
+      return await this.storageService.destroyDeletedRecord(oid);
+    }
+
+    async getDeletedRecords(workflowState: any, recordType: any, start: any, rows: any, username: any, roles: any, brand: any, editAccessOnly: any, packageType: any, sort: any, fieldNames?: any, filterString?: any, filterMode?: any): Promise<any> {
+      return await this.storageService.getDeletedRecords(workflowState,recordType,start,rows,username,roles,brand,editAccessOnly,packageType,sort,fieldNames,filterString,filterMode);
+    }
+
+    async createRecordAudit?(record: any): Promise<any> {
+      return await this.storageService.createRecordAudit(record);
+    }
+
 
     public updateWorkflowStep(currentRec, nextStep): void {
       if (!_.isEmpty(nextStep)) {

--- a/typescript/api/services/RecordsService.ts
+++ b/typescript/api/services/RecordsService.ts
@@ -306,7 +306,7 @@ export module Services {
     async delete(oid: any, permanentlyDelete:boolean, user:any) {
       const response = await this.storageService.delete(oid, permanentlyDelete);
       if (response.isSuccessful()) {
-        let action:RecordAuditActionType = permanentlyDelete? RecordAuditActionType.permanentlyDeleted : RecordAuditActionType.deleted;
+        let action:RecordAuditActionType = permanentlyDelete? RecordAuditActionType.destroyed : RecordAuditActionType.deleted;
         this.auditRecord(oid,{}, user, action)
         this.searchService.remove(oid);
       }
@@ -706,7 +706,7 @@ export module Services {
 
     async destroyDeletedRecord(oid: any, user:any): Promise<any> {
       let record = await this.storageService.destroyDeletedRecord(oid);
-      this.auditRecord(oid, record, user, RecordAuditActionType.permanentlyDeleted)
+      this.auditRecord(oid, record, user, RecordAuditActionType.destroyed)
       return record
     }
 


### PR DESCRIPTION
This PR incorporates the new storage driver functions released in [sails-hook-redbox-storage-mongo](https://github.com/redbox-mint/sails-hook-redbox-storage-mongo/releases/tag/v1.4.4) and adds webservice endpoints to support:
1. Soft deletion of records (records move to a deleted record collection rather than being permanently deleted)
2. List deleted records
3. Restore a deleted record
4. Permanently destroy a deleted record

Also incorporates the new redbox-core-types version v1.4.3 which adds support for including the type of action occurred on the record (i.e. created, updated, deleted, recovered or destroyed).