### PR TITLE
Add default Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,40 @@
+## Summary
+
+Outline the main purpose of this pull request.
+Include a summarised list of changes.
+
+Link to any issues this PR fixes:  "Fixes #<issue>".
+See the available [issue keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests).
+
+Changes made:
+
+* Summary of change 1 from a user's perspective.
+* Summary of change 2 from a user's perspective.
+
+## Context / related work
+
+* Existing features this PR builds on.
+* Other pull requests related to this one.
+* Information or concepts required to understand this change.
+
+## Technical implementation details
+
+Optional section, used for impactful changes.
+
+* Specific changes to code or functionality that should be highlighted.
+* Changes to dependencies or integrations.
+* Implementation choices and rationals for architectural changes.
+
+## Testing
+
+Optional section, but omitted only for trivial changes.
+
+* Describe the automated tests included in the change.
+* Manual testing steps and particular items to check.
+
+## Future work
+
+Optional section, used to indicate next steps.
+
+* Expected functionality that is missing, and why it is missing.
+* Ideas or features that could build on this change.


### PR DESCRIPTION
## Summary

PR template content includes sections we have found useful when reviewing.

Changes made:

* Add GitHub Pull Request template file to ensure we include information for reviewers.

## Context / related work

* The template format was built from the format of recent PR that had the required information to properly review.

## Future work

* It is possible to have more than one PR template, but one will do us for now.

