### PR TITLE
Fix: HEAD requests to the oidc endpoint crashes the app

### DIFF
--- a/api/policies/disallowedHeadRequestHandler.js
+++ b/api/policies/disallowedHeadRequestHandler.js
@@ -1,0 +1,6 @@
+module.exports = function (req, res, next) {
+    if (req.method === 'HEAD') {
+      return res.badRequest('Bad Request: HEAD method is not allowed');;
+    }
+    return next();
+  };

--- a/config/routes.js
+++ b/config/routes.js
@@ -141,6 +141,9 @@ module.exports.routes = {
     action: 'openIdConnectLogin',
     csrf: false
   },
+  'HEAD /user/begin_oidc': {
+    policy: 'disallowedHeadRequestHandler'
+  },
   'get /user/begin_oidc': {
     controller: 'UserController',
     action: 'beginOidc',


### PR DESCRIPTION
Some applications (e.g. teams and outlook) will make a HEAD request to generate a preview for links. Because links are often  to records which require authorization, a redirect occurs which causes the application to crash. This fix adds a policy that returns a 400 bad request to prevent this from occurring. 