### PR TITLE
Fixed slowness in query response when user quickly provides a series of inputs.

### DIFF
--- a/angular-legacy/shared/form/field-repeatable.component.ts
+++ b/angular-legacy/shared/form/field-repeatable.component.ts
@@ -647,6 +647,9 @@ export class RepeatableContributorComponent extends RepeatableComponent implemen
     newElem.setupEventHandlers();
     newElem.showHeader = false;
     newElem.componentReactors.push(this);
+    // Re-initialize the lookup data service for the new element otherwise the subject
+    //  that supplies the results will point to the original record
+    newElem.vocabField.initLookupData();
   }
 
   removeElem(event: any, i: number) {

--- a/angular-legacy/shared/form/field-vocab.component.ts
+++ b/angular-legacy/shared/form/field-vocab.component.ts
@@ -603,6 +603,8 @@ class ExternalLookupDataService extends Subject<CompleterItem[]> implements Comp
 }
 class MintLookupDataService extends Subject<CompleterItem[]> implements CompleterData {
 
+  private searchTerms = new Subject<string>();
+  private searchSubscription: Subscription;
   searchFields: any[];
   stringWildcard: string = '*';
 
@@ -622,9 +624,20 @@ class MintLookupDataService extends Subject<CompleterItem[]> implements Complete
     if(this.exactMatchString) {
       this.stringWildcard = '';
     }
+
+    this.searchSubscription = this.searchTerms.pipe(
+      debounceTime(300), // Wait for a default 300ms of inactivity
+    ).subscribe(term => {
+      this.performSearch(term);
+    });
+    
   }
 
   public search(term: string): void {
+    this.searchTerms.next(term);
+  }
+
+  public performSearch(term: string): void {
     term = _.trim(luceneEscapeQuery.escape(term));
     let searchString = '';
     if (!_.isEmpty(term)) {


### PR DESCRIPTION
The slowdown is apparent when the user enters a name in the RB query backed autocomplete widget. The fix is to wait for the user to stop providing input after a period of time, before performing a request to the server.