### PR TITLE
Add sort parameter to named query config

### DIFF
--- a/config/namedQuery.js
+++ b/config/namedQuery.js
@@ -13,6 +13,7 @@ module.exports.namedQuery = {
       'metadata.title': null,
       'dateCreated': null
     },
+    sort: [{'lastSaveDate': 'DESC'}],
     queryParams: {
       'title': {
         type: 'string',

--- a/core/src/model/storage/NamedQueryModel.ts
+++ b/core/src/model/storage/NamedQueryModel.ts
@@ -9,5 +9,5 @@ export class NamedQueryModel {
     collectionName?: string;
     resultObjectMapping?: string;
     brandIdFieldPath?: string;
-
+    sort?: string;
   }

--- a/typescript/api/controllers/webservice/ReportController.ts
+++ b/typescript/api/controllers/webservice/ReportController.ts
@@ -87,15 +87,8 @@ export module Controllers {
           return this.apiFail(req, res, 400, new APIErrorResponse("Rows must not be greater than 100"));
         }
         let namedQueryConfig = sails.config.namedQuery[queryName];
-
-        let configMongoQuery = namedQueryConfig.mongoQuery;
-        let collectionName = _.get(namedQueryConfig, 'collectionName', '');
-        let resultObjectMapping = _.get(namedQueryConfig, 'resultObjectMapping', {});
-        let brandIdFieldPath = _.get(namedQueryConfig, 'brandIdFieldPath', '');
-        let mongoQuery = _.clone(configMongoQuery);
-        let queryParams = namedQueryConfig.queryParams;
         let paramMap = _.clone(req.query);
-        let response = await NamedQueryService.performNamedQuery(brandIdFieldPath,resultObjectMapping,collectionName,mongoQuery,queryParams,paramMap,brand,start,rows)
+        let response = await NamedQueryService.performNamedQueryFromConfig(namedQueryConfig, paramMap, brand, start, rows);
         sails.log.verbose(`NamedQueryService response: ${JSON.stringify(response)}`);
         return this.apiRespond(req, res, response, 200)
       } catch (error) {

--- a/typescript/api/services/NamedQueryService.ts
+++ b/typescript/api/services/NamedQueryService.ts
@@ -46,8 +46,10 @@ export module Services {
 
     protected _exportedMethods: any = [
       "bootstrap",
+      "getNamedQueryConfig",
       "performNamedQuery",
-      "getNamedQueryConfig"
+      "performNamedQueryFromConfig",
+      "performNamedQueryFromConfigResults",
     ];
 
      public async bootstrap (defBrand) {
@@ -297,6 +299,60 @@ export module Services {
         return _.template(templateOrPath)(variables);
       }
       return _.get(variables, templateOrPath);
+    }
+
+    public async performNamedQueryFromConfig(config: NamedQueryConfig, paramMap, brand, start, rows, user?){
+      const collectionName = _.get(config, 'collectionName', '');
+      const resultObjectMapping = _.get(config, 'resultObjectMapping', {});
+      const brandIdFieldPath = _.get(config, 'brandIdFieldPath', '');
+      const mongoQuery = _.clone(_.get(config, 'mongoQuery', {}));
+      const queryParams = _.get(config, 'queryParams', {});
+      return await this.performNamedQuery(brandIdFieldPath, resultObjectMapping, collectionName, mongoQuery, queryParams, paramMap, brand, start, rows, user);
+    }
+
+    public async performNamedQueryFromConfigResults(config: NamedQueryConfig, paramMap: Record<string, string>, brand, queryName: string, start: number = 0,rows: number = 30, maxRecords: number = 100, user = undefined) {
+      const records = [];
+      let requestCount = 0;
+      sails.log.debug(`All named query results: start query with name '${queryName}' brand ${JSON.stringify(brand)} start ${start} rows ${rows} paramMap ${JSON.stringify(paramMap)}`);
+
+      while (true) {
+        // Keep going while there are more results.
+
+        const response = await this.performNamedQueryFromConfig(config, paramMap, brand, start, rows, user);
+        requestCount += 1;
+
+        if (!response) {
+          // stop if there is no response
+          sails.log.warn(`All named query results: invalid query response for '${queryName}'`);
+          break;
+        }
+
+        // add the new records to the collected records
+        sails.log.debug(`All named query results: add results for '${queryName}': start ${start} rows ${rows} new results ${response.records.length} summary ${JSON.stringify(response.summary)}`);
+        for (const record of response.records) {
+          records.push(record);
+        }
+
+        const currentRetrievedCount = start + rows;
+        if (response.summary.numFound <= currentRetrievedCount) {
+          // stop if the total count is less than or equal to the number of records retrieved so far
+          sails.log.debug(`All named query results: reached end of results for '${queryName}': start ${start} rows ${rows} total results ${records.length}`);
+          break;
+        }
+
+        // update the start point
+        start = currentRetrievedCount;
+
+        // Check the number of records and fail if it is more than maxRecords.
+        if (records.length > maxRecords){
+          sails.log.warn(`All named query results: returning early before finished with ${records.length} results for '${queryName}' from ${requestCount} requests because the number of records is more than max records ${maxRecords}`);
+        }
+
+        // continue the while loop
+      }
+
+      sails.log.log(`All named query results: returning ${records.length} results for '${queryName}' from ${requestCount} requests`);
+      return records;
     }
 
   }

--- a/typescript/api/services/ReportsService.ts
+++ b/typescript/api/services/ReportsService.ts
@@ -160,16 +160,8 @@ export module Services {
       if (report.reportSource == ReportSource.database) {
 
         let namedQueryConfig = await NamedQueryService.getNamedQueryConfig(brand, report.databaseQuery.queryName)
-
-        let configMongoQuery = namedQueryConfig.mongoQuery;
-        let collectionName = _.get(namedQueryConfig, 'collectionName', '');
-        let resultObjectMapping = _.get(namedQueryConfig, 'resultObjectMapping', {});
-        let brandIdFieldPath = _.get(namedQueryConfig, 'brandIdFieldPath', '');
-        let mongoQuery = _.clone(configMongoQuery);
-        let queryParams = namedQueryConfig.queryParams;
         let paramMap = this.buildNamedQueryParamMap(req, report)
-
-        let dbResult = await NamedQueryService.performNamedQuery(brandIdFieldPath, resultObjectMapping, collectionName, mongoQuery, queryParams, paramMap, brand, start, rows);
+        let dbResult = await NamedQueryService.performNamedQueryFromConfig(namedQueryConfig, paramMap, brand, start, rows);
         return this.getTranslateDatabaseResultToReportResult(dbResult, report);
       } else {
         let url = this.buildSolrParams(brand, req, report, start, rows, 'json');
@@ -282,17 +274,9 @@ export module Services {
       let result: ReportResult = null
       if (report.reportSource == ReportSource.database) {
 
-        let namedQueryConfig = await NamedQueryService.getNamedQueryConfig(brand, report.databaseQuery.queryName)
-
-        let configMongoQuery = namedQueryConfig.mongoQuery;
-        let collectionName = _.get(namedQueryConfig, 'collectionName', '');
-        let resultObjectMapping = _.get(namedQueryConfig, 'resultObjectMapping', {});
-        let brandIdFieldPath = _.get(namedQueryConfig, 'brandIdFieldPath', '');
-        let mongoQuery = _.clone(configMongoQuery);
-        let queryParams = namedQueryConfig.queryParams;
-        let paramMap = this.buildNamedQueryParamMap(req, report)
-
-        let dbResult = await NamedQueryService.performNamedQuery(brandIdFieldPath, resultObjectMapping, collectionName, mongoQuery, queryParams, paramMap, brand, start, rows);
+        let namedQueryConfig = await NamedQueryService.getNamedQueryConfig(brand, report.databaseQuery.queryName);
+        let paramMap = this.buildNamedQueryParamMap(req, report);
+        let dbResult = await NamedQueryService.performNamedQueryFromConfig(namedQueryConfig, paramMap, brand, start, rows);
         result = this.getTranslateDatabaseResultToReportResult(dbResult, report);
       } else {
         var url = this.buildSolrParams(brand, req, report, start, rows, 'json');

--- a/typescript/api/services/VocabService.ts
+++ b/typescript/api/services/VocabService.ts
@@ -152,16 +152,8 @@ export module Services {
       if (queryConfig.querySource == 'database') {
 
         let namedQueryConfig = await NamedQueryService.getNamedQueryConfig(brand, queryConfig.databaseQuery.queryName);
-
-        let configMongoQuery = namedQueryConfig.mongoQuery;
-        let collectionName = _.get(namedQueryConfig, 'collectionName', '');
-        let resultObjectMapping = _.get(namedQueryConfig, 'resultObjectMapping', {});
-        let brandIdFieldPath = _.get(namedQueryConfig, 'brandIdFieldPath', '');
-        let mongoQuery = _.clone(configMongoQuery);
-        let queryParams = namedQueryConfig.queryParams;
         let paramMap = this.buildNamedQueryParamMap(queryConfig, searchString, user);
-
-        let dbResults = await NamedQueryService.performNamedQuery(brandIdFieldPath, resultObjectMapping, collectionName, mongoQuery, queryParams, paramMap, brand, start, rows);
+        let dbResults = await NamedQueryService.performNamedQueryFromConfig(namedQueryConfig, paramMap, brand, start, rows);
         if(queryConfig.resultObjectMapping) {
           return this.getResultObjectMappings(dbResults,queryConfig);
         } else {


### PR DESCRIPTION
- Consolidate duplicate instances of using named query config to perform named query into NamedQueryService.
- Introduce `sort` parameter to named query to allow including sort order in database query
- Add service method for iterating over the pages of results