### PR TITLE
Feature: Typescript decorator to populate exportedMethods array

### DIFF
--- a/core/src/decorator/PopulateExportedMethods.decorator.ts
+++ b/core/src/decorator/PopulateExportedMethods.decorator.ts
@@ -1,0 +1,6 @@
+export function PopulateExportedMethods <T extends { new (...args: any[]): {} }>(constructor: T) {
+  return class extends constructor {
+    _exportedMethods: any =Object.getOwnPropertyNames(constructor.prototype)
+    .filter(prop => prop !== 'constructor' && typeof this[prop] === 'function');
+  };
+}

--- a/core/src/decorator/index.ts
+++ b/core/src/decorator/index.ts
@@ -1,0 +1,3 @@
+export {
+    PopulateExportedMethods
+} from './PopulateExportedMethods.decorator';

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -49,3 +49,4 @@ export {
 from "./RecordAuditParams";
 
 export * from './model'
+export * from './decorator'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
       "outDir": "./",
       "rootDir": "./typescript",
       "strict": false,
-      "inlineSourceMap": true
+      "inlineSourceMap": true,
+      "experimentalDecorators": true
     },
     "exclude": [
       "node_modules/**",
@@ -20,5 +21,6 @@
     "buildOnSave": false,
     "atom": {
         "rewriteTsconfig": false
-    }
+    },
+    
 }

--- a/typescript/api/controllers/RenderViewController.ts
+++ b/typescript/api/controllers/RenderViewController.ts
@@ -1,20 +1,17 @@
 //<reference path='./../../typings/loader.d.ts'/>
 
-import { Controllers as controllers} from '@researchdatabox/redbox-core-types';
-
+import { Controllers as controllers,PopulateExportedMethods} from '@researchdatabox/redbox-core-types';
 /**
  * Package that contains all Controllers.
  */
+
+
+
+
 export module Controllers {
-
+    
+    @PopulateExportedMethods
     export class RenderView extends controllers.Core.Controller {
-
-        /**
-         * Exported methods, accessible from internet.
-         */
-        protected _exportedMethods: any = [
-            'render'
-        ];
 
         /**
          **************************************************************************************************


### PR DESCRIPTION
Since we began using typescript with SailsJS. Developers have needed to populate an 'exportedMethods' array with the names of the public methods of our Controllers and Services to allow the functions to be visible in Sails.

To make this easier, a class decorator has been created that will populate the exportedMethods with the public methods automatically.

Usage:
```
@PopulateExportedMethods
export class Record extends controllers.Core.Controller {
```