### PR TITLE
Feature: Use of IS08601 dates for exports

### DIFF
--- a/angular/projects/researchdatabox/export/src/app/export.component.spec.ts
+++ b/angular/projects/researchdatabox/export/src/app/export.component.spec.ts
@@ -93,8 +93,11 @@ describe('ExportComponent', () => {
     let generatedUrl:string = `${recordService.brandingAndPortalUrl}/export/record/download/csv?before=&after=&recType=rdmp`;
     expect(url).toEqual(generatedUrl);
     // test with modified after set
-    const dateNow = DateTime.local();
-    const dateNowStr = dateNow.toFormat('yyyy-MM-ddTHH:mm:ss.SSSZ');
+    let dateNow = DateTime.local();
+    dateNow = dateNow.startOf('day');
+    const dateEnd = dateNow.endOf('day');
+    const dateEndStr = dateEnd.toFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+    const dateNowStr = dateNow.toFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
     app.modAfter = dateNow.toJSDate();
     app.download();
     generatedUrl = `${recordService.brandingAndPortalUrl}/export/record/download/csv?before=&after=${dateNowStr}&recType=rdmp`;
@@ -102,17 +105,17 @@ describe('ExportComponent', () => {
     // test with modified before set
     app.modBefore = dateNow.toJSDate();
     app.download();
-    generatedUrl = `${recordService.brandingAndPortalUrl}/export/record/download/csv?before=${dateNowStr}&after=${dateNowStr}&recType=rdmp`;
+    generatedUrl = `${recordService.brandingAndPortalUrl}/export/record/download/csv?before=${dateEndStr}&after=${dateNowStr}&recType=rdmp`;
     expect(url).toEqual(generatedUrl);
     // test with different data type
     app.setRecordType('dataRecord', event);
     app.download();
-    generatedUrl = `${recordService.brandingAndPortalUrl}/export/record/download/csv?before=${dateNowStr}&after=${dateNowStr}&recType=dataRecord`;
+    generatedUrl = `${recordService.brandingAndPortalUrl}/export/record/download/csv?before=${dateEndStr}&after=${dateNowStr}&recType=dataRecord`;
     expect(url).toEqual(generatedUrl);
     // test with different format
     app.setExportFormat('json', event);
     app.download();
-    generatedUrl = `${recordService.brandingAndPortalUrl}/export/record/download/json?before=${dateNowStr}&after=${dateNowStr}&recType=dataRecord`;
+    generatedUrl = `${recordService.brandingAndPortalUrl}/export/record/download/json?before=${dateEndStr}&after=${dateNowStr}&recType=dataRecord`;
     expect(url).toEqual(generatedUrl);
   });
 });

--- a/angular/projects/researchdatabox/export/src/app/export.component.spec.ts
+++ b/angular/projects/researchdatabox/export/src/app/export.component.spec.ts
@@ -94,7 +94,7 @@ describe('ExportComponent', () => {
     expect(url).toEqual(generatedUrl);
     // test with modified after set
     const dateNow = DateTime.local();
-    const dateNowStr = dateNow.toFormat('yyyy-MM-dd');
+    const dateNowStr = dateNow.toFormat('yyyy-MM-ddTHH:mm:ss.SSSZ');
     app.modAfter = dateNow.toJSDate();
     app.download();
     generatedUrl = `${recordService.brandingAndPortalUrl}/export/record/download/csv?before=&after=${dateNowStr}&recType=rdmp`;

--- a/angular/projects/researchdatabox/export/src/app/export.component.ts
+++ b/angular/projects/researchdatabox/export/src/app/export.component.ts
@@ -72,9 +72,18 @@ export class ExportComponent extends BaseComponent {
   }
 
   download() {
-    const formatStr = 'yyyy-MM-dd'
-    const before = this.modBefore ? DateTime.fromObject(this.modBefore).toFormat(formatStr) : '';
-    const after = this.modAfter ? DateTime.fromObject(this.modAfter).toFormat(formatStr) : '';
+    let before = '';
+    let after = '';
+    if(this.modBefore) {
+      this.modBefore.setHours(23,59,59,999);
+      before = this.modBefore.toISOString();
+    }
+    if(this.modAfter) {
+      this.modAfter.setHours(0,0,0,0);
+      after = this.modAfter.toISOString();
+    }
+    
+    
     const url = `${this.recordService.brandingAndPortalUrl}/export/record/download/${this.export_format}?before=${before}&after=${after}&recType=${this.record_type}`;
     this.window.open(url, '_blank');
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@researchdatabox/raido-openapi-generated-node": "^0.0.2",
         "@researchdatabox/redbox-core-types": "^1.4.3",
-        "@researchdatabox/sails-hook-redbox-storage-mongo": "^1.4.4",
+        "@researchdatabox/sails-hook-redbox-storage-mongo": "^1.4.5",
         "@researchdatabox/sails-ng-common": "^0.1.0",
         "@tsconfig/node18": "^18.2.2",
         "agenda": "github:redbox-mint-contrib/agenda#dist",
@@ -442,9 +442,9 @@
       }
     },
     "node_modules/@researchdatabox/sails-hook-redbox-storage-mongo": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@researchdatabox/sails-hook-redbox-storage-mongo/-/sails-hook-redbox-storage-mongo-1.4.4.tgz",
-      "integrity": "sha512-auhOHmTvJXXFpMs7PWDQzY4uTRSAbf0a7u2dLV/+woCv11ajkemI++qSc/4LHXTFd5BVW2u9YmO1ygErI9RkjQ==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@researchdatabox/sails-hook-redbox-storage-mongo/-/sails-hook-redbox-storage-mongo-1.4.5.tgz",
+      "integrity": "sha512-h5Yb40tkk+LozECSIMgQ5vPDD0zeQ8+aoemKv/ALdqj9QNFzet9JekEw8KbubD+/3Xd3NpA4kTM2Zpyah0+lnA==",
       "dependencies": {
         "json2csv": "^5.0.3",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@researchdatabox/raido-openapi-generated-node": "^0.0.2",
     "@researchdatabox/redbox-core-types": "^1.4.3",
-    "@researchdatabox/sails-hook-redbox-storage-mongo": "^1.4.4",
+    "@researchdatabox/sails-hook-redbox-storage-mongo": "^1.4.5",
     "@researchdatabox/sails-ng-common": "^0.1.0",
     "@tsconfig/node18": "^18.2.2",
     "agenda": "github:redbox-mint-contrib/agenda#dist",


### PR DESCRIPTION
The export screen previously passed the day month and year values for the date modified range to the backend. This no longer works since upgrading to Mongo 6 and didn't meet users expectations as the date range was using UTC on the server side.
This change sends ISO8601 formatted date strings which addresses both issues.
Related change was also made to the storage plugin https://github.com/redbox-mint/sails-hook-redbox-storage-mongo/pull/7