### PR TITLE
Pass on templates to form field components, refactored base component init logic

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/textfield.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/textfield.component.ts
@@ -8,7 +8,9 @@ export class TextFieldModel extends FormFieldModel<string> {
 @Component({
     selector: 'redbox-textfield',
     template: `
-      <input type='text' [formControl]="formControl" />
+    <ng-container *ngTemplateOutlet="getTemplateRef('before')" />
+    <input type='text' [formControl]="formControl" />
+    <ng-container *ngTemplateOutlet="getTemplateRef('after')" />
   `,
     standalone: false
 })

--- a/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
@@ -17,9 +17,11 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 import { APP_BASE_HREF } from '@angular/common'; 
+import { ReactiveFormsModule } from '@angular/forms';
 import { TestBed } from '@angular/core/testing';
 import { FormComponent } from './form.component';
 import { RedboxPortalCoreModule, UtilityService, LoggerService, TranslationService, ConfigService, getStubConfigService, getStubTranslationService, FormConfig } from '@researchdatabox/portal-ng-common';
+import { TextFieldComponent } from './component/textfield.component';
 
 describe('FormComponent', () => {
   let configService:any;
@@ -29,10 +31,12 @@ describe('FormComponent', () => {
     translationService = getStubTranslationService();
     await TestBed.configureTestingModule({
       imports: [
+        ReactiveFormsModule,
         RedboxPortalCoreModule
       ],
       declarations: [
-        FormComponent
+        FormComponent,
+        TextFieldComponent
       ],
       providers: [
         {

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/form/base-wrapper.component.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/form/base-wrapper.component.ts
@@ -9,7 +9,7 @@ import { LoggerService } from '../logger.service';
 /**
  * Form Component Wrapper. 
  * 
-* This component is used to dynamically load a form component based on the provided configuration.
+* This component is used to instantiate a form field based on the provided configuration. It is meant to be a a thin wrapper around the individual form component, offering the FormComponent and layout components an abstraction, rather than individual components.
  *
  * Author: <a href='https://github.com/shilob' target='_blank'>Shilo Banihit</a>
  *
@@ -59,6 +59,7 @@ export class FormBaseWrapperComponent<ValueType = string | undefined> implements
     } else {
       this.loggerService.warn("FormBaseWrapperComponent: componentRef has been destroyed, component is no longer 'ready', but form may not be informed. Ignore if this is displayed during test runs.");
     }
+    this.componentRef.changeDetectorRef.detectChanges();
   }
 
   

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/form/default-layout.component.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/form/default-layout.component.ts
@@ -1,7 +1,8 @@
 import { FormFieldBaseComponent, FormFieldCompMapEntry } from './form-field-base.component';
 import { FormComponentLayoutDefinition } from './config.model';
 import { isEmpty as _isEmpty } from 'lodash-es';
-import { Component } from '@angular/core';
+import { Component, ViewChild, ViewContainerRef, TemplateRef } from '@angular/core';
+import { FormBaseWrapperComponent } from './base-wrapper.component';
 /**
  * Default Form Component Layout
  * 
@@ -26,19 +27,31 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'redbox-form-default-component-layout',
   template: `
-  <ng-container *ngIf="model && componentDefinition"> 
-    <ng-container *ngIf="componentDefinition?.config?.label">
-    <label>
-      <span [innerHtml]="componentDefinition?.config?.label"></span>
-      <span class="form-field-required-indicator" [innerHTML]="componentDefinition?.config?.labelRequiredStr"></span>
-      <button type="button" class="btn btn-default" *ngIf="componentDefinition?.config?.helpText" (click)="toggleHelpTextVisibility()" [attr.aria-label]="'help' | i18next ">
-      <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
-      </button>
-    </label>
-    <span class="help-block" *ngIf="helpTextVisible" [innerHtml]="componentDefinition?.config?.helpText"></span>
-    </ng-container>
-    <redbox-form-base-wrapper *ngIf="componentClass" [model]="model" [componentClass]="componentClass" [formFieldCompMapEntry]="formFieldCompMapEntry" ></redbox-form-base-wrapper>
-  </ng-container>
+  @if (model && componentDefinition) {
+    @if (componentDefinition.config?.label) {
+      <label>
+        <span [innerHtml]="componentDefinition?.config?.label"></span>
+        <span class="form-field-required-indicator" [innerHTML]="componentDefinition?.config?.labelRequiredStr"></span>
+        @if (componentDefinition.config?.helpText) {
+          <button type="button" class="btn btn-default" (click)="toggleHelpTextVisibility()" [attr.aria-label]="'help' | i18next ">
+          <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+          </button>
+        }
+      </label>
+      @if (helpTextVisible) {
+        <span class="help-block" [innerHtml]="componentDefinition?.config?.helpText"></span>
+      }
+    }
+    <ng-container #componentContainer>
+    </ng-container> 
+    <!-- instead of rendering the 'before' and 'after' templates around the componentContainer, we supply named templates so the component can render these as it sees fit -->
+    <ng-template #beforeComponentTemplate>
+      Before, is help showing:  {{ helpTextVisible }}
+    </ng-template>
+    <ng-template #afterComponentTemplate>
+      After, is help showing:  {{ helpTextVisible }}
+    </ng-template>
+  }
   `,
   standalone: false,
   // Note: No need for host property here if using @HostBinding
@@ -48,10 +61,34 @@ export class DefaultLayoutComponent<ValueType> extends FormFieldBaseComponent<Va
   componentClass?: typeof FormFieldBaseComponent | null;
   public override componentDefinition?: FormComponentLayoutDefinition;
 
+  @ViewChild('componentContainer', { read: ViewContainerRef, static: false })
+  componentContainer!: ViewContainerRef;
+
+  @ViewChild('beforeComponentTemplate', { read: TemplateRef, static: false })
+  beforeComponentTemplate!: TemplateRef<any>;
+  @ViewChild('afterComponentTemplate', { read: TemplateRef, static: false })
+  afterComponentTemplate!: TemplateRef<any>;
+
   override async initComponent(formFieldCompMapEntry: FormFieldCompMapEntry | null) {
+    // TODO: remove the "READY" state setting in the initComponent method 
     await super.initComponent(formFieldCompMapEntry);
     this.componentClass = formFieldCompMapEntry?.componentClass;
     this.componentDefinition = formFieldCompMapEntry?.compConfigJson?.layout as FormComponentLayoutDefinition;
+
+    const childRef = this.componentContainer.createComponent(FormBaseWrapperComponent);
+    childRef.instance.componentClass = this.componentClass;
+    childRef.instance.model = this.model;
+    if (this.formFieldCompMapEntry && this.beforeComponentTemplate && this.afterComponentTemplate) {
+      this.formFieldCompMapEntry.componentTemplateRefMap = {
+        before: this.beforeComponentTemplate,
+        after: this.afterComponentTemplate
+      };
+    }
+    childRef.instance.formFieldCompMapEntry = this.formFieldCompMapEntry;
+    childRef.changeDetectorRef.detectChanges();
+  }
+
+  ngAfterViewInit() {
     
   }
 

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/form/form-field-base.component.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/form/form-field-base.component.ts
@@ -1,9 +1,10 @@
 import { FormFieldModel } from './base.model';
 import { FormControl } from '@angular/forms';
 import { FormFieldComponentDefinition, FormComponentLayoutDefinition } from './config.model';
-import { Directive, HostBinding, signal, inject } from '@angular/core'; // Import HostBinding
+import { Directive, HostBinding, signal, inject, TemplateRef } from '@angular/core'; // Import HostBinding
 import { LoggerService } from '../logger.service';
 import { FormFieldComponentStatus } from './status.model';
+import { get as _get, isEmpty as _isEmpty } from 'lodash-es';
 /**
  * Base class for form components. Data binding to a form field is optional.
  * 
@@ -103,6 +104,22 @@ export abstract class FormFieldBaseComponent<ValueType = string | undefined> {
   @HostBinding('class') get hostClasses() {
     return this.hostBindingCssClasses;
   }
+
+  /**
+   * Get the template reference for the specified template name.
+   * 
+   * @param templateName - The name of the template to retrieve.
+   * @returns The TemplateRef instance or null if not found.
+   */
+  getTemplateRef(templateName: string): TemplateRef<any> | null {
+    return _get(this.formFieldCompMapEntry, `componentTemplateRefMap.${templateName}`, null);
+  }
+  /**
+   * Convenience method to check if a template reference exists for the specified template name.
+   */
+  hasTemplateRef(templateName: string): boolean {
+    return !_isEmpty(this.getTemplateRef(templateName));
+  }
 }
 
 /**
@@ -118,4 +135,5 @@ export interface FormFieldCompMapEntry {
   compConfigJson: any,
   model?: FormFieldModel | null;
   component?: FormFieldBaseComponent | null;
+  componentTemplateRefMap? : { [key: string]: TemplateRef<any> } | null | undefined;
 }


### PR DESCRIPTION
This pull request introduces enhancements to the form component system by adding support for dynamic templates, improving component initialization, and refining the layout and wrapper components. The main changes include enabling template rendering before and after form fields, refactoring component initialization for better extensibility, and updating the layout to support dynamic template injection. Refactored form field base component template to use modern control flow syntax. 

### Enhancements to Form Field Components:
* Added `getTemplateRef` and `hasTemplateRef` methods in `FormFieldBaseComponent` to retrieve and check for named templates dynamically. (`[angular/projects/researchdatabox/portal-ng-common/src/lib/form/form-field-base.component.tsR115-R137](diffhunk://#diff-6f7e061404cf8eae6a2e91552214273aa2368b6c84646b16fe30eb940ed00963R115-R137)`)
* Introduced a `componentTemplateRefMap` property in the `FormFieldCompMapEntry` interface to store references to named templates. (`[angular/projects/researchdatabox/portal-ng-common/src/lib/form/form-field-base.component.tsR153](diffhunk://#diff-6f7e061404cf8eae6a2e91552214273aa2368b6c84646b16fe30eb940ed00963R153)`)
* Refactored the `initComponent` method in `FormFieldBaseComponent` to allow child components to override the initialization process with `setPropertiesFromComponentMapEntry` and `setComponentReady` methods. (`[angular/projects/researchdatabox/portal-ng-common/src/lib/form/form-field-base.component.tsR35-R62](diffhunk://#diff-6f7e061404cf8eae6a2e91552214273aa2368b6c84646b16fe30eb940ed00963R35-R62)`)

### Updates to Layout and Wrapper Components:
* Modified `DefaultLayoutComponent` to use `ViewChild` for dynamically injecting `before` and `after` templates, and updated its initialization process to pass these templates to the wrapper component. (`[angular/projects/researchdatabox/portal-ng-common/src/lib/form/default-layout.component.tsL51-R101](diffhunk://#diff-5ecc77eea86a27f59203ec39897a780b5b0cc80f169617b898b17be7f16b03aeL51-R101)`)
* Changed the `DefaultLayoutComponent` template to use Angular's `@if` syntax for conditional rendering and added placeholders for `before` and `after` templates. (`[angular/projects/researchdatabox/portal-ng-common/src/lib/form/default-layout.component.tsL29-R54](diffhunk://#diff-5ecc77eea86a27f59203ec39897a780b5b0cc80f169617b898b17be7f16b03aeL29-R54)`)

### Improvements to Wrapper Component:
* Updated `FormBaseWrapperComponent` to trigger change detection explicitly after initialization, ensuring the component's readiness. (`[angular/projects/researchdatabox/portal-ng-common/src/lib/form/base-wrapper.component.tsR62](diffhunk://#diff-a10715eaff69f00a57993fbd8c622c4eca9e325380a1d3c134589b55ecb15f8cR62)`)

### Test and Dependency Updates:
* Added `ReactiveFormsModule` and `TextFieldComponent` to the test setup for `FormComponent`, ensuring proper testing of the new functionality. (`[[1]](diffhunk://#diff-2e052c7a700798a9676921bfb4bb16adba7b579bfad6d098fd0fb322f8ce41c5R20-R24)`, `[[2]](diffhunk://#diff-2e052c7a700798a9676921bfb4bb16adba7b579bfad6d098fd0fb322f8ce41c5R34-R39)`)

### Documentation and Comments:
* Updated comments in `FormBaseWrapperComponent` to clarify its purpose as a thin wrapper for individual form components. (`[angular/projects/researchdatabox/portal-ng-common/src/lib/form/base-wrapper.component.tsL12-R12](diffhunk://#diff-a10715eaff69f00a57993fbd8c622c4eca9e325380a1d3c134589b55ecb15f8cL12-R12)`)