### PR TITLE
Configure session by environment variables

### DIFF
--- a/config/redboxSession.js
+++ b/config/redboxSession.js
@@ -13,88 +13,88 @@
  */
 
 module.exports.redboxSession = {
-    name: "redbox.sid",
-    
-    /***************************************************************************
-    *                                                                          *
-    * Session secret is automatically generated when your new app is created   *
-    * Replace at your own risk in production-- you will invalidate the cookies *
-    * of your users, forcing them to log in again.                             *
-    *                                                                          *
-    ***************************************************************************/
-    secret: 'a7f06b2584ca1b8e456874024e95ec73',
+  name: "redbox.sid",
   
+  /***************************************************************************
+  *                                                                          *
+  * Session secret is automatically generated when your new app is created   *
+  * Replace at your own risk in production-- you will invalidate the cookies *
+  * of your users, forcing them to log in again.                             *
+  *                                                                          *
+  ***************************************************************************/
+  secret: process.env.sails__redboxSession_secret ? process.env.sails__redboxSession_secret :'a7f06b2584ca1b8e456874024e95ec73',
+
+
+  /***************************************************************************
+  *                                                                          *
+  * Set the session cookie expire time The maxAge is set by milliseconds,    *
+  * the example below is for 24 hours                                        *
+  *                                                                          *
+  ***************************************************************************/
+
+  // cookie: {
+  //   maxAge: 24 * 60 * 60 * 1000
+  // },
+
+  /***************************************************************************
+  *                                                                          *
+  * Uncomment the following lines to set up a Redis session store that can   *
+  * be shared across multiple Sails.js servers.                              *
+  *                                                                          *
+  * Requires connect-redis (https://www.npmjs.com/package/connect-redis)     *
+  *                                                                          *
+  ***************************************************************************/
+
+  // adapter: 'redis',
+
+  /***************************************************************************
+  *                                                                          *
+  * The following values are optional, if no options are set a redis         *
+  * instance running on localhost is expected. Read more about options at:   *
+  *                                                                          *
+  * https://github.com/visionmedia/connect-redis                             *
+  *                                                                          *
+  ***************************************************************************/
+
+  // host: 'localhost',
+  // port: 6379,
+  // ttl: <redis session TTL in seconds>,
+  // db: 0,
+  // pass: <redis auth password>,
+  // prefix: 'sess:',
+
+
+  /***************************************************************************
+  *                                                                          *
+  * Uncomment the following lines to set up a fake session store that can *
+  * be shared across multiple Sails.js servers.                              *
+  *                                                                          *
+  * Requires connect-mongo (https://www.npmjs.com/package/connect-mongo)     *
+  * Requires version 4.1.0 or above                                          *
+  *                                                                          *
+  ***************************************************************************/
+  adapter: process.env.sails__redboxSession_adapter ? process.env.sails__redboxSession_adapter : 'mongo',
+  mongoUrl: process.env.sails__redboxSession_mongoUrl ? process.env.sails__redboxSession_mongoUrl : 'mongodb://mongodb:27017/sessions', // user, password and port optional
   
-    /***************************************************************************
-    *                                                                          *
-    * Set the session cookie expire time The maxAge is set by milliseconds,    *
-    * the example below is for 24 hours                                        *
-    *                                                                          *
-    ***************************************************************************/
-  
-    // cookie: {
-    //   maxAge: 24 * 60 * 60 * 1000
-    // },
-  
-    /***************************************************************************
-    *                                                                          *
-    * Uncomment the following lines to set up a Redis session store that can   *
-    * be shared across multiple Sails.js servers.                              *
-    *                                                                          *
-    * Requires connect-redis (https://www.npmjs.com/package/connect-redis)     *
-    *                                                                          *
-    ***************************************************************************/
-  
-    // adapter: 'redis',
-  
-    /***************************************************************************
-    *                                                                          *
-    * The following values are optional, if no options are set a redis         *
-    * instance running on localhost is expected. Read more about options at:   *
-    *                                                                          *
-    * https://github.com/visionmedia/connect-redis                             *
-    *                                                                          *
-    ***************************************************************************/
-  
-    // host: 'localhost',
-    // port: 6379,
-    // ttl: <redis session TTL in seconds>,
-    // db: 0,
-    // pass: <redis auth password>,
-    // prefix: 'sess:',
-  
-  
-    /***************************************************************************
-    *                                                                          *
-    * Uncomment the following lines to set up a MongoDB session store that can *
-    * be shared across multiple Sails.js servers.                              *
-    *                                                                          *
-    * Requires connect-mongo (https://www.npmjs.com/package/connect-mongo)     *
-    * Requires version 4.1.0 or above                                          *
-    *                                                                          *
-    ***************************************************************************/
-    adapter: 'mongo',
-    mongoUrl: 'mongodb://mongodb:27017/sessions', // user, password and port optional
-    
-  
-    /***************************************************************************
-    *                                                                          *
-    * Optional Values:                                                         *
-    *                                                                          *
-    * See https://github.com/kcbanner/connect-mongo for more                   *
-    * information about connect-mongo options.                                 *
-    *                                                                          *
-    * See http://bit.ly/mongooptions for more information about options        *
-    * available in `mongoOptions`                                              *
-    *                                                                          *
-    ***************************************************************************/
-  
-    // collection: 'sessions',
-    // stringify: true,
-    // mongoOptions: {
-    //   server: {
-    //     ssl: true
-    //   }
-    // }
-  
-  };
+
+  /***************************************************************************
+  *                                                                          *
+  * Optional Values:                                                         *
+  *                                                                          *
+  * See https://github.com/kcbanner/connect-mongo for more                   *
+  * information about connect-mongo options.                                 *
+  *                                                                          *
+  * See http://bit.ly/mongooptions for more information about options        *
+  * available in `mongoOptions`                                              *
+  *                                                                          *
+  ***************************************************************************/
+
+  // collection: 'sessions',
+  // stringify: true,
+  // mongoOptions: {
+  //   server: {
+  //     ssl: true
+  //   }
+  // }
+
+};


### PR DESCRIPTION
Since the move to connect-mongo v5, the normal method to configure sessions in sails has been removed. As a result, the normal method of using sails__key_value no longer works due to where in the application lift sessions is initalised. To make it simpler to change settings such as the mongodb url, the config file will now check for the presence of the environment variables in the expected sails config format and use those in preference to the defaults if they exist.