### PR TITLE
Added logic to better handle disable expressions. There are fields th…

### DIFF
--- a/angular-legacy/shared/form/field-group.component.ts
+++ b/angular-legacy/shared/form/field-group.component.ts
@@ -104,16 +104,20 @@ Generic component for grouping components together. The resulting JSON will have
         </div>
       </ng-container>
       <ng-container *ngIf="!isEmbedded">
+      <span dmp-disable-state="enabled" #dmpFieldContainer>
         <div [formGroup]='form' [ngClass]="field.cssClasses">
           <dmp-field *ngFor="let childField of field.fields" [field]="childField" [form]="form" [fieldMap]="fieldMap" [name] = "childField.name" ></dmp-field>
         </div>
+        </span>
       </ng-container>
     </span>
     </ng-container>
     <ng-container *ngIf="!field.editMode">
+    <span dmp-disable-state="enabled" #dmpFieldContainer>
       <div [formGroup]='form' [ngClass]="field.cssClasses">
         <dmp-field *ngFor="let fieldElem of field.fields" [field]="fieldElem" [form]="form" [fieldMap]="fieldMap"></dmp-field>
       </div>
+      </span>
     </ng-container>
   </ng-container>
   `,

--- a/angular-legacy/shared/form/field-group.component.ts
+++ b/angular-legacy/shared/form/field-group.component.ts
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License along
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-import { Input, Component, ViewChild, ViewContainerRef, OnInit } from '@angular/core';
+import { Input, Component, ViewChild, ViewContainerRef, OnInit, Renderer, ViewChildren, QueryList, ElementRef } from '@angular/core';
 import { EmbeddableComponent, RepeatableComponent } from './field-repeatable.component';
 import * as _ from "lodash";
 /**
@@ -89,6 +89,7 @@ Generic component for grouping components together. The resulting JSON will have
         </label>
         <span id="{{ 'helpBlock_' + field.name }}" class="help-block" *ngIf="this.helpShow" [innerHtml]="field.help">{{field.help}}</span>
       </div>
+      <span dmp-disable-state="enabled" #dmpFieldContainer>
       <ng-container *ngIf="isEmbedded">
         <div [formGroup]='form' [ngClass]="field.cssClasses">
           <div class='row'>
@@ -107,6 +108,7 @@ Generic component for grouping components together. The resulting JSON will have
           <dmp-field *ngFor="let childField of field.fields" [field]="childField" [form]="form" [fieldMap]="fieldMap" [name] = "childField.name" ></dmp-field>
         </div>
       </ng-container>
+    </span>
     </ng-container>
     <ng-container *ngIf="!field.editMode">
       <div [formGroup]='form' [ngClass]="field.cssClasses">
@@ -118,6 +120,48 @@ Generic component for grouping components together. The resulting JSON will have
 })
 export class GenericGroupComponent extends EmbeddableComponent {
   static clName = 'GenericGroupComponent';
+  private originallyDisabledElements: Set<HTMLElement> = new Set();
+  @ViewChild('dmpFieldContainer', { read: ElementRef }) dmpFieldContainer!: ElementRef;
+
+  constructor(private vcr: ViewContainerRef, private renderer: Renderer) {
+    super();
+  }
+
+  public enableInputFields() {
+    const parentElement = this.dmpFieldContainer.nativeElement;
+    if (parentElement.getAttribute("dmp-disable-state") === "disabled") {
+      parentElement.setAttribute("dmp-disable-state", "enabled");
+      ['input', 'button', 'textarea', 'select'].forEach(selector => {
+        const elements = parentElement.querySelectorAll(selector);
+        elements.forEach((el: HTMLElement) => {
+          if (!this.originallyDisabledElements.has(el)) {
+            // Only re-enable elements that were originally enabled
+            this.renderer.setElementAttribute(el, 'disabled', null);
+          }
+        });
+      });
+      this.originallyDisabledElements.clear();
+    }
+  }
+
+  public disableInputFields() {
+    const parentElement = this.dmpFieldContainer.nativeElement;
+    if (parentElement.getAttribute("dmp-disable-state") === "enabled") {
+      parentElement.setAttribute("dmp-disable-state", "disabled");
+      ['input', 'button', 'textarea', 'select'].forEach(selector => {
+        const elements = parentElement.querySelectorAll(selector);
+        elements.forEach((el: HTMLElement) => {
+          if (el.hasAttribute('disabled')) {
+            // Store only elements that were originally disabled
+            this.originallyDisabledElements.add(el);
+          } else {
+            // Disable elements that were initially enabled
+            this.renderer.setElementAttribute(el, 'disabled', 'true');
+          }
+        });
+      });
+    }
+  }
 
 }
 
@@ -205,7 +249,7 @@ export class GenericGroupComponent extends EmbeddableComponent {
       <ng-container *ngFor="let fieldElem of field.fields; let i = index;" >
         <div class="row">
           <span class="col-xs-12">
-            <generic-group-field [name]="fieldElem.name" [field]="fieldElem" [form]="form" [fieldMap]="fieldMap" [isEmbedded]="true" [removeBtnText]="field.removeButtonText" [removeBtnClass]="field.removeButtonClass" [canRemove]="field.fields.length > 1" (onRemoveBtnClick)="removeElem($event[0], $event[1])" [index]="i" ></generic-group-field>
+            <generic-group-field [name]="fieldElem.name" [field]="fieldElem" [form]="form" [fieldMap]="fieldMap" [isEmbedded]="true" [removeBtnText]="field.removeButtonText" [removeBtnClass]="field.removeButtonClass" [canRemove]="!disabled && field.fields.length > 1" (onRemoveBtnClick)="removeElem($event[0], $event[1])" [index]="i" ></generic-group-field>
           </span>
         </div>
         <div class="row">
@@ -216,8 +260,8 @@ export class GenericGroupComponent extends EmbeddableComponent {
         <span class="col-xs-11">&nbsp;
         </span>
         <span class="col-xs-1">
-          <button *ngIf="field.addButtonText" type='button' (click)="addElem($event)" [ngClass]="field.addButtonTextClass" >{{field.addButtonText}}</button>
-          <button *ngIf="!field.addButtonText" type='button' (click)="addElem($event)" [ngClass]="field.addButtonClass" [attr.aria-label]="'add-button-label' | translate"></button>
+          <button *ngIf="field.addButtonText" type='button' (click)="addElem($event)" [attr.disabled]="disabled ? 'disabled': null" [ngClass]="field.addButtonTextClass" >{{field.addButtonText}}</button>
+          <button *ngIf="!field.addButtonText" type='button' (click)="addElem($event)" [attr.disabled]="disabled ? 'disabled': null" [ngClass]="field.addButtonClass" [attr.aria-label]="'add-button-label' | translate"></button>
         </span>
       </div>
     </div>
@@ -234,5 +278,18 @@ export class GenericGroupComponent extends EmbeddableComponent {
 })
 export class RepeatableGroupComponent extends RepeatableComponent {
   static clName = 'RepeatableGroupComponent';
+  @ViewChildren(GenericGroupComponent) fieldComponents!: QueryList<GenericGroupComponent>;
 
+
+  enableInputFields() {
+    this.fieldComponents.forEach(fieldComponent => {
+      fieldComponent.enableInputFields();
+    });
+  }
+
+  disableInputFields() {
+    this.fieldComponents.forEach(fieldComponent => {
+      fieldComponent.disableInputFields();
+    });
+  }
 }

--- a/angular-legacy/shared/form/field-repeatable.component.ts
+++ b/angular-legacy/shared/form/field-repeatable.component.ts
@@ -385,6 +385,7 @@ export class EmbeddableComponent extends SimpleComponent {
 
 export class RepeatableComponent extends SimpleComponent {
   field: RepeatableContainer;
+  disabled: boolean = false;
 
   addElem(event: any) {
     this.field.addElem();
@@ -404,6 +405,8 @@ export class RepeatableComponent extends SimpleComponent {
     });
     return hasError;
   }
+
+ 
 }
 
 export class RepeatableVocab extends RepeatableContainer {
@@ -421,6 +424,8 @@ export class RepeatableVocab extends RepeatableContainer {
     selected['originalObject'] = value;
     this.fields[index].component.onSelect(selected, false, true);
   }
+
+  
 }
 
 @Component({
@@ -437,7 +442,7 @@ export class RepeatableVocab extends RepeatableContainer {
     </div>
     <div *ngFor="let fieldElem of field.fields; let i = index;" class="row">
       <span class="col-xs-12 no-horizontal-padding">
-        <rb-vocab [name]="field.name" [field]="fieldElem" [form]="form" [fieldMap]="fieldMap" [isEmbedded]="true" [removeBtnText]="field.removeButtonText" [removeBtnClass]="field.removeButtonClass" [canRemove]="field.allowZeroRows? true: field.fields.length > 1" (onRemoveBtnClick)="removeElem($event[0], $event[1])" [index]="i"></rb-vocab>
+        <rb-vocab [name]="field.name" [field]="fieldElem" [form]="form" [fieldMap]="fieldMap" [isEmbedded]="true" [removeBtnText]="field.removeButtonText" [removeBtnClass]="field.removeButtonClass" [disableInput]="disabled" [canRemove]="!disabled && field.allowZeroRows? true: field.fields.length > 1" (onRemoveBtnClick)="removeElem($event[0], $event[1])" [index]="i"></rb-vocab>
       </span>
     </div>
     <div class="row">
@@ -445,8 +450,8 @@ export class RepeatableVocab extends RepeatableContainer {
       </span>
       <span class="col-xs-1">
        <ng-container *ngIf="field.addButtonShow">
-         <button *ngIf="field.addButtonText" type='button' [disabled]="field.fields.length >= field.maximumEntries" (click)="addElem($event)" [ngClass]="field.addButtonTextClass" >{{field.addButtonText}}</button>
-          <button *ngIf="!field.addButtonText" type='button' [disabled]="field.fields.length >= field.maximumEntries" (click)="addElem($event)" [ngClass]="field.addButtonClass" [attr.aria-label]="'add-button-label' | translate"></button>
+         <button *ngIf="field.addButtonText" type='button' [disabled]="disabled || field.fields.length >= field.maximumEntries" (click)="addElem($event)" [ngClass]="field.addButtonTextClass" >{{field.addButtonText}}</button>
+          <button *ngIf="!field.addButtonText" type='button' [disabled]="disabled || field.fields.length >= field.maximumEntries" (click)="addElem($event)" [ngClass]="field.addButtonClass" [attr.aria-label]="'add-button-label' | translate"></button>
         </ng-container>
       </span>
     </div>
@@ -466,7 +471,14 @@ export class RepeatableVocab extends RepeatableContainer {
 export class RepeatableVocabComponent extends RepeatableComponent {
   field: RepeatableVocab;
   static clName = 'RepeatableVocabComponent';
+  
+  public enableInputFields() {
+    this.disabled = false;
+  }
 
+  public disableInputFields() {
+    this.disabled = true;
+  }
 }
 
 export class RepeatableContributor extends RepeatableContainer {

--- a/angular-legacy/shared/form/field-simple.component.ts
+++ b/angular-legacy/shared/form/field-simple.component.ts
@@ -774,6 +774,7 @@ export class SaveButtonComponent extends SimpleComponent {
     } else {
       this.field.setValue(this.field.clickedValue);
       // passing the field's disableValidation setting from the form definition
+      
       successObs = this.field.targetStep ?
         this.fieldMap._rootComp.onSubmit(this.field.targetStep, this.field.disableValidation, this.field.additionalData) :
         this.fieldMap._rootComp.onSubmit(null, this.field.disableValidation, this.field.additionalData);
@@ -795,7 +796,9 @@ export class SaveButtonComponent extends SimpleComponent {
       if (this.field.confirmationMessage) {
         this.hideConfirmDlg();
       }
-      if (this.field.closeOnSave != true) {
+    
+      // If there was some server side error or validation fired, we need to re-enable the button even if the field is "closeOnSave" to allow a retry
+      if (!_.isEmpty(this.fieldMap._rootComp.status.error) || this.field.closeOnSave != true) {
         this.actionInProgress = false;
       }
     }, catchError => {

--- a/angular-legacy/shared/form/field-simple.component.ts
+++ b/angular-legacy/shared/form/field-simple.component.ts
@@ -780,7 +780,9 @@ export class SaveButtonComponent extends SimpleComponent {
       if (this.field.confirmationMessage) {
         this.hideConfirmDlg();
       }
-      this.disabled = false;
+      if (this.field.closeOnSave != true) {
+        this.disabled = false;
+      }
     }, catchError => {
       this.disabled = false;
     });

--- a/angular-legacy/shared/form/field-simple.component.ts
+++ b/angular-legacy/shared/form/field-simple.component.ts
@@ -326,8 +326,8 @@ export class DropdownFieldComponent extends SelectionComponent {
         <div *ngFor="let opt of findAvailableOptions(field.value)" [ngClass]="field.controlGroupCssClasses">
           <!-- radio type hard-coded otherwise accessor directive will not work! -->
           <!-- the ID and associated label->for property is now delegated to a Fn rather than inline-templated here, to make it optional, e.g. if it is nested -->
-          <input *ngIf="isRadio()" type="radio" [id]="getInputId(opt)" [formControlName]="field.name" [value]="opt.value" [attr.disabled]="field.readOnly ? '' : null " [ngClass]="field.controlInputCssClasses">
-          <input *ngIf="!isRadio()" type="{{field.controlType}}" name="{{field.name}}" [id]="getInputId(opt)" [value]="opt.value" (change)="onChange(opt, $event)" [ngClass]="field.controlInputCssClasses" [attr.selected]="getCheckedFromOption(opt)" [checked]="getCheckedFromOption(opt)" [attr.disabled]="field.readOnly ? '' : null ">
+          <input *ngIf="isRadio()" type="radio" [id]="getInputId(opt)" [formControlName]="field.name" [value]="opt.value" [attr.disabled]="field.readOnly || disabled ? '' : null " [ngClass]="field.controlInputCssClasses">
+          <input *ngIf="!isRadio()" type="{{field.controlType}}" name="{{field.name}}" [id]="getInputId(opt)" [value]="opt.value" (change)="onChange(opt, $event)" [ngClass]="field.controlInputCssClasses" [attr.selected]="getCheckedFromOption(opt)" [checked]="getCheckedFromOption(opt)" [attr.disabled]="field.readOnly || disabled ? '' : null ">
           <label [attr.for]="getInputId(opt)" class="radio-label" [ngClass]="field.controlLabelCssClasses" [innerHtml]="opt.label"></label>
           
         </div>
@@ -378,6 +378,7 @@ export class SelectionFieldComponent extends SelectionComponent {
   defer: any = {};
   defered: boolean = false;
   confirmChanges: boolean = true;
+  disabled:boolean = false;
   /**
    * Allows radio buttons and checkboxes to use a custom form group. Useful when radio buttons are nested within repeatables.
    *
@@ -513,6 +514,14 @@ export class SelectionFieldComponent extends SelectionComponent {
       id = `${this.field.name}_${opt.value}`;
     }
     return id;
+  }
+
+  public enableInputFields() {
+    this.disabled = false;
+  }
+
+  public disableInputFields() {
+    this.disabled = true;
   }
 
 }
@@ -703,7 +712,7 @@ export class TextBlockComponent extends SimpleComponent {
   selector: 'save-button',
   template: `
     <ng-container *ngIf="field.visible">
-      <button type="button" (click)="onClick($event)" class="btn" [ngClass]="field.cssClasses" [disabled]="(!fieldMap._rootComp.needsSave || fieldMap._rootComp.isSaving()) && !field.isSubmissionButton">{{field.label}}</button>
+      <button type="button" (click)="onClick($event)" class="btn" [ngClass]="field.cssClasses" [disabled]="disabled || ((!fieldMap._rootComp.needsSave || fieldMap._rootComp.isSaving()) && !field.isSubmissionButton)">{{field.label}}</button>
       <div *ngIf="field.confirmationMessage" class="modal fade" id="{{ field.name }}_confirmation" tabindex="-1" role="dialog" >
         <div class="modal-dialog" role="document">
           <div class="modal-content">
@@ -713,7 +722,7 @@ export class TextBlockComponent extends SimpleComponent {
             </div>
             <div class="modal-body" [innerHtml]="field.confirmationMessage"></div>
             <div class="modal-footer">
-              <button (click)="hideConfirmDlg()" type="button" class="btn btn-default" data-bs-dismiss="modal" [innerHtml]="field.cancelButtonMessage"></button>
+              <button (click)="hideConfirmDlg()" type="button" [disabled]="disabled" class="btn btn-default" data-bs-dismiss="modal" [innerHtml]="field.cancelButtonMessage"></button>
               <button (click)="doAction()" type="button" class="btn btn-primary" [innerHtml]="field.confirmButtonMessage"></button>
             </div>
           </div>
@@ -724,6 +733,7 @@ export class TextBlockComponent extends SimpleComponent {
 })
 export class SaveButtonComponent extends SimpleComponent {
   public field: SaveButton;
+  disabled: boolean = false;
 
   public onClick(event: any) {
     if (this.field.confirmationMessage) {
@@ -742,6 +752,7 @@ export class SaveButtonComponent extends SimpleComponent {
   }
 
   public doAction() {
+    this.disabled = true;
     var successObs = null;
     if (this.field.isDelete) {
       successObs = this.fieldMap._rootComp.delete();
@@ -752,6 +763,7 @@ export class SaveButtonComponent extends SimpleComponent {
         this.fieldMap._rootComp.onSubmit(this.field.targetStep, this.field.disableValidation, this.field.additionalData) :
         this.fieldMap._rootComp.onSubmit(null, this.field.disableValidation, this.field.additionalData);
     }
+    
     successObs.subscribe(status => {
       if (status) {
         if (this.field.closeOnSave == true) {
@@ -768,6 +780,9 @@ export class SaveButtonComponent extends SimpleComponent {
       if (this.field.confirmationMessage) {
         this.hideConfirmDlg();
       }
+      this.disabled = false;
+    }, catchError => {
+      this.disabled = false;
     });
 
   }
@@ -1067,7 +1082,7 @@ export class SpacerComponent extends SimpleComponent {
   selector: 'toggle',
   template: `
     <div *ngIf="field.type == 'checkbox'" [formGroup]='form'>
-      <input type="checkbox" name="{{field.name}}" [id]="field.name" [formControl]="getFormControl()" [attr.disabled]="field.editMode ? null : ''" >
+      <input type="checkbox" name="{{field.name}}" [id]="field.name" [formControl]="getFormControl()" [attr.disabled]="disabled ? null : ''" >
       <label for="{{ field.name }}" class="radio-label">{{ field.label }} <button *ngIf="field.editMode && field.help" type="button" class="btn btn-default" (click)="toggleHelp()" [attr.aria-label]="'help' | translate "><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></button></label>
       <span id="{{ 'helpBlock_' + field.name }}" class="help-block" *ngIf="this.helpShow" [innerHtml]="field.help"></span>
     </div>
@@ -1078,6 +1093,7 @@ export class ToggleComponent extends SimpleComponent {
   /* BEGIN UTS IMPORT */
   defer: any = {};
   confirmChanges: boolean = true;
+  disabled:boolean = false;
 
   onChange(opt: any, event: any, defered) {
     defered = defered || !_.isUndefined(defered);
@@ -1115,4 +1131,16 @@ export class ToggleComponent extends SimpleComponent {
     this.onChange(defer.opt, defer.event, true);
   }
   /* END UTS IMPORT */
+
+  public enableInputFields() {
+    if(this.field.editMode) {
+      this.disabled = true;
+    } else {
+      this.disabled = false;
+    }
+  }
+
+  public disableInputFields() {
+    this.disabled = true;
+  }
 }

--- a/angular-legacy/shared/form/field-textfield.component.ts
+++ b/angular-legacy/shared/form/field-textfield.component.ts
@@ -141,10 +141,10 @@ export class TextArea extends FieldBase<string> {
         <button type="button" class="btn btn-default" *ngIf="field.help" (click)="toggleHelp()" [attr.aria-label]="'help' | translate "><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></button>
       </label>
         <span id="{{ 'helpBlock_' + field.name }}" class="help-block" *ngIf="this.helpShow" [innerHtml]="field.help"></span>
-      <input [formGroup]='form' [formControl]="getFormControl()"  [id]="field.name" [type]="field.type" [readonly]="field.readOnly" [ngClass]="field.cssClasses" [attr.aria-label]="''" [attr.maxlength]="field.maxLength" >
+      <input [formGroup]='form' [attr.disabled]="disableInput ? 'disabled': null"  [formControl]="getFormControl()"  [id]="field.name" [type]="field.type" [readonly]="disableInput || field.readOnly" [ngClass]="field.cssClasses" [attr.aria-label]="''" [attr.maxlength]="field.maxLength" >
     </div>
     <div *ngIf="isEmbedded" class="input-group padding-bottom-15">
-      <input [formControl]="getFormControl(name, index)"  [id]="field.name" [type]="field.type" [readonly]="field.readOnly" [ngClass]="field.cssClasses" [attr.aria-labelledby]="name" [attr.maxlength]="field.maxLength">
+      <input [formControl]="getFormControl(name, index)"  [id]="field.name" [type]="field.type" [readonly]="disableInput || field.readOnly" [ngClass]="field.cssClasses" [attr.aria-labelledby]="name" [attr.disabled]="disableInput ? 'disabled': null" [attr.maxlength]="field.maxLength">
       <span class="input-group-btn">
         <button type='button' *ngIf="removeBtnText" [disabled]="!canRemove" (click)="onRemove($event)" [ngClass]="removeBtnClass" >{{removeBtnText}}</button>
         <button [disabled]="!canRemove" type='button' [ngClass]="removeBtnClass" (click)="onRemove($event)" [attr.aria-label]="'remove-button-label' | translate"></button>
@@ -162,7 +162,7 @@ export class TextArea extends FieldBase<string> {
   `,
 })
 export class TextFieldComponent extends EmbeddableComponent {
-
+  @Input() disableInput:boolean = false;
 }
 
 @Component({
@@ -181,7 +181,7 @@ export class TextFieldComponent extends EmbeddableComponent {
     </div>
     <div *ngFor="let fieldElem of field.fields; let i = index;" class="row">
       <span class="col-xs-12">
-        <textfield [name]="field.name" [field]="fieldElem" [form]="form" [fieldMap]="fieldMap" [isEmbedded]="true" [removeBtnText]="field.removeButtonText" [removeBtnClass]="field.removeButtonClass" [canRemove]="field.fields.length > field.minimumEntries" (onRemoveBtnClick)="removeElem($event[0], $event[1])" [index]="i"></textfield>
+        <textfield [name]="field.name" [field]="fieldElem" [form]="form" [fieldMap]="fieldMap" [isEmbedded]="true" [removeBtnText]="field.removeButtonText" [removeBtnClass]="field.removeButtonClass" [disableInput]="disabled" [canRemove]="!disabled && field.fields.length > 1" (onRemoveBtnClick)="removeElem($event[0], $event[1])" [index]="i"></textfield>
       </span>
     </div>
     <div class="row">
@@ -192,8 +192,8 @@ export class TextFieldComponent extends EmbeddableComponent {
     </div>
     <div class="row">
       <span *ngIf="field.addButtonShow" class="col-xs-12">
-        <button *ngIf="field.addButtonText" type='button' [disabled]="field.fields.length >= field.maximumEntries" (click)="addElem($event)" [ngClass]="field.addButtonTextClass" >{{field.addButtonText}}</button>
-        <button *ngIf="!field.addButtonText" type='button' [disabled]="field.fields.length >= field.maximumEntries" (click)="addElem($event)" [ngClass]="field.addButtonClass" [attr.aria-label]="'add-button-label' | translate"></button>
+        <button *ngIf="field.addButtonText" type='button' [disabled]="disabled || field.fields.length >= field.maximumEntries" (click)="addElem($event)" [ngClass]="field.addButtonTextClass" >{{field.addButtonText}}</button>
+        <button *ngIf="!field.addButtonText" type='button' [disabled]="disabled || field.fields.length >= field.maximumEntries" (click)="addElem($event)" [ngClass]="field.addButtonClass" [attr.aria-label]="'add-button-label' | translate"></button>
       </span>
     </div>
   </div>
@@ -201,7 +201,7 @@ export class TextFieldComponent extends EmbeddableComponent {
     <span *ngIf="field.label" class="key">{{field.label}}</span>
     <span class="value">
       <ul class="key-value-list">
-        <textfield *ngFor="let fieldElem of field.fields; let i = index;"  [field]="fieldElem" [form]="form" [fieldMap]="fieldMap"></textfield>
+        <textfield *ngFor="let fieldElem of field.fields; let i = index;"  [field]="fieldElem" [form]="form"  [fieldMap]="fieldMap"></textfield>
       </ul>
     </span>
   </li>
@@ -221,6 +221,14 @@ export class RepeatableTextfieldComponent extends RepeatableComponent {
 
   removeElem(event: any, i: number) {
     this.field.removeElem(i);
+  }
+
+  public enableInputFields() {
+    this.disabled = false;
+  }
+
+  public disableInputFields() {
+    this.disabled = true;
   }
 }
 

--- a/angular-legacy/shared/form/field-vocab.component.ts
+++ b/angular-legacy/shared/form/field-vocab.component.ts
@@ -852,7 +852,7 @@ export class VocabFieldComponent extends SimpleComponent {
   @Input() index: number;
   @Input() disableEditAfterSelect: boolean = true;
   @Output() onRemoveBtnClick: EventEmitter<any> = new EventEmitter<any>();
-  disableInput: boolean;
+  @Input() disableInput: boolean = false;
   @ViewChild('ngCompleter') public ngCompleter: ElementRef;
 
   constructor() {

--- a/angular-legacy/shared/util-service.ts
+++ b/angular-legacy/shared/util-service.ts
@@ -30,6 +30,7 @@ import numeral from 'numeral';
 @Injectable()
 export class UtilityService {
 
+  compiledTemplateMap: any = {};
   /**
    * returns concatenated string
    *
@@ -363,9 +364,13 @@ export class UtilityService {
 
   public runTemplate(data: any, config: any, field: any = undefined) {
     const imports = _.extend({data: data, config: config, moment: moment, numeral:numeral, field: field}, this);
-    const templateData = {imports: imports};
-    const template = _.template(config.template, templateData);
-    const templateRes = template();
+    const templateData = imports;
+    let template = this.compiledTemplateMap[config.template]
+    if(template === undefined) {
+      template = _.template(config.template);
+      this.compiledTemplateMap[config.template] = template;
+    }
+    const templateRes = template(templateData);
     // added ability to parse the string template result into JSON
     // requirement: template must return a valid JSON string object
     if (config.json == true && !_.isEmpty(templateRes)) {


### PR DESCRIPTION
The default behaviour for disable expressions is to use jQuery to find and disable any input fields or buttons. The issue with this is that some components have elements within their component that need to be disabled to ensure correct operation and the disable logic within the angular component was being overridden. For example, the remove button in a repeatable field will be enabled even when the minimum number of fields is present.
This fix introduces the ability to delegate enable and disable control to the component directly when a disable expression returns true. This is performed by calling the component's `enableInputFields` and `disableInputFields` function when they exist