### PR TITLE
Feature: Add support for merge updates in legacy harvest API

### DIFF
--- a/test/bruno/1 - REST API/9 - Harvesting/Update HARVEST Legacy Record - merge.bru
+++ b/test/bruno/1 - REST API/9 - Harvesting/Update HARVEST Legacy Record - merge.bru
@@ -1,0 +1,58 @@
+meta {
+  name: Update HARVEST Legacy Record - merge
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{host}}/default/rdmp/api/mint/harvest/rdmp?merge=true
+  body: json
+  auth: none
+}
+
+query {
+  merge: true
+}
+
+headers {
+  Content-Type: application/json
+  Authorization: Bearer {{token}}
+}
+
+body:json {
+  {
+    "records": [
+        {
+            "harvest_id": "s123456",
+            "metadata": {
+                "data": {
+                  "anExampleNewMergedProperty": "true"
+                }
+            }
+        }
+    ]
+  }
+}
+
+assert {
+  res.body[0].harvestId: eq s123456
+  res.body[0].message: eq Record merged successfully
+}
+
+tests {
+  
+  test("Status code is 200", function () {
+      expect(res.getStatus()).to.equal(200);
+  });
+  
+  test("Test oid exists", function () {
+        var jsonData = res.getBody();
+        expect(jsonData[0]).to.have.property('oid');
+  });
+  
+  test("Test harvestId exists and value is as expected", function () {
+        var jsonData = res.getBody();
+        expect(jsonData[0]).to.have.property('harvestId');
+        expect(jsonData[0].harvestId).to.equal('s123456');
+  });
+}

--- a/typescript/api/controllers/webservice/RecordController.ts
+++ b/typescript/api/controllers/webservice/RecordController.ts
@@ -1147,17 +1147,18 @@ export module Controllers {
               let oid = existingRecord[0].redboxOid;
               let oldMetadata = existingRecord[0].metadata;
               let newMetadata = record['metadata']['data'];
-              let response = { 
-                details: '',
-                message: `skip update of harvestId ${harvestId} oid ${oid} metadata sent is equal to metadata in existing record`,
-                harvestId: harvestId,
-                oid: oid,
-                status: true
-              };
+              
               if(this.isMetadataEqual(newMetadata,oldMetadata)) {
+                const response =  {
+                  details: '',
+                  message: `skip update of harvestId ${harvestId} oid ${oid} metadata sent is equal to metadata in existing record`,
+                  harvestId: harvestId,
+                  oid: oid,
+                  status: true
+                }
                 recordResponses.push(response);
               } else {
-                response = await this.updateHarvestRecord(brand, recordTypeModel, updateMode, newMetadata, oid, harvestId, user);
+                const response = await this.updateHarvestRecord(brand, recordTypeModel, updateMode, newMetadata, oid, harvestId, user);
                 recordResponses.push(response);
               }
             }

--- a/typescript/api/controllers/webservice/RecordController.ts
+++ b/typescript/api/controllers/webservice/RecordController.ts
@@ -1139,6 +1139,11 @@ export module Controllers {
             if (existingRecord.length == 0) {
               recordResponses.push(await this.createHarvestRecord(brand, recordTypeModel, record['metadata']['data'], harvestId, 'update', user));
             } else {
+              const merge = req.query['merge'];
+              let updateMode = 'update';
+              if(merge == 'true') {
+                updateMode = 'merge';
+              }
               let oid = existingRecord[0].redboxOid;
               let oldMetadata = existingRecord[0].metadata;
               let newMetadata = record['metadata']['data'];
@@ -1152,7 +1157,7 @@ export module Controllers {
               if(this.isMetadataEqual(newMetadata,oldMetadata)) {
                 recordResponses.push(response);
               } else {
-                response = await this.updateHarvestRecord(brand, recordTypeModel, 'update', newMetadata, oid, harvestId, user);
+                response = await this.updateHarvestRecord(brand, recordTypeModel, updateMode, newMetadata, oid, harvestId, user);
                 recordResponses.push(response);
               }
             }
@@ -1189,7 +1194,11 @@ export module Controllers {
           }
           let result = await this.RecordsService.updateMeta(brand, oid, record, user);
 
-          return new APIHarvestResponse(harvestId, oid, true, `Record updated successfully`)
+          let updateMessage = "Record updated successfully";
+          if(shouldMerge) {
+            updateMessage = "Record merged successfully";
+          }
+          return new APIHarvestResponse(harvestId, oid, true, updateMessage)
 
         } catch (error) {
           const result = new APIHarvestResponse(harvestId, oid, false, "Failed to update meta");


### PR DESCRIPTION
Adds support for merging updates via the harvester rather than a complete replace in the legacy harvest API. To enable the mode ?merge=true needs to be added to the URL.