### PR TITLE
Remove unresolved promise warnings in dev

### DIFF
--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -31,19 +31,19 @@
    sails.log.verbose("Pathrules service, bootstrapped.");
    let pathRulesBootstrapResult = await sails.services.pathrulesservice.bootstrap(defUserAndDefRoles.defUser, defUserAndDefRoles.defRoles).toPromise();
    sails.log.verbose("Record types service, bootstrapped.");
-   let recordsTypes = await sails.services.recordtypesservice.bootstrap(sails.services.brandingservice.getDefault()).toPromise();
+   let recordsTypes = await sails.services.recordtypesservice.bootstrap(sails.services.brandingservice.getDefault());
    sails.log.verbose("Workflowsteps service, bootstrapped.");
-   let dashboardTypes = await sails.services.dashboardtypesservice.bootstrap(sails.services.brandingservice.getDefault()).toPromise();
+   let dashboardTypes = await sails.services.dashboardtypesservice.bootstrap(sails.services.brandingservice.getDefault());
    sails.log.verbose("DashboardTypes service, bootstrapped.");
-   let workflowSteps = await sails.services.workflowstepsservice.bootstrap(recordsTypes).toPromise();
+   let workflowSteps = await sails.services.workflowstepsservice.bootstrap(recordsTypes);
    sails.log.verbose("Workflowsteps service, bootstrapped.");
    if (_.isArray(workflowSteps)) {
  
      for (let workflowStep of workflowSteps) {
-       await sails.services.formsservice.bootstrap(workflowStep).toPromise();
+       await sails.services.formsservice.bootstrap(workflowStep);
      }
    } else {
-     await sails.services.formsservice.bootstrap(workflowSteps).toPromise();
+     await sails.services.formsservice.bootstrap(workflowSteps);
    }
  
  


### PR DESCRIPTION
Some bootstrap functions were declaring promises that are never resolved due to business logic. A library named parley was detecting these promises and warning that they weren't (correctly) resolving when in development mode. To avoid misinterpretation, the services have been refactored so they do resolve removing the warnings. 