### PR TITLE
Bugfix dashboard filter initialisation

### DIFF
--- a/angular/projects/researchdatabox/dashboard/src/app/dashboard.component.spec.ts
+++ b/angular/projects/researchdatabox/dashboard/src/app/dashboard.component.spec.ts
@@ -300,7 +300,7 @@ describe('DashboardComponent workspace', () => {
     let defaultSortObject = {
       sort: 'desc',
       secondarySort: '',
-      step: 'existing-locations-draft',
+      step: 'draft',
       title: '',
       variable: 'metaMetadata.lastSaveDate'
     };
@@ -525,13 +525,7 @@ describe('DashboardComponent consolidated group by record type', () => {
     expect(dashboardComponent.workflowSteps.length).toBeGreaterThan(0);
     expect(dashboardComponent.defaultRowConfig.length).toBeGreaterThan(0);
     expect(dashboardComponent.dashboardTypeSelected).toEqual('consolidated');
-    let defaultSortObject = {
-      sort: 'desc',
-      secondarySort: '',
-      step: 'consolidated',
-      title: '',
-      variable: 'metaMetadata.lastSaveDate'
-    };
+    let defaultSortObject = {};
     await dashboardComponent.initStep('','consolidated','rdmp','',1, defaultSortObject);
     let groupedRecords = recordDataConsolidated['groupedRecords'];
     let planTable = dashboardComponent.evaluatePlanTableColumns(dashboardComponent.groupRowConfig, 

--- a/angular/projects/researchdatabox/dashboard/src/app/dashboard.component.ts
+++ b/angular/projects/researchdatabox/dashboard/src/app/dashboard.component.ts
@@ -833,30 +833,31 @@ export class DashboardComponent extends BaseComponent {
 
 
   private getSortStringFromSortMap(sortMapAtStep: any, step: string, forceDefault: boolean = false) {
-
     let fields = _get(this.sortFields,step);
     let sortString = 'metaMetadata.lastSaveDate:-1';
-    for (let i = 0; i < fields.length; i++) {
-      let sortField = fields[i];
-      if(!_isEmpty(sortMapAtStep) && !_isEmpty(sortField) && _has(sortMapAtStep,sortField)) {
-        if (sortMapAtStep[sortField].sort != null && forceDefault && sortMapAtStep[sortField].defaultSort == true) {
-          sortString = `${sortField}:`;
-          if (sortMapAtStep[sortField].sort == 'desc') {
-            sortString = sortString + "-1";
-          } else {
-            sortString = sortString + "1";
-          }
-          return sortString;
-        } else {
-          if (sortMapAtStep[sortField].sort != null) {
+    if(!_isUndefined(fields) && !_isEmpty(fields)) {
+      for (let i = 0; i < fields.length; i++) {
+        let sortField = fields[i];
+        if(!_isEmpty(sortMapAtStep) && !_isEmpty(sortField) && _has(sortMapAtStep,sortField)) {
+          if (sortMapAtStep[sortField].sort != null && forceDefault && sortMapAtStep[sortField].defaultSort == true) {
             sortString = `${sortField}:`;
             if (sortMapAtStep[sortField].sort == 'desc') {
               sortString = sortString + "-1";
             } else {
               sortString = sortString + "1";
             }
-          }
-        } 
+            return sortString;
+          } else {
+            if (sortMapAtStep[sortField].sort != null) {
+              sortString = `${sortField}:`;
+              if (sortMapAtStep[sortField].sort == 'desc') {
+                sortString = sortString + "-1";
+              } else {
+                sortString = sortString + "1";
+              }
+            }
+          } 
+        }
       }
     }
     return sortString;


### PR DESCRIPTION
# Bug fix
1. Fix dashboard app not initialising filter for record types with multiple step workflow. It was only initialising the filter correctly for first step of the workflow but not for the next steps.
2. Fix dashboard app using default field header columns for sorting in all workflow steps instead of using header columns defined by step.