### PR TITLE
Fix: Contributors don't populate correctly from event subscriptions

### DIFF
--- a/angular-legacy/shared/form/field-repeatable.component.ts
+++ b/angular-legacy/shared/form/field-repeatable.component.ts
@@ -493,6 +493,11 @@ export class RepeatableContributor extends RepeatableContainer {
   setValueAtElem(index, value: any) {
     // error thrown when on view mode, only set when on edit mode...
     if (this.editMode) {
+      // if there's no title, but there's a full name the data is coming from an event so construct the expected object
+      if(!value.title && value.text_full_name) {
+        const originalObject = _.clone(value)
+        value = { originalObject: originalObject, title: value.text_full_name };
+      }
       this.fields[index].component.onSelect(value, false, true);
     }
   }


### PR DESCRIPTION
Contributors weren't populating correctly from event subscriptions due to value being set using the onSelect method. This method expects the object structure to be in the shape that the ng2-completer provides which is not necessarily the same.
This fix detects this and re-structures the object to match so that its able to be processed correctly.