### PR TITLE
Feature: Trigger to validate fields using a lodash template

### DIFF
--- a/test/unit/services/TriggerService.test.js
+++ b/test/unit/services/TriggerService.test.js
@@ -13,6 +13,7 @@ describe('The TriggerService', function () {
                 fieldLanguageCode: "title-required",
                 arrayObjFieldDBName: 'row-item',
                 trimLeadingAndTrailingSpacesBeforeValidation: true,
+                forceRun: true
                 // caseSensitive: true, - default
                 // allowNulls: true, - default
             };
@@ -31,6 +32,7 @@ describe('The TriggerService', function () {
                 trimLeadingAndTrailingSpacesBeforeValidation: false,
                 caseSensitive: true,
                 allowNulls: false,
+                forceRun: true
             };
             try {
                 await TriggerService.validateFieldUsingRegex(oid, record, options);
@@ -55,6 +57,7 @@ describe('The TriggerService', function () {
                 trimLeadingAndTrailingSpacesBeforeValidation: false,
                 caseSensitive: false,
                 allowNulls: true,
+                forceRun: true
             };
 
             try {
@@ -77,6 +80,7 @@ describe('The TriggerService', function () {
                 trimLeadingAndTrailingSpacesBeforeValidation: false,
                 caseSensitive: false,
                 allowNulls: true,
+                forceRun: true
             };
             const result = await TriggerService.validateFieldUsingRegex(oid, record, options);
             expect(result).to.eql(record);
@@ -92,6 +96,7 @@ describe('The TriggerService', function () {
                 trimLeadingAndTrailingSpacesBeforeValidation: false,
                 caseSensitive: false,
                 allowNulls: false,
+                forceRun: true
             };
             try {
                 await TriggerService.validateFieldUsingRegex(oid, record, options);
@@ -114,7 +119,8 @@ describe('The TriggerService', function () {
                 if (_.get(record,'testing-field') !== 'valid-value') { 
                     addError(errorList, 'testing-field', 'title-required', 'invalid-format' );
                 }
-                return errorList; %>`
+                return errorList; %>`,
+                forceRun: true
             };
             
             try {
@@ -134,7 +140,8 @@ describe('The TriggerService', function () {
                 if (_.get(record,'testing-field') !== 'valid-value') { 
                     addError(errorList, 'testing-field', 'title-required', 'invalid-format' );
                 }
-                return errorList; %>`
+                return errorList; %>`,
+                forceRun: true
             };
             try {
                 const result = await TriggerService.validateFieldsUsingTemplate(oid, record, options);

--- a/test/unit/services/TriggerService.test.js
+++ b/test/unit/services/TriggerService.test.js
@@ -103,4 +103,48 @@ describe('The TriggerService', function () {
             }
         });
     });
+
+
+    describe('should validate fields using lodash template', function () {
+        it('valid value passes', async function () {
+            const oid = "triggerservice-template-validpasses";
+            const record = {'testing-field': 'valid-value'};
+            const options = {
+                template: `<% let errorList = [] 
+                if (_.get(record,'testing-field') !== 'valid-value') { 
+                    addError(errorList, 'testing-field', 'title-required', 'invalid-format' );
+                }
+                return errorList; %>`
+            };
+            
+            try {
+                const result = await TriggerService.validateFieldsUsingTemplate(oid, record, options);
+                expect(result).to.eql({'testing-field': 'valid-value'});
+            } catch (err) {
+                expect.fail("Should not have thrown error");
+            }
+            
+        });
+
+        it('invalid value fails', async function () {
+            const oid = "triggerservice-template-validpasses";
+            const record = {'testing-field': 'invalid-value'};
+            const options = {
+                template: `<% let errorList = [] 
+                if (_.get(record,'testing-field') !== 'valid-value') { 
+                    addError(errorList, 'testing-field', 'title-required', 'invalid-format' );
+                }
+                return errorList; %>`
+            };
+            try {
+                const result = await TriggerService.validateFieldsUsingTemplate(oid, record, options);
+            } catch (err) {
+                expect(err).to.be.an('error');
+                expect(err.name).to.eq("RBValidationError");
+                expect(err.message).to.eq("Title is required Submission format is invalid");
+            }
+            
+        });
+    
+    });
 });

--- a/test/unit/services/TriggerService.test.js
+++ b/test/unit/services/TriggerService.test.js
@@ -148,7 +148,8 @@ describe('The TriggerService', function () {
             } catch (err) {
                 expect(err).to.be.an('error');
                 expect(err.name).to.eq("RBValidationError");
-                expect(err.message).to.eq("Title is required Submission format is invalid");
+                const errorMap = JSON.parse(err.message)
+                expect(errorMap.errorFieldList[0].label).to.eq("Title is required");
             }
             
         });

--- a/typescript/api/services/TriggerService.ts
+++ b/typescript/api/services/TriggerService.ts
@@ -304,7 +304,6 @@ export module Services {
 
         const getErrorMessage = function (errorLanguageCode: string) {
           let baseErrorMessage = TranslationService.t(errorLanguageCode);
-          sails.log.error('validateFieldMapUsingRegex ' + baseErrorMessage);
           return baseErrorMessage;
         }
 

--- a/typescript/api/services/TriggerService.ts
+++ b/typescript/api/services/TriggerService.ts
@@ -353,7 +353,19 @@ export module Services {
 
         sails.log.verbose('validateFieldMapUsingRegex - metTriggerCondition');
 
-
+        // re-usable functions
+        const textRegex = function (value, regexPattern, caseSensitive) {
+          if(regexPattern == '') {
+            return true;
+          } else {
+            let flags = '';
+            if (caseSensitive) {
+              flags += 'i';
+            }
+            const re = new RegExp(regexPattern, flags);
+            return re.test(value);
+          }
+        }
         const getError = function (errorLanguageCode: string) {
           let baseErrorMessage = TranslationService.t(errorLanguageCode);
           sails.log.error('validateFieldMapUsingRegex ' + baseErrorMessage);
@@ -392,7 +404,6 @@ export module Services {
 
           return true;
         }
-
 
         let fieldObjectList = _.get(options,'fieldObjectList',[]);
         let altErrorMessage = _.get(options,'altErrorMessage',[]);

--- a/typescript/api/services/TriggerService.ts
+++ b/typescript/api/services/TriggerService.ts
@@ -22,6 +22,7 @@ import {
   RBValidationError,
   BrandingModel,
   Services as services,
+  PopulateExportedMethods,
 } from '@researchdatabox/redbox-core-types';
 import { Sails, Model } from "sails";
 import { default as moment } from 'moment';
@@ -43,16 +44,9 @@ export module Services {
    * Author: <a href='https://github.com/shilob' target='_blank'>Shilo Banihit</a>
    *
    */
+  @PopulateExportedMethods
   export class Trigger extends services.Core.Service {
 
-    protected _exportedMethods: any = [
-      'transitionWorkflow',
-      'runHooksSync',
-      'validateFieldUsingRegex',
-      'applyFieldLevelPermissions',
-      'validateFieldMapUsingRegex',
-      'runTemplatesOnRelatedRecord'
-    ];
 
     /**
      * Used in changing the workflow stages automatically based on configuration.
@@ -285,6 +279,22 @@ export module Services {
       return record;
     }
 
+    /**
+     * Trigger function that will run a lodash template that can be used to validate a record.
+     * The trigger expects the template to return an array of error objects of the format:
+     *  {
+     *   name: 'the field name that is in validation error',
+     *   label: 'the human readable label for the field',
+     *   error: 'optional error message'
+     *  }
+     * 
+     *  An empty array should be returned if no errors are found.
+     * 
+     * @param oid 
+     * @param record 
+     * @param options 
+     * @returns 
+     */
     public async validateFieldsUsingTemplate(oid, record, options) {
       sails.log.verbose('validateFieldsUsingTemplate - enter');
       if (this.metTriggerCondition(oid, record, options) === "true") {
@@ -328,7 +338,7 @@ export module Services {
           template = compiledTemplate;
         }
 
-        const errorFieldList = template({record: record, options: options});
+        const errorFieldList = template({oid:oid, record: record, options: options});
 
         
         const errorMap = { 

--- a/typescript/api/services/TriggerService.ts
+++ b/typescript/api/services/TriggerService.ts
@@ -324,8 +324,6 @@ export module Services {
           moment: moment,
           numeral: numeral,
           _ : _,
-          addError: addError,
-          getErrorMessage: getErrorMessage,
           TranslationService: TranslationService
         }
 
@@ -337,7 +335,8 @@ export module Services {
           template = compiledTemplate;
         }
 
-        const errorFieldList = template({oid:oid, record: record, options: options});
+        const errorFieldList = template({oid:oid, record: record, options: options, addError: addError,
+          getErrorMessage: getErrorMessage});
 
         
         const errorMap = { 


### PR DESCRIPTION
Trigger function that will run a lodash template that can be used to validate a record.
The trigger expects the template to return an array of error objects of the format:
```
{
  name: 'the field name that is in validation error',
  label: 'the human readable label for the field',
  error: 'optional error message'
}
```

An empty array should be returned if no errors are found.