### PR TITLE
Feature: ng19 Forms Create record URL rewrite

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { Location } from '@angular/common';
 import { FormComponent } from './form.component';
 import { FormConfigFrame } from '@researchdatabox/sails-ng-common';
 import { SimpleInputComponent } from './component/simple-input.component';
@@ -165,6 +166,48 @@ describe('FormComponent', () => {
 
     expect(debugValues['enabled_text']).toBe('enabled value');
     expect(debugValues['disabled_group']).toBeUndefined();
+  });
+
+  it('updates URL to edit path after successful create', async () => {
+    const formConfig: FormConfigFrame = {
+      name: 'create-url-update',
+      debugValue: false,
+      componentDefinitions: [
+        {
+          name: 'text_create',
+          model: {
+            class: 'SimpleInputModel',
+            config: {
+              value: 'create value'
+            }
+          },
+          component: {
+            class: 'SimpleInputComponent'
+          }
+        }
+      ]
+    };
+
+    const { fixture, formComponent } = await createFormAndWaitForReady(formConfig, {
+      oid: '',
+      recordType: 'rdmp',
+      editMode: true,
+      formName: 'default-1.0-draft',
+      downloadAndCreateOnInit: false
+    });
+
+    const location = fixture.debugElement.injector.get(Location);
+    const replaceStateSpy = spyOn(location, 'replaceState').and.stub();
+    (formComponent.recordService as any).brandingAndPortalUrl = 'http://localhost/default/rdmp';
+    spyOn(formComponent.recordService, 'create').and.resolveTo({
+      success: true,
+      oid: 'oid-123'
+    } as any);
+
+    await formComponent.saveForm(true);
+
+    expect(formComponent.oid()).toBe('oid-123');
+    expect(replaceStateSpy).toHaveBeenCalledWith('/default/rdmp/record/edit/oid-123');
   });
 
 });

--- a/angular/projects/researchdatabox/form/src/app/form.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.ts
@@ -177,6 +177,10 @@ export class FormComponent extends BaseComponent implements OnDestroy {
    */
   recordService = inject(RecordService);
   /**
+   * Browser location service used for URL state updates
+   */
+  private locationService = inject(Location);
+  /**
    * Save response after save operations, also used to track in-flight saves (null)
    */
   saveResponse = signal<RecordActionResult | null | undefined>(undefined);
@@ -609,7 +613,9 @@ export class FormComponent extends BaseComponent implements OnDestroy {
           if (response?.success) {
             this.loggerService.info(`${this.logName}: Form submitted successfully:`, response);
             if (_isEmpty(this.trimmedParams.oid()) && !_isEmpty(response?.oid)) {
-              this.oid.set(String(response?.oid));
+              const createdOid = String(response?.oid);
+              this.oid.set(createdOid);
+              this.locationService.replaceState(this.buildEditRecordPath(createdOid));
             }
             // Emit success event
             this.eventBus.publish(
@@ -712,6 +718,24 @@ export class FormComponent extends BaseComponent implements OnDestroy {
 
   public get componentQuerySource(): JSONataQuerySource | undefined {
     return this.componentDefQuerySource;
+  }
+
+  private buildEditRecordPath(oid: string): string {
+    const createdOid = String(oid ?? '').trim();
+    if (_isEmpty(createdOid)) {
+      return 'record/edit';
+    }
+    const brandingAndPortalUrl = String(this.recordService.brandingAndPortalUrl ?? '').trim();
+    if (!_isEmpty(brandingAndPortalUrl)) {
+      try {
+        const parsedUrl = new URL(brandingAndPortalUrl);
+        const basePath = parsedUrl.pathname.replace(/\/+$/, '');
+        return `${basePath}/record/edit/${createdOid}`;
+      } catch {
+        this.loggerService.warn(`${this.logName}: Invalid brandingAndPortalUrl '${brandingAndPortalUrl}', falling back to relative path.`);
+      }
+    }
+    return `record/edit/${createdOid}`;
   }
 }
 


### PR DESCRIPTION
## Summary

This pull request improves post-create navigation behaviour in the Angular `FormComponent`.

Previously, after successfully creating a new record, the browser URL remained on the original create route. This PR ensures that once a record is successfully created, the browser URL is updated to the canonical edit path (`/record/edit/{oid}`), without triggering a full navigation reload.

This results in:

* A consistent and bookmarkable edit URL immediately after record creation.
* Better alignment between browser state and application state.
* Improved UX when refreshing or sharing the page after creating a record.

## Context / related work

* Aligns create → edit behavior with expected RESTful routing semantics.
* Supports features that rely on being on the canonical edit route (e.g. file uploads, tab navigation, deep linking).
* Complements earlier work that standardised record save events and post-save handling.

## Technical implementation details

### URL update after record creation

* Injected Angular’s `Location` service into `FormComponent`.
* After a successful create operation:
  * The component now updates the browser URL using `Location.replaceState(...)`.
  * The URL is updated to the correct edit path:  
    `/record/edit/{oid}` (including branding/portal prefix where applicable).
* This does **not** trigger a route reload, preserving component state and avoiding unnecessary reinitialisation.

### Edit path construction

* Introduced a new private method:

  ```ts
  private buildEditRecordPath(oid: string): string
  ```

This method:
	•	Builds the correct edit path using the configured branding and portal URL.
	•	Centralises path construction logic for maintainability and future reuse.
	•	Ensures consistent formatting across environments.



### Testing
	•	Added a new unit test in form.component.spec.ts to verify:
	•	The URL is updated to the correct edit path after a successful create.
	•	Updated test setup to include and mock Angular’s Location service.
	•	Existing tests continue to pass.
	•	Angular build and test suite complete successfully.


### Impact
	•	Users are immediately placed on the canonical edit route after record creation.
	•	Browser refresh now correctly reloads the edit view instead of re-triggering create logic.
	•	Improved consistency between frontend state and URL.
	•	Cleaner, centralised path construction logic.

### Future work
	•	Consider centralising record route construction into a shared routing utility service.
	•	Evaluate whether similar URL correction is required in other create flows across the platform.
	•	Add integration tests covering full create → edit lifecycle.

