### PR TITLE
Contributor validation not active when enabled from an event handler

### DIFF
--- a/angular-legacy/shared/form/field-contributor.component.ts
+++ b/angular-legacy/shared/form/field-contributor.component.ts
@@ -452,6 +452,15 @@ export class ContributorField extends FieldBase<any> implements CustomValidation
       this.formModel.controls[f].updateValueAndValidity({ onlySelf: true, emitEvent: false });
       this.formModel.controls[f].markAsTouched();
     });
+    // Fixed missing validation error when validation is enabled from an event-handler, i.e. 'enableValidators()' call. 
+    // Set the FormGroup error according to member status
+    if (this.isValid) {
+      this.formModel.setErrors(null);
+    } else {
+      this.formModel.setErrors({invalid: true});
+    }
+    this.formModel.updateValueAndValidity();
+    this.formModel.markAsTouched();
   }
 
   public getValidationError(): any {

--- a/angular-legacy/shared/util-service.ts
+++ b/angular-legacy/shared/util-service.ts
@@ -371,6 +371,7 @@ export class UtilityService {
     if (config.json == true && !_.isEmpty(templateRes)) {
       return JSON.parse(templateRes);
     }
-    return templateRes;
+    // Added to allow arbitrary execution of field functions that won't change the value of a field
+    return config.returnUndefinedOnEmpty && (_.isUndefined(templateRes) || _.isEmpty(templateRes)) ? undefined : templateRes;
   }
 }


### PR DESCRIPTION
- Enabling or disabling validation is not properly supported in the contributor component. 
- Added support for running templates without setting off the "reactEvent" and downstream "setValue" component, which will cause issues with "empty" contributor values.
- Fixed showing validation error message when contributor fields fail validation