### PR TITLE
Bugfix trigger service regex not working

### DIFF
--- a/test/unit/services/TriggerService.test.js
+++ b/test/unit/services/TriggerService.test.js
@@ -1,113 +1,130 @@
-// describe('The TriggerService', function () {
-//     before(function (done) {
-//         done();
-//     });
-//     describe('should validate fields using regex', function () {
-//         it('valid value passes', async function () {
-//             const oid = "triggerservice-validateFieldUsingRegex-validpasses";
-//             const record = {'testing-field': [{'row-item': '  field-value  '}]};
-//             const options = {
-//                 fieldDBName: 'testing-field',
-//                 errorLanguageCode: "invalid-format",
-//                 regexPattern: '^field-VALUE$',
-//                 fieldLanguageCode: "title-required",
-//                 arrayObjFieldDBName: 'row-item',
-//                 trimLeadingAndTrailingSpacesBeforeValidation: true,
-//                 forceRun: true
-//                 // caseSensitive: true, - default
-//                 // allowNulls: true, - default
-//             };
-//             const result = await TriggerService.validateFieldUsingRegex(oid, record, options);
-//             expect(result).to.eql({'testing-field': [{'row-item': 'field-value'}]});
-//         });
-        // it('value with spaces fails when not trimmmed', async function () {
-        //     const oid = "triggerservice-validateFieldUsingRegex-validpasses";
-        //     const record = {'testing-field': [{'row-item': '  field-value  '}]};
-        //     const options = {
-        //         fieldDBName: 'testing-field',
-        //         errorLanguageCode: "invalid-format",
-        //         regexPattern: '^field-VALUE$',
-        //         fieldLanguageCode: "title-required",
-        //         arrayObjFieldDBName: 'row-item',
-        //         trimLeadingAndTrailingSpacesBeforeValidation: false,
-        //         caseSensitive: false,
-        //         allowNulls: false,
-        //         forceRun: true
-        //     };
-        //     try {
-        //         await TriggerService.validateFieldUsingRegex(oid, record, options);
-        //         expect.fail("Should have thrown error");
-        //     } catch (err) {
-        //         expect(err).to.be.an('error');
-        //         expect(err.name).to.eq("RBValidationError");
-        //         expect(err.message).to.eq("Title is required Submission format is invalid");
-        //     }
-        // });
-        // it('invalid value fails with RBValidationError', async function () {
-        //     const oid = "triggerservice-validateFieldUsingRegex-invalidfails";
-        //     const record = {
-        //         'testing-field': [{'row-item': 'field-value'}],
-        //     };
-        //     const options = {
-        //         fieldDBName: 'testing-field',
-        //         errorLanguageCode: "invalid-format",
-        //         regexPattern: '^field-not-VALUE$',
-        //         fieldLanguageCode: "title-required",
-        //         arrayObjFieldDBName: 'row-item',
-        //         trimLeadingAndTrailingSpacesBeforeValidation: false,
-        //         caseSensitive: false,
-        //         allowNulls: true,
-        //         forceRun: true
-        //     };
+describe('The TriggerService', function () {
+    before(function (done) {
+        done();
+    });
+    describe('should validate fields using regex', function () {
+        it('valid value passes', async function () {
+            const oid = "triggerservice-validateFieldUsingRegex-validpasses";
+            const record = {'testing-field': [{'row-item': '  field-value  '}]};
+            const options = {
+                fieldDBName: 'testing-field',
+                errorLanguageCode: "invalid-format",
+                regexPattern: '^field-VALUE$',
+                fieldLanguageCode: "title-required",
+                arrayObjFieldDBName: 'row-item',
+                trimLeadingAndTrailingSpacesBeforeValidation: true,
+                forceRun: true,
+                caseSensitive: false,
+                allowNulls: true,
+            };
+            const result = await TriggerService.validateFieldUsingRegex(oid, record, options);
+            expect(result).to.eql({'testing-field': [{'row-item': 'field-value'}]});
+        });
+        it('value with different case fails when case sensitive', async function () {
+            const oid = "triggerservice-validateFieldUsingRegex-validpasses";
+            const record = {'testing-field': [{'row-item': '  field-value  '}]};
+            const options = {
+                fieldDBName: 'testing-field',
+                errorLanguageCode: "invalid-format",
+                regexPattern: '^field-value$',
+                fieldLanguageCode: "title-required",
+                arrayObjFieldDBName: 'row-item',
+                trimLeadingAndTrailingSpacesBeforeValidation: true,
+                forceRun: true,
+                caseSensitive: true,
+                allowNulls: true,
+            };
+            const result = await TriggerService.validateFieldUsingRegex(oid, record, options);
+            expect(result).to.eql({'testing-field': [{'row-item': 'field-value'}]});
+        });
+        it('value with spaces fails when not trimmed', async function () {
+            const oid = "triggerservice-validateFieldUsingRegex-validpasses";
+            const record = {'testing-field': [{'row-item': '  field-value  '}]};
+            const options = {
+                fieldDBName: 'testing-field',
+                errorLanguageCode: "invalid-format",
+                regexPattern: '^field-VALUE$',
+                fieldLanguageCode: "title-required",
+                arrayObjFieldDBName: 'row-item',
+                trimLeadingAndTrailingSpacesBeforeValidation: false,
+                caseSensitive: false,
+                allowNulls: false,
+                forceRun: true
+            };
+            try {
+                await TriggerService.validateFieldUsingRegex(oid, record, options);
+                expect.fail("Should have thrown error");
+            } catch (err) {
+                expect(err).to.be.an('error');
+                expect(err.name).to.eq("RBValidationError");
+                expect(err.message).to.eq("Title is required Submission format is invalid");
+            }
+        });
+        it('invalid value fails with RBValidationError', async function () {
+            const oid = "triggerservice-validateFieldUsingRegex-invalidfails";
+            const record = {
+                'testing-field': [{'row-item': 'field-value'}],
+            };
+            const options = {
+                fieldDBName: 'testing-field',
+                errorLanguageCode: "invalid-format",
+                regexPattern: '^field-not-VALUE$',
+                fieldLanguageCode: "title-required",
+                arrayObjFieldDBName: 'row-item',
+                trimLeadingAndTrailingSpacesBeforeValidation: false,
+                caseSensitive: false,
+                allowNulls: true,
+                forceRun: true
+            };
 
-        //     try {
-        //         await TriggerService.validateFieldUsingRegex(oid, record, options);
-        //         expect.fail("Should have thrown error");
-        //     } catch (err) {
-        //         expect(err).to.be.an('error');
-        //         expect(err.name).to.eq("RBValidationError");
-        //         expect(err.message).to.eq("Title is required Submission format is invalid");
-        //     }
-        // });
-    //     it('empty value passes for allowNulls', async function () {
-    //         const oid = "triggerservice-validateFieldUsingRegex-emptyfails";
-    //         const record = {'testing-field': ''};
-    //         const options = {
-    //             fieldDBName: 'testing-field',
-    //             errorLanguageCode: "invalid-format",
-    //             regexPattern: 'field-value',
-    //             fieldLanguageCode: "title-required",
-    //             trimLeadingAndTrailingSpacesBeforeValidation: false,
-    //             caseSensitive: false,
-    //             allowNulls: true,
-    //             forceRun: true
-    //         };
-    //         const result = await TriggerService.validateFieldUsingRegex(oid, record, options);
-    //         expect(result).to.eql(record);
-    //     });
-    //     it('empty value fails for allowNulls false field with RBValidationError', async function () {
-    //         const oid = "triggerservice-validateFieldUsingRegex-emptyfails";
-    //         const record = {'testing-field': ''};
-    //         const options = {
-    //             fieldDBName: 'testing-field',
-    //             errorLanguageCode: "invalid-format",
-    //             regexPattern: 'field-value',
-    //             fieldLanguageCode: "title-required",
-    //             trimLeadingAndTrailingSpacesBeforeValidation: false,
-    //             caseSensitive: false,
-    //             allowNulls: false,
-    //             forceRun: true
-    //         };
-    //         try {
-    //             await TriggerService.validateFieldUsingRegex(oid, record, options);
-    //             expect.fail("Should have thrown error");
-    //         } catch (err) {
-    //             expect(err).to.be.an('error');
-    //             expect(err.name).to.eq("RBValidationError");
-    //             expect(err.message).to.eq("Title is required Submission format is invalid");
-    //         }
-    //     });
-    // });
+            try {
+                await TriggerService.validateFieldUsingRegex(oid, record, options);
+                expect.fail("Should have thrown error");
+            } catch (err) {
+                expect(err).to.be.an('error');
+                expect(err.name).to.eq("RBValidationError");
+                expect(err.message).to.eq("Title is required Submission format is invalid");
+            }
+        });
+        it('empty value passes for allowNulls', async function () {
+            const oid = "triggerservice-validateFieldUsingRegex-emptyfails";
+            const record = {'testing-field': ''};
+            const options = {
+                fieldDBName: 'testing-field',
+                errorLanguageCode: "invalid-format",
+                regexPattern: 'field-value',
+                fieldLanguageCode: "title-required",
+                trimLeadingAndTrailingSpacesBeforeValidation: false,
+                caseSensitive: false,
+                allowNulls: true,
+                forceRun: true
+            };
+            const result = await TriggerService.validateFieldUsingRegex(oid, record, options);
+            expect(result).to.eql(record);
+        });
+        it('empty value fails for allowNulls false field with RBValidationError', async function () {
+            const oid = "triggerservice-validateFieldUsingRegex-emptyfails";
+            const record = {'testing-field': ''};
+            const options = {
+                fieldDBName: 'testing-field',
+                errorLanguageCode: "invalid-format",
+                regexPattern: 'field-value',
+                fieldLanguageCode: "title-required",
+                trimLeadingAndTrailingSpacesBeforeValidation: false,
+                caseSensitive: false,
+                allowNulls: false,
+                forceRun: true
+            };
+            try {
+                await TriggerService.validateFieldUsingRegex(oid, record, options);
+                expect.fail("Should have thrown error");
+            } catch (err) {
+                expect(err).to.be.an('error');
+                expect(err.name).to.eq("RBValidationError");
+                expect(err.message).to.eq("Title is required Submission format is invalid");
+            }
+        });
+    });
 
 
     describe('should validate fields using lodash template', function () {

--- a/test/unit/services/TriggerService.test.js
+++ b/test/unit/services/TriggerService.test.js
@@ -1,25 +1,25 @@
-describe('The TriggerService', function () {
-    before(function (done) {
-        done();
-    });
-    describe('should validate fields using regex', function () {
-        it('valid value passes', async function () {
-            const oid = "triggerservice-validateFieldUsingRegex-validpasses";
-            const record = {'testing-field': [{'row-item': '  field-value  '}]};
-            const options = {
-                fieldDBName: 'testing-field',
-                errorLanguageCode: "invalid-format",
-                regexPattern: '^field-VALUE$',
-                fieldLanguageCode: "title-required",
-                arrayObjFieldDBName: 'row-item',
-                trimLeadingAndTrailingSpacesBeforeValidation: true,
-                forceRun: true
-                // caseSensitive: true, - default
-                // allowNulls: true, - default
-            };
-            const result = await TriggerService.validateFieldUsingRegex(oid, record, options);
-            expect(result).to.eql({'testing-field': [{'row-item': 'field-value'}]});
-        });
+// describe('The TriggerService', function () {
+//     before(function (done) {
+//         done();
+//     });
+//     describe('should validate fields using regex', function () {
+//         it('valid value passes', async function () {
+//             const oid = "triggerservice-validateFieldUsingRegex-validpasses";
+//             const record = {'testing-field': [{'row-item': '  field-value  '}]};
+//             const options = {
+//                 fieldDBName: 'testing-field',
+//                 errorLanguageCode: "invalid-format",
+//                 regexPattern: '^field-VALUE$',
+//                 fieldLanguageCode: "title-required",
+//                 arrayObjFieldDBName: 'row-item',
+//                 trimLeadingAndTrailingSpacesBeforeValidation: true,
+//                 forceRun: true
+//                 // caseSensitive: true, - default
+//                 // allowNulls: true, - default
+//             };
+//             const result = await TriggerService.validateFieldUsingRegex(oid, record, options);
+//             expect(result).to.eql({'testing-field': [{'row-item': 'field-value'}]});
+//         });
         // it('value with spaces fails when not trimmmed', async function () {
         //     const oid = "triggerservice-validateFieldUsingRegex-validpasses";
         //     const record = {'testing-field': [{'row-item': '  field-value  '}]};
@@ -43,71 +43,71 @@ describe('The TriggerService', function () {
         //         expect(err.message).to.eq("Title is required Submission format is invalid");
         //     }
         // });
-        it('invalid value fails with RBValidationError', async function () {
-            const oid = "triggerservice-validateFieldUsingRegex-invalidfails";
-            const record = {
-                'testing-field': [{'row-item': 'field-value'}],
-            };
-            const options = {
-                fieldDBName: 'testing-field',
-                errorLanguageCode: "invalid-format",
-                regexPattern: '^field-not-VALUE$',
-                fieldLanguageCode: "title-required",
-                arrayObjFieldDBName: 'row-item',
-                trimLeadingAndTrailingSpacesBeforeValidation: false,
-                caseSensitive: false,
-                allowNulls: true,
-                forceRun: true
-            };
+        // it('invalid value fails with RBValidationError', async function () {
+        //     const oid = "triggerservice-validateFieldUsingRegex-invalidfails";
+        //     const record = {
+        //         'testing-field': [{'row-item': 'field-value'}],
+        //     };
+        //     const options = {
+        //         fieldDBName: 'testing-field',
+        //         errorLanguageCode: "invalid-format",
+        //         regexPattern: '^field-not-VALUE$',
+        //         fieldLanguageCode: "title-required",
+        //         arrayObjFieldDBName: 'row-item',
+        //         trimLeadingAndTrailingSpacesBeforeValidation: false,
+        //         caseSensitive: false,
+        //         allowNulls: true,
+        //         forceRun: true
+        //     };
 
-            try {
-                await TriggerService.validateFieldUsingRegex(oid, record, options);
-                expect.fail("Should have thrown error");
-            } catch (err) {
-                expect(err).to.be.an('error');
-                expect(err.name).to.eq("RBValidationError");
-                expect(err.message).to.eq("Title is required Submission format is invalid");
-            }
-        });
-        it('empty value passes for allowNulls', async function () {
-            const oid = "triggerservice-validateFieldUsingRegex-emptyfails";
-            const record = {'testing-field': ''};
-            const options = {
-                fieldDBName: 'testing-field',
-                errorLanguageCode: "invalid-format",
-                regexPattern: 'field-value',
-                fieldLanguageCode: "title-required",
-                trimLeadingAndTrailingSpacesBeforeValidation: false,
-                caseSensitive: false,
-                allowNulls: true,
-                forceRun: true
-            };
-            const result = await TriggerService.validateFieldUsingRegex(oid, record, options);
-            expect(result).to.eql(record);
-        });
-        it('empty value fails for allowNulls false field with RBValidationError', async function () {
-            const oid = "triggerservice-validateFieldUsingRegex-emptyfails";
-            const record = {'testing-field': ''};
-            const options = {
-                fieldDBName: 'testing-field',
-                errorLanguageCode: "invalid-format",
-                regexPattern: 'field-value',
-                fieldLanguageCode: "title-required",
-                trimLeadingAndTrailingSpacesBeforeValidation: false,
-                caseSensitive: false,
-                allowNulls: false,
-                forceRun: true
-            };
-            try {
-                await TriggerService.validateFieldUsingRegex(oid, record, options);
-                expect.fail("Should have thrown error");
-            } catch (err) {
-                expect(err).to.be.an('error');
-                expect(err.name).to.eq("RBValidationError");
-                expect(err.message).to.eq("Title is required Submission format is invalid");
-            }
-        });
-    });
+        //     try {
+        //         await TriggerService.validateFieldUsingRegex(oid, record, options);
+        //         expect.fail("Should have thrown error");
+        //     } catch (err) {
+        //         expect(err).to.be.an('error');
+        //         expect(err.name).to.eq("RBValidationError");
+        //         expect(err.message).to.eq("Title is required Submission format is invalid");
+        //     }
+        // });
+    //     it('empty value passes for allowNulls', async function () {
+    //         const oid = "triggerservice-validateFieldUsingRegex-emptyfails";
+    //         const record = {'testing-field': ''};
+    //         const options = {
+    //             fieldDBName: 'testing-field',
+    //             errorLanguageCode: "invalid-format",
+    //             regexPattern: 'field-value',
+    //             fieldLanguageCode: "title-required",
+    //             trimLeadingAndTrailingSpacesBeforeValidation: false,
+    //             caseSensitive: false,
+    //             allowNulls: true,
+    //             forceRun: true
+    //         };
+    //         const result = await TriggerService.validateFieldUsingRegex(oid, record, options);
+    //         expect(result).to.eql(record);
+    //     });
+    //     it('empty value fails for allowNulls false field with RBValidationError', async function () {
+    //         const oid = "triggerservice-validateFieldUsingRegex-emptyfails";
+    //         const record = {'testing-field': ''};
+    //         const options = {
+    //             fieldDBName: 'testing-field',
+    //             errorLanguageCode: "invalid-format",
+    //             regexPattern: 'field-value',
+    //             fieldLanguageCode: "title-required",
+    //             trimLeadingAndTrailingSpacesBeforeValidation: false,
+    //             caseSensitive: false,
+    //             allowNulls: false,
+    //             forceRun: true
+    //         };
+    //         try {
+    //             await TriggerService.validateFieldUsingRegex(oid, record, options);
+    //             expect.fail("Should have thrown error");
+    //         } catch (err) {
+    //             expect(err).to.be.an('error');
+    //             expect(err.name).to.eq("RBValidationError");
+    //             expect(err.message).to.eq("Title is required Submission format is invalid");
+    //         }
+    //     });
+    // });
 
 
     describe('should validate fields using lodash template', function () {

--- a/test/unit/services/TriggerService.test.js
+++ b/test/unit/services/TriggerService.test.js
@@ -20,29 +20,29 @@ describe('The TriggerService', function () {
             const result = await TriggerService.validateFieldUsingRegex(oid, record, options);
             expect(result).to.eql({'testing-field': [{'row-item': 'field-value'}]});
         });
-        it('value with spaces fails when not trimmmed', async function () {
-            const oid = "triggerservice-validateFieldUsingRegex-validpasses";
-            const record = {'testing-field': [{'row-item': '  field-value  '}]};
-            const options = {
-                fieldDBName: 'testing-field',
-                errorLanguageCode: "invalid-format",
-                regexPattern: '^field-VALUE$',
-                fieldLanguageCode: "title-required",
-                arrayObjFieldDBName: 'row-item',
-                trimLeadingAndTrailingSpacesBeforeValidation: false,
-                caseSensitive: false,
-                allowNulls: false,
-                forceRun: true
-            };
-            try {
-                await TriggerService.validateFieldUsingRegex(oid, record, options);
-                expect.fail("Should have thrown error");
-            } catch (err) {
-                expect(err).to.be.an('error');
-                expect(err.name).to.eq("RBValidationError");
-                expect(err.message).to.eq("Title is required Submission format is invalid");
-            }
-        });
+        // it('value with spaces fails when not trimmmed', async function () {
+        //     const oid = "triggerservice-validateFieldUsingRegex-validpasses";
+        //     const record = {'testing-field': [{'row-item': '  field-value  '}]};
+        //     const options = {
+        //         fieldDBName: 'testing-field',
+        //         errorLanguageCode: "invalid-format",
+        //         regexPattern: '^field-VALUE$',
+        //         fieldLanguageCode: "title-required",
+        //         arrayObjFieldDBName: 'row-item',
+        //         trimLeadingAndTrailingSpacesBeforeValidation: false,
+        //         caseSensitive: false,
+        //         allowNulls: false,
+        //         forceRun: true
+        //     };
+        //     try {
+        //         await TriggerService.validateFieldUsingRegex(oid, record, options);
+        //         expect.fail("Should have thrown error");
+        //     } catch (err) {
+        //         expect(err).to.be.an('error');
+        //         expect(err.name).to.eq("RBValidationError");
+        //         expect(err.message).to.eq("Title is required Submission format is invalid");
+        //     }
+        // });
         it('invalid value fails with RBValidationError', async function () {
             const oid = "triggerservice-validateFieldUsingRegex-invalidfails";
             const record = {

--- a/test/unit/services/TriggerService.test.js
+++ b/test/unit/services/TriggerService.test.js
@@ -30,7 +30,7 @@ describe('The TriggerService', function () {
                 fieldLanguageCode: "title-required",
                 arrayObjFieldDBName: 'row-item',
                 trimLeadingAndTrailingSpacesBeforeValidation: false,
-                caseSensitive: true,
+                caseSensitive: false,
                 allowNulls: false,
                 forceRun: true
             };

--- a/test/unit/services/TriggerService.test.js
+++ b/test/unit/services/TriggerService.test.js
@@ -127,49 +127,49 @@ describe('The TriggerService', function () {
     });
 
 
-//     describe('should validate fields using lodash template', function () {
-//         it('valid value passes', async function () {
-//             const oid = "triggerservice-template-validpasses";
-//             const record = {'testing-field': 'valid-value'};
-//             const options = {
-//                 template: `<% let errorList = [] 
-//                 if (_.get(record,'testing-field') !== 'valid-value') { 
-//                     addError(errorList, 'testing-field', 'title-required', 'invalid-format' );
-//                 }
-//                 return errorList; %>`,
-//                 forceRun: true
-//             };
-            
-//             try {
-//                 const result = await TriggerService.validateFieldsUsingTemplate(oid, record, options);
-//                 expect(result).to.eql({'testing-field': 'valid-value'});
-//             } catch (err) {
-//                 expect.fail("Should not have thrown error");
-//             }
-            
-//         });
+    describe('should validate fields using lodash template', function () {
+        it('valid value passes', async function () {
+            const oid = "triggerservice-template-validpasses";
+            const record = {'testing-field': 'valid-value'};
+            const options = {
+                template: `<% let errorList = [] 
+                if (_.get(record,'testing-field') !== 'valid-value') { 
+                    addError(errorList, 'testing-field', 'title-required', 'invalid-format' );
+                }
+                return errorList; %>`,
+                forceRun: true
+            };
 
-//         it('invalid value fails', async function () {
-//             const oid = "triggerservice-template-validpasses";
-//             const record = {'testing-field': 'invalid-value'};
-//             const options = {
-//                 template: `<% let errorList = [] 
-//                 if (_.get(record,'testing-field') !== 'valid-value') { 
-//                     addError(errorList, 'testing-field', 'title-required', 'invalid-format' );
-//                 }
-//                 return errorList; %>`,
-//                 forceRun: true
-//             };
-//             try {
-//                 const result = await TriggerService.validateFieldsUsingTemplate(oid, record, options);
-//             } catch (err) {
-//                 expect(err).to.be.an('error');
-//                 expect(err.name).to.eq("RBValidationError");
-//                 const errorMap = JSON.parse(err.message)
-//                 expect(errorMap.errorFieldList[0].label).to.eq("Title is required");
-//             }
-            
-//         });
-    
-//     });
-// });
+            try {
+                const result = await TriggerService.validateFieldsUsingTemplate(oid, record, options);
+                expect(result).to.eql({'testing-field': 'valid-value'});
+            } catch (err) {
+                expect.fail("Should not have thrown error");
+            }
+
+        });
+
+        it('invalid value fails', async function () {
+            const oid = "triggerservice-template-validpasses";
+            const record = {'testing-field': 'invalid-value'};
+            const options = {
+                template: `<% let errorList = [] 
+                if (_.get(record,'testing-field') !== 'valid-value') { 
+                    addError(errorList, 'testing-field', 'title-required', 'invalid-format' );
+                }
+                return errorList; %>`,
+                forceRun: true
+            };
+            try {
+                const result = await TriggerService.validateFieldsUsingTemplate(oid, record, options);
+            } catch (err) {
+                expect(err).to.be.an('error');
+                expect(err.name).to.eq("RBValidationError");
+                const errorMap = JSON.parse(err.message)
+                expect(errorMap.errorFieldList[0].label).to.eq("Title is required");
+            }
+
+        });
+
+    });
+});

--- a/typescript/api/services/TriggerService.ts
+++ b/typescript/api/services/TriggerService.ts
@@ -190,7 +190,7 @@ export module Services {
       // re-usable functions
       const textRegex = function (value) {
         let flags = '';
-        if (caseSensitive) {
+        if (!caseSensitive) {
           flags += 'i';
         }
         const re = new RegExp(regexPattern, flags);
@@ -367,7 +367,7 @@ export module Services {
             return true;
           } else {
             let flags = '';
-            if (caseSensitive) {
+            if (!caseSensitive) {
               flags += 'i';
             }
             const re = new RegExp(regexPattern, flags);

--- a/typescript/api/services/TriggerService.ts
+++ b/typescript/api/services/TriggerService.ts
@@ -175,17 +175,10 @@ export module Services {
       // then it will modify the value in the record if the regex validation is passed therefore handle with care
       let trimLeadingAndTrailingSpacesBeforeValidation = _.get(options, 'trimLeadingAndTrailingSpacesBeforeValidation') || false;
 
-      let caseSensitive = _.get(options, 'caseSensitive');
-      if (caseSensitive !== false && caseSensitive !== true) {
-        // default to true
-        caseSensitive = true;
-      }
-
-      let allowNulls = _.get(options, 'allowNulls');
-      if (allowNulls !== false && allowNulls !== true) {
-        // default to true for backwards compatibility
-        allowNulls = true;
-      }
+      // default to true - is only false when set to bool false or string 'false'
+      let caseSensitive = _.get(options, 'caseSensitive',true)?.toString() !== 'false';
+      // default to true for backwards compatibility - is only false when set to bool false or string 'false'
+      let allowNulls = _.get(options, 'allowNulls', true)?.toString() !== 'false';
 
       // re-usable functions
       const textRegex = function (value) {
@@ -425,7 +418,8 @@ export module Services {
         for(let field of fieldObjectList) {
           // get the data
           const data = _.get(record, 'metadata.'+field.name);
-          let caseSensitive = _.get(field,'caseSensitive',true) ;
+          // caseSensitive default is true - is only false when set to bool false or string 'false'
+          let caseSensitive = _.get(field, 'caseSensitive', true)?.toString() !== 'false';
           sails.log.debug('validateFieldMapUsingRegex field.allowNulls '+field.allowNulls);
           let allowNulls = _.get(field,'allowNulls',true);
           sails.log.debug('validateFieldMapUsingRegex allowNulls '+allowNulls);


### PR DESCRIPTION
Fix methods validateFieldUsingRegex and validateFieldMapUsingRegex in Trigger Service where the caseSensitive flag that was set to true was setting the regex validation to be case insensitive 