### PR TITLE
Reduce agenda queue mongodb concurrency

### DIFF
--- a/config/agendaQueue.js
+++ b/config/agendaQueue.js
@@ -20,8 +20,8 @@ module.exports.agendaQueue = {
       fnName: 'solrsearchservice.solrAddOrUpdate',
       options: {
         lockLifetime: 3 * 1000, // 3 seconds max runtime
-        lockLimit: 10,
-        concurrency: 10 
+        lockLimit: 1,
+        concurrency: 1
       }
     },
     {
@@ -29,8 +29,8 @@ module.exports.agendaQueue = {
       fnName: 'solrsearchservice.solrDelete',
       options: {
         lockLifetime: 3 * 1000, // 3 seconds max runtime
-        lockLimit: 10,
-        concurrency: 10 
+        lockLimit: 1,
+        concurrency: 1
       }
     },
     {
@@ -38,8 +38,8 @@ module.exports.agendaQueue = {
       fnName: 'recordsservice.storeRecordAudit',
       options: {
         lockLifetime: 30 * 1000,
-        lockLimit: 10,
-        concurrency: 10 
+        lockLimit: 1,
+        concurrency: 1
       }
     },
     {


### PR DESCRIPTION
After integrating Mint into ReDBox, when the harvester runs, it can slow down ReDBox due to some issues in the agenda queue set up. While we decide how to deal with the bigger agenda queue issues, reduce the concurrency to reduce the impact on the web app.