### PR TITLE
Fixed: removed the "status" flag requirements for displaying error messages from the catch block.

### DIFF
--- a/angular-legacy/dmp/app/dmp-form.component.ts
+++ b/angular-legacy/dmp/app/dmp-form.component.ts
@@ -201,9 +201,7 @@ export class DmpFormComponent extends LoadableComponent {
         }).catch((err:any) => {
           console.log("Error loading form...");
           console.log(err);
-          if (err.status == false) {
-              this.criticalError = err.message;
-          }
+          this.criticalError = err.message;
           this.setLoading(false);
         });
       });


### PR DESCRIPTION
Currently the status flag is checked before displaying a critical error. This is unnecessary.