### PR TITLE
Improve runtemplates performance

### DIFF
--- a/typescript/api/services/RDMPService.ts
+++ b/typescript/api/services/RDMPService.ts
@@ -662,7 +662,7 @@ export module Services {
         _.each(options.templates, (templateConfig) => {
           tmplConfig = templateConfig;
           const imports = _.extend({
-            options: options,
+            
             moment: moment,
             numeral: numeral
           }, this);
@@ -672,7 +672,8 @@ export module Services {
           const templateData = {
             oid: oid,
             record: record,
-            user: user
+            user: user,
+            options: options
           }
           if (_.isString(templateConfig.template)) {
             const compiledTemplate = _.template(templateConfig.template, templateImportsData);


### PR DESCRIPTION
The runTemplates trigger was compiling the templates each execution resulting in performance issues. This change allows for the templates to be compiled only once.