### PR TITLE
Bugfix: deselect children when parent node is deselected by default

### DIFF
--- a/angular-legacy/shared/form/field-tree-selector.component.ts
+++ b/angular-legacy/shared/form/field-tree-selector.component.ts
@@ -49,6 +49,7 @@ export class TreeSelectorField extends FieldBase<any> {
   public expandChildrenWhenParentSeclected:boolean;
   public selectParentWhenChildSelected: boolean;
   public enforceAvoidDuplicates: boolean;
+  public deselectChildrenWhenParentUnselected: boolean;
 
   constructor(options: any, injector: any) {
     super(options, injector);
@@ -63,6 +64,7 @@ export class TreeSelectorField extends FieldBase<any> {
     this.ccsClassName = options['cssClassName'] || 'tree-node-checkbox';
     this.expandChildrenWhenParentSeclected = options['expandChildrenWhenParentSeclected'] || false;
     this.selectParentWhenChildSelected = options['selectParentWhenChildSelected'] || true;
+    this.deselectChildrenWhenParentUnselected = options['deselectChildrenWhenParentUnselected'] || true;
     this.enforceAvoidDuplicates = options['enforceAvoidDuplicates'] || true;
   }
 
@@ -290,10 +292,25 @@ export class TreeSelectorComponent extends SimpleComponent {
         if(this.field.expandChildrenWhenParentSeclected) {
           if(!_.isEmpty(event.node.children)) {
             event.node.collapse();
+            if(this.field.deselectChildrenWhenParentUnselected) {
+              try {
+                for(let child of event.node.data.children) {
+                  this.field.setSelected(child, false);
+                  let foundNode = this.findChildNodeById(event.node,child.id);
+                  if(!_.isUndefined(foundNode)) {
+                    this.updateSingleNodeSelectedState(foundNode, false);
+                  }
+                }
+              } catch(err) { }
+            }
           }
         }
         break;
     }
+  }
+
+  private findChildNodeById(node: TreeNode, childId: string): any {
+    return _.find(node.children, { id: childId });
   }
 
   protected handleNodeEvent(eventArr) {


### PR DESCRIPTION
Deselect children when parent node is deselected as default behavior in angular legacy tree component