### PR TITLE
Allow setting log levels per namespace

### DIFF
--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -113,7 +113,6 @@
 
  }
  
- 
  module.exports.bootstrap = function (cb) {
    if (sails.config.security.csrf === "false") {
      sails.config.security.csrf = false;
@@ -125,8 +124,10 @@
      sails.config.ng2.use_bundled = true;
      console.log("Using NG2 Bundled files.......");
    }
- 
-   
+
+   // Update the pino log level to the sails.log.level.
+   sails.config.log.customLogger.level = sails.config.log.level;
+
    // actual bootstrap...
    sails.log.debug("Starting boostrap process with boostrapAlways set to: " + sails.config.appmode.bootstrapAlways);
    actualBootstrap().then(response => {

--- a/config/log.js
+++ b/config/log.js
@@ -2,14 +2,195 @@
  * Built-in Log Configuration
  * (sails.config.log)
  *
- * Configure the log level for your app, as well as the transport
- * (Underneath the covers, Sails uses Winston for logging, which
- * allows for some pretty neat custom transports/adapters for log messages)
+ * Configure the log level for your app, as well as the transport.
  *
  * For more information on the Sails logger, check out:
  * http://sailsjs.org/#!/documentation/concepts/Logging
+ *
+ * Using pino for namespace logging and different formats to different transports.
+ * https://getpino.io
  */
 
-module.exports.log = {
+const _ = require("lodash");
+const pino = require('pino');
 
+/**
+ * Create a pino logger, using an optional log level and an optional destination.
+ * @param level The log level (a sails.js log level).
+ * @param destination An additional pino destination
+ * @returns {*}
+ */
+function createPinoLogger(level, destination) {
+    // TODO: Set up transports to send:
+    //       - JSON formatted logs to Grafana (at log level e.g. warn)
+    //       - Simple logs to stdout (using the provided log level)
+
+    // At the moment, all logs are sent only to stdout, in logfmt format.
+
+    // Set the pino log level. This must be kept in sync with the sails log level.
+    // Set the log level by:
+    // 1. using the provided log level, or
+    // 2. getting the sails log level if it is set, otherwise
+    // 3. default to 'verbose'.
+    // if (typeof sails !== undefined) {
+    //     level = sails?.config?.log?.level ?? null;
+    // }
+    if (!level) {
+        level = 'verbose';
+    }
+
+    // Set up a default configuration for pino.
+    // This is used in configuring the logger and for testing.
+    const options = {
+        // use level labels instead of numbers
+        formatters: {
+            level: (label) => {
+                return {
+                    level: label
+                }
+            }
+        },
+
+        // This adds more log levels to pino to match the levels expected by sails.js.
+        // Only the sails.js log levels are recognised.
+        customLevels: {
+            // sails.js 'silly' is 'more verbose' than pino 'trace'
+            silly: 5,
+
+            // sails.js 'verbose' is pino 'trace'
+            verbose: 9,
+
+            // trace: 10, // pino only
+            // debug: 20, // sails.js & pino
+
+            // 'log' is 'info'
+            log: 29,
+
+            // info: 30, // sails.js & pino
+            // warn: 40, // sails.js & pino
+            // error: 50, // sails.js & pino
+
+            // sails.js 'crit' is pino 'fatal'
+            crit: 59,
+
+            // fatal: 60, // pino
+
+            // sails.js 'blank' is pino 'silent'
+            blank: _.noop,
+
+            // pino 'silent' is also a no-op
+        },
+        level: level,
+    };
+
+    if (destination) {
+        return pino(options, destination);
+    } else {
+        // Use the logfmt format instead of the default JSON format.
+        // options.transport = {
+        //     target: "pino-logfmt",
+        //     options: {
+        //         formatTime: true,
+        //         flattenNestedObjects: true,
+        //         convertToSnakeCase: true,
+        //     }
+        // };
+        return pino(options);
+    }
+}
+
+/**
+ * Create a custom sails.js logger using pino.
+ * @param customLogger The custom logger to use as the sails.js logger.
+ */
+function createCustomSailsLogger(customLogger) {
+    return {
+        // Wrap the pino logger so it passes the sails.js 'valid custom logger' check.
+        // Include the additional pino levels so that any log calls within pino work.
+        custom: {
+            silly: () => customLogger.silly(...arguments),
+            verbose: () => customLogger.verbose(...arguments),
+            // trace: () => customLogger.trace(...arguments),
+            debug: () => customLogger.debug(...arguments),
+            log: () => customLogger.log(...arguments),
+            info: () => customLogger.info(...arguments),
+            warn: () => customLogger.warn(...arguments),
+            error: () => customLogger.error(...arguments),
+            // crit: () => customLogger.crit(...arguments),
+            // fatal: () => customLogger.fatal(...arguments),
+            silent: () => customLogger.silent(...arguments),
+            // blank: () => customLogger.blank(...arguments),
+        },
+        inspect: false,
+    };
+}
+
+/**
+ * Create a namespaced logger using the pino 'childlogger' feature.
+ * @param name The name for the namespace.
+ * @param parentLogger The existing logger to use. Will use the default sails logger if not provided.
+ * @param prefix A prefix to apply to every log created by this namespaced logger.
+ * @param level The log level for the new namespaced logger.
+ * @returns The new namespaced logger.
+ */
+function createNamespaceLogger(name, parentLogger, prefix, level) {
+    // Refs:
+    // https://getpino.io/#/docs/api?id=child
+    // https://getpino.io/#/docs/child-loggers
+    // https://github.com/pinojs/pino/issues/1886
+
+    // if (!parentLogger && typeof sails !== undefined) {
+    //     parentLogger = sails.log;
+    // }
+    if (!name) {
+        throw new Error(`Must provide a logger name.`);
+    }
+
+
+    let calcLevel = level ?? null;
+    // if (typeof sails !== undefined) {
+    //     calcLevel = sails.config.lognamespace[name] ?? null;
+    // }
+
+    const bindings = {name: name};
+    const options = {};
+
+    // Set any customisations.
+    if (calcLevel !== null) {
+        options['level'] = calcLevel;
+    }
+    if (prefix) {
+        options['msgPrefix'] = prefix;
+    }
+
+    const newLogger = parentLogger.child(bindings, options);
+
+    // // for debugging:
+    // // Helper function to check the type of the item.
+    // function checkType(item) {
+    //     // see: https://github.com/balderdashy/captains-log/blob/28fb8e0ce903e23d2eabf881bc4020223847ac54/index.js#L57
+    //     return {
+    //         'obj': item,
+    //         'toString.call': Object.prototype.toString.call(item),
+    //         'typeof': typeof item,
+    //         'isObject': _.isObject(item),
+    //         'isFunction': _.isFunction(item.log),
+    //     };
+    // }
+    // console.log(`createNamespaceLogger result`, JSON.stringify({
+    //     bindings: bindings,
+    //     options: options,
+    //     checkType: checkType(newLogger)
+    // }));
+
+    return newLogger;
+}
+
+module.exports.log = {
+    ...createCustomSailsLogger(createPinoLogger()),
+};
+
+module.exports.logHelpers = {
+    createNamespaceLogger: createNamespaceLogger,
+    createPinoLogger: createPinoLogger,
 };

--- a/config/lognamespace.js
+++ b/config/lognamespace.js
@@ -1,0 +1,14 @@
+/*
+ * Namespace loggers:
+ * Change the log level individually per logger.
+ * The convention is to use class names.
+ *
+ * Implementation:
+ * Key is the case-sensitive name passed to 'createNamespaceLogger'.
+ * Value is the log level, one of the sails.js levels.
+ *
+ * These can be set in a config file named 'lognamespace.js' using 'module.exports.lognamespace',
+ * or set via env var e.g. `'sails_lognamespace__EmailService=info'`
+ */
+
+module.exports.lognamespace = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,8 @@
         "passport-http-bearer": "^1.0.1",
         "passport-jwt": "^4.0.1",
         "passport-local": "^1.0.0",
+        "pino": "^9.6.0",
+        "pino-logfmt": "^0.1.1",
         "postcss": "^8.5.3",
         "rc": "1.2.8",
         "redux": "5.0.1",
@@ -100,6 +102,7 @@
         "istanbul": "^0.4.5",
         "mocha": "^11.1.0",
         "mocha-junit-reporter": "^2.2.1",
+        "pino-test": "^1.1.0",
         "supertest": "^7.0.0",
         "uglify-es": "^3.3.10"
       }
@@ -133,10 +136,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.24.7",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -315,14 +321,18 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.7",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.7",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -336,82 +346,26 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.24.7",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.10.tgz",
+      "integrity": "sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/template": "^7.26.9",
+        "@babel/types": "^7.26.10"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.24.7",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "license": "MIT"
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.24.7",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
+      "integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
       "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.26.10"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -420,7 +374,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.23.8",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -430,12 +386,14 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.24.7",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
+      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/parser": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.26.9",
+        "@babel/types": "^7.26.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -461,12 +419,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.24.7",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+      "integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.7",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -922,6 +881,146 @@
         "@parcel/watcher-win32-x64": "2.4.1"
       }
     },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.4.1.tgz",
+      "integrity": "sha512-LOi/WTbbh3aTn2RYddrO8pnapixAziFl6SMxHM69r3tvdSm94JtCenaKgk1GRg5FJ5wpMCpHeW+7yqPlvZv7kg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.4.1.tgz",
+      "integrity": "sha512-ln41eihm5YXIY043vBrrHfn94SIBlqOWmoROhsMVTSXGh0QahKGy77tfEywQ7v3NywyxBBkGIfrWRHm0hsKtzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.4.1.tgz",
+      "integrity": "sha512-yrw81BRLjjtHyDu7J61oPuSoeYWR3lDElcPGJyOvIXmor6DEo7/G2u1o7I38cwlcoBHQFULqF6nesIX3tsEXMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.4.1.tgz",
+      "integrity": "sha512-TJa3Pex/gX3CWIx/Co8k+ykNdDCLx+TuZj3f3h7eOjgpdKM+Mnix37RYsYU4LHhiYJz3DK5nFCCra81p6g050w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.4.1.tgz",
+      "integrity": "sha512-4rVYDlsMEYfa537BRXxJ5UF4ddNwnr2/1O4MHM5PjI9cvV2qymvhwZSFgXqbS8YoTk5i/JR0L0JDs69BUn45YA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.4.1.tgz",
+      "integrity": "sha512-BJ7mH985OADVLpbrzCLgrJ3TOpiZggE9FMblfO65PlOCdG++xJpKUJ0Aol74ZUIYfb8WsRlUdgrZxKkz3zXWYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.4.1.tgz",
+      "integrity": "sha512-p4Xb7JGq3MLgAfYhslU2SjoV9G0kI0Xry0kuxeG/41UfpjHGOhv7UoUDAz/jb1u2elbhazy4rRBL8PegPJFBhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/@parcel/watcher-linux-x64-glibc": {
       "version": "2.4.1",
       "cpu": [
@@ -949,6 +1048,66 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.4.1.tgz",
+      "integrity": "sha512-Uq2BPp5GWhrq/lcuItCHoqxjULU1QYEcyjSO5jqqOK8RNFDBQnenMMx4gAl3v8GiWa59E9+uDM7yZ6LxwUIfRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.4.1.tgz",
+      "integrity": "sha512-maNRit5QQV2kgHFSYwftmPBxiuK5u4DXjbXx7q6eKjq5dsLXZ4FJiVvlcw35QXzk0KrUecJmuVFbj4uV9oYrcw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.4.1.tgz",
+      "integrity": "sha512-+DvS92F9ezicfswqrvIRM2njcYJbd5mb9CUgtrHCHmvn7pPPa+nMDRu1o1bYYz/l5IB2NVGNJWiH7h1E58IF2A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10.0.0"
@@ -1145,14 +1304,16 @@
       "version": "0.2.10"
     },
     "node_modules/@sailshq/router": {
-      "version": "1.3.9",
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@sailshq/router/-/router-1.3.10.tgz",
+      "integrity": "sha512-6h5IE0PrSEkF03Fze1lUwnDMnYMbBPkUgKaUG/mkthHpiO/VDzbD0QJXyD7xmhlD05dEzuZnGqrrUeY5oZIMAg==",
       "license": "MIT",
       "dependencies": {
         "array-flatten": "3.0.0",
         "debug": "2.6.9",
         "methods": "~1.1.2",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.11",
+        "path-to-regexp": "0.1.12",
         "setprototypeof": "1.2.0",
         "utils-merge": "1.0.1"
       },
@@ -1168,7 +1329,9 @@
       }
     },
     "node_modules/@sailshq/router/node_modules/path-to-regexp": {
-      "version": "0.1.11",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
     "node_modules/@scienta/axios-oauth2": {
@@ -1844,6 +2007,15 @@
       "version": "0.4.0",
       "license": "MIT"
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "license": "MIT",
@@ -1916,9 +2088,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.1.tgz",
-      "integrity": "sha512-NN+fvwH/kV01dYUQ3PTOZns4LWtWhOFCAhQ/pHb88WQ1hNe5V/dvFwc4VJcDL11LT9xSX0QtsR8sWUuyOuOq7g==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
+      "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -2191,6 +2363,30 @@
         "node": ">=16.20.1"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "license": "BSD-3-Clause"
@@ -2353,6 +2549,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/caseless": {
@@ -2874,24 +3082,33 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "4.0.2",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
       "dependencies": {
-        "lru-cache": "^4.0.1",
-        "which": "^1.2.9"
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
-    "node_modules/cross-spawn/node_modules/lru-cache": {
-      "version": "4.1.5",
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "license": "ISC",
       "dependencies": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
-    },
-    "node_modules/cross-spawn/node_modules/yallist": {
-      "version": "2.1.2",
-      "license": "ISC"
     },
     "node_modules/crypt": {
       "version": "0.0.2",
@@ -3206,6 +3423,15 @@
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-5.0.3.tgz",
+      "integrity": "sha512-Kvr6HmPXUMerlLcLF+Pwq3K7apHpYmGDVqrxcDasBg86UcKeTSNWbEzU8bwdXnxnR44FtMhJAxI4Bov6Y/KUfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
       }
     },
     "node_modules/debug": {
@@ -4110,6 +4336,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-redact": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "dev": true,
@@ -4320,18 +4555,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/foreground-child/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/foreground-child/node_modules/signal-exit": {
       "version": "4.1.0",
       "license": "ISC",
@@ -4340,19 +4563,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/foreground-child/node_modules/which": {
-      "version": "2.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/forever-agent": {
@@ -5050,6 +5260,26 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.1",
       "license": "MIT",
@@ -5382,18 +5612,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/istanbul-lib-processinfo/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/istanbul-lib-processinfo/node_modules/glob": {
       "version": "7.2.3",
       "license": "ISC",
@@ -5430,19 +5648,6 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/istanbul-lib-processinfo/node_modules/which": {
-      "version": "2.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/istanbul-lib-report": {
@@ -5724,6 +5929,8 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -6429,6 +6636,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/logfmt": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/logfmt/-/logfmt-1.4.0.tgz",
+      "integrity": "sha512-p1Ow0C2dDJYaQBhRHt+HVMP6ELuBm4jYSYNHPMfz0J5wJ9qA6/7oBOlBZBfT1InqguTYcvJzNea5FItDxTcbyw==",
+      "license": "MIT",
+      "dependencies": {
+        "split": "0.2.x",
+        "through": "2.3.x"
+      },
+      "bin": {
+        "logfmt": "bin/logfmt"
+      }
+    },
     "node_modules/logform": {
       "version": "2.6.0",
       "license": "MIT",
@@ -6668,10 +6888,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -7547,6 +7769,15 @@
         "node": "^10.13.0 || >=12.0.0"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.3.0",
       "license": "MIT",
@@ -7963,6 +8194,153 @@
       "optional": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pino": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.6.0.tgz",
+      "integrity": "sha512-i85pKRCt4qMjZ1+L7sy2Ag4t1atFcdbEt76+7iRJn1g2BvsnRMGu9p8pivl9fs63M2kF/A0OacFZhTub+m/qMg==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^4.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
+      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pino-abstract-transport/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/pino-logfmt": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pino-logfmt/-/pino-logfmt-0.1.1.tgz",
+      "integrity": "sha512-Q0rG4rs88ag0Ssb+lzWIzZOLS5/eC/sw7yBD/jRuqDizDRF5QHMLLVDowPSTGVOC5w82UDbgm+g2oT0EtP6ccQ==",
+      "license": "MIT",
+      "dependencies": {
+        "case-anything": "^2.1.13",
+        "commander": "^12.0.0",
+        "dateformat": "^5.0.3",
+        "logfmt": "^1.4.0",
+        "pino-abstract-transport": "^1.1.0",
+        "pump": "^3.0.0",
+        "sonic-boom": "^3.8.0"
+      },
+      "bin": {
+        "pino-logfmt": "src/bin.js"
+      }
+    },
+    "node_modules/pino-logfmt/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "license": "MIT"
+    },
+    "node_modules/pino-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pino-test/-/pino-test-1.1.0.tgz",
+      "integrity": "sha512-eAD3qqt23jiJrwAWHSEdKyBRUjflodcTW14u9i/k4sdDsIT0r3v1cv+JyLJERFYfWgVkqAjgfOCkHVFiPNvpmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.2.0"
+      }
+    },
+    "node_modules/pino/node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino/node_modules/sonic-boom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -8484,6 +8862,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "license": "MIT"
@@ -8497,6 +8884,22 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/process-warning": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+      "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/promise": {
       "version": "5.0.0",
@@ -8544,13 +8947,19 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/pseudomap": {
-      "version": "1.0.2",
-      "license": "ISC"
-    },
     "node_modules/psl": {
       "version": "1.8.0",
       "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -8589,6 +8998,12 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
     "node_modules/random-bytes": {
@@ -8727,6 +9142,15 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/rechoir": {
@@ -9108,13 +9532,14 @@
       }
     },
     "node_modules/sails-generate": {
-      "version": "2.0.11",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/sails-generate/-/sails-generate-2.0.13.tgz",
+      "integrity": "sha512-ky+YcxSe2pBTohfIZIxU+XARuYu7ZxjFOTvWcivfF3oVHBmpc22VihbNjotNA4QWdKw13vfHWvoJpyHjccGOoA==",
       "license": "MIT",
       "dependencies": {
         "@sailshq/lodash": "^3.10.3",
         "async": "2.6.4",
         "chalk": "2.3.0",
-        "cross-spawn": "4.0.2",
         "flaverr": "^1.0.0",
         "fs-extra": "0.30.0",
         "machinepack-process": "^4.0.0",
@@ -10045,6 +10470,15 @@
       "version": "3.7.2",
       "license": "MIT"
     },
+    "node_modules/sonic-boom": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
+      "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/sort-route-addresses": {
       "version": "0.0.4",
       "license": "MIT",
@@ -10100,18 +10534,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/spawn-wrap/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/spawn-wrap/node_modules/foreground-child": {
@@ -10187,6 +10609,26 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/split": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
+      "integrity": "sha512-e0pKq+UUH2Xq/sXbYpZBZc3BawsfDZ7dgv+JtRTUPNcvF5CMR4Y9cvJqkMY0MoxWzTHvZuz1beg6pNEKlszPiQ==",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -10668,6 +11110,15 @@
       "version": "1.0.0",
       "license": "MIT"
     },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "license": "MIT"
@@ -10682,13 +11133,6 @@
     "node_modules/tmpl": {
       "version": "1.0.5",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -11397,6 +11841,7 @@
     },
     "node_modules/which": {
       "version": "1.3.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "passport-http-bearer": "^1.0.1",
     "passport-jwt": "^4.0.1",
     "passport-local": "^1.0.0",
+    "pino": "^9.6.0",
+    "pino-logfmt": "^0.1.1",
     "postcss": "^8.5.3",
     "rc": "1.2.8",
     "redux": "5.0.1",
@@ -121,6 +123,7 @@
     "istanbul": "^0.4.5",
     "mocha": "^11.1.0",
     "mocha-junit-reporter": "^2.2.1",
+    "pino-test": "^1.1.0",
     "supertest": "^7.0.0",
     "uglify-es": "^3.3.10"
   },

--- a/test/unit/services/logs.test.js
+++ b/test/unit/services/logs.test.js
@@ -1,0 +1,279 @@
+const pino = require('pino');
+const pinoTest = require('pino-test');
+const {logHelpers} = require('../../../config/log');
+
+// Custom assert function for pino testing
+function expectFunc(received, expected, msg){
+    const actualItem = `LEVEL ${received.level} MSG ${received.msg}`;
+    const expectedItem = `LEVEL ${expected.level} MSG ${expected.msg}`;
+    expect(expectedItem).to.eql(actualItem);
+}
+
+function logAll(loggerInstance, msg) {
+    // pino defaults
+    loggerInstance.trace(msg);
+    loggerInstance.debug(msg);
+    loggerInstance.info(msg);
+    loggerInstance.warn(msg);
+    loggerInstance.error(msg);
+    loggerInstance.fatal(msg);
+    loggerInstance.silent(msg);
+
+    // additional sails.js levels
+    loggerInstance.silly(msg);
+    loggerInstance.verbose(msg);
+    loggerInstance.log(msg);
+    loggerInstance.crit(msg);
+    loggerInstance.blank(msg);
+}
+
+
+describe('The custom logger', function () {
+
+    it('should log a info message', async () => {
+        const stream = pinoTest.sink();
+        const logger = pino(stream);
+
+        logger.info('hello world');
+
+        const expected = {msg: 'hello world', level: 30};
+        await pinoTest.once(stream, expected, expectFunc);
+    })
+
+
+    it('should log a info message using a own assert function', async () => {
+        const stream = pinoTest.sink();
+        const logger = pino(stream);
+
+        logger.info('hello world');
+
+        const expected = {msg: 'hello world', level: 30};
+        await pinoTest.once(stream, expected, expectFunc);
+    })
+
+    it("should have expected logs for default logger with level 'silly'", async function () {
+        const stream = pinoTest.sink();
+        const defaultLogger = logHelpers.createPinoLogger('silly', stream);
+
+        const defaultLoggerMsg = "log message for default logger";
+        logAll(defaultLogger, defaultLoggerMsg);
+
+        const expectedItems = [
+            {msg: defaultLoggerMsg, level: "trace"},
+            {msg: defaultLoggerMsg, level: "debug"},
+            {msg: defaultLoggerMsg, level: "info"},
+            {msg: defaultLoggerMsg, level: "warn"},
+            {msg: defaultLoggerMsg, level: "error"},
+            {msg: defaultLoggerMsg, level: "fatal"},
+            // {msg: defaultLoggerMsg, level: "silent"},
+            {msg: defaultLoggerMsg, level: "silly"},
+            {msg: defaultLoggerMsg, level: "verbose"},
+            {msg: defaultLoggerMsg, level: "log"},
+            {msg: defaultLoggerMsg, level: "crit"},
+            // {msg: defaultLoggerMsg, level: "blank"},
+        ];
+        await pinoTest.consecutive(stream, expectedItems, expectFunc);
+    });
+    it("should have expected logs for namespace logger with level 'silly'", async function () {
+        const stream = pinoTest.sink();
+        const defaultLogger = logHelpers.createPinoLogger('crit', stream);
+
+        const prefix = '[testing] ';
+        const namespaceLogger = logHelpers.createNamespaceLogger('childlogger', defaultLogger, prefix, 'silly');
+
+        const namespaceLoggerMsg = "log message for namespace logger";
+        logAll(namespaceLogger, namespaceLoggerMsg);
+
+        const namespaceMsg = prefix + namespaceLoggerMsg;
+        const expectedItems = [
+            {msg: namespaceMsg, level: "trace"},
+            {msg: namespaceMsg, level: "debug"},
+            {msg: namespaceMsg, level: "info"},
+            {msg: namespaceMsg, level: "warn"},
+            {msg: namespaceMsg, level: "error"},
+            {msg: namespaceMsg, level: "fatal"},
+            // {msg: namespaceMsg, level: "silent"},
+            {msg: namespaceMsg, level: "silly"},
+            {msg: namespaceMsg, level: "verbose"},
+            {msg: namespaceMsg, level: "log"},
+            {msg: namespaceMsg, level: "crit"},
+            // {msg: namespaceMsg, level: "blank"},
+        ];
+        await pinoTest.consecutive(stream, expectedItems, expectFunc);
+    });
+
+    it("should have expected values for child logger with level 'verbose' default logger with level 'error'", async function () {
+        const stream = pinoTest.sink();
+        const defaultLogger = logHelpers.createPinoLogger('error', stream);
+        const prefix = '[testing] ';
+        const namespaceLogger = logHelpers.createNamespaceLogger('childlogger', defaultLogger, prefix, 'verbose');
+
+        const defaultLoggerMsg = "log message for default logger";
+        logAll(defaultLogger, defaultLoggerMsg);
+
+        const namespaceLoggerMsg = "log message for namespace logger";
+        logAll(namespaceLogger, namespaceLoggerMsg);
+
+        const defaultMsg = defaultLoggerMsg;
+        const namespaceMsg = prefix + namespaceLoggerMsg;
+        const expectedItems = [
+            // default
+            // {msg: defaultMsg, level: "trace"},
+            // {msg: defaultMsg, level: "debug"},
+            // {msg: defaultMsg, level: "info"},
+            // {msg: defaultMsg, level: "warn"},
+            {msg: defaultMsg, level: "error"},
+            {msg: defaultMsg, level: "fatal"},
+            // {msg: defaultMsg, level: "silent"},
+            // {msg: defaultMsg, level: "silly"},
+            // {msg: defaultMsg, level: "verbose"},
+            // {msg: defaultMsg, level: "log"},
+            {msg: defaultMsg, level: "crit"},
+            // {msg: defaultMsg, level: "blank"},
+
+            // namespace
+            {msg: namespaceMsg, level: "trace"},
+            {msg: namespaceMsg, level: "debug"},
+            {msg: namespaceMsg, level: "info"},
+            {msg: namespaceMsg, level: "warn"},
+            {msg: namespaceMsg, level: "error"},
+            {msg: namespaceMsg, level: "fatal"},
+            // {msg: namespaceMsg, level: "silent"},
+            // {msg: namespaceMsg, level: "silly"},
+            {msg: namespaceMsg, level: "verbose"},
+            {msg: namespaceMsg, level: "log"},
+            {msg: namespaceMsg, level: "crit"},
+            // {msg: namespaceMsg, level: "blank"},
+        ];
+        await pinoTest.consecutive(stream, expectedItems, expectFunc);
+    });
+
+    it("should have expected values for child logger with level 'log' default logger with level 'verbose'", async function () {
+        const stream = pinoTest.sink();
+        const defaultLogger = logHelpers.createPinoLogger('verbose', stream);
+        const prefix = '[my prefix] ';
+        const namespaceLogger = logHelpers.createNamespaceLogger('childlogger', defaultLogger, prefix, 'log');
+
+        const defaultLoggerMsg = "log message for default logger";
+        logAll(defaultLogger, defaultLoggerMsg);
+
+        const namespaceLoggerMsg = "log message for namespace logger";
+        logAll(namespaceLogger, namespaceLoggerMsg);
+
+        const defaultMsg = defaultLoggerMsg;
+        const namespaceMsg = prefix + namespaceLoggerMsg;
+        const expectedItems = [
+            // default
+            {msg: defaultMsg, level: "trace"},
+            {msg: defaultMsg, level: "debug"},
+            {msg: defaultMsg, level: "info"},
+            {msg: defaultMsg, level: "warn"},
+            {msg: defaultMsg, level: "error"},
+            {msg: defaultMsg, level: "fatal"},
+            // {msg: defaultMsg, level: "silent"},
+            // {msg: defaultMsg, level: "silly"},
+            {msg: defaultMsg, level: "verbose"},
+            {msg: defaultMsg, level: "log"},
+            {msg: defaultMsg, level: "crit"},
+            // {msg: defaultMsg, level: "blank"},
+
+            // namespace
+            // {msg: namespaceMsg, level: "trace"},
+            // {msg: namespaceMsg, level: "debug"},
+            {msg: namespaceMsg, level: "info"},
+            {msg: namespaceMsg, level: "warn"},
+            {msg: namespaceMsg, level: "error"},
+            {msg: namespaceMsg, level: "fatal"},
+            // {msg: namespaceMsg, level: "silent"},
+            // {msg: namespaceMsg, level: "silly"},
+            // {msg: namespaceMsg, level: "verbose"},
+            {msg: namespaceMsg, level: "log"},
+            {msg: namespaceMsg, level: "crit"},
+            // {msg: namespaceMsg, level: "blank"},
+        ];
+        await pinoTest.consecutive(stream, expectedItems, expectFunc);
+    });
+
+    it("should use the configured namedspace log level", async function () {
+        sails.config.lognamespace['EmailService'] = 'info';
+        sails.config.lognamespace['ConfigService'] = 'crit';
+
+        const prefix = "[testing namespaces] "
+        const defaultLoggerMsg = "log message for default logger";
+        const namespaceLoggerMsg = "log message for namespace logger";
+
+        const defaultMsg = defaultLoggerMsg;
+        const namespaceMsg = prefix + namespaceLoggerMsg;
+
+        const stream = pinoTest.sink();
+        const defaultLogger = logHelpers.createPinoLogger('silly', stream);
+
+        const namespaceLogger1 = logHelpers.createNamespaceLogger('EmailService', defaultLogger, prefix);
+        logAll(defaultLogger, defaultLoggerMsg);
+        logAll(namespaceLogger1, namespaceLoggerMsg);
+        const expectedItems1 = [
+            // default
+            {msg: defaultMsg, level: "trace"},
+            {msg: defaultMsg, level: "debug"},
+            {msg: defaultMsg, level: "info"},
+            {msg: defaultMsg, level: "warn"},
+            {msg: defaultMsg, level: "error"},
+            {msg: defaultMsg, level: "fatal"},
+            // {msg: defaultMsg, level: "silent"},
+            {msg: defaultMsg, level: "silly"},
+            {msg: defaultMsg, level: "verbose"},
+            {msg: defaultMsg, level: "log"},
+            {msg: defaultMsg, level: "crit"},
+            // {msg: defaultMsg, level: "blank"},
+
+            // namespace
+            // {msg: namespaceMsg, level: "trace"},
+            // {msg: namespaceMsg, level: "debug"},
+            {msg: namespaceMsg, level: "info"},
+            {msg: namespaceMsg, level: "warn"},
+            {msg: namespaceMsg, level: "error"},
+            {msg: namespaceMsg, level: "fatal"},
+            // {msg: namespaceMsg, level: "silent"},
+            // {msg: namespaceMsg, level: "silly"},
+            // {msg: namespaceMsg, level: "verbose"},
+            {msg: namespaceMsg, level: "log"},
+            {msg: namespaceMsg, level: "crit"},
+            // {msg: namespaceMsg, level: "blank"},
+        ];
+        await pinoTest.consecutive(stream, expectedItems1, expectFunc);
+
+        const namespaceLogger2 = logHelpers.createNamespaceLogger('ConfigService', defaultLogger, prefix);
+        logAll(defaultLogger, defaultLoggerMsg);
+        logAll(namespaceLogger2, namespaceLoggerMsg);
+        const expectedItems2 = [
+            // default
+            {msg: defaultMsg, level: "trace"},
+            {msg: defaultMsg, level: "debug"},
+            {msg: defaultMsg, level: "info"},
+            {msg: defaultMsg, level: "warn"},
+            {msg: defaultMsg, level: "error"},
+            {msg: defaultMsg, level: "fatal"},
+            // {msg: defaultMsg, level: "silent"},
+            {msg: defaultMsg, level: "silly"},
+            {msg: defaultMsg, level: "verbose"},
+            {msg: defaultMsg, level: "log"},
+            {msg: defaultMsg, level: "crit"},
+            // {msg: defaultMsg, level: "blank"},
+
+            // namespace
+            // {msg: namespaceMsg, level: "trace"},
+            // {msg: namespaceMsg, level: "debug"},
+            // {msg: namespaceMsg, level: "info"},
+            // {msg: namespaceMsg, level: "warn"},
+            // {msg: namespaceMsg, level: "error"},
+            {msg: namespaceMsg, level: "fatal"},
+            // {msg: namespaceMsg, level: "silent"},
+            // {msg: namespaceMsg, level: "silly"},
+            // {msg: namespaceMsg, level: "verbose"},
+            // {msg: namespaceMsg, level: "log"},
+            {msg: namespaceMsg, level: "crit"},
+            // {msg: namespaceMsg, level: "blank"},
+        ];
+        await pinoTest.consecutive(stream, expectedItems2, expectFunc);
+    });
+});


### PR DESCRIPTION
Introduce [pino](https://getpino.io) to enable new logging features:

- change the log format to logfmt or json
- send logs to different transports e.g. json format to log management service, logfmt to stdout
- allow different log levels in different parts of the app ( separate 'namedspace' / 'child' loggers)

This is set up using the sails log config customisation.