### PR TITLE
Fix tab contents display on component load

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/tab.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/tab.component.spec.ts
@@ -5,6 +5,7 @@ import {TestBed} from "@angular/core/testing";
 import { TabComponent, TabSelectionErrorType } from './tab.component';
 
 let formConfig: FormConfigFrame;
+let formConfigNoSelectedTab: FormConfigFrame;
 
 describe('TabComponent', () => {
   beforeEach(async () => {
@@ -104,6 +105,96 @@ describe('TabComponent', () => {
         }
       ]
     };
+    formConfigNoSelectedTab = {
+      name: 'testing',
+      debugValue: true,
+      domElementType: 'form',
+      defaultComponentConfig: {
+        defaultComponentCssClasses: 'row',
+      },
+      editCssClasses: "redbox-form form",
+      componentDefinitions: [
+        {
+          name: 'main_tab',
+          layout: {
+            class: 'TabLayout',
+            config: {
+                // layout-specific config goes here
+                hostCssClasses: 'd-flex align-items-start',
+                buttonSectionCssClass: 'nav flex-column nav-pills me-5',
+                tabPaneCssClass: 'tab-pane fade',
+                tabPaneActiveCssClass: 'active show',
+            }
+          },
+          component: {
+            class: 'TabComponent',
+            config: {
+              hostCssClasses: 'tab-content',
+              tabs: [
+                {
+                  name: 'tab1',
+                  layout: {
+                    class: 'TabContentLayout',
+                    config: {
+                      buttonLabel: 'Tab 1',
+                    }
+                  },
+                  component: {
+                    class: 'TabContentComponent',
+                    config: {
+                      componentDefinitions: [
+                        {
+                          name: 'textfield_1',
+                          model: {
+                            class: 'SimpleInputModel',
+                            config: {
+                              value: 'Hello from Tab 1!',
+                            }
+                          },
+                          component: {
+                            class: 'SimpleInputComponent'
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  name: 'tab2',
+                  layout: {
+                    class: 'TabContentLayout',
+                    config: {
+                      buttonLabel: 'Tab 2',
+                    }
+                  },
+                  component: {
+                    class: 'TabContentComponent',
+                    config: {
+
+                      componentDefinitions: [
+                        {
+                          name: 'textfield_2',
+                          model: {
+                            class: 'SimpleInputModel',
+                            config: {
+                              value: 'Hello from Tab 2!',
+                            }
+                          },
+                          component: {
+                            class: 'SimpleInputComponent'
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    };
+
   });
 
   it('should create component', () => {
@@ -114,7 +205,7 @@ describe('TabComponent', () => {
 
   it('should render the tab with a text field component', async () => {
     // act
-    const {fixture, formComponent, componentDefinitions} = await createFormAndWaitForReady(formConfig);
+    const {fixture} = await createFormAndWaitForReady(formConfig);
     // assert text field component is rendered with name 'textfield_1'
     const compiled = fixture.nativeElement as HTMLElement;
     let inputElements = compiled.querySelectorAll('input[type="text"]');
@@ -195,7 +286,7 @@ describe('TabComponent', () => {
   });
 
   it('should have selectedTabId correctly set on initial load', async () => {
-    const {fixture, formComponent, componentDefinitions} = await createFormAndWaitForReady(formConfig);
+    const {formComponent, componentDefinitions} = await createFormAndWaitForReady(formConfig);
     if (!componentDefinitions?.component) {
       throw new Error("Component definition is not defined");
     }
@@ -214,7 +305,7 @@ describe('TabComponent', () => {
   });
 
   it('should mark non-selected tabs as inactive on initial load', async () => {
-    const {fixture, formComponent, componentDefinitions} = await createFormAndWaitForReady(formConfig);
+    const {fixture, componentDefinitions} = await createFormAndWaitForReady(formConfig);
     if (!componentDefinitions?.component) {
       throw new Error("Component definition is not defined");
     }
@@ -239,7 +330,7 @@ describe('TabComponent', () => {
   });
 
   it('should have all tab buttons rendered on initial load', async () => {
-    const {fixture, formComponent, componentDefinitions} = await createFormAndWaitForReady(formConfig);
+    const {fixture, componentDefinitions} = await createFormAndWaitForReady(formConfig);
     if (!componentDefinitions?.component) {
       throw new Error("Component definition is not defined");
     }
@@ -260,8 +351,28 @@ describe('TabComponent', () => {
     });
   });
 
+  it('should have exactly one tab selected despite no "selected" property on initial load', async () => {
+    const {fixture, componentDefinitions} = await createFormAndWaitForReady(formConfigNoSelectedTab);
+    if (!componentDefinitions?.component) {
+      throw new Error("Component definition is not defined");
+    }
+
+    const compiled = fixture.nativeElement as HTMLElement;
+
+    // Count active tab buttons
+    const activeTabButtons = compiled.querySelectorAll('[role="tab"].active');
+    expect(activeTabButtons.length).toBe(1);
+
+    // Count tabs with aria-selected="true"
+    const selectedTabs = compiled.querySelectorAll('[role="tab"][aria-selected="true"]');
+    expect(selectedTabs.length).toBe(1);
+
+    // Verify it's the correct tab
+    expect(activeTabButtons[0].getAttribute('id')).toBe('tab1-tab-button');
+  });
+
   it('should have exactly one tab selected on initial load', async () => {
-    const {fixture, formComponent, componentDefinitions} = await createFormAndWaitForReady(formConfig);
+    const {fixture, componentDefinitions} = await createFormAndWaitForReady(formConfig);
     if (!componentDefinitions?.component) {
       throw new Error("Component definition is not defined");
     }

--- a/angular/projects/researchdatabox/form/src/app/component/tab.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/tab.component.ts
@@ -159,6 +159,14 @@ export class TabComponent extends FormFieldBaseComponent<undefined> {
     this.tabs = this.tabConfig?.tabs || [];
   }
 
+  /**
+   * Initializes all tab wrappers, merges their form controls into the parent map, and selects an initial tab.
+   *
+   * - Defers tab selection until every tab is created and initialized to avoid flashes of content.
+   * - If multiple tabs are configured with `selected: true`, the last one encountered wins; this behavior is intentional
+   *   but may be reconsidered if a warning or first-selected preference is desired.
+   * - Falls back to selecting the first tab when none are explicitly marked as selected.
+   */
   protected override async setComponentReady(): Promise<void> {
     await this.untilViewIsInitialised();
     this.loggerService.debug(`${this.logName}: Initializing TabComponent with ${this.tabs.length} tabs.`);
@@ -199,15 +207,14 @@ export class TabComponent extends FormFieldBaseComponent<undefined> {
         }
         _merge(this.formFieldCompMapEntry.formControlMap, fieldMapDefEntry.formControlMap);
       }
+      // Note: the last tab with `selected` true will take precedence
       if (tab.component?.config?.selected) {
         selectedTabName = tab.name;
       }
     }
-    if (selectedTabName !== null) {
-      this.selectTab(selectedTabName);
-    } else if (this.tabs.length > 0) {
-      this.selectTab(this.tabs[0].name!);
-    }
+    // Note: selection is deferred to the layout component to avoid flashes and incorrect display of content. For now, we just set the selectedTabId here for the layout to pick up.
+    // This will select the first tab if none are marked as selected.
+    this.selectedTabId = selectedTabName ?? this.tabs[0]?.name ?? '0';
     await super.setComponentReady();
   }
 


### PR DESCRIPTION
## Summary

Fix for https://github.com/redbox-mint/redbox-portal/issues/3533. This pull request improves the tab component’s initialization and selection logic to deliver a smoother user experience and prevent UI glitches such as content flickering during initial render.

It ensures the correct tab is selected on startup, hides tab content until selection is finalised, and strengthens lifecycle handling so tabs are only activated when the component is fully ready.

Changes made:

* Prevents tab content flickering during initial render by deferring tab button rendering until selection is complete.
* Ensures the correct initial tab is consistently selected based on configuration or sensible defaults.
* Improves robustness of tab activation and lifecycle readiness handling.

## Context / related work

* Builds on the existing tab component and its selection and wrapper lifecycle logic.
* Addresses UX issues observed during initial tab rendering and component startup.
* Aligns with broader efforts to improve visual stability and predictability of form and layout components.

## Technical implementation details

* Introduced an `initialSelectionDone` flag and updated the template to render tab buttons only after the initial tab selection is finalised.
* Refactored tab initialisation to hide all tab contents immediately on creation, avoiding flashes of unselected content.
* Improved initial tab selection logic to prioritise tabs explicitly marked as selected in configuration, falling back to the first tab when none is specified.
* Updated `setComponentReady` to activate the selected tab only once all tab wrappers are ready and to apply the appropriate `flexGrow` styling.
* Enhanced `selectTab` to safely handle cases where the requested tab is already selected.

## Testing

* Manually verified that tab content does not flicker during initial render.
* Confirmed correct initial tab selection when a tab is explicitly marked as selected.
* Verified default behaviour selects the first tab when no selection is configured.
* Checked tab switching behaviour remains unchanged once the component is fully initialised.

## Future work

* Evaluate whether additional lifecycle hooks are required to further simplify readiness handling.
* Explore extending similar initialisation patterns to other layout or container components.
