### PR TITLE
Fix workflow transition metadata being updated multiple times

### DIFF
--- a/core/src/RecordsService.ts
+++ b/core/src/RecordsService.ts
@@ -9,8 +9,10 @@ export interface RecordsService {
   hasEditAccess(brand, user, roles, record): boolean;
   hasViewAccess(brand, user, roles, record): boolean;
   appendToRecord(targetRecordOid: string, linkData: any, fieldName: string, fieldType: string, targetRecord: any): Promise<any>
-  transitionWorkflowStep(currentRec: any, recordType: any, nextStep: any, user: any, triggerPreSaveTriggers: boolean, triggerPostSaveTriggers: boolean): Promise<any>;
   setWorkflowStepRelatedMetadata(currentRec:any, nextStep:any): void;
+  transitionWorkflowStepMetadata(currentRec:any, nextStep:any): void;
+  triggerPreSaveTransitionWorkflowTriggers(oid: string, record: any, recordType: object, nextStep: any, user: object): Promise<any>;
+  triggerPostSaveTransitionWorkflowTriggers(oid: string, record: any, recordType: any, nextStep: any, user: object, response: any): any;
   getAttachments(oid: string, labelFilterStr?: string): Promise<any>;
   getDeletedRecords(workflowState, recordType, start, rows, username, roles, brand, editAccessOnly, packageType, sort, fieldNames?, filterString?, filterMode?): Promise<any>;
   getRecords(workflowState, recordType, start, rows, username, roles, brand, editAccessOnly, packageType, sort, fieldNames?, filterString?, filterMode?, secondarySort?): Promise<any>;

--- a/typescript/api/controllers/webservice/RecordController.ts
+++ b/typescript/api/controllers/webservice/RecordController.ts
@@ -891,8 +891,7 @@ export module Controllers {
         }
         const recType = await RecordTypesService.get(brand, record.metaMetadata.type).toPromise();
         const nextStep = await WorkflowStepsService.get(recType, targetStepName).toPromise();
-        await this.RecordsService.transitionWorkflowStep(record, recType, nextStep, req.user, true, true);
-        const response = await this.RecordsService.updateMeta(brand, oid, record, req.user);
+        const response = await this.RecordsService.updateMeta(brand, oid, record, req.user, true, true, nextStep);
         this.apiRespond(req, res, response);
       } catch (err) {
         this.apiFailWrapper(req, res, 500, new APIErrorResponse("Failed to transition workflow, please check server logs."), err,

--- a/typescript/api/services/RecordsService.ts
+++ b/typescript/api/services/RecordsService.ts
@@ -181,23 +181,26 @@ export module Services {
 
     async create(brand: any, record: any, recordType: any, user ? : any, triggerPreSaveTriggers = true, triggerPostSaveTriggers = true, targetStep = null) {
 
-      //set the initial workflow metadata to the first step
-      let wfStep = await WorkflowStepsService.getFirst(recordType).toPromise();
-      this.setWorkflowStepRelatedMetadata(record, wfStep);
+     
 
+      
+      let wfStep = await WorkflowStepsService.getFirst(recordType).toPromise();
       let formName = _.get(wfStep, 'config.form');
 
       let form = await FormsService.getForm(brand, formName, true, recordType.name, record);
 
       let metaMetadata = this.initRecordMetaMetadata(brand.id, user.username, recordType, wfStep, form, moment().format());
       _.set(record,'metaMetadata',metaMetadata);
+       //set the initial workflow metadata to the first step
+       this.setWorkflowStepRelatedMetadata(record, wfStep);
 
       if (targetStep) {
         wfStep = await WorkflowStepsService.get(recordType.name, targetStep).toPromise();
         record = await this.triggerPreSaveTransitionWorkflowTriggers(null, record, recordType, wfStep, user);
         this.setWorkflowStepRelatedMetadata(record, wfStep);
       }
-
+      
+      
 
       let createResponse = new StorageServiceResponse();
       const failedMessage = "Failed to created record, please check server logs.";

--- a/typescript/api/services/RecordsService.ts
+++ b/typescript/api/services/RecordsService.ts
@@ -142,6 +142,7 @@ export module Services {
       'exportAllPlans',
       'storeRecordAudit',
       'exists',
+      'transitionWorkflowStep',
       'setWorkflowStepRelatedMetadata',
       'transitionWorkflowStepMetadata',
       'triggerPreSaveTransitionWorkflowTriggers',
@@ -953,6 +954,10 @@ export module Services {
 
     async createRecordAudit?(record: any): Promise<any> {
       return await this.storageService.createRecordAudit(record);
+    }
+
+    public async transitionWorkflowStep(currentRec: any, recordType: any, nextStep: any, user: any, triggerPreSaveTriggers: boolean = true, triggerPostSaveTriggers: boolean = true) {
+      throw new Error("Use separate calls to 'transitionWorkflowStepMetadata', 'triggerPreSaveTransitionWorkflowTriggers', and 'triggerPostSaveTransitionWorkflowTriggers' instead.")
     }
 
     public setWorkflowStepRelatedMetadata(currentRec: any, nextStep: any) {


### PR DESCRIPTION
Split transition workflow triggers into pre- and post-methods.
Call the transition workflow update separately to triggers.