### PR TITLE
Bugfix: Set a default logout redirect url

### DIFF
--- a/typescript/api/controllers/UserController.ts
+++ b/typescript/api/controllers/UserController.ts
@@ -122,6 +122,12 @@ export module Controllers {
       if (req.session.user && req.session.user.type == 'oidc') {
         redirUrl = req.session.logoutUrl;
       }
+      
+      // If the redirect URL is empty then revert back to the default
+      if(_.isEmpty(redirUrl)) {
+        redirUrl = _.isEmpty(sails.config.auth.postLogoutRedir)?`${BrandingService.getBrandAndPortalPath(req)}/home`: sails.config.auth.postLogoutRedir;
+      }
+
       let user = req.session.user ? req.session.user : req.user;
       req.logout(function(err) {
         if (err) { res.send(500, 'Logout failed'); }


### PR DESCRIPTION
Previously with OIDC authentication, there are scenarios where the post redirect url is not available on the session which means the user is redirected to a error page. With this fix, in those scenarios the user will redirect to the default configure logout page (or the home page if this isn't set)