### PR TITLE
Introduce Group component

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/groupfield.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/groupfield.component.spec.ts
@@ -1,0 +1,233 @@
+// Copyright (c) 2023 Queensland Cyber Infrastructure Foundation (http://www.qcif.edu.au/)
+//
+// GNU GENERAL PUBLIC LICENSE
+//    Version 2, June 1991
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+import {APP_BASE_HREF} from '@angular/common';
+import {ReactiveFormsModule} from '@angular/forms';
+import {TestBed} from '@angular/core/testing';
+
+import {
+  ConfigService,
+  FormConfig,
+  getStubConfigService,
+  getStubTranslationService,
+  LoggerService,
+  RedboxPortalCoreModule,
+  TranslationService,
+  UtilityService
+} from '@researchdatabox/portal-ng-common';
+import { FormComponent } from '../form.component';
+import { TextFieldComponent } from './textfield.component';
+import {GroupFieldComponent} from "./groupfield.component";
+
+
+describe('FormComponent', () => {
+  let configService: any;
+  let translationService: any;
+  beforeEach(async () => {
+    configService = getStubConfigService();
+    translationService = getStubTranslationService();
+    await TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        RedboxPortalCoreModule
+      ],
+      declarations: [
+        FormComponent,
+        TextFieldComponent,
+        GroupFieldComponent,
+      ],
+      providers: [
+        {
+          provide: APP_BASE_HREF,
+          useValue: 'base'
+        },
+        LoggerService,
+        UtilityService,
+        {
+          provide: TranslationService,
+          useValue: translationService
+        },
+        {
+          provide: ConfigService,
+          useValue: configService
+        }
+      ]
+    }).compileComponents();
+  });
+
+  it('should create the app', () => {
+    const fixture = TestBed.createComponent(FormComponent);
+    const app = fixture.componentInstance;
+    expect(app).toBeTruthy();
+  });
+
+  it('should render the group and child components', async () => {
+    const fixture = TestBed.createComponent(FormComponent);
+    const formComponent = fixture.componentInstance;
+    formComponent.downloadAndCreateOnInit = false;
+
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const formConfig: FormConfig = {
+      debugValue: true,
+      domElementType: 'form',
+      defaultComponentConfig: {
+        defaultComponentCssClasses: 'row',
+      },
+      editCssClasses: "redbox-form form",
+      componentDefinitions: [
+        {
+          // first group component
+          name: 'group_1_component',
+          layout: {
+            // TODO: create a new layout
+            class: 'InlineLayoutComponent',
+            config: {
+              label: 'GroupField label',
+              helpText: 'GroupField help',
+              labelRequiredStr: '*',
+              cssClassesMap: {},
+            }
+          },
+          model: {
+            name: 'group_1_model',
+            class: 'GroupFieldModel',
+            config: {
+              defaultValue: {},
+            }
+          },
+          component: {
+            class: 'GroupFieldComponent',
+            config: {
+              componentDefinitions: [
+                {
+                  name: 'text_3',
+                  layout: {
+                    class: 'DefaultLayoutComponent',
+                    config: {
+                      label: 'TextField with default wrapper defined',
+                      helpText: 'This is a help text',
+                      labelRequiredStr: '*',
+                      cssClassesMap: {},
+                    }
+                  },
+                  model: {
+                    class: 'TextFieldModel',
+                    config: {
+                      value: 'hello world 3!',
+                    }
+                  },
+                  component: {
+                    class: 'TextFieldComponent'
+                  }
+                },
+                {
+                  name: 'text_4',
+                  model: {
+                    class: 'TextFieldModel',
+                    config: {
+                      value: 'hello world 4!',
+                      defaultValue: 'hello world 4!'
+                    }
+                  },
+                  component: {
+                    class: 'TextFieldComponent'
+                  }
+                },
+                {
+                  // second group component, nested in first group component
+                  name: 'group_2_component',
+                  layout: {
+                    class: 'DefaultLayoutComponent',
+                    config: {
+                      label: 'GroupField 2 label',
+                      helpText: 'GroupField 2 help',
+                      labelRequiredStr: '*',
+                      cssClassesMap: {},
+                    }
+                  },
+                  model: {
+                    name: 'group_2_model',
+                    class: 'GroupFieldModel',
+                    config: {
+                      defaultValue: {},
+                    }
+                  },
+                  component: {
+                    class: 'GroupFieldComponent',
+                    config: {
+                      componentDefinitions: [
+                        {
+                          name: 'text_5',
+                          layout: {
+                            class: 'DefaultLayoutComponent',
+                            config: {
+                              label: 'TextField with default wrapper defined',
+                              helpText: 'This is a help text',
+                              labelRequiredStr: '*',
+                              cssClassesMap: {},
+                            }
+                          },
+                          model: {
+                            class: 'TextFieldModel',
+                            config: {
+                              value: 'hello world 5!',
+                            }
+                          },
+                          component: {
+                            class: 'TextFieldComponent'
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    };
+    formComponent.downloadAndCreateFormComponents(formConfig);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject('Timeout waiting for componentsLoaded'), 3000);
+      const check = () => {
+        fixture.detectChanges();
+        if (formComponent.componentsLoaded()) {
+          clearTimeout(timeout);
+          resolve();
+        } else {
+          setTimeout(check, 50);
+        }
+      };
+      check();
+    });
+
+    fixture.detectChanges(); // Ensure DOM is updated
+    console.log('Components Loaded:', formComponent.componentsLoaded());
+    // Now run your expectations
+    const compiled = fixture.nativeElement as HTMLElement;
+    const inputElements = compiled.querySelectorAll('input[type="text"]');
+    expect(inputElements).toHaveSize(3);
+  });
+
+});

--- a/angular/projects/researchdatabox/form/src/app/component/groupfield.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/groupfield.component.ts
@@ -1,171 +1,226 @@
-import {Component, effect, inject, Injector, Input, signal, untracked} from '@angular/core';
+import {
+  Component,
+  ComponentRef,
+  inject,
+  Injector,
+  Input,
+  OnDestroy,
+  signal,
+  ViewChild,
+  ViewContainerRef
+} from '@angular/core';
 import {FormGroup} from "@angular/forms";
 import {
+  FormBaseWrapperComponent,
   FormConfig,
   FormFieldBaseComponent,
   FormFieldCompMapEntry,
   FormFieldModel,
-  FormStatus,
-  FormComponentDefinition,
-  FormFieldComponentStatus,
+  FormStatus
 } from "@researchdatabox/portal-ng-common";
 import {FormComponentsMap, FormService} from "../form.service";
 import {FormComponent} from "../form.component";
+import {get as _get} from "lodash-es";
 
 
 export type GroupFieldModelValueType = { [key: string]: unknown };
 
+/**
+ * The model for the Group Component.
+ *
+ * Contains the FormGroup component, which contains the child components.
+ */
 export class GroupFieldModel extends FormFieldModel<GroupFieldModelValueType> {
+  /**
+   * The definitions and config for the child components.
+   */
+  public formDefMap?: FormComponentsMap;
 
-  // TODO: Should the formControl in this model:
-  //  1. be kept in sync with the child controls by calls to model.formControl.setValue in the GroupFieldComponent?
-  //  2. or should GroupFieldModel.formControl be a FormGroup that contains the components?
-  //  The current implementation is option 1.
+  public override formControl: FormGroup | null | undefined;
+
+  public get components(): FormFieldCompMapEntry[] {
+    return this.formDefMap?.components ?? [];
+  }
+
+  public get debugValue() {
+    return this.formDefMap?.formConfig?.debugValue ?? false;
+  }
+
+  public get defaultComponentConfig() {
+    return this.formDefMap?.formConfig?.defaultComponentConfig;
+  }
+
+  override postCreate(): void {
+    // Don't call the super method, as this model needs a FormGroup, and needs to populate it differently.
+    // super.postCreate();
+
+    // Store the initial value.
+    this.initValue = _get(this.fieldConfig.config, 'value', this.fieldConfig.config?.defaultValue);
+
+    // TODO: create or configure the validators
+
+    // Create the empty FormGroup here, not in the component.
+    // This is different from FormComponent, which has no model.
+    // Creating the FormGroup here allows encapsulating the FormGroup & children in the same way as other components.
+    this.formControl = new FormGroup({});
+    console.log(`GroupFieldModel: created form control '${this.fieldConfig?.name ?? '(no name)'}' with model class '${this.fieldConfig?.class}' and initial value '${this.initValue}'`);
+  }
+
+  /**
+   * Add the child components to the FormGroup.
+   *
+   * @param formDefMap The built components and definitions.
+   */
+  public registerChildComponents(formDefMap: FormComponentsMap) {
+    // Store the components and definitions.
+    this.formDefMap = formDefMap;
+
+    if (!this.formControl) {
+      throw new Error("Must register child controls after form group has been created.");
+    }
+
+    // Set the controls to the FormGroup, without emitting events.
+    const formGroup = this.formControl as FormGroup;
+    for (const [key, value] of Object.entries(formDefMap.withFormControl ?? {})) {
+      formGroup.addControl(key, value, {emitEvent: false});
+    }
+  }
 }
 
 @Component({
   selector: 'redbox-groupfield',
   template: `
     <ng-container *ngTemplateOutlet="getTemplateRef('before')"/>
-    <ng-container [ngTemplateOutlet]="compsTemplate"></ng-container>
+    <ng-container #componentContainer/>
     <ng-container *ngTemplateOutlet="getTemplateRef('after')"/>
 
-    <ng-template #compsTemplate>
-      <ng-container *ngFor="let component of components">
-        <redbox-form-base-wrapper [model]="component.model"
-                                  [componentClass]="component.layoutClass || component.componentClass"
-                                  [formFieldCompMapEntry]="component"
-                                  [defaultComponentConfig]="getFormComponent.formDefMap?.formConfig?.defaultComponentConfig"
-                                  (componentReady)="registerComponentReady(component)"></redbox-form-base-wrapper>
-      </ng-container>
-    </ng-template>
-    <ng-container *ngIf="components.length > 0 && formDefMap?.formConfig?.debugValue">
+    <ng-container *ngIf="(model?.components?.length ?? 0) > 0 && model?.debugValue">
       <div class="alert alert-info" role="alert">
-      <h4>Group Component Debug</h4>
-      <ul>
-        <li>status: {{ status() }}</li>
-        <li>groupStatus: {{ groupStatus() }}</li>
-        <li>componentsLoaded: {{ componentsLoaded() }}</li>
-      </ul>
+        <h4>Group Component Debug</h4>
+        <ul>
+          <li>status: {{ status() }}</li>
+          <li>groupStatus: {{ groupStatus() }}</li>
+          <li>componentsLoaded: {{ componentsLoaded() }}</li>
+          <li>children:
+            <ul>
+              @for(component of model?.components; track component.component){
+                <li>{{ utilityService.getNameClass(component?.component?.formFieldCompMapEntry) }}: {{component?.component?.status()}}</li>
+              }
+            </ul>
+          </li>
+        </ul>
       </div>
     </ng-container>
   `,
   standalone: false
 })
-export class GroupFieldComponent extends FormFieldBaseComponent<GroupFieldModelValueType> {
-  protected override logName: string = "GroupFieldComponent";
-  /**
-   * The FormGroup instance
-   */
-  form?: FormGroup;
-  /**
-   * The form components
-   */
-  components: FormFieldCompMapEntry[] = [];
-  /**
-   *
-   */
-  formDefMap?: FormComponentsMap;
+export class GroupFieldComponent extends FormFieldBaseComponent<GroupFieldModelValueType> implements OnDestroy {
   /**
    * The model associated with this component.
    */
   @Input() public override model?: GroupFieldModel;
-
-  groupStatus = signal<FormStatus>(FormStatus.INIT);
-  componentsLoaded = signal<boolean>(false);
-
+  protected override logName: string = "GroupFieldComponent";
+  /**
+   * A group status separate from this component's own status.
+   * @private
+   */
+  protected groupStatus = signal<FormStatus>(FormStatus.INIT);
+  protected componentsLoaded = signal<boolean>(false);
+  /**
+   * Provide access to the NgContainer to allow creating child components.
+   * @private
+   */
+  @ViewChild('componentContainer', {
+    read: ViewContainerRef,
+    static: false
+  })
+  private componentContainer!: ViewContainerRef;
+  /**
+   * Store references to the created wrapper components.
+   * @private
+   */
+  private readonly wrapperComponentRefs: ComponentRef<FormBaseWrapperComponent<unknown>>[];
   private formService = inject(FormService);
   private injector = inject(Injector);
 
   constructor() {
     super();
-
-    effect(() => {
-      this.loggerService.info(`${this.logName}: groupStatus value is:` , this.groupStatus());
-      untracked(() => {
-        this.checkReadyAndSetIfReady();
-      })
-    });
-    effect(() => {
-      this.loggerService.info(`${this.logName}: componentsLoaded value is:`, this.componentsLoaded());
-      untracked(() => {
-        this.checkReadyAndSetIfReady();
-      })
-    });
+    this.wrapperComponentRefs = [];
   }
 
   protected get getFormComponent(): FormComponent {
     return this.injector.get(FormComponent);
   }
 
-  protected checkReadyAndSetIfReady(){
-    const status = this.status();
-    const componentsLoaded = this.componentsLoaded();
-    const groupStatus = this.groupStatus();
-    this.loggerService.info(`${this.logName}: status check:`, {
-      componentsLoaded: componentsLoaded, groupStatus: groupStatus, status: status
-    });
-    if (groupStatus === FormStatus.READY && componentsLoaded) {
-      this.status.set(FormFieldComponentStatus.READY);
+  ngOnDestroy() {
+    // Clean up the dynamically created component when the wrapper is destroyed
+    for (const compRef of this.wrapperComponentRefs ?? []) {
+      if (compRef) {
+        compRef.destroy();
+      }
     }
   }
 
   /**
    * Notification hook for when a component is ready.
+   *
+   * @param componentEntry - The component entry that is ready.
    */
   protected registerComponentReady(componentEntry: FormFieldCompMapEntry): void {
-    const thisName = this.utilityService.getName(this.model);
-    const componentName = this.utilityService.getName(componentEntry);
-    this.loggerService.debug(`${this.logName}: '${thisName}' component '${componentName}' registered as ready.`);
-    this.formService.triggerComponentReady(thisName, this.formDefMap, this.componentsLoaded, this.groupStatus);
-    // TODO: The approach of setting the component ready here doesn't work, as the base wrapper only emits the event after initComponent.
-    //       By the time the call to registerComponentReady occurs after the children have initialised,
-    //       the GroupFieldComponent has already emitted the componentReady event and doesn't emit it again.
-    //       To fix this, I added `componentReady.emit()` in the base wrapper constructor when the component status changes.
-    //       And used signal effects to emit the event when all statuses are ready.
+    const thisName = this.utilityService.getNameClass(this.formFieldCompMapEntry);
+    const componentName = this.utilityService.getNameClass(componentEntry);
+    this.loggerService.debug(`${this.logName}: component '${componentName}' registered as ready.`);
+    this.formService.triggerComponentReady(thisName, this.model?.formDefMap, this.componentsLoaded, this.groupStatus);
   }
 
-  protected override async setPropertiesFromComponentMapEntry(formFieldCompMapEntry: FormFieldCompMapEntry) {
-    super.setPropertiesFromComponentMapEntry(formFieldCompMapEntry);
-
-    // get the component definitions for this group
-    const childComponentDefinitions: FormComponentDefinition[] = formFieldCompMapEntry?.compConfigJson?.component?.config?.componentDefinitions ?? [];
-
-    // build a form config to then build the form components map
+  protected override async initData() {
+    // Build a form config to store the info needed to build the components.
     const formConfig = new FormConfig();
-    formConfig.componentDefinitions = childComponentDefinitions;
-    // TODO: how to inherit formConfig.debugValue from the parent form component?
-    formConfig.debugValue = true;
-    this.formDefMap = await this.formService.createFormComponentsMap(formConfig);
+
+    // Store the child component definitions.
+    formConfig.componentDefinitions = this.formFieldCompMapEntry?.compConfigJson?.component?.config?.componentDefinitions ?? [];
+
+    // Get the debugValue from the FormComponent.
+    formConfig.debugValue = this.getFormComponent.formDefMap?.formConfig?.debugValue;
+
+    // Get the default config
+    formConfig.defaultComponentConfig = this.getFormComponent.formDefMap?.formConfig?.defaultComponentConfig;
+
+    // Construct the components.
+    const formDefMap = await this.formService.createFormComponentsMap(formConfig);
+
+    // Create the form group from the form components map.
+    const formGroupMap = this.formService.groupComponentsByName(formDefMap);
+    if (formGroupMap !== undefined) {
+      // Now set the components to the model.
+      this.model?.registerChildComponents(formGroupMap)
+    }
   }
 
-  protected override setComponentReady(): Promise<void> {
-    this.loggerService.debug(`${this.logName}: this component is ready, it will now initialise child components.`);
+  protected override async setComponentReady(): Promise<void> {
+    const thisName = this.utilityService.getNameClass(this.formFieldCompMapEntry);
+    this.loggerService.debug(`${this.logName}: component '${thisName}' is ready, it will now create child components.`);
 
-    if (this.formDefMap) {
-      // create the form group from the form components map
-      const formGroupInfo = this.formService.createFormGroup(this.formDefMap);
-      if (formGroupInfo !== undefined) {
-        this.form = formGroupInfo.form;
+    // Create the wrapper components and set the properties from the model components.
+    for (const component of this.model?.components ?? []) {
+      const wrapperCompRef = this.componentContainer.createComponent(FormBaseWrapperComponent<unknown>);
+      wrapperCompRef.instance.model = component.model;
+      wrapperCompRef.instance.componentClass = component.layoutClass || component.componentClass;
+      wrapperCompRef.instance.formFieldCompMapEntry = component;
+      wrapperCompRef.instance.defaultComponentConfig = this.model?.defaultComponentConfig;
 
-        // Initialise the model value from the FormGroup.
-        this.model?.setValue(this.form.value);
+      // TODO: is this needed? FormBaseWrapperComponent.initComponent doesn't exist.
+      // prepare the FormFieldCompMapEntry including the 'model' field
+      // await wrapperCompRef.instance.initComponent(<the prepared compMapEntry as above>);
 
-        // Update the model value whenever the FormGroup value changes.
-        // TODO: This feels a little hacky, but it does work.
-        //       Is there a better / easier way?
-        this.form.valueChanges.subscribe((val) => {
-          this.loggerService.info(`${this.logName}: form.value is:`, val);
-          this.model?.setValue(val);
-        });
+      // child should be ready at this point
+      this.wrapperComponentRefs.push(wrapperCompRef);
 
-        // setting components will trigger the form to be rendered
-        this.components = formGroupInfo.components;
-      }
+      // call detectChanges to run ngOnInit
+      wrapperCompRef.changeDetectorRef.detectChanges();
     }
 
-    // don't set form ready yet, that is done in registerComponentReady and the signal effects
-    // return super.setComponentReady();
-    return Promise.resolve();
+    // finally set the status to 'READY'
+    await super.setComponentReady();
   }
 }

--- a/angular/projects/researchdatabox/form/src/app/component/groupfield.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/groupfield.component.ts
@@ -1,0 +1,156 @@
+import {Component, effect, inject, Injector, Input, signal, untracked} from '@angular/core';
+import {FormGroup} from "@angular/forms";
+import {
+  FormConfig,
+  FormFieldBaseComponent,
+  FormFieldCompMapEntry,
+  FormFieldModel,
+  FormStatus,
+  FormComponentDefinition,
+  FormFieldComponentStatus,
+} from "@researchdatabox/portal-ng-common";
+import {FormComponentsMap, FormService} from "../form.service";
+import {FormComponent} from "../form.component";
+
+
+export type GroupFieldModelValueType = { [key: string]: unknown };
+
+export class GroupFieldModel extends FormFieldModel<GroupFieldModelValueType> {
+
+  // TODO: Should the formControl in this model:
+  //  1. be kept in sync with the child controls by calls to model.formControl.setValue in the GroupFieldComponent?
+  //  2. or should GroupFieldModel.formControl be a FormGroup that contains the components?
+  //  The current implementation is option 1.
+}
+
+@Component({
+  selector: 'redbox-groupfield',
+  template: `
+    <ng-container *ngTemplateOutlet="getTemplateRef('before')"/>
+    <ng-container [ngTemplateOutlet]="compsTemplate"></ng-container>
+    <ng-container *ngTemplateOutlet="getTemplateRef('after')"/>
+
+    <ng-template #compsTemplate>
+      <ng-container *ngFor="let component of components">
+        <redbox-form-base-wrapper [model]="component.model"
+                                  [componentClass]="component.layoutClass || component.componentClass"
+                                  [formFieldCompMapEntry]="component"
+                                  [defaultComponentConfig]="getFormComponent.formDefMap?.formConfig?.defaultComponentConfig"
+                                  (componentReady)="registerComponentReady(component)"></redbox-form-base-wrapper>
+      </ng-container>
+    </ng-template>
+    <ng-container *ngIf="components.length > 0 && formDefMap?.formConfig?.debugValue">
+      <h3>Live Group Value</h3>
+      <pre [innerHtml]="form?.value | json"></pre>
+    </ng-container>
+    <ng-container *ngIf="components.length > 0 && formDefMap?.formConfig?.debugValue">
+      <h3>Group Statuses</h3>
+      <ul>
+        <li>component status: {{ status() }}</li>
+        <li>form status: {{ groupStatus() }}</li>
+        <li>components loaded: {{ componentsLoaded() }}</li>
+      </ul>
+    </ng-container>
+  `,
+  standalone: false
+})
+export class GroupFieldComponent extends FormFieldBaseComponent<GroupFieldModelValueType> {
+  protected override logName: string = "GroupFieldComponent";
+  /**
+   * The FormGroup instance
+   */
+  form?: FormGroup;
+  /**
+   * The form components
+   */
+  components: FormFieldCompMapEntry[] = [];
+  /**
+   *
+   */
+  formDefMap?: FormComponentsMap;
+  /**
+   * The model associated with this component.
+   */
+  @Input() public override model?: GroupFieldModel;
+
+  groupStatus = signal<FormStatus>(FormStatus.INIT);
+  componentsLoaded = signal<boolean>(false);
+
+  private formService = inject(FormService);
+  private injector = inject(Injector);
+
+  constructor() {
+    super();
+
+    effect(() => {
+      this.loggerService.info(`${this.logName}: groupStatus value is:` , this.groupStatus());
+    });
+    effect(() => {
+      this.loggerService.info(`${this.logName}: componentsLoaded value is:`, this.componentsLoaded());
+    });
+  }
+
+  protected get getFormComponent(): FormComponent {
+    return this.injector.get(FormComponent);
+  }
+
+  /**
+   * Notification hook for when a component is ready.
+   */
+  protected registerComponentReady(componentEntry: FormFieldCompMapEntry): void {
+    const name = this.utilityService.getName(componentEntry);
+    this.loggerService.debug(`${this.logName}: component '${name}' registered as ready.`);
+    this.formService.triggerComponentReady(this.logName, this.formDefMap, this.componentsLoaded, this.groupStatus);
+    if (this.groupStatus() === FormStatus.READY) {
+      // TODO: The approach of setting the component ready here doesn't work, as the base wrapper only emits the event after initComponent.
+      //       By the time the call to registerComponentReady occurs after the children have initialised,
+      //       the GroupFieldComponent has already emitted the componentReady event and doesn't emit it again.
+      //       To fix this, I added `componentReady.emit()` in the base wrapper constructor when the component status changes.
+      this.status.set(FormFieldComponentStatus.READY);
+    }
+  }
+
+  protected override async setPropertiesFromComponentMapEntry(formFieldCompMapEntry: FormFieldCompMapEntry) {
+    super.setPropertiesFromComponentMapEntry(formFieldCompMapEntry);
+
+    // get the component definitions for this group
+    const childComponentDefinitions: FormComponentDefinition[] = formFieldCompMapEntry?.compConfigJson?.component?.config?.componentDefinitions ?? [];
+
+    // build a form config to then build the form components map
+    const formConfig = new FormConfig();
+    formConfig.componentDefinitions = childComponentDefinitions;
+    // TODO: how to inherit formConfig.debugValue from the parent form component?
+    formConfig.debugValue = true;
+    this.formDefMap = await this.formService.createFormComponentsMap(formConfig);
+  }
+
+  protected override setComponentReady(): Promise<void> {
+    this.loggerService.debug(`${this.logName}: this component is ready, it will now initialise child components.`);
+
+    if (this.formDefMap) {
+      // create the form group from the form components map
+      const formGroupInfo = this.formService.createFormGroup(this.formDefMap);
+      if (formGroupInfo !== undefined) {
+        this.form = formGroupInfo.form;
+
+        // Initialise the model value from the FormGroup.
+        this.model?.setValue(this.form.value);
+
+        // Update the model value whenever the FormGroup value changes.
+        // TODO: This feels a little hacky, but it does work.
+        //       Is there a better / easier way?
+        this.form.valueChanges.subscribe((val) => {
+          this.loggerService.info(`${this.logName}: form.value is:`, val);
+          this.model?.setValue(val);
+        });
+
+        // setting components will trigger the form to be rendered
+        this.components = formGroupInfo.components;
+      }
+    }
+
+    // don't set form ready yet, that is done in registerComponentReady
+    // return super.setComponentReady();
+    return Promise.resolve();
+  }
+}

--- a/angular/projects/researchdatabox/form/src/app/component/groupfield.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/groupfield.component.ts
@@ -63,7 +63,7 @@ export class GroupFieldModel extends FormFieldModel<GroupFieldModelValueType> {
     // This is different from FormComponent, which has no model.
     // Creating the FormGroup here allows encapsulating the FormGroup & children in the same way as other components.
     this.formControl = new FormGroup({});
-    console.log(`GroupFieldModel: created form control '${this.fieldConfig?.name ?? '(no name)'}' with model class '${this.fieldConfig?.class}' and initial value '${this.initValue}'`);
+    console.log(`GroupFieldModel: created form control '${this.fieldConfig?.name ?? '(no model name)'}' with model class '${this.fieldConfig?.class}' and initial value '${this.initValue}'`);
   }
 
   /**

--- a/angular/projects/researchdatabox/form/src/app/component/textfield.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/textfield.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { FormFieldBaseComponent, FormFieldModel, FormComponentDefinition } from "@researchdatabox/portal-ng-common";
-import { get as _get } from 'lodash-es';
+import { FormFieldBaseComponent, FormFieldModel } from "@researchdatabox/portal-ng-common";
 
 export class TextFieldModel extends FormFieldModel<string> {  
 }
@@ -15,6 +14,7 @@ export class TextFieldModel extends FormFieldModel<string> {
     standalone: false
 })
 export class TextFieldComponent extends FormFieldBaseComponent<string> {
+  protected override logName: string = "TextFieldComponent";
   /**
      * The model associated with this component.
      * 

--- a/angular/projects/researchdatabox/form/src/app/form.component.html
+++ b/angular/projects/researchdatabox/form/src/app/form.component.html
@@ -1,19 +1,28 @@
 <ng-container [ngSwitch]="formDefMap?.formConfig?.domElementType">
-  <form *ngSwitchCase="'form'" [id]="formDefMap?.formConfig?.domId" >
+  <form *ngSwitchCase="'form'" [id]="formDefMap?.formConfig?.domId">
     <ng-container [ngTemplateOutlet]="compsTemplate"></ng-container>
-  </form>  
+  </form>
   <ng-container *ngSwitchDefault>
     <ng-container [ngTemplateOutlet]="compsTemplate"></ng-container>
+  </ng-container>
 </ng-container>
 <ng-template #compsTemplate>
   <ng-container *ngFor="let component of components">
-    <redbox-form-base-wrapper [model]="component.model" [componentClass]="component.layoutClass || component.componentClass" [formFieldCompMapEntry]="component" [defaultComponentConfig]="formDefMap?.formConfig?.defaultComponentConfig" (componentReady)="registerComponentReady(component)" ></redbox-form-base-wrapper>
+    <redbox-form-base-wrapper [model]="component.model"
+                              [componentClass]="component.layoutClass || component.componentClass"
+                              [formFieldCompMapEntry]="component"
+                              [defaultComponentConfig]="formDefMap?.formConfig?.defaultComponentConfig"
+                              (componentReady)="registerComponentReady(component)"></redbox-form-base-wrapper>
   </ng-container>
 </ng-template>
 <ng-container *ngIf="components.length > 0 && formDefMap?.formConfig?.debugValue">
-  <h3>Live Form Value</h3>
-  <pre [innerHtml]="form?.value | json"></pre>
-</ng-container>
-<ng-container *ngIf="components.length > 0 && formDefMap?.formConfig?.debugValue">
-  <h3>Form Status: {{ status() }}</h3>
+  <div class="alert alert-info" role="alert">
+    <h4>Form Component Debug</h4>
+    <pre [innerHtml]="form?.value | json"></pre>
+    <ul>
+      <li>status: {{ status() }}</li>
+      <li>componentsLoaded: {{ componentsLoaded() }}</li>
+      <li>isReady: {{ isReady }}</li>
+    </ul>
+  </div>
 </ng-container>

--- a/angular/projects/researchdatabox/form/src/app/form.component.html
+++ b/angular/projects/researchdatabox/form/src/app/form.component.html
@@ -18,11 +18,18 @@
 <ng-container *ngIf="components.length > 0 && formDefMap?.formConfig?.debugValue">
   <div class="alert alert-info" role="alert">
     <h4>Form Component Debug</h4>
-    <pre [innerHtml]="form?.value | json"></pre>
     <ul>
       <li>status: {{ status() }}</li>
       <li>componentsLoaded: {{ componentsLoaded() }}</li>
       <li>isReady: {{ isReady }}</li>
+      <li>children:
+      <ul>
+        @for(component of components; track component.component){
+          <li>{{ utilityService.getNameClass(component?.component?.formFieldCompMapEntry) }}: {{component?.component?.status()}}</li>
+        }
+      </ul>
+      </li>
     </ul>
+    <pre [innerHtml]="form?.value | json"></pre>
   </div>
 </ng-container>

--- a/angular/projects/researchdatabox/form/src/app/form.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.ts
@@ -86,7 +86,7 @@ export class FormComponent extends BaseComponent {
     @Inject(TranslationService) private translationService: TranslationService,
     @Inject(ElementRef) elementRef: ElementRef,
     @Inject(FormService) private formService: FormService,
-    @Inject(UtilityService) private utilityService: UtilityService
+    @Inject(UtilityService) protected utilityService: UtilityService
   ) {
     super();
     this.initDependencies = [this.translationService];
@@ -94,15 +94,8 @@ export class FormComponent extends BaseComponent {
     this.recordType = elementRef.nativeElement.getAttribute('recordType');
     this.editMode = elementRef.nativeElement.getAttribute('editMode') === "true";
     this.formName = elementRef.nativeElement.getAttribute('formName') || "";
-    this.appName = `Form::${this.recordType}::${this.formName} ${ this.oid ? ' - ' + this.oid : ''}`;
-    this.loggerService.debug(`'${this.logName}' waiting for deps to init...`);
-
-    effect(() => {
-      this.loggerService.info(`${this.logName}: status value is:`, this.status());
-    });
-    effect(() => {
-      this.loggerService.info(`${this.logName}: componentsLoaded value is:`, this.componentsLoaded());
-    });
+    this.appName = `Form::${this.recordType}::${this.formName} ${ this.oid ? ' - ' + this.oid : ''}`.trim();
+    this.loggerService.debug(`'${this.logName}' waiting for '${this.formName}' deps to init...`);
   }
 
   protected async initComponent(): Promise<void> {
@@ -144,7 +137,7 @@ export class FormComponent extends BaseComponent {
    */
   protected registerComponentReady(componentEntry: FormFieldCompMapEntry): void {
     const thisName = this.appName;
-    const componentName = this.utilityService.getName(componentEntry);
+    const componentName = this.utilityService.getNameClass(componentEntry);
     this.loggerService.debug(`${this.logName}: component '${componentName}' registered as ready.`);
     this.formService.triggerComponentReady(thisName, this.formDefMap, this.componentsLoaded, this.status);
   }

--- a/angular/projects/researchdatabox/form/src/app/form.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.ts
@@ -95,7 +95,7 @@ export class FormComponent extends BaseComponent {
     this.editMode = elementRef.nativeElement.getAttribute('editMode') === "true";
     this.formName = elementRef.nativeElement.getAttribute('formName') || "";
     this.appName = `Form::${this.recordType}::${this.formName} ${ this.oid ? ' - ' + this.oid : ''}`;
-    this.loggerService.debug(`'${this.appName}' waiting for deps to init...`);
+    this.loggerService.debug(`'${this.logName}' waiting for deps to init...`);
 
     effect(() => {
       this.loggerService.info(`${this.logName}: status value is:`, this.status());
@@ -143,9 +143,10 @@ export class FormComponent extends BaseComponent {
    * @param componentEntry - The component entry that is ready.
    */
   protected registerComponentReady(componentEntry: FormFieldCompMapEntry): void {
-    const name = this.utilityService.getName(componentEntry);
-    this.loggerService.debug(`${this.logName}: component '${name}' registered as ready.`);
-    this.formService.triggerComponentReady(this.appName, this.formDefMap, this.componentsLoaded, this.status);
+    const thisName = this.appName;
+    const componentName = this.utilityService.getName(componentEntry);
+    this.loggerService.debug(`${this.logName}: component '${componentName}' registered as ready.`);
+    this.formService.triggerComponentReady(thisName, this.formDefMap, this.componentsLoaded, this.status);
   }
 
   @HostBinding('class.edit-mode') get isEditMode() {

--- a/angular/projects/researchdatabox/form/src/app/form.module.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.module.ts
@@ -24,10 +24,12 @@ import { CommonModule, APP_BASE_HREF, PlatformLocation } from '@angular/common';
 import { FormComponent } from './form.component';
 import { TextFieldComponent } from './component/textfield.component';
 import { FormService } from './form.service';
+import {GroupFieldComponent} from "./component/groupfield.component";
 @NgModule({
   declarations: [
     FormComponent,
-    TextFieldComponent
+    TextFieldComponent,
+    GroupFieldComponent,
   ],
   imports: [
     CommonModule,
@@ -46,7 +48,7 @@ import { FormService } from './form.service';
   ],
   bootstrap: [FormComponent],
   exports: [
-    
+
   ]
 })
 export class FormModule { }

--- a/angular/projects/researchdatabox/form/src/app/form.service.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.service.ts
@@ -17,20 +17,35 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-import { Injectable, Inject } from '@angular/core';
-import { FormControl } from '@angular/forms';
-import { isEmpty as _isEmpty, toLower as _toLower, merge as _merge, isUndefined as _isUndefined, filter as _filter, forOwn as _forOwn } from 'lodash-es';
-import { FormComponentClassMap, FormFieldModelClassMap, StaticComponentClassMap, StaticModelClassMap } from './static-comp-field.dictionary';
-import { FormConfig, FormFieldModel, LoggerService, FormFieldModelConfig, FormFieldBaseComponent, FormFieldCompMapEntry } from '@researchdatabox/portal-ng-common';
-import { PortalNgFormCustomService } from '@researchdatabox/portal-ng-form-custom';
+import {Inject, Injectable, WritableSignal} from '@angular/core';
+import {FormControl, FormGroup} from '@angular/forms';
+import {isEmpty as _isEmpty, isUndefined as _isUndefined, merge as _merge, get as _get} from 'lodash-es';
+import {
+  FormComponentDefinition,
+  FormConfig,
+  FormFieldBaseComponent,
+  FormFieldCompMapEntry, FormFieldComponentStatus,
+  FormFieldModel,
+  FormFieldModelConfig, FormStatus,
+  LoggerService,
+  UtilityService
+} from '@researchdatabox/portal-ng-common';
+import {PortalNgFormCustomService} from '@researchdatabox/portal-ng-form-custom';
+import {
+  FormComponentClassMap,
+  FormFieldModelClassMap,
+  StaticComponentClassMap,
+  StaticModelClassMap
+} from './static-comp-field.dictionary';
+
 /**
  *
  * FormService
  * - retrieves form configuration
- * 
+ *
  * Author: <a href='https://github.com/shilob' target='_blank'>Shilo Banihit</a>
  *
- * 
+ *
  */
 @Injectable(
   {
@@ -38,27 +53,29 @@ import { PortalNgFormCustomService } from '@researchdatabox/portal-ng-form-custo
   }
 )
 export class FormService {
+  protected logName = "FormService";
   protected compClassMap:FormComponentClassMap = {};
   protected modelClassMap:FormFieldModelClassMap = {};
 
   constructor(
     @Inject(PortalNgFormCustomService) private customModuleFormCmpResolverService: PortalNgFormCustomService,
     @Inject(LoggerService) private loggerService: LoggerService,
+    @Inject(UtilityService) private utilityService: UtilityService,
     ) {
     // start with the static version, will dynamically merge any custom components later
     _merge(this.modelClassMap, StaticModelClassMap);
     _merge(this.compClassMap, StaticComponentClassMap);
-    this.loggerService.debug(`FormService: Static component classes:`, this.compClassMap);
-    this.loggerService.debug(`FormService: Static model classes:`, this.modelClassMap);
+    this.loggerService.debug(`${this.logName}: Static component classes:`, this.compClassMap);
+    this.loggerService.debug(`${this.logName}: Static model classes:`, this.modelClassMap);
   }
-  /** 
-   * 
+  /**
+   *
    * Download and consequently loads the form config.
-   * 
+   *
    * Fields can use:
    * - components that are included in this app module
-   * - components 
-   * 
+   * - components
+   *
    * Returns:
    *  array of form fields containing the corresponding component information, ready for rendering.
    */
@@ -73,7 +90,7 @@ export class FormService {
       componentDefinitions: [
         {
           name: 'text_1_event',
-          model: { 
+          model: {
             name: 'text_1_for_the_form',
             class: 'TextFieldModel',
             config: {
@@ -94,7 +111,7 @@ export class FormService {
               helpText: 'This is a help text',
             }
           },
-          model: { 
+          model: {
             class: 'TextFieldModel',
             config: {
               value: 'hello world 2!',
@@ -104,6 +121,62 @@ export class FormService {
             class: 'TextFieldComponent'
           }
         },
+        {
+          name: 'group_1_component',
+          layout: {
+            class: 'DefaultLayoutComponent',
+            config: {
+              label: 'GroupField label',
+              helpText: 'GroupField help',
+            }
+          },
+          model: {
+            name: 'group_1_model',
+            class: 'GroupFieldModel',
+            config: {
+              defaultValue: {},
+            }
+          },
+          component: {
+            class: 'GroupFieldComponent',
+            config: {
+              componentDefinitions: [
+                {
+                  name: 'text_3',
+                  layout: {
+                    class: 'DefaultLayoutComponent',
+                    config: {
+                      label: 'TextField with default wrapper defined',
+                      helpText: 'This is a help text',
+                    }
+                  },
+                  model: {
+                    class: 'TextFieldModel',
+                    config: {
+                      value: 'hello world 3!',
+                    }
+                  },
+                  component: {
+                    class: 'TextFieldComponent'
+                  }
+                },
+                {
+                  name: 'text_4',
+                  model: {
+                    class: 'TextFieldModel',
+                    config: {
+                      value: 'hello world 4!',
+                      defaultValue: 'hello world 4!'
+                    }
+                  },
+                  component: {
+                    class: 'TextFieldComponent'
+                  }
+                },
+              ]
+            }
+          }
+        }
         // {
         //   module: 'custom',
         //   component: {
@@ -119,14 +192,20 @@ export class FormService {
         //     }
         //   }
         // }
-      ] 
+      ]
     } as FormConfig;
     // Resove the field and component pairs
     return this.createFormComponentsMap(formConfig);
   }
 
+  /**
+   * Create form components from the form component definition configuration.
+   *
+   * @param formConfig The form configuration.
+   * @returns The config and the components built from the config.
+   */
   public async createFormComponentsMap(formConfig: FormConfig): Promise<FormComponentsMap> {
-    const components = await this.resolveFormComponentClasses(formConfig);
+    const components = await this.resolveFormComponentClasses(formConfig?.componentDefinitions);
     // Instantiate the field classes, note these are optional, i.e. components may not have a form bound value
     this.createFormFieldModelInstances(components);
     return new FormComponentsMap(components, formConfig);
@@ -136,10 +215,14 @@ export class FormService {
     _merge(this.compClassMap, additionalTypes);
   }
 
-  protected async resolveFormComponentClasses(formConfig: FormConfig): Promise<FormFieldCompMapEntry[]> {
+  /**
+   * Builds an array of form component details by using the config to find the component details.
+   * @param componentDefinitions The config for the components.
+   */
+  public async resolveFormComponentClasses(componentDefinitions:  FormComponentDefinition[] | null | undefined): Promise<FormFieldCompMapEntry[]> {
     const fieldArr = [];
-    this.loggerService.debug('Resolving form component types...', formConfig);
-    const components = formConfig.componentDefinitions || [];
+    this.loggerService.debug(`${this.logName}: resolving ${componentDefinitions?.length ?? 0} component definitions ${this.utilityService.getNames(componentDefinitions)}`);
+    const components = componentDefinitions || [];
     for (let componentConfig of components) {
       let modelClass: typeof FormFieldModel | undefined = undefined;
       let componentClass: typeof FormFieldBaseComponent | undefined = undefined;
@@ -148,7 +231,7 @@ export class FormService {
       let componentClassName:string = componentConfig.component?.class || '';
       let layoutClassName:string = componentConfig.layout?.class || '';
       if (_isEmpty(modelClassName)) {
-        this.loggerService.error(`Model class name is empty for component: ${JSON.stringify(componentConfig)}`);
+        this.loggerService.error(`${this.logName}: model class name is empty for component.`, componentConfig);
         continue;
       }
       if (!_isEmpty(componentConfig.module)) {
@@ -174,13 +257,13 @@ export class FormService {
               layoutClass = await this.getComponentClass(layoutClassName, componentConfig.module);
             }
           } catch (e) {
-            this.loggerService.error(`FormService failed to resolve component: ${componentClassName || modelClassName}`);
+            this.loggerService.error(`${this.logName}: failed to resolve component.`,{componentClassName: componentClassName, modelClassName: modelClassName});
           }
         }
       } else {
         // should be resolved already
         modelClass = this.modelClassMap[modelClassName];
-        // if the compClass isn't explicitly defined, use the field class name, make sure a 'default' component is defined for each field 
+        // if the compClass isn't explicitly defined, use the field class name, make sure a 'default' component is defined for each field
         componentClass = this.compClassMap[componentClassName || modelClassName];
 
         if (!_isEmpty(layoutClassName)) {
@@ -196,56 +279,70 @@ export class FormService {
             layoutClass: layoutClass,
           } as FormFieldCompMapEntry);
         } else {
-          this.loggerService.error(`Component class with name: ${componentClassName} not found in class list. Check spelling and whether it is declared in the following list.`);
-          this.loggerService.error(this.compClassMap);
+          this.logNotAvailable(componentClassName, "component class", this.compClassMap);
         }
       } else {
-        this.loggerService.error(`Model class with name: ${modelClassName} not found class list. Check spelling and whether it is declared in the following list.`);
-        this.loggerService.error(this.modelClassMap);
+        this.logNotAvailable(modelClassName, "model class", this.modelClassMap);
       }
     }
-    this.loggerService.debug('Resolved form component types:', fieldArr);
+    this.loggerService.debug(`${this.logName}: resolved form component types:`, fieldArr);
     return fieldArr;
   }
 
+  /**
+   * Get a component class from the class name.
+   * @param componentClassName The name of the component class.
+   * @param module
+   */
   public async getComponentClass(componentClassName: string, module?:string | null): Promise<typeof FormFieldBaseComponent | undefined> {
     if (_isEmpty(componentClassName)) {
-      this.loggerService.error('Component class name is empty');
-      throw new Error('Component class name is empty');
+      throw new Error(`${this.logName}: cannot get component class because the class name is empty.`);
     }
+    this.loggerService.debug(`${this.logName}: get component class for name '${componentClassName}'.`);
+
     let componentClass = this.compClassMap[componentClassName];
     if (_isUndefined(componentClass) && !_isEmpty(module)) {
       componentClass = await this.customModuleFormCmpResolverService.getComponentClass(componentClassName);
     }
     if (_isUndefined(componentClass)) {
-      this.loggerService.error(`Component class with name: ${componentClassName} not found in class list. Check spelling and whether it is declared in the following list.`);
-      this.loggerService.error(this.compClassMap);
-      throw new Error(`Component class with name: ${componentClassName} not found in class list. Check`);
+      this.logNotAvailable(componentClassName, "component class", this.compClassMap);
+      throw new Error(`${this.logName}: cannot get component class with name '${componentClassName}' because it was not found in class list.`);
     }
     return componentClass
   }
-  
-  protected createFormFieldModelInstances(components:FormFieldCompMapEntry[]): FormFieldCompMapEntry[] {
+
+  public createFormFieldModelInstances(components:FormFieldCompMapEntry[]): FormFieldCompMapEntry[] {
+    this.loggerService.debug(`${this.logName}: create form field model instances from ${components?.length ?? 0} components ${this.utilityService.getNames(components)}.`);
     for (let compEntry of components) {
       if (compEntry.modelClass) {
         const model = new (compEntry.modelClass as any) (compEntry.compConfigJson.model as FormFieldModelConfig) as FormFieldModel;
         compEntry.model = model;
       } else {
-        this.loggerService.warn(`Model class with name: ${compEntry.modelClass} not found field class list. Check spelling and whether it is declared in the following list.`);
-        this.loggerService.error(this.modelClassMap);
+        this.logNotAvailable(compEntry.modelClass ?? "(unknown)", "model class", this.modelClassMap);
       }
     }
     return components;
   }
 
+
+
+  /**
+   * Create maps so the component and control can be accessed using the component name.
+   * @param compMap
+   */
   public groupComponentsByName(compMap: FormComponentsMap): FormComponentsMap {
+    this.loggerService.debug(`${this.logName}: group components by name`, compMap);
     const groupMap: any = {};
     const groupWithFormControl: any = {};
     for (let compEntry of compMap.components) {
       const fieldName:string = compEntry.compConfigJson.name;
       if (_isEmpty(fieldName)) {
-        this.loggerService.info(`Field name is empty for component: ${JSON.stringify(compEntry)}. If you need this component to be part of the form or participate in events, please provide a name.`);
+        this.loggerService.info(`Field name is empty for component. If you need this component to be part of the form or participate in events, please provide a name.`, compEntry);
         continue;
+      }
+      if (groupMap[fieldName]) {
+        throw new Error(`${this.logName}: Field name '${fieldName}' is already used. Names must be unique, please change the names to be unique. ` +
+          `The components are: ${JSON.stringify([groupMap[fieldName], compEntry])}`);
       }
       groupMap[fieldName] = compEntry;
       if (compEntry.model) {
@@ -260,15 +357,87 @@ export class FormService {
     compMap.withFormControl = groupWithFormControl;
     return compMap;
   }
+
+  /**
+   * Create the form group based on the form definition map.
+   * @param formDefMap The form components map.
+   */
+  public createFormGroup(formDefMap: FormComponentsMap): {
+    form: FormGroup,
+    components: FormFieldCompMapEntry[]
+  } | undefined {
+    this.loggerService.debug(`${this.logName}: create form group`, formDefMap);
+    if (formDefMap && formDefMap.formConfig) {
+      const components = formDefMap.components;
+      // set up the form group
+      const formGroupMap = this.groupComponentsByName(formDefMap);
+      this.loggerService.debug(`${this.logName}: form group map`, formGroupMap);
+      // create the form group
+      if (!_isEmpty(formGroupMap.withFormControl)) {
+        return {form: new FormGroup(formGroupMap.withFormControl), components: components};
+      } else {
+        const msg = `No form controls found in the form definition. Form will not be rendered.`;
+        this.loggerService.warn(`${this.logName}: ${msg}`);
+        throw new Error(msg);
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Notification hook for when components are ready.
+   */
+  public triggerComponentReady(
+    name: string,
+    formDefMap: FormComponentsMap | undefined,
+    componentsLoaded: WritableSignal<boolean>,
+    status: WritableSignal<FormStatus>
+  ): void {
+    if (formDefMap && formDefMap.components && !componentsLoaded()) {
+      // Set the overall loaded flag to true if all components are loaded
+      const componentsCount = formDefMap.components?.length ?? 0;
+      const componentsReady = formDefMap.components.filter(componentDef =>
+        componentDef.component && componentDef.component.status() === FormFieldComponentStatus.READY
+      );
+      const componentsNotReady = formDefMap.components.filter(componentDef =>
+        !componentDef.component || componentDef.component.status() !== FormFieldComponentStatus.READY
+      );
+      componentsLoaded.set(componentsReady.length === componentsCount);
+
+      if (componentsLoaded()) {
+        status.set(FormStatus.READY);
+        this.loggerService.debug(`${this.logName}: All components for ${name} are ready. Form is ready to be used.`);
+      } else{
+        this.loggerService.debug(
+          `${this.logName}: Waiting for components for ${name} to be ready. Waiting for ${componentsNotReady.length} components to be ready ${this.utilityService.getNames(componentsNotReady)}. ` +
+          `${componentsReady.length} components are ready ${this.utilityService.getNames(componentsReady)}`);
+      }
+    }
+  }
+
+  private logNotAvailable(name: string, itemType: string, availableItems: { [index: string]: any }): void {
+    this.loggerService.error(`${this.logName}: ${itemType} with name '${name}' not found in list. ` +
+      `Check the spelling and whether it is declared in the following list.`, availableItems);
+  }
 }
 
 /**
- *  This client-side, Angular specific data model of the downloaded form configuration. This includes Angular's FormControl instances for binding UI components to the form.
+ *  This client-side, Angular specific data model of the downloaded form configuration.
+ *  This includes Angular's FormControl instances for binding UI components to the form.
  */
 export class FormComponentsMap {
+  /**
+   * The form component details create from the form configuration.
+   */
   components: FormFieldCompMapEntry[];
+  /**
+   * The form configuration from the server.
+   */
   formConfig: FormConfig;
   completeGroupMap: { [key: string]: FormFieldCompMapEntry } | undefined;
+  /**
+   * Mapping of name to angular FormControl. Used to create angular form.
+   */
   withFormControl: { [key: string]: FormControl } | undefined;
 
   constructor(components: FormFieldCompMapEntry[], formConfig: FormConfig) {

--- a/angular/projects/researchdatabox/form/src/app/form.service.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.service.ts
@@ -122,6 +122,7 @@ export class FormService {
           }
         },
         {
+          // first group component
           name: 'group_1_component',
           layout: {
             class: 'DefaultLayoutComponent',
@@ -173,6 +174,50 @@ export class FormService {
                     class: 'TextFieldComponent'
                   }
                 },
+                {
+                  // second group component, nested in first group component
+                  name: 'group_2_component',
+                  layout: {
+                    class: 'DefaultLayoutComponent',
+                    config: {
+                      label: 'GroupField 2 label',
+                      helpText: 'GroupField 2 help',
+                    }
+                  },
+                  model: {
+                    name: 'group_2_model',
+                    class: 'GroupFieldModel',
+                    config: {
+                      defaultValue: {},
+                    }
+                  },
+                  component: {
+                    class: 'GroupFieldComponent',
+                    config: {
+                      componentDefinitions: [
+                        {
+                          name: 'text_5',
+                          layout: {
+                            class: 'DefaultLayoutComponent',
+                            config: {
+                              label: 'TextField with default wrapper defined',
+                              helpText: 'This is a help text',
+                            }
+                          },
+                          model: {
+                            class: 'TextFieldModel',
+                            config: {
+                              value: 'hello world 5!',
+                            }
+                          },
+                          component: {
+                            class: 'TextFieldComponent'
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
               ]
             }
           }
@@ -404,13 +449,13 @@ export class FormService {
       );
       componentsLoaded.set(componentsReady.length === componentsCount);
 
+      const readyMsg = `Waiting for ${componentsNotReady.length} components to be ready ${this.utilityService.getNames(componentsNotReady)}. ` +
+          `${componentsReady.length} components are ready ${this.utilityService.getNames(componentsReady)}`
       if (componentsLoaded()) {
         status.set(FormStatus.READY);
-        this.loggerService.debug(`${this.logName}: All components for ${name} are ready. Form is ready to be used.`);
+        this.loggerService.debug(`${this.logName}: All components for ${name} are ready. Form is ready to be used. ${readyMsg}`);
       } else{
-        this.loggerService.debug(
-          `${this.logName}: Waiting for components for ${name} to be ready. Waiting for ${componentsNotReady.length} components to be ready ${this.utilityService.getNames(componentsNotReady)}. ` +
-          `${componentsReady.length} components are ready ${this.utilityService.getNames(componentsReady)}`);
+        this.loggerService.debug(`${this.logName}: Waiting for components for ${name} to be ready. ${readyMsg}`);
       }
     }
   }

--- a/angular/projects/researchdatabox/form/src/app/form.service.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.service.ts
@@ -261,7 +261,12 @@ export class FormService {
               ]
             }
           }
-        }
+        },
+        {
+          name: 'validation_summary_1',
+          model: {name: 'validation_summary_2', class: 'ValidationSummaryFieldModel'},
+          component: {class: "ValidationSummaryFieldComponent"}
+        },
         // {
         //   module: 'custom',
         //   component: {
@@ -277,11 +282,6 @@ export class FormService {
         //     }
         //   }
         // }
-        {
-          name: 'validation_summary_1',
-          model: {name: 'validation_summary_2', class: 'ValidationSummaryFieldModel'},
-          component: {class: "ValidationSummaryFieldComponent"}
-        },
       ]
     } as FormConfig;
     // Resove the field and component pairs
@@ -462,7 +462,7 @@ export class FormService {
    * @return An array of validation errors.
    */
   public getFormValidatorSummaryErrors(
-    componentDefs: FormComponentDefinition[] | null | undefined,
+    componentDefs: FormComponentDefinition<unknown>[] | null | undefined,
     name: string | null | undefined = null,
     control: AbstractControl | null | undefined = null,
     parents: string[] | null = null,
@@ -515,7 +515,7 @@ export class FormService {
    *
    * @param componentDef The component definition from the form config.
    */
-  public componentIdLabel(componentDef: FormComponentDefinition | null): {
+  public componentIdLabel(componentDef: FormComponentDefinition<unknown> | null): {
     id: string | null,
     labelMessage: string | null
   } {
@@ -537,7 +537,6 @@ export class FormService {
     // build the result
     return {id: id, labelMessage: labelMessage};
   }
-}
 
   /**
    * Create the form group based on the form definition map.

--- a/angular/projects/researchdatabox/form/src/app/static-comp-field.dictionary.ts
+++ b/angular/projects/researchdatabox/form/src/app/static-comp-field.dictionary.ts
@@ -1,24 +1,29 @@
 import { TextFieldModel, TextFieldComponent } from "./component/textfield.component";
 import { DefaultLayoutComponent } from "@researchdatabox/portal-ng-common";
 import { each as _each, map as _map, endsWith as _endsWith } from 'lodash-es';
+import {GroupFieldModel, GroupFieldComponent } from "./component/groupfield.component";
 
 /** Field related */
 export interface FormFieldModelClassMap {
   [index: string]: any;
 }
 
-/** 
- * For built-in components, add the mapping here 
- * 
+/**
+ * For built-in components, add the mapping here
+ *
  * Note that each model and component are optional
 */
 export const StaticModelCompClassMap = {
-  'TextField': { 
-    model: TextFieldModel, 
-    component: TextFieldComponent 
+  'TextField': {
+    model: TextFieldModel,
+    component: TextFieldComponent
   },
   'DefaultLayoutComponent': {
     component: DefaultLayoutComponent
+  },
+  'GroupField': {
+    model: GroupFieldModel,
+    component: GroupFieldComponent
   }
 };
 
@@ -33,7 +38,7 @@ _each(StaticModelCompClassMap, (value:any, key:any) => {
     // add an entry for the model name to make it easier to find the corresponding component's model
     if (value.component) {
       const componentKeyName = _endsWith(key, 'Component') ? key : key + 'Component';
-      StaticModelClassMap[componentKeyName] = value.model; 
+      StaticModelClassMap[componentKeyName] = value.model;
     }
   }
 });
@@ -53,7 +58,7 @@ _each(StaticModelCompClassMap, (value:any, key:any) => {
     // add an entry for the component name to make it easier to find the corresponding model's component
     if (value.model) {
       const modelKeyName = _endsWith(key, 'Model') ? key : key + 'Model';
-      StaticComponentClassMap[modelKeyName] = value.component; 
+      StaticComponentClassMap[modelKeyName] = value.component;
     }
   }
 });

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/form/base.model.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/form/base.model.ts
@@ -1,10 +1,10 @@
 import { FormFieldModelConfig } from './config.model';
 import { get as _get, set as _set, extend as _extend, isEmpty as _isEmpty, isUndefined as _isUndefined, merge as _merge, trim as _trim, isNull as _isNull, orderBy as _orderBy, map as _map, find as _find, indexOf as _indexOf, isArray as _isArray, forEach as _forEach, join as _join, first as _first, template as _template, toLower as _toLowe, clone as _clone, cloneDeep as _cloneDeep } from 'lodash-es';
 
-import { FormControl } from '@angular/forms';
+import {AbstractControl, FormControl} from '@angular/forms';
 /**
  * Core model for form elements.
- * 
+ *
  */
 export abstract class FormModel<ConfigType> {
   // The configuration when the field is created
@@ -21,19 +21,19 @@ export abstract class FormModel<ConfigType> {
    * Custom initialization logic when constructing the model
    */
   public postCreate(): void {
-    
+
   }
 }
 /**
  * Model for the form field configuration.
- * 
+ *
  */
-export class FormFieldModel<ValueType = string> extends FormModel< FormFieldModelConfig<ValueType> > {
+export class FormFieldModel<ValueType> extends FormModel< FormFieldModelConfig<ValueType> > {
   // The value when the field is created
   public initValue?: ValueType | null | undefined;
 
-  public formControl: FormControl<ValueType | null | undefined> | null | undefined;
-  // TODO: strongly type 
+  public formControl: AbstractControl<ValueType | null | undefined> | null | undefined;
+  // TODO: strongly type
   public validators?: any[] = [];
 
   constructor(initConfig: FormFieldModelConfig<ValueType>) {
@@ -46,9 +46,8 @@ export class FormFieldModel<ValueType = string> extends FormModel< FormFieldMode
     // TODO: create or configure the validators
 
     // create the form model
-    console.log("FormFieldModel: creating form model with value:", this.initValue);
-    this.formControl = new FormControl<ValueType | null | undefined>(this.initValue) as FormControl<ValueType | null | undefined>;
-    console.log("FormFieldModel: created form model:", this.formControl);
+    this.formControl = new FormControl<ValueType | null | undefined>(this.initValue) as AbstractControl<ValueType | null | undefined>;
+    console.log(`FormFieldModel: created form control '${this.fieldConfig?.name ?? '(no name)'}' with model class '${this.fieldConfig?.class}' and initial value '${this.initValue}'`);
   }
   /**
    * Get the value of the field
@@ -65,10 +64,11 @@ export class FormFieldModel<ValueType = string> extends FormModel< FormFieldMode
   }
 
   /**
-   * Primitive implementation returns the form control. Complex implementations should override this method to create complex form controls.
+   * Primitive implementation returns the form control.
+   * Complex implementations should override this method to create complex form controls.
    * @returns the form control
    */
-  public getFormGroupEntry(): FormControl {
+  public getFormGroupEntry(): AbstractControl<ValueType | null | undefined> | null | undefined {
     if (this.formControl) {
       return this.formControl;
     } else {

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/form/base.model.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/form/base.model.ts
@@ -53,7 +53,7 @@ export class FormFieldModel<ValueType> extends FormModel<FormFieldModelConfig<Va
 
     // create the form model
     this.formControl = new FormControl<FormFieldModelValueType<ValueType>>(this.initValue) as AbstractControl<FormFieldModelValueType<ValueType>>;
-    console.log(`FormFieldModel: created form control '${this.fieldConfig?.name ?? '(no name)'}' with model class '${this.fieldConfig?.class}' and initial value '${this.initValue}'`);
+    console.log(`FormFieldModel: created form control '${this.fieldConfig?.name ?? '(no model name)'}' with model class '${this.fieldConfig?.class}' and initial value '${this.initValue}'`);
   }
 
   /**

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/form/config.model.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/form/config.model.ts
@@ -1,6 +1,6 @@
 /**
- * These classes are used to define the configuration for the form and form components. 
- * 
+ * These classes are used to define the configuration for the form and form components.
+ *
  * These can be used to generate JSON schema for validation, etc. both on the client and server side.
  */
 
@@ -14,7 +14,7 @@ export class FormConfig {
   // DOM related config
   // the dom element type to inject, e.g. div, span, etc. leave empty to use 'ng-container'
   domElementType?: string | null | undefined = null;
-  // optional form dom id property. When set, value will be injected into the overall dom node 
+  // optional form dom id property. When set, value will be injected into the overall dom node
   domId?: string | null | undefined = null;
   // the optional css clases to be applied to the form dom node
   viewCssClasses?: { [key: string]: string } | string | null | undefined = null;
@@ -22,8 +22,8 @@ export class FormConfig {
   // optional configuration to set in each compoment
   defaultComponentConfig?: { [key: string]: { [key: string]: string } | string | null } | string | null | undefined = null;
 
-  
-  
+
+
   // validation related config
   // whether to trigger validation on save
   skipValidationOnSave?: boolean = false;
@@ -33,7 +33,7 @@ export class FormConfig {
   // the default layout component
   defaultLayoutComponent?: string | null | undefined = null;
   // the components of this form
-  componentDefinitions?: FormComponentDefinition[] | null | undefined = null;
+  componentDefinitions?: FormComponentDefinition<unknown>[] | null | undefined = null;
 
   // debug: show the form JSON
   debugValue?: boolean = false;
@@ -52,16 +52,16 @@ export interface HasFormComponentConfigBlock {
 }
 /**
  * The form component configuration definition.
- * 
+ *
  */
-export class FormComponentDefinition implements HasFormComponentIdentity {
+export class FormComponentDefinition<ValueType> implements HasFormComponentIdentity {
   name?: string | null | undefined; // top-level field name, applies to field and the component, etc.
   // Either 'class' or 'layout' should be defined, but not both.
   // Note: This exclusivity is not enforced at compile time by this class definition alone.
   // the inheried `class` property makes the 'layout' optional
   layout?: FormComponentLayoutDefinition | null | undefined;
-  model?: FormFieldModelConfig | null | undefined = null;
-  component?: FormFieldComponentDefinition | null | undefined = null; 
+  model?: FormFieldModelConfig<ValueType> | null | undefined = null;
+  component?: FormFieldComponentDefinition | null | undefined = null;
   module?: string | null | undefined = null;
 }
 
@@ -96,11 +96,11 @@ export class FormFieldModelConfigBlock<ValueType> {
 /**
  * Config for the field model configuration, aka the data binding
  */
-export class FormFieldModelConfig<ValueType = string | undefined> implements HasFormComponentIdentity, HasFormComponentClass, HasFormComponentConfigBlock {
+export class FormFieldModelConfig<ValueType> implements HasFormComponentIdentity, HasFormComponentClass, HasFormComponentConfigBlock {
   public name?: string | null | undefined; // top-level field name, applies to field and the component, etc.
   public class: string = ''; // make the class mandatory
   // set the `disabled` property: https://angular.dev/api/forms/FormControl#disabled
-  
+
   public config?: FormFieldModelConfigBlock<ValueType> | null | undefined = null;
 
 }
@@ -110,21 +110,21 @@ export class FormLayoutConfig extends FormComponentBaseConfig {
   public helpText: string = '';
   public cssClassesMap: { [key: string]: string } = {};
 }
-/** 
+/**
  * Config for the layout component configuration.
  */
 export class FormComponentLayoutDefinition implements HasFormComponentIdentity, HasFormComponentClass, HasFormComponentConfigBlock {
   public name?: string | null | undefined; // top-level field name, applies to field and the component, etc.
   public class?: string | null | undefined; // makes the 'layout' optional
 
-  public config?: FormLayoutConfig | null | undefined = null; 
+  public config?: FormLayoutConfig | null | undefined = null;
 }
 
 /**
  * the UI-specific config block
  */
 export class FormFieldConfig extends FormComponentBaseConfig {
-  
+
 }
 /**
  * Config for the main component configuration.

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/form/config.model.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/form/config.model.ts
@@ -139,7 +139,7 @@ export class FormComponentLayoutDefinition implements HasFormComponentIdentity, 
  * the UI-specific config block
  */
 export class FormFieldConfig extends FormComponentBaseConfig {
-
+  componentDefinitions?: FormComponentDefinition<unknown>[] | null | undefined = null;
 }
 /**
  * Config for the main component configuration.

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/form/default-layout.component.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/form/default-layout.component.ts
@@ -1,26 +1,26 @@
 import { FormFieldBaseComponent, FormFieldCompMapEntry } from './form-field-base.component';
 import { FormComponentLayoutDefinition } from './config.model';
-import { isEmpty as _isEmpty } from 'lodash-es';
-import { Component, ViewChild, ViewContainerRef, TemplateRef, ComponentRef } from '@angular/core';
+import {Component, ViewChild, ViewContainerRef, TemplateRef, ComponentRef} from '@angular/core';
 import { FormBaseWrapperComponent } from './base-wrapper.component';
+
 /**
  * Default Form Component Layout
- * 
- * This component provides additional layout-specific functionality for form components. 
- * 
+ *
+ * This component provides additional layout-specific functionality for form components.
+ *
  * The default layout is the following, which based by the legacy form field layout:
- * 
+ *
  * <div>
  *   <label>
  *    Label
  *    <span>Required indicator</span>
  *    <button>Help Button</button>
  *  </label>
- *  <span>Help Text</span> 
+ *  <span>Help Text</span>
  *  <ng-container>The component</ng-container>
  * </div>
  *
- * Other layouts can be defined, 
+ * Other layouts can be defined,
  * Author: <a href='https://github.com/shilob' target='_blank'>Shilo Banihit</a>
  *
  */
@@ -43,13 +43,13 @@ import { FormBaseWrapperComponent } from './base-wrapper.component';
       }
     }
     <ng-container #componentContainer>
-    </ng-container> 
+    </ng-container>
     <!-- instead of rendering the 'before' and 'after' templates around the componentContainer, we supply named templates so the component can render these as it sees fit -->
     <ng-template #beforeComponentTemplate>
-      Before, is help showing:  {{ helpTextVisible }}
+      Before {{ componentName }}
     </ng-template>
     <ng-template #afterComponentTemplate>
-      After, is help showing:  {{ helpTextVisible }}
+      After {{ componentName }}
     </ng-template>
   }
   `,
@@ -57,6 +57,7 @@ import { FormBaseWrapperComponent } from './base-wrapper.component';
   // Note: No need for host property here if using @HostBinding
 })
 export class DefaultLayoutComponent<ValueType> extends FormFieldBaseComponent<ValueType> {
+  protected override logName = "DefaultLayoutComponent";
   helpTextVisible: boolean = false;
   componentClass?: typeof FormFieldBaseComponent | null;
   public override componentDefinition?: FormComponentLayoutDefinition;
@@ -73,8 +74,8 @@ export class DefaultLayoutComponent<ValueType> extends FormFieldBaseComponent<Va
 
   /**
    * Override to set additional properties required by the wrapper component.
-   * 
-   * @param formFieldCompMapEntry 
+   *
+   * @param formFieldCompMapEntry
    */
   protected override setPropertiesFromComponentMapEntry(formFieldCompMapEntry: FormFieldCompMapEntry): void {
     super.setPropertiesFromComponentMapEntry(formFieldCompMapEntry);
@@ -87,9 +88,12 @@ export class DefaultLayoutComponent<ValueType> extends FormFieldBaseComponent<Va
   protected override async setComponentReady(): Promise<void> {
     // Set all the bound properties to the component
     this.wrapperComponentRef = this.componentContainer.createComponent(FormBaseWrapperComponent);
-    this.wrapperComponentRef.instance.componentClass = this.componentClass;
     this.wrapperComponentRef.instance.model = this.model;
+    this.wrapperComponentRef.instance.componentClass = this.componentClass;
     this.wrapperComponentRef.instance.formFieldCompMapEntry = this.formFieldCompMapEntry;
+    this.wrapperComponentRef.instance.defaultComponentConfig = {
+      defaultComponentCssClasses: this.formFieldCompMapEntry?.compConfigJson?.component?.config?.defaultComponentCssClasses
+    };
     if (this.formFieldCompMapEntry && this.beforeComponentTemplate && this.afterComponentTemplate) {
       this.formFieldCompMapEntry.componentTemplateRefMap = {
         before: this.beforeComponentTemplate,
@@ -103,5 +107,9 @@ export class DefaultLayoutComponent<ValueType> extends FormFieldBaseComponent<Va
 
   toggleHelpTextVisibility() {
    this.helpTextVisible = !this.helpTextVisible;
+  }
+
+  protected get componentName(){
+    return this.utilityService.getNameClass(this.formFieldCompMapEntry);
   }
 }

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/form/form-field-base.component.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/form/form-field-base.component.ts
@@ -1,19 +1,21 @@
 import { FormFieldModel } from './base.model';
 import { FormControl } from '@angular/forms';
 import { FormFieldComponentDefinition, FormComponentLayoutDefinition } from './config.model';
-import { Directive, HostBinding, signal, inject, TemplateRef } from '@angular/core'; // Import HostBinding
+import {Directive, HostBinding, signal, inject, TemplateRef, effect} from '@angular/core'; // Import HostBinding
 import { LoggerService } from '../logger.service';
 import { FormFieldComponentStatus } from './status.model';
 import { get as _get, isEmpty as _isEmpty } from 'lodash-es';
+import {UtilityService} from "../utility.service";
 /**
  * Base class for form components. Data binding to a form field is optional.
- * 
+ *
  * Notes:
  *  - No 'field' property to enforce type safety, i.e. avoid `any`
- * 
+ *
  */
 @Directive()
 export abstract class FormFieldBaseComponent<ValueType = string | undefined> {
+  protected logName: string | null = "FormFieldBaseComponent";
   public model?: FormFieldModel<ValueType> | null | undefined = null;
   public componentDefinition?: FormFieldComponentDefinition | FormComponentLayoutDefinition;
   public formFieldCompMapEntry?: FormFieldCompMapEntry | null | undefined = null;
@@ -21,25 +23,34 @@ export abstract class FormFieldBaseComponent<ValueType = string | undefined> {
   // The status of the component
   public status = signal<FormFieldComponentStatus>(FormFieldComponentStatus.INIT);
 
-  private loggerService: LoggerService = inject(LoggerService);
+  protected loggerService = inject(LoggerService);
+  protected utilityService = inject(UtilityService);
+
+  constructor() {
+    effect(() => {
+      this.loggerService.info(`${this.logName}: status value is:`, this.status());
+    });
+  }
   /**
    * This method is called to initialize the component with the provided configuration.
-   * 
+   *
    * The framework expects the method to prepare the component for rendering, and at minimum, should prepare:
-   * 
+   *
    * - Any external/remote data sources
    * - The model responsible for the data binding
    * - Any static or dynamic styling or layout information, including CSS classes
    * - Any event handlers
-   * 
+   *
    * For more advanced use cases, override method to define the component init behavior. Just don't forget to call 'super.setComponentReady()' or change the status manually, when the component is ready.
-   * 
-   * @param formFieldCompMapEntry 
+   *
+   * @param formFieldCompMapEntry
    */
   async initComponent(formFieldCompMapEntry: FormFieldCompMapEntry | null | undefined) {
     if (!formFieldCompMapEntry) {
-      throw new Error("FieldComponent: formFieldCompMapEntry is null.");
+      throw new Error(`${this.logName}: cannot initialise component because formFieldCompMapEntry was invalid.`);
     }
+    const name = this.utilityService.getName(formFieldCompMapEntry);
+    this.loggerService.debug(`${this.logName}: starting initialise component for '${name}' with component class '${formFieldCompMapEntry?.component?.componentDefinition?.class}'.`);
     try {
       // Create a method that children can override to set their own properties
       this.setPropertiesFromComponentMapEntry(formFieldCompMapEntry);
@@ -49,12 +60,15 @@ export abstract class FormFieldBaseComponent<ValueType = string | undefined> {
       // Create a method that children to prepare their state.
       await this.setComponentReady();
     } catch (error) {
-      this.loggerService.error("FieldComponent: initComponent failed", error);
+      this.loggerService.error(`${this.logName}: initialise component failed`, error);
       this.status.set(FormFieldComponentStatus.ERROR);
     }
   }
 
   protected setPropertiesFromComponentMapEntry(formFieldCompMapEntry: FormFieldCompMapEntry) {
+    if (!formFieldCompMapEntry) {
+      throw new Error(`${this.logName}: cannot set component properties because formFieldCompMapEntry was invalid.`);
+    }
     this.formFieldCompMapEntry = formFieldCompMapEntry;
     this.formFieldCompMapEntry.component = this as FormFieldBaseComponent;
     this.model = this.formFieldCompMapEntry?.model as FormFieldModel<ValueType> | null;
@@ -63,23 +77,21 @@ export abstract class FormFieldBaseComponent<ValueType = string | undefined> {
   /**
    * Retrieve or compute any data needed for the component.
    */
-  protected async initData() { 
-    
+  protected async initData() {
   }
   /**
    * Prepare any layout-specific information, including CSS classes.
    */
   protected async initLayout() {
     this.initHostBindingCssClasses();
-  } 
+  }
   /**
    * Prepare the event handlers for this component.
    */
   protected async initEventHandlers() {
-
   }
-  /** 
-  * Prepare the CSS classes for the host element. 
+  /**
+  * Prepare the CSS classes for the host element.
   */
   protected initHostBindingCssClasses() {
     if (this.componentDefinition?.config?.defaultComponentCssClasses) {
@@ -93,16 +105,16 @@ export abstract class FormFieldBaseComponent<ValueType = string | undefined> {
       this.hostBindingCssClasses = {}; // Initialize as empty object if no default classes
     }
   }
-  
+
   /**
    * The FormControl instance for this field.
    */
   get formControl(): FormControl<ValueType> {
     const control = this.model?.formControl;
     if (!control) {
-      console.error("FieldComponent formControl returned null for field:", this.model);
       // Return a dummy control or throw, depending on desired behavior
-      throw new Error("FieldComponent: field.formModel is null.");
+      const name = this.utilityService.getName(this.model);
+      throw new Error(`${this.logName}: could not get form control from model for '${name}'.`);
     }
     return control as FormControl<ValueType>;
   }
@@ -115,7 +127,7 @@ export abstract class FormFieldBaseComponent<ValueType = string | undefined> {
 
   /**
    * Get the template reference for the specified template name.
-   * 
+   *
    * @param templateName - The name of the template to retrieve.
    * @returns The TemplateRef instance or null if not found.
    */
@@ -133,13 +145,15 @@ export abstract class FormFieldBaseComponent<ValueType = string | undefined> {
    * Set the component status to READY.
    */
   protected async setComponentReady() {
+    const name = this.utilityService.getName(this.model);
+    this.loggerService.debug(`${this.logName}: component '${name}' with component class '${this.componentDefinition?.class}' is ready.`);
     this.status.set(FormFieldComponentStatus.READY);
   }
 }
 
 /**
  * The complete metadata data structure describing a form field component, including the necessary constructors to create and init the component and model.
- * 
+ *
  * @export
  * @interface FormFieldCompMapEntry
  */

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/form/form-field-base.component.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/form/form-field-base.component.ts
@@ -14,7 +14,7 @@ import {UtilityService} from "../utility.service";
  *
  */
 @Directive()
-export abstract class FormFieldBaseComponent<ValueType = string | undefined> {
+export abstract class FormFieldBaseComponent<ValueType> {
   protected logName: string | null = "FormFieldBaseComponent";
   public model?: FormFieldModel<ValueType> | null | undefined = null;
   public componentDefinition?: FormFieldComponentDefinition | FormComponentLayoutDefinition;
@@ -26,11 +26,6 @@ export abstract class FormFieldBaseComponent<ValueType = string | undefined> {
   protected loggerService = inject(LoggerService);
   protected utilityService = inject(UtilityService);
 
-  constructor() {
-    effect(() => {
-      this.loggerService.info(`${this.logName}: status value is:`, this.status());
-    });
-  }
   /**
    * This method is called to initialize the component with the provided configuration.
    *
@@ -49,8 +44,8 @@ export abstract class FormFieldBaseComponent<ValueType = string | undefined> {
     if (!formFieldCompMapEntry) {
       throw new Error(`${this.logName}: cannot initialise component because formFieldCompMapEntry was invalid.`);
     }
-    const name = this.utilityService.getName(formFieldCompMapEntry);
-    this.loggerService.debug(`${this.logName}: starting initialise component for '${name}' with component class '${formFieldCompMapEntry?.component?.componentDefinition?.class}'.`);
+    const name = this.utilityService.getNameClass(formFieldCompMapEntry);
+    this.loggerService.debug(`${this.logName}: starting initialise component for '${name}'.`);
     try {
       // Create a method that children can override to set their own properties
       this.setPropertiesFromComponentMapEntry(formFieldCompMapEntry);
@@ -70,7 +65,7 @@ export abstract class FormFieldBaseComponent<ValueType = string | undefined> {
       throw new Error(`${this.logName}: cannot set component properties because formFieldCompMapEntry was invalid.`);
     }
     this.formFieldCompMapEntry = formFieldCompMapEntry;
-    this.formFieldCompMapEntry.component = this as FormFieldBaseComponent;
+    this.formFieldCompMapEntry.component = this as FormFieldBaseComponent<ValueType>;
     this.model = this.formFieldCompMapEntry?.model as FormFieldModel<ValueType> | null;
     this.componentDefinition = this.formFieldCompMapEntry.compConfigJson.component as FormFieldComponentDefinition | FormComponentLayoutDefinition;
   }
@@ -113,7 +108,7 @@ export abstract class FormFieldBaseComponent<ValueType = string | undefined> {
     const control = this.model?.formControl;
     if (!control) {
       // Return a dummy control or throw, depending on desired behavior
-      const name = this.utilityService.getName(this.model);
+      const name = this.utilityService.getNameClass(this.formFieldCompMapEntry);
       throw new Error(`${this.logName}: could not get form control from model for '${name}'.`);
     }
     return control as FormControl<ValueType>;
@@ -145,8 +140,8 @@ export abstract class FormFieldBaseComponent<ValueType = string | undefined> {
    * Set the component status to READY.
    */
   protected async setComponentReady() {
-    const name = this.utilityService.getName(this.model);
-    this.loggerService.debug(`${this.logName}: component '${name}' with component class '${this.componentDefinition?.class}' is ready.`);
+    const name = this.utilityService.getNameClass(this.formFieldCompMapEntry);
+    this.loggerService.debug(`${this.logName}: in setComponentReady component '${name}' is ready.`);
     this.status.set(FormFieldComponentStatus.READY);
   }
 }
@@ -162,7 +157,7 @@ export interface FormFieldCompMapEntry {
   layoutClass?: typeof FormFieldBaseComponent | null;
   componentClass?: typeof FormFieldBaseComponent | null;
   compConfigJson: any,
-  model?: FormFieldModel | null;
-  component?: FormFieldBaseComponent | null;
-  componentTemplateRefMap? : { [key: string]: TemplateRef<any> } | null | undefined;
+  model?: FormFieldModel<unknown> | null;
+  component?: FormFieldBaseComponent<unknown> | null;
+  componentTemplateRefMap? : { [key: string]: TemplateRef<unknown> } | null | undefined;
 }

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/utility.service.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/utility.service.ts
@@ -385,30 +385,25 @@ export class UtilityService {
     }
   }
 
-  public getName(data?: any): string {
+  public getNameClass(data?: any): string {
+    // The name from the form config.
+    let name = null;
     if (data?.name) {
-      return data?.name;
+      name = data.name;
     }
-    if (data?.compConfigJson?.name) {
-      return data?.compConfigJson?.name;
+    if (!name && data?.compConfigJson?.name) {
+      name = data.compConfigJson.name;
     }
-    if (data?.model?.name) {
-      return data?.model?.name;
+
+    if (!name) {
+      console.error('Cannot find a name in data', data);
     }
-    if (data?.fieldConfig?.name) {
-      return data?.fieldConfig?.name;
-    }
-    if (data?.model?.fieldConfig?.name) {
-      return data?.model?.fieldConfig?.name;
-    }
-    if (data?.fieldConfig?.class) {
-      return data?.fieldConfig?.class;
-    }
-    console.error('Cannot find a name in data', data);
-    return "(unknown)";
+
+    const unknown = '(unknown)';
+    return `${name ?? unknown}`;
   }
 
-  public getNames(data?: any[] | null | undefined): string[] {
-    return data?.map(this.getName) ?? [];
+  public getNamesClasses(data?: any[] | null | undefined): string {
+    return ((data ?? [])?.map(this.getNameClass) ?? []).join(', ');
   }
 }

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/utility.service.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/utility.service.ts
@@ -63,7 +63,7 @@ export class UtilityService {
 
   /**
    * check that all the values to match have values for a given object
-   * 
+   *
    * Author: <a href='https://github.com/andrewbrazzatti' target='_blank'>Andrew Brazzatti</a>
    * @param  {any} valueObject
    * @param  {any} fieldsToMatch
@@ -82,7 +82,7 @@ export class UtilityService {
 
   /**
    * check a given object is not already present in the container list
-   * 
+   *
    * Author: <a href='https://github.com/andrewbrazzatti' target='_blank'>Andrew Brazzatti</a>
    * @param  {any} valueObject
    * @param  {any} fieldsToMatch
@@ -93,7 +93,7 @@ export class UtilityService {
     let concatReq = true;
     for (let fieldValue of fieldValues) {
       for (let fieldToMatch of fieldsToMatch) {
-        let fieldValueToMatch = _get(fieldValue, fieldToMatch); 
+        let fieldValueToMatch = _get(fieldValue, fieldToMatch);
         let emittedValueToMatch = _get(valueObject, fieldToMatch);
         if(_isEqual(fieldValueToMatch,emittedValueToMatch)) {
           concatReq = false;
@@ -159,24 +159,24 @@ export class UtilityService {
     if(!_isArray(data)) {
       wrappedData = [data];
     }
-    
+
     for (let emittedDataValue of wrappedData) {
-      //There are cases where the emitter may send null values just after the field  
-      //gets cleared therefore need to checkDataOk if any of the fields to match are  
-      //undefined not enter the if block and the same value will be sent back to the 
-      //subscriber field 
+      //There are cases where the emitter may send null values just after the field
+      //gets cleared therefore need to checkDataOk if any of the fields to match are
+      //undefined not enter the if block and the same value will be sent back to the
+      //subscriber field
       let checkDataOk = this.checkData(emittedDataValue,fieldsToMatch);
       if(checkDataOk){
         let concatReq = this.checkConcatReq(emittedDataValue,fieldsToMatch,fieldValues);
         if(concatReq) {
           let value = _clone(templateObject);
           for (let fieldToSet of fieldsToSet) {
-              let val = _get(emittedDataValue, fieldToSet); 
+              let val = _get(emittedDataValue, fieldToSet);
               _set(value, fieldToSet, val);
           }
-          //If there is only one item in fieldValues array it may be empty and must be re-used 
-          //if there is more than one item in the array it's too cumbersome to manage all  
-          //scenarios and edge cases therefore it's better to add a new item to the array 
+          //If there is only one item in fieldValues array it may be empty and must be re-used
+          //if there is more than one item in the array it's too cumbersome to manage all
+          //scenarios and edge cases therefore it's better to add a new item to the array
           if(fieldValues.length == 1) {
             let checkFieldValuesDataOk = this.checkData(fieldValues[0],fieldsToMatch);
             if(checkFieldValuesDataOk) {
@@ -383,5 +383,32 @@ export class UtilityService {
     for (let dep of deps) {
       await dep.waitForInit();
     }
+  }
+
+  public getName(data?: any): string {
+    if (data?.name) {
+      return data?.name;
+    }
+    if (data?.compConfigJson?.name) {
+      return data?.compConfigJson?.name;
+    }
+    if (data?.model?.name) {
+      return data?.model?.name;
+    }
+    if (data?.fieldConfig?.name) {
+      return data?.fieldConfig?.name;
+    }
+    if (data?.model?.fieldConfig?.name) {
+      return data?.model?.fieldConfig?.name;
+    }
+    if (data?.fieldConfig?.class) {
+      return data?.fieldConfig?.class;
+    }
+    console.error('Cannot find a name in data', data);
+    return "(unknown)";
+  }
+
+  public getNames(data?: any[] | null | undefined): string[] {
+    return data?.map(this.getName) ?? [];
   }
 }

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/utility.service.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/utility.service.ts
@@ -386,6 +386,11 @@ export class UtilityService {
   }
 
   public getNameClass(data?: any): string {
+    const unknown = '(unknown)';
+    if (!data){
+      return unknown;
+    }
+
     // The name from the form config.
     let name = null;
     if (data?.name) {
@@ -399,7 +404,6 @@ export class UtilityService {
       console.error('Cannot find a name in data', data);
     }
 
-    const unknown = '(unknown)';
     return `${name ?? unknown}`;
   }
 


### PR DESCRIPTION
Implemented:
- angular component - GroupFieldComponent
- extracted functionality shared with GroupFieldComponent from FormComponent to FormService
- group component keeps parent component model up to date
- group component works with in signal / lifecycle changes
- config is in `[GroupFieldComponent].component.config.componentDefinitions` to mirror FormComponent
- very simple tests that the group component renders the components it contains