### PR TITLE
Use ChromeHeadlessNoSandbox only when running Angular tests as root

### DIFF
--- a/angular/projects/researchdatabox/app-config/karma.conf.js
+++ b/angular/projects/researchdatabox/app-config/karma.conf.js
@@ -39,9 +39,14 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage']
+      }
+    },
     browsers: ['Chrome'],
     singleRun: false,
     restartOnFileChange: true
   });
 };
-

--- a/angular/projects/researchdatabox/branding/karma.conf.js
+++ b/angular/projects/researchdatabox/branding/karma.conf.js
@@ -23,6 +23,12 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage']
+      }
+    },
     browsers: ['Chrome'],
     singleRun: false,
     restartOnFileChange: true

--- a/angular/projects/researchdatabox/dashboard/karma.conf.js
+++ b/angular/projects/researchdatabox/dashboard/karma.conf.js
@@ -39,9 +39,14 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage']
+      }
+    },
     browsers: ['Chrome'],
     singleRun: false,
     restartOnFileChange: true
   });
 };
-

--- a/angular/projects/researchdatabox/deleted-records/karma.conf.js
+++ b/angular/projects/researchdatabox/deleted-records/karma.conf.js
@@ -39,9 +39,14 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage']
+      }
+    },
     browsers: ['Chrome'],
     singleRun: false,
     restartOnFileChange: true
   });
 };
-

--- a/angular/projects/researchdatabox/export/karma.conf.js
+++ b/angular/projects/researchdatabox/export/karma.conf.js
@@ -39,9 +39,14 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage']
+      }
+    },
     browsers: ['Chrome'],
     singleRun: false,
     restartOnFileChange: true
   });
 };
-

--- a/angular/projects/researchdatabox/form/karma.conf.js
+++ b/angular/projects/researchdatabox/form/karma.conf.js
@@ -39,9 +39,14 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage']
+      }
+    },
     browsers: ['Chrome'],
     singleRun: false,
     restartOnFileChange: true
   });
 };
-

--- a/angular/projects/researchdatabox/local-auth/karma.conf.js
+++ b/angular/projects/researchdatabox/local-auth/karma.conf.js
@@ -39,9 +39,14 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage']
+      }
+    },
     browsers: ['Chrome'],
     singleRun: false,
     restartOnFileChange: true
   });
 };
-

--- a/angular/projects/researchdatabox/manage-roles/karma.conf.js
+++ b/angular/projects/researchdatabox/manage-roles/karma.conf.js
@@ -39,9 +39,14 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage']
+      }
+    },
     browsers: ['Chrome'],
     singleRun: false,
     restartOnFileChange: true
   });
 };
-

--- a/angular/projects/researchdatabox/manage-users/karma.conf.js
+++ b/angular/projects/researchdatabox/manage-users/karma.conf.js
@@ -39,9 +39,14 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage']
+      }
+    },
     browsers: ['Chrome'],
     singleRun: false,
     restartOnFileChange: true
   });
 };
-

--- a/angular/projects/researchdatabox/portal-ng-common/karma.conf.js
+++ b/angular/projects/researchdatabox/portal-ng-common/karma.conf.js
@@ -39,6 +39,12 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage']
+      }
+    },
     browsers: ['Chrome'],
     singleRun: false,
     restartOnFileChange: true,
@@ -50,4 +56,3 @@ module.exports = function (config) {
     }
   });
 };
-

--- a/angular/projects/researchdatabox/report/karma.conf.js
+++ b/angular/projects/researchdatabox/report/karma.conf.js
@@ -39,9 +39,14 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage']
+      }
+    },
     browsers: ['Chrome'],
     singleRun: false,
     restartOnFileChange: true
   });
 };
-

--- a/angular/projects/researchdatabox/translation/karma.conf.js
+++ b/angular/projects/researchdatabox/translation/karma.conf.js
@@ -34,6 +34,12 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage']
+      }
+    },
     browsers: ['Chrome'],
     singleRun: false,
     restartOnFileChange: true

--- a/support/unit-testing/angular/testDevAngular.sh
+++ b/support/unit-testing/angular/testDevAngular.sh
@@ -8,7 +8,12 @@ function testAngular() {
   echo "-------------------------------------------"
   echo "Testing ${1} (${2})"
   echo "-------------------------------------------"
-  node_modules/.bin/ng t --browsers=ChromeHeadless "@researchdatabox/${1}" --no-watch --no-progress --code-coverage
+  # Some test runs happen inside containers (e.g. Codex Web) as root and need the no-sandbox launcher.
+  if [ "$(id -u)" -eq 0 ]; then
+    node_modules/.bin/ng t --browsers=ChromeHeadlessNoSandbox "@researchdatabox/${1}" --no-watch --no-progress --code-coverage
+  else
+    node_modules/.bin/ng t --browsers=ChromeHeadless "@researchdatabox/${1}" --no-watch --no-progress --code-coverage
+  fi
 }
 
 export NVM_DIR="$HOME/.nvm"


### PR DESCRIPTION
### Motivation
- Headless Chrome fails when running as root in some CI/container environments without the `--no-sandbox` flag, causing Angular tests to fail. 
- A launcher that includes `--no-sandbox` is required for tests run as root inside containers (e.g. Codex Web). 

### Description
- Added a `ChromeHeadlessNoSandbox` `customLaunchers` entry (flags: `--no-sandbox`, `--disable-gpu`, `--disable-dev-shm-usage`) to the per-project `karma.conf.js` files under `angular/projects/researchdatabox/*`.
- Updated the Angular test wrapper `support/unit-testing/angular/testDevAngular.sh` to detect root with `id -u` and run tests with `ChromeHeadlessNoSandbox` when UID is `0`, otherwise use `ChromeHeadless`.
- Documented the container/root use case in the `testDevAngular.sh` script.

### Testing
- No automated tests were executed as part of this change.
- The change was committed and the wrapper script was validated for correct conditional invocation (manual verification of the script change only).