### PR TITLE
Feature: Improve Agenda Queue Performance

### DIFF
--- a/config/agendaQueue.js
+++ b/config/agendaQueue.js
@@ -45,6 +45,14 @@ module.exports.agendaQueue = {
     {
       name: 'RaidMintRetryJob',
       fnName: 'raidservice.mintRetryJob'
+    },
+    {
+      name: 'MoveCompletedJobsToHistory',
+      fnName: 'agendaqueueservice.moveCompletedJobsToHistory',
+      schedule: {
+        method: 'every',
+        intervalOrSchedule: '5 minutes'
+      }
     }
   ]
 };


### PR DESCRIPTION
When the number of jobs in the Agenda queue database gets large, the job polling query starts to tax MongoDB even with appropriate indices on the collection. This PR adds a scheduled Agenda job that moves all the completed jobs to a new history collection so that they can still be interrogated without affecting polling performance.