### PR TITLE
Feature: Add completerLabelField to VocabField and related services

### DIFF
--- a/angular-legacy/shared/form/field-vocab.component.ts
+++ b/angular-legacy/shared/form/field-vocab.component.ts
@@ -74,8 +74,10 @@ export class VocabField extends FieldBase<any> {
   public inputClass: string;
   storedEventData: null;
   public storeFreeTextAsString: boolean;
+  completerLabelField: string;
 
   @Output() onItemSelect: EventEmitter<any> = new EventEmitter<any>();
+  
   
 
   constructor(options: any, injector: any) {
@@ -108,6 +110,7 @@ export class VocabField extends FieldBase<any> {
     this.groupClasses = _.isUndefined(options['groupClasses']) ? '' : options['groupClasses'];
     this.cssClasses = _.isUndefined(options['cssClasses']) ? '' : options['cssClasses'];
     this.storeFreeTextAsString = _.isUndefined(options['storeFreeTextAsString']) ? false : options['storeFreeTextAsString'];
+    this.completerLabelField = _.isUndefined(options['completerLabelField']) ? null : options['completerLabelField'];
   }
 
   createFormModel(valueElem: any = undefined, createFormGroup: boolean = false) {
@@ -234,7 +237,8 @@ export class VocabField extends FieldBase<any> {
         this.titleFieldDelim,
         this.vocabQueryResultMaxRows,
         this.queryDelayTimeMs,
-        this.storeFreeTextAsString
+        this.storeFreeTextAsString,
+        this.completerLabelField
       );
     }
   }
@@ -457,7 +461,8 @@ class ReDBoxQueryLookupDataService extends Subject<CompleterItem[]> implements C
     private titleFieldDelim: string,
     private maxRows: string,
     private queryDelayTimeMs: number = 300,
-    private storeFreeTextAsString: boolean = false) {
+    private storeFreeTextAsString: boolean = false,
+    private completerLabelField:string) {
     super();
     this.searchSubscription = this.searchTerms.pipe(
       debounceTime(this.queryDelayTimeMs), // Wait for a default 300ms of inactivity
@@ -482,9 +487,12 @@ class ReDBoxQueryLookupDataService extends Subject<CompleterItem[]> implements C
         itemArray = _.get(data, arrayPath);
       }
       // Convert the result to CompleterItem[]
-      let matches: CompleterItem[] = [];
+      let matches: (CompleterItem)[] = [];
       _.each(itemArray, item => {
-        matches.push(this.convertToItem(item));
+        const completerItem = this.convertToItem(item)
+        if(completerItem != null) {
+          matches.push(completerItem);
+        }
       });
 
       this.next(matches);
@@ -501,6 +509,7 @@ class ReDBoxQueryLookupDataService extends Subject<CompleterItem[]> implements C
     }
     let completerItem = {};
     completerItem[this.compositeTitleName] = this.getTitle(data);
+    completerItem['description'] = _.get(data, this.completerLabelField, this.getTitle(data)) ;
     completerItem['originalObject'] = data;
     return completerItem as CompleterItem;
   }


### PR DESCRIPTION
This pull request updates the `VocabField` component and its associated lookup service to support a new field for customizing the label shown in autocomplete results. The main changes add the `completerLabelField` option throughout the component and service, and ensure that autocomplete items use this field for their description when available.

### Support for custom autocomplete label field

* Added a new `completerLabelField` property to the `VocabField` class, initialized from the component options, allowing configuration of which field to use for autocomplete item labels. [[1]](diffhunk://#diff-68616160d46967d47b91300fc02959406a8ed8cb95c9e20b6fbd8ecad29c20b6R77-R82) [[2]](diffhunk://#diff-68616160d46967d47b91300fc02959406a8ed8cb95c9e20b6fbd8ecad29c20b6R113)
* Updated the `ReDBoxQueryLookupDataService` constructor and usage to accept and store the new `completerLabelField` parameter, ensuring it is available during autocomplete item processing. [[1]](diffhunk://#diff-68616160d46967d47b91300fc02959406a8ed8cb95c9e20b6fbd8ecad29c20b6L237-R241) [[2]](diffhunk://#diff-68616160d46967d47b91300fc02959406a8ed8cb95c9e20b6fbd8ecad29c20b6L460-R465)

### Improvements to autocomplete item generation

* Enhanced the logic for converting data objects to autocomplete items by setting the item description to the value of `completerLabelField` if present, falling back to the title otherwise.
* Improved robustness of autocomplete item generation by skipping null results from the conversion function, preventing invalid items from being added to the results.