### PR TITLE
Chore: silence event error and debug logging

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
@@ -196,14 +196,14 @@ export abstract class FormComponentEventBaseConsumer extends FormComponentEventB
 		const expressions: FormExpressionsConfigFrame[] | undefined  = options.definition?.expressions;
 		if (expressions === undefined || _isEmpty(expressions)) {
 			const msg = `${this.constructor.name}: No expressions defined for component '${options.component?.formFieldConfigName()}'. Change events will not be consumed.`;
-			this.loggerService.debug(msg, options.definition);
-			throw new Error(msg);
-		}	
+			this.logDebug(msg, options.definition);
+			return;
+		}
 		this.expressions = expressions;
 		// FormControl is optional for some components
 		const control: AbstractControl | undefined = options.definition?.model?.formControl ?? options.component?.model?.formControl;
 		if (!control) {
-			this.loggerService.debug(`${this.constructor.name}: No form control found for component '${options.component?.formFieldConfigName()}'. Change events may or may not be properly consumed.`, options.definition);
+			this.logDebug(`${this.constructor.name}: No form control found for component '${options.component?.formFieldConfigName()}'. Change events may or may not be properly consumed.`, options.definition);
 		} else {
 			this.control = control;
 		}

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-producer-consumer.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-producer-consumer.ts
@@ -135,4 +135,13 @@ export abstract class FormComponentEventBaseProducerConsumer {
 				}));
 		}
 	}
+
+	/**
+	 * Helper to debug messages 
+	 */
+	protected logDebug(message: string, ...optionalParams: any[]) {
+		if (this.formComp?.config['debugEvents'] == "true") {
+			this.loggerService.debug(message, ...optionalParams);
+		}
+	}
 }

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-change-event-producer.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-change-event-producer.ts
@@ -31,13 +31,13 @@ export class FormComponentValueChangeEventProducer extends FormComponentEventBas
 		this.options = options;
 		const control: AbstractControl | undefined = options.definition?.model?.formControl ?? options.component?.model?.formControl;
 		if (!control) {
-			this.loggerService.debug(`FormComponentChangeEventProducer: No form control found for component '${options.component?.formFieldConfigName()}'. Change events will not be published.`, options.definition);
+			this.logDebug(`FormComponentChangeEventProducer: No form control found for component '${options.component?.formFieldConfigName()}'. Change events will not be published.`, options.definition);
 			return;
 		}
 
 		const fieldId = this.resolveFieldId(options);
 		if (!fieldId) {
-			this.loggerService.debug(`FormComponentChangeEventProducer: Unable to resolve field ID for component '${options.component?.formFieldConfigName()}'. Change events will not be published.`, options.definition);
+			this.logDebug(`FormComponentChangeEventProducer: Unable to resolve field ID for component '${options.component?.formFieldConfigName()}'. Change events will not be published.`, options.definition);
 			return;
 		}
 

--- a/angular/projects/researchdatabox/form/src/app/form.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.ts
@@ -217,6 +217,12 @@ export class FormComponent extends BaseComponent implements OnDestroy {
    */
   private valueChangeEventConsumer = new FormComponentValueChangeEventConsumer(this.eventBus);
 
+  protected configObj: Record<string, unknown> = {};
+
+  public get config() {
+    return this.configObj;
+  }
+
   constructor(
     @Inject(LoggerService) private loggerService: LoggerService,
     @Inject(ConfigService) private configService: ConfigService,
@@ -258,6 +264,7 @@ export class FormComponent extends BaseComponent implements OnDestroy {
   protected async initComponent(): Promise<void> {
     this.loggerService.info(`${this.logName}: Loading form with OID: ${this.trimmedParams.oid()}, on edit mode:${this.editMode()}, Record Type: ${this.trimmedParams.recordType()}, formName: ${this.trimmedParams.formName()}`);
     try {
+      this.configObj = await this.configService.getConfig();
       if (this.downloadAndCreateOnInit()) {
         await this.downloadAndCreateFormComponents();
       } else {


### PR DESCRIPTION
## Summary

This pull request introduces a configurable debugging mechanism for form component event producers and consumers, reducing unnecessary logging in production while allowing targeted debugging when needed.

Instead of always emitting debug logs, event-related classes now check a `debugEvents` flag in the component configuration before logging. A new configuration object has also been added to `FormComponent` to provide structured access to runtime component settings.

Changes made:

* Makes event debug logging configurable via a `debugEvents` flag instead of always logging.
* Introduces a component-level configuration object to store and expose runtime settings.
* Reduces noise in production logs while preserving detailed diagnostics when explicitly enabled.

## Context / related work

* Builds on the recent introduction of the form component event bus and event producer/consumer architecture.
* Supports cleaner production deployments by preventing excessive debug logging.
* Aligns with efforts to make form components more configurable and extensible at runtime.

## Technical implementation details

### Debug logging improvements

* Added a `logDebug` helper method to `FormComponentEventBaseProducerConsumer`.
* Replaced direct calls to `loggerService.debug` with `logDebug`, which only logs messages if the component configuration contains `debugEvents === "true"`.
* Centralised conditional logging logic to ensure consistent behaviour across event producers and consumers.

### Component configuration support

* Introduced a `configObj` property in `FormComponent` to store component-specific configuration.
* Added a `config` getter to provide structured access to the configuration.
* Populated the configuration object asynchronously during component initialization.
* Enabled event producers/consumers to read runtime configuration values (e.g. `debugEvents`) from the component instance.

This approach ensures that debugging behaviour is opt-in and controlled via configuration rather than hard-coded logging statements.

## Testing

* Verified that debug messages are emitted only when `debugEvents` is set to `"true"` in the component configuration.
* Confirmed that no debug logs are generated when the flag is unset or set to a different value.
* Manually validated that existing event behaviour remains unchanged aside from logging.

## Future work

* Extend the configuration mechanism to support additional runtime flags (e.g. event tracing levels or performance diagnostics).
* Consider introducing environment-based defaults for debugging behaviour.
* Add automated tests to explicitly validate conditional logging behaviour.
