### PR TITLE
Allow providing reusable form defs to controllers and services

### DIFF
--- a/packages/sails-ng-common/src/config/visitor/construct.visitor.ts
+++ b/packages/sails-ng-common/src/config/visitor/construct.visitor.ts
@@ -139,8 +139,8 @@ export class ConstructFormConfigVisitor extends CurrentPathFormConfigVisitor {
     private result?: FormConfigOutline;
     private data?: FormConfigFrame;
     private formMode: FormModesConfig = "view";
-    private reusableFormConfig: ReusableFormDefinitions = {};
-    private reusableFormConfigNames: string[] = [];
+    private reusableFormDefs: ReusableFormDefinitions = {};
+    private reusableFormDefNames: string[] = [];
 
     private fieldComponentMap?: ComponentClassDefMapType;
     private fieldModelMap?: ModelClassDefMapType;
@@ -159,14 +159,20 @@ export class ConstructFormConfigVisitor extends CurrentPathFormConfigVisitor {
         this.constructOverrides = new ConstructOverrides();
     }
 
-    start(data: FormConfigFrame, formMode?: FormModesConfig, reusableFormConfig?: ReusableFormDefinitions): FormConfigOutline {
-        this.reusableFormConfig = reusableFormConfig ?? {};
-        this.reusableFormConfigNames = Object.keys(this.reusableFormConfig).sort();
+    start(data: FormConfigFrame, formMode?: FormModesConfig, reusableFormDefs?: ReusableFormDefinitions): FormConfigOutline {
+        this.reusableFormDefs = reusableFormDefs ?? {};
+        this.reusableFormDefNames = Object.keys(this.reusableFormDefs).sort();
         this.formMode = formMode ?? "view";
         this.result = new FormConfig();
         this.data = _cloneDeep(data);
         this.resetCurrentPath();
         this.result.accept(this);
+
+        // for debugging:
+        // this.logger.verbose(`${this.logName}: constructed form config ${JSON.stringify({
+        //     data, formMode, reusableFormDefs,
+        // })}`);
+
         return this.result;
     }
 
@@ -887,7 +893,7 @@ export class ConstructFormConfigVisitor extends CurrentPathFormConfigVisitor {
         const itemReusableFormName = item?.overrides?.reusableFormName ?? "";
 
         const isReusableComponent = componentClassName === ReusableComponentName;
-        const hasReusableFormName = itemReusableFormName && this.reusableFormConfigNames.includes(itemReusableFormName);
+        const hasReusableFormName = itemReusableFormName && this.reusableFormDefNames.includes(itemReusableFormName);
 
         if (!isReusableComponent && !hasReusableFormName) {
             return false;
@@ -908,12 +914,12 @@ export class ConstructFormConfigVisitor extends CurrentPathFormConfigVisitor {
 
         throw new Error("Invalid usage of reusable form config. " +
             `Component class '${componentClassName}' must be '${ReusableComponentName}' ` +
-            `and reusableFormName '${itemReusableFormName}' must be one of '${this.reusableFormConfigNames.join(', ')}'.`);
+            `and reusableFormName '${itemReusableFormName}' must be one of '${this.reusableFormDefNames.join(', ')}'.`);
     }
 
     protected applyOverrideReusableExpand(item: ReusableFormComponentDefinitionFrame): AvailableFormComponentDefinitionFrames[] {
         const reusableFormName = item?.overrides?.reusableFormName ?? "";
-        const expandedItemsRaw = this.reusableFormConfigNames.includes(reusableFormName) ? this.reusableFormConfig[reusableFormName] : [];
+        const expandedItemsRaw = this.reusableFormDefNames.includes(reusableFormName) ? this.reusableFormDefs[reusableFormName] : [];
         const expandedItems = this.applyOverrideReusable(expandedItemsRaw);
         const additionalItemsRaw = item.component.config?.componentDefinitions ?? [];
         const additionalItems = this.applyOverrideReusable(additionalItemsRaw);

--- a/packages/sails-ng-common/test/unit/construct.visitor.test.ts
+++ b/packages/sails-ng-common/test/unit/construct.visitor.test.ts
@@ -121,7 +121,7 @@ describe("Construct Visitor", async () => {
         const cases: {
             title: string,
             args: {
-                reusableFormConfig: ReusableFormDefinitions,
+                reusableFormDefs: ReusableFormDefinitions,
                 formConfig: FormConfigFrame,
                 formMode?: FormModesConfig
             };
@@ -130,7 +130,7 @@ describe("Construct Visitor", async () => {
             {
                 title: "expand reusable form config to standard form config in view mode",
                 args: {
-                    reusableFormConfig: reusableDefinitionsExample1,
+                    reusableFormDefs: reusableDefinitionsExample1,
                     formConfig: formConfigExample2,
                     formMode: "view",
                 },
@@ -157,7 +157,7 @@ describe("Construct Visitor", async () => {
             {
                 title: "expand reusable form config to standard form config in edit mode",
                 args: {
-                    reusableFormConfig: reusableDefinitionsExample1,
+                    reusableFormDefs: reusableDefinitionsExample1,
                     formConfig: formConfigExample2,
                     formMode: "edit",
                 },
@@ -185,7 +185,7 @@ describe("Construct Visitor", async () => {
         cases.forEach(({title, args, expected}) => {
             it(`should ${title}`, async function () {
                 const visitor = new ConstructFormConfigVisitor(logger);
-                const actual = visitor.start(args.formConfig, args.formMode, args.reusableFormConfig);
+                const actual = visitor.start(args.formConfig, args.formMode, args.reusableFormDefs);
                 expect(actual).to.containSubset(expected);
             });
         });

--- a/typescript/api/controllers/DynamicAssetController.ts
+++ b/typescript/api/controllers/DynamicAssetController.ts
@@ -82,7 +82,9 @@ export module Controllers {
 
       try {
         const form = await firstValueFrom<any>(FormsService.getFormByStartingWorkflowStep(brand, recordType, editMode));
-        const entries = FormRecordConsistencyService.extractRawTemplates(form, editMode ? "edit" : "view");
+        const formMode = editMode ? "edit" : "view";
+        const reusableFormDefs = sails.config.reusableFormDefinitions;
+        const entries = FormRecordConsistencyService.extractRawTemplates(form, formMode, reusableFormDefs);
         return this.sendClientMappingJavascript(res, entries);
       } catch (error) {
         sails.log.error("Could not build compiled items from form config:", error);

--- a/typescript/api/controllers/RecordController.ts
+++ b/typescript/api/controllers/RecordController.ts
@@ -162,7 +162,9 @@ export module Controllers {
 
       // get the default data model for the form with 'name'
       const form = await firstValueFrom<any>(FormsService.getFormByStartingWorkflowStep(brand, recordType, editMode));
-      const modelDataDefault = FormRecordConsistencyService.buildDataModelDefaultForFormConfig(form, editMode ? "edit" : "view");
+      const formMode = editMode ? "edit" : "view";
+      const reusableFormDefs = sails.config.reusableFormDefinitions;
+      const modelDataDefault = FormRecordConsistencyService.buildDataModelDefaultForFormConfig(form, formMode, reusableFormDefs);
 
       // return the matching format, return the model data as json
       return this.sendResp(req, res, {
@@ -343,7 +345,8 @@ export module Controllers {
         const formMode = editMode ? "edit" : "view";
         const userRoles = req.user?.roles || [];
         const recordData = currentRec;
-        const mergedForm = FormsService.buildClientFormConfig(form, formMode, userRoles, recordData?.metadata ?? {});
+        const reusableFormDefs = sails.config.reusableFormDefinitions;
+        const mergedForm = FormsService.buildClientFormConfig(form, formMode, userRoles, recordData?.metadata, reusableFormDefs);
 
         // return the form config
         if (!_.isEmpty(mergedForm)) {

--- a/typescript/api/services/FormsService.ts
+++ b/typescript/api/services/FormsService.ts
@@ -26,7 +26,7 @@ import {
     ClientFormConfigVisitor,
     ConstructFormConfigVisitor,
     FormConfigFrame,
-    FormModesConfig
+    FormModesConfig, ReusableFormDefinitions
 } from "@researchdatabox/sails-ng-common";
 
 declare var sails: Sails;
@@ -516,24 +516,22 @@ export module Services {
      * @param formMode The form mode.
      * @param userRoles The current user's roles.
      * @param recordData The record data.
+     * @param reusableFormDefs The reusable form definitions.
      */
     public buildClientFormConfig(
         item: FormConfigFrame,
         formMode?: FormModesConfig,
         userRoles?: string[],
-        recordData?: Record<string, unknown>
+        recordData?: Record<string, unknown> | null,
+        reusableFormDefs?: ReusableFormDefinitions
     ): Record<string, unknown> {
-        // sails.log.verbose(`FormsService - build client form config for name '${item?.name}': ${JSON.stringify({
-        //     item, formMode, userRoles, recordData,
-        // })}`);
-
       const constructor = new ConstructFormConfigVisitor(this.logger);
-      const constructed = constructor.start(item, formMode);
+      const constructed = constructor.start(item, formMode, reusableFormDefs);
 
       // create the client form config
       const visitor = new ClientFormConfigVisitor(this.logger);
       let result: FormConfigFrame;
-      if (recordData) {
+      if (recordData !== null && recordData !== undefined) {
         result = visitor.startExistingRecord(constructed, formMode, userRoles, recordData);
       } else {
         result = visitor.startNewRecord(constructed, formMode, userRoles);
@@ -542,7 +540,6 @@ export module Services {
       if (!result) {
         throw new Error(`The form config is invalid because all form fields were removed, the form config must have at least one field the current user can view.`)
       }
-      // sails.log.verbose(`FormsService - built client form config for name '${item?.name}': ${JSON.stringify({result})}`);
       // TODO: can return type be done 'properly' instead of forcing the type?
       return result as unknown as Record<string, unknown>;
     }

--- a/typescript/config/reusableFormDefinitions.ts
+++ b/typescript/config/reusableFormDefinitions.ts
@@ -87,4 +87,4 @@ const reusableDefinitions: ReusableFormDefinitions = {
     // TODO: The standard project info fields: title, description, keywords, SEO codes, FOR codes
     "standard-project-info-fields": [],
 };
-module.exports = reusableDefinitions;
+module.exports.reusableFormDefinitions = reusableDefinitions;

--- a/typescript/test/unit/services/FormsService.test.ts
+++ b/typescript/test/unit/services/FormsService.test.ts
@@ -119,7 +119,112 @@ describe('The FormsService', function () {
     });
 
     describe("build client form config", function () {
+        it('should use the record data in the form', function(done){
+            const formConfig: FormConfigFrame = {
+                name: "basic-form",
+                type: "rdmp",
+                debugValue: true,
+                domElementType: 'form',
+                defaultComponentConfig: {
+                    defaultComponentCssClasses: 'row',
+                },
+                editCssClasses: "redbox-form form",
+                enabledValidationGroups: ["all"],
+                componentDefinitions: [
+                    {
+                        name: 'text_2',
+                        layout: {
+                            class: 'DefaultLayout',
+                            config: {
+                                label: 'TextField with default wrapper defined',
+                                helpText: 'This is a help text',
+                            }
+                        },
+                        model: {
+                            class: 'SimpleInputModel',
+                            config: {
+                                defaultValue: 'hello world 2!',
+                            }
+                        },
+                        component: {
+                            class: 'SimpleInputComponent',
+                        },
+                        constraints: {
+                            authorization: {
+                                allowRoles: [],
+                            },
+                            allowModes: [],
+                        },
+                    }
+                ]
+            };
+            const expected: FormConfigFrame = {
+                name: "basic-form",
+                type: "rdmp",
+                debugValue: true,
+                domElementType: 'form',
+                defaultComponentConfig: {
+                    defaultComponentCssClasses: 'row',
+                },
+                editCssClasses: "redbox-form form",
+                enabledValidationGroups: ["all"],
+                validators: [],
+                validationGroups: {
+                    all: {description: "Validate all fields with validators.", initialMembership: "all"},
+                    none: {description: "Validate none of the fields.", initialMembership: "none"},
+                },
+                componentDefinitions: [
+                    {
+                        name: 'text_2',
+                        layout: {
+                            class: 'DefaultLayout',
+                            config: {
+                                label: 'TextField with default wrapper defined',
+                                helpText: 'This is a help text',
+                                autofocus: false,
+                                cssClassesMap: {},
+                                disabled: false,
+                                editMode: true,
+                                helpTextVisible: false,
+                                helpTextVisibleOnInit: false,
+                                labelRequiredStr: "*",
+                                readonly: false,
+                                visible: true,
+                            }
+                        },
+                        model: {
+                            class: 'SimpleInputModel',
+                            config: {
+                                value: "record text_2 value",
+                            }
+                        },
+                        component: {
+                            class: 'SimpleInputComponent',
+                            config: {
+                                autofocus: false,
+                                disabled: false,
+                                editMode: true,
+                                readonly: false,
+                                type: "text",
+                                visible: true,
+                            },
+                        },
+                    }
+                ]
+            };
+            const recordMetadata = {
+                text_2: "record text_2 value"
+            };
+            const original = JSON.stringify(formConfig);
+            const result = FormsService.buildClientFormConfig(formConfig, "edit", null, recordMetadata);
 
+            // ensure the formConfig has not been modified
+            expect(JSON.stringify(formConfig)).to.eql(original);
+
+            // confirm the client form config looks as expected
+            expect(result).to.eql(expected);
+            done();
+        });
         it('should build the expected config', function (done) {
             const formConfig: FormConfigFrame = {
                 name: "basic-form",


### PR DESCRIPTION
Features:
- Allow providing reusable form defs to controllers and services.
- Reusable form definitions can be defined in ` typescript/config/reusableFormDefinitions.ts`

Fixes:
- Form config now uses record data when it is not null or undefined. This makes it clearer about when record data or the form defaults will be used.