### PR TITLE
Bugfix: OIDC post login redirects

### DIFF
--- a/config/http.js
+++ b/config/http.js
@@ -89,6 +89,7 @@ module.exports.http = {
 
     order: [
       'cacheControl',
+      'redirectNoCacheHeaders',
       'startRequestTimer',
       'cookieParser',
       'redboxSession',
@@ -166,6 +167,22 @@ module.exports.http = {
 
     poweredBy:  function (req, res, next) {
       res.set('X-Powered-By', "QCIF");      
+      return next();
+    },
+
+    redirectNoCacheHeaders: function (req, res, next) {
+      const originalRedirect = res.redirect;
+
+      // Patch the redirect function so that it sets the no-cache headers
+      res.redirect = function(location) {
+
+        res.set('Cache-Control', 'no-cache, no-store, must-revalidate');
+        res.set('Pragma', 'no-cache');
+        res.set('Expires', '0');
+
+        return originalRedirect.call(this, location);
+      };
+
       return next();
     },
 

--- a/typescript/api/controllers/UserController.ts
+++ b/typescript/api/controllers/UserController.ts
@@ -109,6 +109,8 @@ export module Controllers {
       let postLoginUrl = null;
       if (req.session.redirUrl) {
         postLoginUrl = req.session.redirUrl;
+      } else if (req.query.redirUrl) {
+        postLoginUrl = req.query.redirUrl;
       } else {
         postLoginUrl = `${BrandingService.getBrandAndPortalPath(req)}/${ConfigService.getBrand(branding, 'auth').local.postLoginRedir}`;
       }

--- a/typescript/api/services/UsersService.ts
+++ b/typescript/api/services/UsersService.ts
@@ -702,6 +702,11 @@ export module Services {
       } else {
         req.session.logoutUrl = sails.config.auth.postLogoutRedir
       }
+      if(req.session.redirUrl != null) {
+        //the session url changes after login so we lose this value if we don't put it on the queru string
+        req.query.redirUrl = req.session.redirUrl;
+      }
+      
       sails.log.verbose(`OIDC login success, tokenset: `);
       sails.log.verbose(JSON.stringify(tokenSet));
       sails.log.verbose(`Claims:`);


### PR DESCRIPTION
In more recent versions of the openid connect library, the session on the request appears to be wiped on login which causes the redirect to the page that the user was trying to access fail. This fix adds the url as a query parameter so that it  persists to the end of the login request process.