### PR TITLE
Feature: Remove dumb-init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
 FROM node:20.18-bullseye
-ENV node_env production
+ENV node_env=production
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH=$PATH:/home/node/.npm-global/bin
-RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64
-RUN chmod +x /usr/local/bin/dumb-init
+ENV NODE_ENV=$node_env
 RUN echo "Australia/Brisbane" > /etc/timezone && dpkg-reconfigure -f noninteractive tzdata
 COPY --chown=node:node . /opt/redbox-portal
 RUN chown -R node:node /opt/redbox-portal; ls -l /opt; ls -l /opt/redbox-portal;
 USER node
 RUN echo "Permissions should be set, running as 'node' user, dumping permissions again: "; ls -l /opt; ls -l /opt/redbox-portal;
-CMD NODE_ENV=$node_env node app.js
+CMD ["node", "app.js"]

--- a/support/deployment-examples/docker/docker-compose.yml
+++ b/support/deployment-examples/docker/docker-compose.yml
@@ -18,6 +18,7 @@ services:
         networks:
             main:
                 aliases: [rbportal]
+        init: true
         entrypoint: '/bin/bash -c "cd /opt/redbox-portal && node app.js"'
     redbox:
         image: 'qcifengineering/redbox:2.x'

--- a/support/development/docker-compose.yml
+++ b/support/development/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       main:
         aliases:
           - rbportal
+    init: true
     entrypoint: /bin/bash -c "cd /opt/redbox-portal && node --inspect=0.0.0.0:9876 app.js"
   mongodb:
     #image: mvertes/alpine-mongo:latest

--- a/support/integration-testing/docker-compose.bruno.yml
+++ b/support/integration-testing/docker-compose.bruno.yml
@@ -67,6 +67,7 @@ services:
        aliases:
          - redboxportal
     # add 'node --inspect=0.0.0.0:9876' to entrypoint for debugging
+    init: true
     entrypoint: >-
       /bin/bash -c "cd /opt/redbox-portal &&
       ./support/integration-testing/prepare-guest.sh /opt/redbox-portal &&

--- a/support/integration-testing/docker-compose.mocha.yml
+++ b/support/integration-testing/docker-compose.mocha.yml
@@ -43,6 +43,7 @@ services:
        aliases:
          - redboxportal
     # add 'node --inspect=0.0.0.0:9876' to entrypoint for debugging
+    init: true
     entrypoint: >-
       /bin/bash -c "cd /opt/redbox-portal &&
       ./support/integration-testing/prepare-guest.sh /opt/redbox-portal &&

--- a/support/integration-testing/docker-compose.yml
+++ b/support/integration-testing/docker-compose.yml
@@ -3,6 +3,7 @@ networks:
   main:
 services:
   redboxportal:
+    
     image: qcifengineering/redbox-portal:latest
     ports:
        - "1500:1500"
@@ -24,6 +25,7 @@ services:
      main:
        aliases:
          - rbportal
+    init: true
     entrypoint: /bin/bash -c "cd /opt/redbox-portal && node app.js"
   mongodb:
     image: mvertes/alpine-mongo:latest


### PR DESCRIPTION
ReDBox had been using [dumb-init](https://github.com/Yelp/dumb-init) to allow the application to launch from a PID other than 1 so that processes such as those spawned by the PDF plugin were properly reaped. Docker now has it's [own implementation](https://docs.docker.com/reference/compose-file/services/#init) of this via the init flag so this PR removes dumb-init.