### PR TITLE
Record assign permission fix and more unit tests

### DIFF
--- a/test/unit/services/RDMPService.test.js
+++ b/test/unit/services/RDMPService.test.js
@@ -1,0 +1,389 @@
+describe('The RDMPService', function () {
+    const userAdminDefault = {
+        type: 'local',
+        name: 'admin',
+        username: 'admin',
+        password: 'rbadmin',
+        email: "admin@redboxresearchdata.com.au"
+    };
+    const userAdmin1 = {
+        type: 'local',
+        name: 'admin1',
+        username: 'admin1',
+        password: 'rbadmin1',
+        email: "admin1@redboxresearchdata.com.au"
+    };
+    const userNotInDB1 = {
+        type: 'local',
+        name: 'standard1',
+        username: 'standard1',
+        password: 'rbstandard1',
+        email: "standard1@redboxresearchdata.com.au"
+    };
+    const userNotInDB2 = {
+        type: 'local',
+        name: 'standard2',
+        username: 'standard2',
+        password: 'rbstandard2',
+        email: "standard2@redboxresearchdata.com.au"
+    };
+    before(function () {
+        // add another user
+        return User.create(userAdmin1);
+    });
+    after(function () {
+        // remove the users added in `before`
+        return User.destroyOne({name: userAdmin1.name});
+    });
+    describe('assign permissions as expected', function () {
+        it('assignPermissions with no viewers or editors', function (done) {
+            const oid = "assignPermissions-no-viewers-no-editors";
+            const record = {
+                metaMetadata: {},
+                workflow: {},
+                authorization: {
+                    edit: [],
+                    view: [],
+                    editRoles: ['Admin'],
+                    viewRoles: ['Admin'],
+                    editPending: [],
+                    viewPending: []
+                },
+                metadata: {
+                    contributor_ci: {
+                        "text_full_name": "AAAA AAAA",
+                        "full_name_honorific": " AAAA AAAA",
+                        "email": [userAdminDefault.email],
+                        "orcid": ""
+                    }
+                }
+            };
+            const options = {
+                "emailProperty": "email",
+                "editContributorProperties": [
+                    "metadata.contributor_data_manager",
+                    "metadata.dataowner_email"
+                ],
+                "viewContributorProperties": [
+                    "metadata.contributor_data_manager",
+                    "metadata.contributor_supervisor",
+                    "metadata.contributors"
+                ],
+                "recordCreatorPermissions": "view&edit"
+            };
+            RDMPService.assignPermissions(oid, record, options).subscribe(function (record) {
+                expect(record.authorization.edit).to.be.empty;
+                expect(record.authorization.view).to.be.empty;
+                expect(record.authorization.editPending).to.be.empty;
+                expect(record.authorization.viewPending).to.be.empty;
+                User.count().then(function (count) {
+                    expect(count).equal(2);
+                    done();
+                });
+            });
+        });
+        it('assignPermissions with only viewers', function (done) {
+            const oid = "assignPermissions-has-viewers-no-editors";
+            const record = {
+                metaMetadata: {},
+                workflow: {},
+                authorization: {
+                    edit: [],
+                    view: [],
+                    editRoles: ['Admin'],
+                    viewRoles: ['Admin'],
+                    editPending: [],
+                    viewPending: []
+                },
+                metadata: {
+                    contributor_ci: {
+                        "text_full_name": "AAAA AAAA",
+                        "full_name_honorific": " AAAA AAAA",
+                        "email": [userAdminDefault.email],
+                        "orcid": ""
+                    }
+                }
+            };
+            const options = {
+                "emailProperty": "email",
+                "editContributorProperties": [
+                    "metadata.contributor_data_manager",
+                    "metadata.dataowner_email"
+                ],
+                "viewContributorProperties": [
+                    "metadata.contributor_ci",
+                    "metadata.contributor_data_manager",
+                    "metadata.contributor_supervisor",
+                    "metadata.contributors"
+                ],
+                "recordCreatorPermissions": "view&edit"
+            };
+            RDMPService.assignPermissions(oid, record, options).subscribe(function (record) {
+                expect(record.authorization.edit).to.be.empty;
+                expect(record.authorization.view).eql([userAdminDefault.name, undefined]);
+                expect(record.authorization.editPending).to.be.empty;
+                expect(record.authorization.viewPending).to.be.empty;
+                User.count().then(function (count) {
+                    expect(count).equal(2);
+                    done();
+                });
+            });
+        });
+        it('assignPermissions with only editors', function (done) {
+            const oid = "assignPermissions-no-viewers-has-editors";
+            const record = {
+                metaMetadata: {},
+                workflow: {},
+                authorization: {
+                    edit: [],
+                    view: [],
+                    editRoles: ['Admin'],
+                    viewRoles: ['Admin'],
+                    editPending: [],
+                    viewPending: []
+                },
+                metadata: {
+                    contributor_ci: {
+                        "text_full_name": "AAAA AAAA",
+                        "full_name_honorific": " AAAA AAAA",
+                        "email": [userAdminDefault.email],
+                        "orcid": ""
+                    }
+                }
+            };
+            const options = {
+                "emailProperty": "email",
+                "editContributorProperties": [
+                    "metadata.contributor_ci",
+                    "metadata.contributor_data_manager",
+                    "metadata.dataowner_email"
+                ],
+                "viewContributorProperties": [
+                    "metadata.contributor_data_manager",
+                    "metadata.contributor_supervisor",
+                    "metadata.contributors"
+                ],
+                "recordCreatorPermissions": "view&edit"
+            };
+            RDMPService.assignPermissions(oid, record, options).subscribe(function (record) {
+                expect(record.authorization.edit).eql([userAdminDefault.name, undefined]);
+                expect(record.authorization.view).eql([undefined,undefined,undefined,undefined,undefined]);
+                expect(record.authorization.editPending).to.be.empty;
+                expect(record.authorization.viewPending).to.be.empty;
+                User.count().then(function (count) {
+                    expect(count).equal(2);
+                    done();
+                });
+            });
+        });
+    });
+    describe('complex assign permissions as expected', function () {
+        it('complexAssignPermissions with no viewers or editors', function (done) {
+            const oid = "complexAssignPermissions-no-viewers-no-editors";
+            const record = {
+                metaMetadata: {},
+                workflow: {},
+                authorization: {
+                    edit: [],
+                    view: [],
+                    editRoles: ['Admin'],
+                    viewRoles: ['Admin'],
+                    editPending: [],
+                    viewPending: []
+                },
+                metadata: {
+                    contributor_dmp_permissions: [
+                        {
+                            "text_full_name": "AAAA AAAA",
+                            "full_name_honorific": "AAAA AAAA",
+                            "email": [userAdminDefault.email],
+                            "role": "View&Edit"
+                        },
+                        {
+                            "text_full_name": "BBBB BBBB",
+                            "full_name_honorific": "",
+                            "email": [userAdmin1.email],
+                            "role": "View"
+                        }
+                    ],
+                    contributor_ci: {
+                        "text_full_name": "AAAA AAAA",
+                        "full_name_honorific": " AAAA AAAA",
+                        "email": [userAdminDefault.email],
+                        "orcid": "",
+                        "role": "",
+                    }
+                }
+            };
+            const options = {
+                "emailProperty": "email",
+                "userProperties": [
+                    "metadata.contributor_ci"
+                ],
+                "editPermissionRule": "<%= role == 'View&Edit' %>",
+                "viewPermissionRule": "<%= role == 'View&Edit' ||  role == 'View' %>",
+                "recordCreatorPermissions": "view&edit"
+            };
+            RDMPService.complexAssignPermissions(oid, record, options).subscribe(function (record) {
+                expect(record.authorization.edit).to.be.empty;
+                expect(record.authorization.view).to.be.empty;
+                expect(record.authorization.editPending).to.be.empty;
+                expect(record.authorization.viewPending).to.be.empty;
+                User.count().then(function (count) {
+                    expect(count).equal(2);
+                    done();
+                });
+            });
+        });
+        it('complexAssignPermissions with only editors', function (done) {
+            const oid = "complexAssignPermissions-no-viewers-has-editors";
+            const record = {
+                metaMetadata: {},
+                workflow: {},
+                authorization: {
+                    edit: [],
+                    view: [],
+                    editRoles: ['Admin'],
+                    viewRoles: ['Admin'],
+                    editPending: [],
+                    viewPending: []
+                },
+                metadata: {
+                    contributor_dmp_permissions: [
+                        {
+                            "text_full_name": "AAAA AAAA",
+                            "full_name_honorific": "AAAA AAAA",
+                            "email": [userAdminDefault.email],
+                            "role": "View&Edit"
+                        }
+                    ]
+                }
+            };
+            const options = {
+                "emailProperty": "email",
+                "userProperties": [
+                    "metadata.contributor_dmp_permissions"
+                ],
+                "editPermissionRule": "<%= role == 'View&Edit' %>",
+                "viewPermissionRule": "<%= role == 'View' %>",
+                "recordCreatorPermissions": "view&edit"
+            };
+            RDMPService.complexAssignPermissions(oid, record, options).subscribe(function (record) {
+                expect(record.authorization.edit).to.eql([userAdminDefault.name, undefined]);
+                expect(record.authorization.view).to.eql([undefined,undefined,undefined,undefined,undefined]);
+                expect(record.authorization.editPending).to.be.empty;
+                expect(record.authorization.viewPending).to.be.empty;
+                User.count().then(function (count) {
+                    expect(count).equal(2);
+                    done();
+                });
+            });
+        });
+        it('complexAssignPermissions with only viewers', function (done) {
+            const oid = "complexAssignPermissions-has-viewers-no-editors";
+            const record = {
+                metaMetadata: {},
+                workflow: {},
+                authorization: {
+                    edit: [],
+                    view: [],
+                    editRoles: ['Admin'],
+                    viewRoles: ['Admin'],
+                    editPending: [],
+                    viewPending: []
+                },
+                metadata: {
+                    contributor_dmp_permissions: [
+                        {
+                            "text_full_name": "BBBB BBBB",
+                            "full_name_honorific": "",
+                            "email": [userAdmin1.email],
+                            "role": "View"
+                        }
+                    ]
+                }
+            };
+            const options = {
+                "emailProperty": "email",
+                "userProperties": [
+                    "metadata.contributor_dmp_permissions"
+                ],
+                "editPermissionRule": "<%= role == 'View&Edit' %>",
+                "viewPermissionRule": "<%= role == 'View&Edit' ||  role == 'View' %>",
+                "recordCreatorPermissions": "view&edit"
+            };
+            RDMPService.complexAssignPermissions(oid, record, options).subscribe(function (record) {
+                expect(record.authorization.edit).to.be.empty;
+                expect(record.authorization.view).eql([userAdmin1.name, undefined]);
+                expect(record.authorization.editPending).to.be.empty;
+                expect(record.authorization.viewPending).to.be.empty;
+                User.count().then(function (count) {
+                    expect(count).equal(2);
+                    done();
+                });
+            });
+        });
+        it('complexAssignPermissions to expected users', function (done) {
+            const oid = "complexAssignPermissions-to-expected-users";
+            const record = {
+                metaMetadata: {},
+                workflow: {},
+                authorization: {
+                    edit: [],
+                    view: [],
+                    editRoles: ['Admin'],
+                    viewRoles: ['Admin'],
+                    editPending: [],
+                    viewPending: []
+                },
+                metadata: {
+                    contributor_dmp_permissions: [
+                        {
+                            "text_full_name": "AAAA AAAA",
+                            "full_name_honorific": "AAAA AAAA",
+                            "email": [userAdminDefault.email],
+                            "role": "View&Edit"
+                        },
+                        {
+                            "text_full_name": "BBBB BBBB",
+                            "full_name_honorific": "",
+                            "email": [userAdmin1.email],
+                            "role": "View"
+                        },
+                        {
+                            "text_full_name": "CCCC CCCC",
+                            "full_name_honorific": "",
+                            "email": [userNotInDB1.email],
+                            "role": "View&Edit"
+                        },
+                        {
+                            "text_full_name": "DDDD DDDD",
+                            "full_name_honorific": "",
+                            "email": [userNotInDB2.email],
+                            "role": "View"
+                        }
+                    ]
+                }
+            };
+            const options = {
+                "emailProperty": "email",
+                "userProperties": [
+                    "metadata.contributor_dmp_permissions"
+                ],
+                "editPermissionRule": "<%= role == 'View&Edit' %>",
+                "viewPermissionRule": "<%= role == 'View&Edit' ||  role == 'View' %>",
+                "recordCreatorPermissions": "view&edit"
+            };
+            RDMPService.complexAssignPermissions(oid, record, options).subscribe(function (record) {
+                expect(record.authorization.edit).eql([userAdminDefault.name, undefined]);
+                expect(record.authorization.view).eql([userAdminDefault.name, userAdmin1.name, undefined]);
+                expect(record.authorization.editPending).eql([userNotInDB1.email]);
+                expect(record.authorization.viewPending).eql([userNotInDB1.email, userNotInDB2.email]);
+                User.count().then(function (count) {
+                    expect(count).equal(2);
+                    done();
+                });
+            });
+        });
+    });
+});

--- a/typescript/api/services/RDMPService.ts
+++ b/typescript/api/services/RDMPService.ts
@@ -450,6 +450,12 @@ export module Services {
       return response;
     }
 
+    /**
+     * Assign editor and viewer permissions to the record using rules.
+     * @param oid {string} The identifier.
+     * @param record The record to update.
+     * @param options The options for modifying the record.
+     */
     public complexAssignPermissions(oid, record, options) {
       sails.log.verbose(`Complex Assign Permissions executing on oid: ${oid}, using options:`);
       sails.log.verbose(JSON.stringify(options));
@@ -472,59 +478,19 @@ export module Services {
       // get the new viewer list...
       viewContributorEmails = this.getContribListByRule(userProperties, record, viewPermissionRule, emailProperty, viewContributorEmails);
 
-
-      if (_.isEmpty(editContributorEmails)) {
-        sails.log.error(`No editors for record: ${oid}`);
-      }
-      if (_.isEmpty(viewContributorEmails)) {
-        sails.log.error(`No viewers for record: ${oid}`);
-      }
-      // when both are empty, simpy return the record
-      if (_.isEmpty(editContributorEmails) && _.isEmpty(viewContributorEmails)) {
-        return Observable.of(record);
-      }
-      _.each(editContributorEmails, editorEmail => {
-        editContributorObs.push(this.getObservable(User.findOne({
-          email: editorEmail.toLowerCase()
-        })));
-      });
-      _.each(viewContributorEmails, viewerEmail => {
-        viewContributorObs.push(this.getObservable(User.findOne({
-          email: viewerEmail.toLowerCase()
-        })));
-      });
-      let zippedViewContributorUsers = null;
-      if (editContributorObs.length == 0) {
-        zippedViewContributorUsers = Observable.zip(...viewContributorObs);
-      } else {
-        zippedViewContributorUsers = Observable.zip(...editContributorObs)
-          .flatMap(editContributorUsers => {
-            let newEditList = [];
-            this.filterPending(editContributorUsers, editContributorEmails, newEditList);
-            if (recordCreatorPermissions == "edit" || recordCreatorPermissions == "view&edit") {
-              newEditList.push(record.metaMetadata.createdBy);
-            }
-            record.authorization.edit = newEditList;
-            record.authorization.editPending = editContributorEmails;
-            return Observable.zip(...viewContributorObs);
-          })
-      }
-      if (zippedViewContributorUsers.length == 0) {
-        return Observable.of(record);
-      } else {
-        return zippedViewContributorUsers.flatMap(viewContributorUsers => {
-          let newviewList = [];
-          this.filterPending(viewContributorUsers, viewContributorEmails, newviewList);
-          if (recordCreatorPermissions == "view" || recordCreatorPermissions == "view&edit") {
-            newviewList.push(record.metaMetadata.createdBy);
-          }
-          record.authorization.view = newviewList;
-          record.authorization.viewPending = viewContributorEmails;
-          return Observable.of(record);
-        });
-      }
+      return this.assignContributorRecordPermissions(
+          oid, record, recordCreatorPermissions,
+          editContributorEmails, editContributorObs,
+          viewContributorEmails, viewContributorObs
+      );
     }
 
+    /**
+     * Assign editor and viewer permissions to the record using properties.
+     * @param oid {string} The identifier.
+     * @param record The record to update.
+     * @param options The options for modifying the record.
+     */
     public assignPermissions(oid, record, options) {
       sails.log.verbose(`Assign Permissions executing on oid: ${oid}, using options:`);
       sails.log.verbose(JSON.stringify(options));
@@ -545,7 +511,28 @@ export module Services {
       // get the new viewer list...
       viewContributorEmails = this.populateContribList(viewContributorProperties, record, emailProperty, viewContributorEmails);
 
+      return this.assignContributorRecordPermissions(
+          oid, record, recordCreatorPermissions,
+          editContributorEmails, editContributorObs,
+          viewContributorEmails, viewContributorObs
+      );
+    }
 
+    /**
+     * Assign contributor permissions to the record.
+     * @param oid The identifier.
+     * @param record The record to update.
+     * @param recordCreatorPermissions {string} The creator permission from the options.
+     * @param editContributorEmails {Array<string>} The list of editor emails.
+     * @param editContributorObs {Array<Observable>} The list of editor observables.
+     * @param viewContributorEmails {Array<string>} The list of viewer emails.
+     * @param viewContributorObs {Array<Observable>} The list of viewer observables.
+     * @private
+     */
+    private assignContributorRecordPermissions(
+        oid, record, recordCreatorPermissions,
+        editContributorEmails, editContributorObs,
+        viewContributorEmails, viewContributorObs) {
       if (_.isEmpty(editContributorEmails)) {
         sails.log.error(`No editors for record: ${oid}`);
       }
@@ -566,32 +553,36 @@ export module Services {
           email: viewerEmail.toLowerCase()
         })));
       });
-      let zippedViewContributorUsers = null;
+      let zippedViewContributorUsers;
       if (editContributorObs.length == 0) {
         zippedViewContributorUsers = Observable.zip(...viewContributorObs);
       } else {
         zippedViewContributorUsers = Observable.zip(...editContributorObs)
-          .flatMap(editContributorUsers => {
-            let newEditList = [];
-            this.filterPending(editContributorUsers, editContributorEmails, newEditList);
-            if (recordCreatorPermissions == "edit" || recordCreatorPermissions == "view&edit") {
-              newEditList.push(record.metaMetadata.createdBy);
-            }
-            record.authorization.edit = newEditList;
-            record.authorization.editPending = editContributorEmails;
-            return Observable.zip(...viewContributorObs);
-          })
+            .flatMap(editContributorUsers => {
+              let newEditList = [];
+              this.filterPending(editContributorUsers, editContributorEmails, newEditList);
+              if (recordCreatorPermissions == "edit" || recordCreatorPermissions == "view&edit") {
+                newEditList.push(record.metaMetadata.createdBy);
+              }
+              record.authorization.edit = newEditList;
+              record.authorization.editPending = editContributorEmails;
+              if (viewContributorObs.length === 0) {
+                return Observable.of(record);
+              } else {
+                return Observable.zip(...viewContributorObs);
+              }
+            });
       }
       if (zippedViewContributorUsers.length == 0) {
-        return Observable.of(record);
+        return zippedViewContributorUsers;
       } else {
         return zippedViewContributorUsers.flatMap(viewContributorUsers => {
-          let newviewList = [];
-          this.filterPending(viewContributorUsers, viewContributorEmails, newviewList);
+          let newViewList = [];
+          this.filterPending(viewContributorUsers, viewContributorEmails, newViewList);
           if (recordCreatorPermissions == "view" || recordCreatorPermissions == "view&edit") {
-            newviewList.push(record.metaMetadata.createdBy);
+            newViewList.push(record.metaMetadata.createdBy);
           }
-          record.authorization.view = newviewList;
+          record.authorization.view = newViewList;
           record.authorization.viewPending = viewContributorEmails;
           return Observable.of(record);
         });


### PR DESCRIPTION
Add unit tests for RDMPService.assignPermissions and RDMPService.complexAssignPermissions.

FIx a bug when assigning edit-only permissions.