### PR TITLE
include record workflow details in the form api response meta

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/content.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/content.component.ts
@@ -76,9 +76,6 @@ export class ContentComponent extends FormFieldBaseComponent<string> {
       const name = this.name;
       const templateLineagePath = [...(this.formFieldCompMapEntry?.lineagePaths?.formConfig ?? []), 'component', 'config', 'template'];
       try {
-        // Build the variables available to the template.
-        const context = {content: content, translationService: this.translationService};
-        const extra = {libraries: this.handlebarsTemplateService.getLibraries()};
         const compiledItems = await this.getFormComponent.getRecordCompiledItems();
         const renderTemplate = (formData: Record<string, unknown> = {}) => {
           const runtimeContext = this.getRuntimeTemplateContext();
@@ -89,7 +86,8 @@ export class ContentComponent extends FormFieldBaseComponent<string> {
             translationService: this.translationService,
             branding: runtimeContext.branding,
             portal: runtimeContext.portal,
-            oid: runtimeContext.oid
+            oid: runtimeContext.oid,
+            workflow: this.formComponent.formConfigMeta['workflow'] ?? {},
           };
           const extra = {libraries: this.handlebarsTemplateService.getLibraries()};
           this.content = compiledItems.evaluate(templateLineagePath, context, extra);

--- a/angular/projects/researchdatabox/form/src/app/form.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.ts
@@ -1129,6 +1129,10 @@ export class FormComponent extends BaseComponent implements OnDestroy {
     return this.componentDefQuerySource;
   }
 
+  public get formConfigMeta(): Record<string,unknown> {
+    return this.formDefMap?.formConfigMeta ?? {};
+  }
+
   private parseRequestParamsFromUrl(rawHref?: string): FormRequestParamsMap {
     const fallbackOrigin = typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
     const href = rawHref ?? (typeof window !== 'undefined' ? window.location.href : fallbackOrigin);

--- a/angular/projects/researchdatabox/form/src/app/form.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.ts
@@ -1215,7 +1215,7 @@ export class FormComponent extends BaseComponent implements OnDestroy {
   }
 
   private resolveRedirectLocation(template: string, oid: string): string {
-    const contextVariables = (this.formDefMap?.formConfig?.contextVariables ?? {}) as Record<string, unknown>;
+    const contextVariables = (this.formConfigMeta["contextVariables"] ?? {}) as Record<string, unknown>;
     return template
       .replaceAll('@oid', oid)
       .replaceAll('@branding', String(contextVariables['@branding'] ?? '@branding'))

--- a/angular/projects/researchdatabox/form/src/app/form.service.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.service.spec.ts
@@ -12,9 +12,10 @@ import {
 } from "@researchdatabox/portal-ng-common";
 import { APP_BASE_HREF } from "@angular/common";
 import { Title } from "@angular/platform-browser";
-import { provideHttpClient } from "@angular/common/http";
+import {HttpContext, provideHttpClient} from "@angular/common/http";
 import { HttpTestingController, provideHttpClientTesting } from "@angular/common/http/testing";
 import {
+  FormConfigFrame,
   FormFieldValidationGroup,
   FormModesConfig,
   FormValidationGroups,
@@ -54,10 +55,18 @@ describe('The FormService', () => {
     });
     service = TestBed.inject(FormService);
     httpTesting = TestBed.inject(HttpTestingController);
+    (service as any).brandingAndPortalUrl = "http://localhost/default/rdmp";
+    (service as any).httpContext = new HttpContext();
   });
+
+  afterEach(() => {
+    if (httpTesting) {
+      httpTesting.verify();
+    }
+  });
+
   it('should create an instance', () => {
     expect(service).toBeTruthy();
-    httpTesting.verify();
   });
 
   it('should resolve accordion component classes from static map', async () => {
@@ -274,4 +283,43 @@ describe('The FormService', () => {
     });
   });
 
+  it("should download form components and form config meta", async function () {
+    const basicFormConfig: FormConfigFrame = {
+      name: 'testing',
+      debugValue: true,
+      defaultComponentConfig: {
+        defaultComponentCssClasses: 'form-control'
+      },
+      editCssClasses: 'redbox-form form',
+      componentDefinitions: [
+        {
+          name: 'test_field',
+          model: {
+            class: 'SimpleInputModel',
+            config: {
+              value: 'initial value'
+            }
+          },
+          component: {
+            class: 'SimpleInputComponent',
+            config: {
+              type: 'text',
+              label: 'Test Field'
+            }
+          }
+        }
+      ]
+    };
+    const meta: Record<string, unknown> = {
+      workflow: {stage: 'draft', stageLabel: 'Draft'},
+      contextVariables: {'one': 1},
+    };
+    const oid = "oid", recordType = "auto", editMode = false, formName = "", modulePaths: string[] = [];
+    const result = service.downloadFormComponents(oid, recordType, editMode, formName, modulePaths);
+    const req = httpTesting.expectOne((request) =>
+      request.url.startsWith(`http://localhost/default/rdmp/record/form/${recordType}/${oid}`));
+    expect(req.request.method).toBe('GET');
+    req.flush({data: basicFormConfig, meta: meta});
+    expect((await result).formConfigMeta).toEqual(meta);
+  });
 });

--- a/angular/projects/researchdatabox/form/src/app/form.service.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.service.ts
@@ -148,7 +148,9 @@ export class FormService extends HttpClientService {
   public async downloadFormComponents(oid: string, recordType: string, editMode: boolean, formName: string, modulePaths: string[]): Promise<FormComponentsMap> {
     // Get the form config from the server.
     // Includes the integrated model data (in componentDefinition.model.config.value) for rendering the form.
-    const formConfig = await this.getFormConfig(oid, recordType, editMode, formName);
+    const formConfigResp = await this.getFormConfig(oid, recordType, editMode, formName);
+    const formConfig = formConfigResp?.data;
+    const formConfigMeta = formConfigResp?.meta ?? {};
     if (!formConfig) {
       throw new Error("Form config from server was empty.");
     }
@@ -162,7 +164,7 @@ export class FormService extends HttpClientService {
     });
 
     // Resolve the field and component pairs
-    return this.createFormComponentsMap(formConfig, parentLineagePaths);
+    return this.createFormComponentsMap(formConfig, parentLineagePaths, formConfigMeta);
   }
 
   /**
@@ -170,9 +172,11 @@ export class FormService extends HttpClientService {
    *
    * @param formConfig The form configuration.
    * @param parentLineagePaths The linage paths of the parent item.
+   * @param meta The metadata from the API request to get the form config.
    * @returns The config and the components built from the config.
    */
-  public async createFormComponentsMap(formConfig: FormConfigFrame, parentLineagePaths: LineagePaths): Promise<FormComponentsMap> {
+  public async createFormComponentsMap(
+    formConfig: FormConfigFrame, parentLineagePaths: LineagePaths, meta?: Record<string, unknown>): Promise<FormComponentsMap> {
     if (this.loadedValidatorDefinitions === null || this.loadedValidatorDefinitions === undefined) {
       // load the validator definitions to be used when constructing the form controls
       this.loadedValidatorDefinitions = this.validatorsSupport.createValidatorDefinitionMapping(redboxClientScript.formValidatorDefinitions);
@@ -188,11 +192,7 @@ export class FormService extends HttpClientService {
 
     // Instantiate the field classes, note these are optional, i.e. components may not have a form bound value
     this.createFormFieldModelInstances(components, formConfig?.enabledValidationGroups, formConfig?.validationGroups);
-    return new FormComponentsMap(components, formConfig);
-  }
-
-  public appendFormFieldType(additionalTypes: AllComponentClassMapType) {
-    _merge(this.compClassMap, additionalTypes);
+    return new FormComponentsMap(components, formConfig, meta);
   }
 
   /**
@@ -632,9 +632,11 @@ export class FormService extends HttpClientService {
       url.searchParams.set('formName', formName?.toString());
     }
 
-    const result = await firstValueFrom(this.http.get<{ data: FormConfigFrame }>(url.href, this.requestOptions));
+    type rawRespType = { data: FormConfigFrame, meta: Record<string, unknown> };
+    const rawResp = this.http.get<rawRespType>(url.href, this.requestOptions);
+    const result = await firstValueFrom(rawResp);
     this.loggerService.info(`Get form fields from url: ${url}`, result);
-    return result?.data;
+    return result;
   }
 
   /**
@@ -812,9 +814,6 @@ export class FormService extends HttpClientService {
 
   /**
    * Reshapes a FormFieldCompMapEntry array into a JSONataQuerySource. Needed to prepare for JSONata queries.
-   *
-   * @param origObject
-   * @returns
    */
   public getJSONataQuerySource(origObject: FormFieldCompMapEntry[], runtimeContext?: JSONataQueryRuntimeContext): JSONataQuerySource {
     let queryDoc: JSONataQuerySourceProperty[] = [];
@@ -956,10 +955,15 @@ export class FormComponentsMap {
    * Mapping of name to angular FormControl. Used to create angular form.
    */
   withFormControl?: { [key: string]: FormControl };
+  /**
+   * Metadata returned with the form config API call.
+   */
+  formConfigMeta?: Record<string, unknown>;
 
-  constructor(components: FormFieldCompMapEntry[], formConfig: FormConfigFrame) {
+  constructor(components: FormFieldCompMapEntry[], formConfig: FormConfigFrame, meta?: Record<string, unknown>) {
     this.components = components;
     this.formConfig = formConfig;
+    this.formConfigMeta = meta;
     this.completeGroupMap = undefined;
     this.withFormControl = undefined;
   }

--- a/angular/projects/researchdatabox/form/src/app/form.service.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.service.ts
@@ -135,7 +135,7 @@ export class FormService extends HttpClientService {
     return this;
   }
 
-  /** *
+  /**
    * Download and consequently loads the form config.
    *
    * Fields can use:

--- a/packages/redbox-core/src/controllers/RecordController.ts
+++ b/packages/redbox-core/src/controllers/RecordController.ts
@@ -473,7 +473,13 @@ export namespace Controllers {
         if (!_.isEmpty(mergedForm)) {
           return this.sendResp(req, res, {
             data: mergedForm,
-            meta: { formName: formParam, recordType: recordType, oid: oid, contextVariables: contextVariablesMap },
+            meta: {
+              formName: formParam,
+              recordType: recordType,
+              oid: oid,
+              workflow: recordData?.workflow,
+              contextVariables: contextVariablesMap
+            },
           });
         } else {
           const msg = `Failed to get form with name ${formParam} and record type ${recordType} and oid ${oid}`;

--- a/packages/redbox-core/src/model/storage/RecordModel.ts
+++ b/packages/redbox-core/src/model/storage/RecordModel.ts
@@ -28,7 +28,7 @@ export interface RecordModel {
 
   export interface RecordWorkflow {
     stage: string;
-    name: string;
+    stageLabel: string;
   }
 
   export interface StoredRecordAuthorization {

--- a/packages/redbox-core/src/services/FormsService.ts
+++ b/packages/redbox-core/src/services/FormsService.ts
@@ -171,7 +171,6 @@ export namespace Services {
           componentDefinitions: formConfigRaw.componentDefinitions as FormConfigFrame['componentDefinitions'],
           debugValue: formConfigRaw.debugValue as FormConfigFrame['debugValue'],
           attachmentFields: (formConfigRaw.attachmentFields ?? []) as FormConfigFrame['attachmentFields'],
-          contextVariables: formConfigRaw.contextVariables as FormConfigFrame['contextVariables'],
 
           // Deprecated legacy properties (now removed):
           // fields → replaced by componentDefinitions

--- a/packages/redbox-core/src/services/FormsService.ts
+++ b/packages/redbox-core/src/services/FormsService.ts
@@ -654,10 +654,6 @@ export namespace Services {
         }
       }
 
-      if (contextVariablesMap && Object.keys(contextVariablesMap).length > 0) {
-        result.contextVariables = contextVariablesMap;
-      }
-
       return result;
     }
 

--- a/packages/redbox-core/test/services/FormsService.test.ts
+++ b/packages/redbox-core/test/services/FormsService.test.ts
@@ -414,7 +414,7 @@ describe('FormsService', function () {
       expect(templates).to.have.length(expected.length);
     });
 
-    it('should apply context variables and include contextVariables in the returned form', async function () {
+    it('should apply context variables in the returned form', async function () {
       const item: FormConfigFrame = {
         name: 'custom-fields-test',
         componentDefinitions: [
@@ -460,7 +460,7 @@ describe('FormsService', function () {
       const titleConfig = form.componentDefinitions?.[1]?.model?.config as { defaultValue?: string };
 
       expect(contentConfig.content).to.equal('Welcome Alice');
-      expect(form.contextVariables).to.deep.equal(contextVariablesMap);
+      expect(titleConfig.defaultValue).to.equal('Title for Alice');
     });
 
     it('should populate generated view-only metadata display content from the record metadata', async function () {

--- a/packages/redbox-core/test/services/FormsService.test.ts
+++ b/packages/redbox-core/test/services/FormsService.test.ts
@@ -450,17 +450,19 @@ describe('FormsService', function () {
         item,
         'edit',
         [],
-        {},
+        null,
         {},
         'default',
         contextVariablesMap
       );
 
       const contentConfig = form.componentDefinitions?.[0]?.component?.config as { content?: string };
-      const titleConfig = form.componentDefinitions?.[1]?.model?.config as { defaultValue?: string };
+      const titleConfig = form.componentDefinitions?.[1]?.model?.config as { defaultValue?: string, value?: string };
 
       expect(contentConfig.content).to.equal('Welcome Alice');
-      expect(titleConfig.defaultValue).to.equal('Title for Alice');
+      expect(titleConfig.defaultValue).to.be.undefined;
+      expect(titleConfig.value).to.equal('Title for Alice');
+
     });
 
     it('should populate generated view-only metadata display content from the record metadata', async function () {

--- a/packages/sails-ng-common/src/config/form-config.model.ts
+++ b/packages/sails-ng-common/src/config/form-config.model.ts
@@ -34,7 +34,6 @@ export class FormConfig implements FormConfigOutline {
   public behaviours?: FormBehaviourConfigFrame[];
 
   public attachmentFields?: string[];
-  public contextVariables?: Record<string, unknown>;
 
   accept(visitor: FormConfigVisitorOutline): void {
     visitor.visitFormConfig(this);

--- a/packages/sails-ng-common/src/config/form-config.outline.ts
+++ b/packages/sails-ng-common/src/config/form-config.outline.ts
@@ -112,8 +112,6 @@ export interface FormConfigFrame {
    * This is automatically populated by the form config visitor.
    */
   attachmentFields?: string[];
-  // Optional resolved context variables (request scoped variables) available for this form response.
-  contextVariables?: Record<string, unknown>;
 }
 
 export interface FormConfigOutline extends FormConfigFrame, CanVisit {


### PR DESCRIPTION
## Summary

Provide the record workflow stage to the client.

Changes made:

* This will allow showing the current workflow stage in the record view page.

## Technical implementation details

* Added `record.workflow` (with properties `stage` and `stageLabel`) to the `meta` from the form api call.
* Removed `contextVariables` from `FormConfigFrame` - the context variables are oriented to user and site-wide data, so should not be part of the record form config data.

## Testing

* Remove server `FormsService` test and replace with angular `FormService` test.

## Future work

* Review the use of the form API `data` and `meta`, to see if there are other parts that make more sense in `meta`.
