### PR TITLE
chore: move to more recent Ubuntu and Debian base images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
             - docker-images/redbox-portal-runtime-cloud-pdfgen-test.tar
   test-bruno-general:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     resource_class: large
     environment:
       RBPORTAL_IMAGE: redbox-portal:test
@@ -175,7 +175,7 @@ jobs:
             - ~/.npm
   test-bruno-oidc:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     resource_class: large
     environment:
       RBPORTAL_IMAGE: redbox-portal:test
@@ -238,7 +238,7 @@ jobs:
             - ~/.npm
   test-playwright:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     resource_class: large
     environment:
       RBPORTAL_IMAGE: redbox-portal:test
@@ -285,7 +285,7 @@ jobs:
             - ~/.npm
   test-mocha:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     resource_class: large
     environment:
       RBPORTAL_IMAGE: redbox-portal:test
@@ -351,7 +351,7 @@ jobs:
       angular_app:
         type: string
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     resource_class: large
     steps:
       - checkout
@@ -400,7 +400,7 @@ jobs:
             - ~/.npm
   test-sails-ng-common:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     resource_class: large
     steps:
       - checkout
@@ -444,7 +444,7 @@ jobs:
           path: packages/sails-ng-common/support/junit
   test-redbox-core:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     resource_class: large
     steps:
       - checkout
@@ -491,7 +491,7 @@ jobs:
           path: packages/redbox-core/support/junit
   test-redbox-dev-tools-cli:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     resource_class: medium
     steps:
       - checkout
@@ -621,7 +621,7 @@ jobs:
             npm run lint
   # test-sails-hook-redbox-storage-mongo:
   #   machine:
-  #     image: ubuntu-2004:current
+  #     image: ubuntu-2204:current
   #   resource_class: medium
   #   environment:
   #     BUILDKIT_PROGRESS: 'plain'
@@ -793,7 +793,7 @@ jobs:
             docker push "${REPO}:${DEPLOY_TAG}-cloud-pdfgen-amd64"
   deploy-arm64:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     resource_class: arm.medium
     steps:
       - checkout
@@ -844,7 +844,7 @@ jobs:
             docker manifest push "${REPO}:${DEPLOY_TAG}"
   generate-docs:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     steps:
       - add_ssh_keys:
           fingerprints:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM node:24.14.1-bullseye AS base
+FROM node:24.14.1-bookworm AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -63,7 +63,7 @@ RUN npm prune --omit=dev \
     angular-legacy/node_modules \
     support/build/api-descriptors/node_modules
 
-FROM node:24.14.1-bullseye-slim AS runtime
+FROM node:24.14.1-bookworm-slim AS runtime
 
 ENV NODE_ENV=production
 ENV TZ=Australia/Brisbane

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
     build-essential \
     git \
-    python2 \
     python3 \
     python-is-python3 \
     curl \
@@ -17,8 +16,8 @@ RUN apt-get update \
     openjdk-17-jre-headless \
  && rm -rf /var/lib/apt/lists/*
 
-ENV PYTHON=/usr/bin/python2
-ENV npm_config_python=/usr/bin/python2
+ENV PYTHON=/usr/bin/python3
+ENV npm_config_python=/usr/bin/python3
 ENV NVM_DIR=/root/.nvm
 RUN bash -lc "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash"
 

--- a/support/integration-testing/docker-compose.bruno.general.yml
+++ b/support/integration-testing/docker-compose.bruno.general.yml
@@ -2,7 +2,7 @@ networks:
   main:
 
 x-bruno-service: &bruno-service
-  image: node:24.14.1-bullseye
+  image: node:24.14.1-bookworm
   pull_policy: 'missing'
   volumes:
     - '../../.tmp/junit/backend-bruno:/opt/junit/backend-bruno'

--- a/support/integration-testing/docker-compose.bruno.oidc.yml
+++ b/support/integration-testing/docker-compose.bruno.oidc.yml
@@ -2,7 +2,7 @@ networks:
   main:
 
 x-bruno-service: &bruno-service
-  image: node:24.14.1-bullseye
+  image: node:24.14.1-bookworm
   pull_policy: 'missing'
   volumes:
     - "../../.tmp/junit/backend-bruno:/opt/junit/backend-bruno"

--- a/support/integration-testing/docker-compose.bruno.yml
+++ b/support/integration-testing/docker-compose.bruno.yml
@@ -4,7 +4,7 @@ networks:
 
 services:
   bruno:
-    image: node:24.14.1-bullseye
+    image: node:24.14.1-bookworm
     pull_policy: 'missing'
     volumes:
       - "../../.tmp/junit/backend-bruno:/opt/junit/backend-bruno"


### PR DESCRIPTION
## Summary

Move from Ubuntu 20.04 LTS to 22.04 LTS in CircleCI (EOL in 2025 May).
Move from Debian 11 bullseye to Debian 12 bookworm (EOL in 2026 August).

Changes made:

* Use more recent base machines in CI and docker containers.
