### PR TITLE
Hotfix: Publish event emitters keep a reference to the previous subscribers when cloned in a repeatable container

### DIFF
--- a/angular-legacy/shared/form/field-repeatable.component.ts
+++ b/angular-legacy/shared/form/field-repeatable.component.ts
@@ -207,6 +207,15 @@ export class RepeatableContainer extends Container {
     }
     const newFormModel = newElem.createFormModel();
     this.formModel.push(newFormModel);
+
+    // After cloning the first element, the publish event emitters still have the old subscribers.
+    // Iterate over the list of configured published events and set a new event emitter
+    let fields = newElem.fields;
+    for(let field of fields){
+      for(let event in field['publish']) {
+        field[event] = new EventEmitter();
+      }
+    }
     // Group component event handling: will need to set up event handlers within the new element
     newElem.setupEventHandlers();
     // finally, render in the UI


### PR DESCRIPTION
To add a new element, repeatable containers clone the first element to add a new one. The publish event emitters after cloning still hold their previous subscribers which means the sub-elements in the first elements subscribing react to changes in the new element. This fix creates new event emitter objects for each publish event so that it no longer occurs.