### PR TITLE
Bugfix: Ensure re-directs include no cache headers

### DIFF
--- a/config/http.js
+++ b/config/http.js
@@ -89,6 +89,7 @@ module.exports.http = {
 
     order: [
       'cacheControl',
+      'redirectNoCacheHeaders',
       'startRequestTimer',
       'cookieParser',
       'redboxSession',
@@ -166,6 +167,22 @@ module.exports.http = {
 
     poweredBy:  function (req, res, next) {
       res.set('X-Powered-By', "QCIF");      
+      return next();
+    },
+
+    redirectNoCacheHeaders: function (req, res, next) {
+      const originalRedirect = res.redirect;
+
+      // Patch the redirect function so that it sets the no-cache headers
+      res.redirect = function(location) {
+
+        res.set('Cache-Control', 'no-cache, no-store, must-revalidate');
+        res.set('Pragma', 'no-cache');
+        res.set('Expires', '0');
+
+        return originalRedirect.call(this, location);
+      };
+
       return next();
     },
 


### PR DESCRIPTION
Firefox (and potentially other browsers) will cache 302 redirects when there are cache headers on the response. This breaks our authentication and authorization process as we redirect the user to login when not authenticated, when the user tries to return to the page post login the browser returns the login redirect rather than the actual page.

This fix uses express middleware to patch the res.redirect function to set no cache headers before continuing on with the standard process.