### PR TITLE
chore: consolidate type for dynamic script asset response

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/checkbox-tree.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/checkbox-tree.component.ts
@@ -7,7 +7,7 @@ import {
   CheckboxTreeModelName,
   CheckboxTreeModelValueType,
   CheckboxTreeNode,
-  CheckboxTreeSelectedItem
+  CheckboxTreeSelectedItem, DynamicScriptResponse
 } from "@researchdatabox/sails-ng-common";
 import { FormComponent } from "../form.component";
 import { VocabTreeService, VocabTreeApiNode } from "../service/vocab-tree.service";
@@ -234,7 +234,7 @@ export class CheckboxTreeComponent extends FormFieldBaseComponent<CheckboxTreeMo
   private maxDepth?: number;
   private labelTemplate = "";
   private labelTemplatePath: (string | number)[] = [];
-  private compiledItems?: { evaluate: (key: (string | number)[], context: unknown, extra?: unknown) => unknown };
+  private compiledItems?: DynamicScriptResponse;
 
   @Input() public override model?: CheckboxTreeModel;
   public readonly selectedItem = signal<CheckboxTreeSelectedItem | null>(null);

--- a/angular/projects/researchdatabox/form/src/app/component/content.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/content.component.ts
@@ -90,7 +90,7 @@ export class ContentComponent extends FormFieldBaseComponent<string> {
             workflow: this.formComponent.formConfigMeta['workflow'] ?? {},
           };
           const extra = {libraries: this.handlebarsTemplateService.getLibraries()};
-          this.content = compiledItems.evaluate(templateLineagePath, context, extra);
+          this.content = compiledItems.evaluate(templateLineagePath, context, extra)?.toString() ?? "";
         };
         const initialForm = this.getFormComponent.form;
         renderTemplate(initialForm?.getRawValue?.() ?? initialForm?.value ?? {});

--- a/angular/projects/researchdatabox/form/src/app/component/content.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/content.component.ts
@@ -76,9 +76,6 @@ export class ContentComponent extends FormFieldBaseComponent<string> {
       const name = this.name;
       const templateLineagePath = [...(this.formFieldCompMapEntry?.lineagePaths?.formConfig ?? []), 'component', 'config', 'template'];
       try {
-        // Build the variables available to the template.
-        const context = {content: content, translationService: this.translationService};
-        const extra = {libraries: this.handlebarsTemplateService.getLibraries()};
         const compiledItems = await this.getFormComponent.getRecordCompiledItems();
         const renderTemplate = (formData: Record<string, unknown> = {}) => {
           const runtimeContext = this.getRuntimeTemplateContext();
@@ -89,7 +86,8 @@ export class ContentComponent extends FormFieldBaseComponent<string> {
             translationService: this.translationService,
             branding: runtimeContext.branding,
             portal: runtimeContext.portal,
-            oid: runtimeContext.oid
+            oid: runtimeContext.oid,
+            workflow: this.formComponent.formConfigMeta['workflow'] ?? {},
           };
           const extra = {libraries: this.handlebarsTemplateService.getLibraries()};
           this.content = compiledItems.evaluate(templateLineagePath, context, extra);

--- a/angular/projects/researchdatabox/form/src/app/component/pdf-list.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/pdf-list.component.ts
@@ -1,12 +1,13 @@
 import { Component, HostListener, Injector, Input, inject } from "@angular/core";
 import { FormFieldBaseComponent, FormFieldCompMapEntry, FormFieldModel, HandlebarsTemplateService } from "@researchdatabox/portal-ng-common";
 import {
-    PDFListComponentName,
-    PDFListFieldComponentConfig,
-    PDFListFieldComponentConfigOutline,
-    PDFListModelName,
-    PDFListModelValueType,
-    RecordAttachment
+  DynamicScriptResponse,
+  PDFListComponentName,
+  PDFListFieldComponentConfig,
+  PDFListFieldComponentConfigOutline,
+  PDFListModelName,
+  PDFListModelValueType,
+  RecordAttachment
 } from "@researchdatabox/sails-ng-common";
 import { FormComponent } from "../form.component";
 import { FormService } from "../form.service";
@@ -51,7 +52,7 @@ export class PDFListComponent extends FormFieldBaseComponent<PDFListModelValueTy
     private readonly injector = inject(Injector);
     private readonly formService = inject(FormService);
     private readonly handlebarsTemplateService = inject(HandlebarsTemplateService);
-    private compiledItems?: { evaluate: (key: Array<string | number>, context: Record<string, unknown>, extra?: Record<string, unknown>) => unknown };
+    private compiledItems?: DynamicScriptResponse;
     private fileNameTemplatePath: Array<string | number> = [];
 
     protected get getFormComponent(): FormComponent {

--- a/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.ts
@@ -8,6 +8,7 @@ import {
   HandlebarsTemplateService,
 } from '@researchdatabox/portal-ng-common';
 import {
+  DynamicScriptResponse,
   TypeaheadInputComponentName,
   TypeaheadInputFieldComponentConfig,
   TypeaheadInputModelName,
@@ -119,7 +120,7 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
   private lastAutoDisplaySyncSignature = '';
   private labelTemplate = '';
   private labelTemplatePath: (string | number)[] = [];
-  private compiledItems?: { evaluate: (key: (string | number)[], context: unknown, extra?: unknown) => unknown };
+  private compiledItems?: DynamicScriptResponse;
   private readonly destroyRef = inject(DestroyRef);
   private readonly handlebarsTemplateService = inject(HandlebarsTemplateService);
   private readonly typeaheadDataService = inject(TypeaheadDataService);

--- a/angular/projects/researchdatabox/form/src/app/form-state/behaviours/behaviour-compiled-template-evaluator.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/behaviours/behaviour-compiled-template-evaluator.ts
@@ -1,5 +1,6 @@
 import jsonata from 'jsonata';
 import { LoggerService } from '@researchdatabox/portal-ng-common';
+import {DynamicScriptResponse} from "@researchdatabox/sails-ng-common";
 
 /**
  * Minimal shape needed from the dynamically imported compiled-items module.
@@ -7,9 +8,7 @@ import { LoggerService } from '@researchdatabox/portal-ng-common';
  * Behaviours reuse the same compiled asset mechanism as expressions, but with a
  * different key space rooted at `behaviours[]` instead of component lineage.
  */
-export interface BehaviourCompiledItemsModule {
-  evaluate: (key: (string | number)[], context: unknown, extra?: unknown) => unknown;
-}
+export interface BehaviourCompiledItemsModule extends DynamicScriptResponse {}
 
 /**
  * Evaluates compiled JSONata entries for form behaviours.

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
@@ -11,7 +11,7 @@ import {
   ExpressionsConditionKind,
   ExpressionsConditionKindType,
   FormExpressionsTargetModelValue, FormExpressionsTargetLayoutPrefix, FormExpressionsTargetComponentPrefix,
-  FormExpressionsTargetValidationGroups
+  FormExpressionsTargetValidationGroups, DynamicScriptResponse,
 } from '@researchdatabox/sails-ng-common';
 import jsonata from 'jsonata';
 import { isEmpty as _isEmpty, set as _set } from 'lodash-es';
@@ -49,7 +49,7 @@ export interface FormComponentEventJSONataQueryMatchOptions extends FormComponen
 export abstract class FormComponentEventBaseConsumer extends FormComponentEventBaseProducerConsumer {
 
 	/** Cache for the compiled items module */
-	protected compiledItemsCache?: { evaluate: (key: (string | number)[], context: unknown, extra?: unknown) => unknown };
+	protected compiledItemsCache?: DynamicScriptResponse;
 
 	/** The event type this consumer listens to - must be set by subclasses */
 	protected abstract readonly consumedEventType: FormComponentEventTypeValue;
@@ -86,7 +86,7 @@ export abstract class FormComponentEventBaseConsumer extends FormComponentEventB
 	/**
 	 * Get the compiled items module, caching the result for subsequent calls.
 	 */
-	protected async getCompiledItems(): Promise<{ evaluate: (key: (string | number)[], context: unknown, extra?: unknown) => unknown } | undefined> {
+	protected async getCompiledItems(): Promise<DynamicScriptResponse | undefined> {
 		if (this.compiledItemsCache) {
 			return this.compiledItemsCache;
 		}

--- a/angular/projects/researchdatabox/form/src/app/form.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.ts
@@ -18,44 +18,54 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 import {
   Component,
-  Inject,
-  ElementRef,
-  signal,
-  HostBinding,
-  ViewChild,
-  ViewContainerRef,
-  inject,
   effect,
+  ElementRef,
+  HostBinding,
+  Inject,
+  inject,
   model,
   OnDestroy,
+  signal,
+  ViewChild,
+  ViewContainerRef,
   ViewEncapsulation,
 } from '@angular/core';
-import { Subscription } from 'rxjs';
-import { Location, LocationStrategy, PathLocationStrategy } from '@angular/common';
-import { FormGroup, FormControlStatus, StatusChangeEvent, PristineChangeEvent, ValueChangeEvent } from '@angular/forms';
-import { isEmpty as _isEmpty, isString as _isString, isNull as _isNull, get as _get, trim as _trim, set as _set } from 'lodash-es';
+import {Subscription} from 'rxjs';
+import {Location, LocationStrategy, PathLocationStrategy} from '@angular/common';
+import {FormControlStatus, FormGroup, PristineChangeEvent, StatusChangeEvent, ValueChangeEvent} from '@angular/forms';
 import {
-  ConfigService,
-  LoggerService,
-  TranslationService,
+  get as _get,
+  isEmpty as _isEmpty,
+  isNull as _isNull,
+  isString as _isString,
+  set as _set,
+  trim as _trim
+} from 'lodash-es';
+import {
   BaseComponent,
+  ConfigService,
   FormFieldCompMapEntry,
-  UtilityService,
-  RecordService,
+  LoggerService,
   RecordActionResult,
+  RecordService,
+  TranslationService,
+  UtilityService,
 } from '@researchdatabox/portal-ng-common';
 import {
-  FormStatus,
+  DynamicScriptResponse,
   FormConfigFrame,
-  JSONataQuerySource,
-  FormValidatorSummaryErrors,
-  FormRequestParamValue,
   FormRequestParamsMap,
+  FormRequestParamValue,
+  FormStatus,
+  FormValidatorSummaryErrors,
+  JSONataQuerySource,
 } from '@researchdatabox/sails-ng-common';
-import { FormBaseWrapperComponent } from './component/base-wrapper.component';
-import { FormComponentsMap, FormService } from './form.service';
-import { FormComponentEventBus } from './form-state/events/form-component-event-bus.service';
-import { FormComponentFocusRequestCoordinator } from './form-state/events/form-component-focus-request-coordinator.service';
+import {FormBaseWrapperComponent} from './component/base-wrapper.component';
+import {FormComponentsMap, FormService} from './form.service';
+import {FormComponentEventBus} from './form-state/events/form-component-event-bus.service';
+import {
+  FormComponentFocusRequestCoordinator
+} from './form-state/events/form-component-focus-request-coordinator.service';
 import {
   createFormDefinitionChangedEvent,
   createFormDefinitionReadyEvent,
@@ -66,14 +76,16 @@ import {
   createFormValidationBroadcastEvent,
   FormComponentEvent,
   FormComponentEventType,
-  FormStatusDirtyRequestEvent, FormValidationGroupsChangeInitial, FormValidationGroupsChangeRequestEvent,
+  FormStatusDirtyRequestEvent,
+  FormValidationGroupsChangeInitial,
+  FormValidationGroupsChangeRequestEvent,
 } from './form-state/events/form-component-event.types';
-import { FormStateFacade } from './form-state/facade/form-state.facade';
-import { Store } from '@ngrx/store';
+import {FormStateFacade} from './form-state/facade/form-state.facade';
+import {Store} from '@ngrx/store';
 import * as FormActions from './form-state/state/form.actions';
-import { FormComponentValueChangeEventConsumer } from './form-state/events/';
-import { DebugInfo, FormDebugStateService } from './form-debug/form-debug-state.service';
-import { FormBehaviourManager } from './form-state/behaviours/form-behaviour-manager.service';
+import {FormComponentValueChangeEventConsumer} from './form-state/events/';
+import {DebugInfo, FormDebugStateService} from './form-debug/form-debug-state.service';
+import {FormBehaviourManager} from './form-state/behaviours/form-behaviour-manager.service';
 
 /**
  * The ReDBox Form
@@ -1047,24 +1059,22 @@ export class FormComponent extends BaseComponent implements OnDestroy {
   /**
    * Get the compiled items for the form with the default values.
    */
-  public async getFormCompiledItems() {
+  public async getFormCompiledItems(): Promise<DynamicScriptResponse> {
     const recordType = this.trimmedParams.recordType();
     const formMode = this.editMode() ? 'edit' : 'view';
-    const result = await this.formService.getDynamicImportFormCompiledItems(recordType, undefined, formMode);
-    // TODO: cache?
-    return result;
+    // Response is cached in utilityService.getDynamicImport.
+    return await this.formService.getDynamicImportFormCompiledItems(recordType, undefined, formMode);
   }
 
   /**
    * Get the compiled items for the form with the record's values.
    */
-  public async getRecordCompiledItems() {
+  public async getRecordCompiledItems(): Promise<DynamicScriptResponse> {
     const recordType = this.trimmedParams.recordType();
     const oid = this.trimmedParams.oid();
     const formMode = this.editMode() ? 'edit' : 'view';
-    const result = await this.formService.getDynamicImportFormCompiledItems(recordType, oid, formMode);
-    // TODO: cache?
-    return result;
+    // Response is cached in utilityService.getDynamicImport.
+    return await this.formService.getDynamicImportFormCompiledItems(recordType, oid, formMode);
   }
 
   // Expose the `form` status

--- a/angular/projects/researchdatabox/form/src/app/form.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.ts
@@ -1129,6 +1129,10 @@ export class FormComponent extends BaseComponent implements OnDestroy {
     return this.componentDefQuerySource;
   }
 
+  public get formConfigMeta(): Record<string,unknown> {
+    return this.formDefMap?.formConfigMeta ?? {};
+  }
+
   private parseRequestParamsFromUrl(rawHref?: string): FormRequestParamsMap {
     const fallbackOrigin = typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
     const href = rawHref ?? (typeof window !== 'undefined' ? window.location.href : fallbackOrigin);

--- a/angular/projects/researchdatabox/form/src/app/form.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.ts
@@ -1215,7 +1215,7 @@ export class FormComponent extends BaseComponent implements OnDestroy {
   }
 
   private resolveRedirectLocation(template: string, oid: string): string {
-    const contextVariables = (this.formDefMap?.formConfig?.contextVariables ?? {}) as Record<string, unknown>;
+    const contextVariables = (this.formConfigMeta["contextVariables"] ?? {}) as Record<string, unknown>;
     return template
       .replaceAll('@oid', oid)
       .replaceAll('@branding', String(contextVariables['@branding'] ?? '@branding'))

--- a/angular/projects/researchdatabox/form/src/app/form.service.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.service.spec.ts
@@ -12,9 +12,10 @@ import {
 } from "@researchdatabox/portal-ng-common";
 import { APP_BASE_HREF } from "@angular/common";
 import { Title } from "@angular/platform-browser";
-import { provideHttpClient } from "@angular/common/http";
+import {HttpContext, provideHttpClient} from "@angular/common/http";
 import { HttpTestingController, provideHttpClientTesting } from "@angular/common/http/testing";
 import {
+  FormConfigFrame,
   FormFieldValidationGroup,
   FormModesConfig,
   FormValidationGroups,
@@ -54,10 +55,18 @@ describe('The FormService', () => {
     });
     service = TestBed.inject(FormService);
     httpTesting = TestBed.inject(HttpTestingController);
+    (service as any).brandingAndPortalUrl = "http://localhost/default/rdmp";
+    (service as any).httpContext = new HttpContext();
   });
+
+  afterEach(() => {
+    if (httpTesting) {
+      httpTesting.verify();
+    }
+  });
+
   it('should create an instance', () => {
     expect(service).toBeTruthy();
-    httpTesting.verify();
   });
 
   it('should resolve accordion component classes from static map', async () => {
@@ -274,4 +283,43 @@ describe('The FormService', () => {
     });
   });
 
+  it("should download form components and form config meta", async function () {
+    const basicFormConfig: FormConfigFrame = {
+      name: 'testing',
+      debugValue: true,
+      defaultComponentConfig: {
+        defaultComponentCssClasses: 'form-control'
+      },
+      editCssClasses: 'redbox-form form',
+      componentDefinitions: [
+        {
+          name: 'test_field',
+          model: {
+            class: 'SimpleInputModel',
+            config: {
+              value: 'initial value'
+            }
+          },
+          component: {
+            class: 'SimpleInputComponent',
+            config: {
+              type: 'text',
+              label: 'Test Field'
+            }
+          }
+        }
+      ]
+    };
+    const meta: Record<string, unknown> = {
+      workflow: {stage: 'draft', stageLabel: 'Draft'},
+      contextVariables: {'one': 1},
+    };
+    const oid = "oid", recordType = "auto", editMode = false, formName = "", modulePaths: string[] = [];
+    const result = service.downloadFormComponents(oid, recordType, editMode, formName, modulePaths);
+    const req = httpTesting.expectOne((request) =>
+      request.url.startsWith(`http://localhost/default/rdmp/record/form/${recordType}/${oid}`));
+    expect(req.request.method).toBe('GET');
+    req.flush({data: basicFormConfig, meta: meta});
+    expect((await result).formConfigMeta).toEqual(meta);
+  });
 });

--- a/angular/projects/researchdatabox/form/src/app/form.service.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.service.ts
@@ -148,7 +148,9 @@ export class FormService extends HttpClientService {
   public async downloadFormComponents(oid: string, recordType: string, editMode: boolean, formName: string, modulePaths: string[]): Promise<FormComponentsMap> {
     // Get the form config from the server.
     // Includes the integrated model data (in componentDefinition.model.config.value) for rendering the form.
-    const formConfig = await this.getFormConfig(oid, recordType, editMode, formName);
+    const formConfigResp = await this.getFormConfig(oid, recordType, editMode, formName);
+    const formConfig = formConfigResp?.data;
+    const formConfigMeta = formConfigResp?.meta ?? {};
     if (!formConfig) {
       throw new Error("Form config from server was empty.");
     }
@@ -162,7 +164,7 @@ export class FormService extends HttpClientService {
     });
 
     // Resolve the field and component pairs
-    return this.createFormComponentsMap(formConfig, parentLineagePaths);
+    return this.createFormComponentsMap(formConfig, parentLineagePaths, formConfigMeta);
   }
 
   /**
@@ -170,9 +172,11 @@ export class FormService extends HttpClientService {
    *
    * @param formConfig The form configuration.
    * @param parentLineagePaths The linage paths of the parent item.
+   * @param meta The metadata from the API request to get the form config.
    * @returns The config and the components built from the config.
    */
-  public async createFormComponentsMap(formConfig: FormConfigFrame, parentLineagePaths: LineagePaths): Promise<FormComponentsMap> {
+  public async createFormComponentsMap(
+    formConfig: FormConfigFrame, parentLineagePaths: LineagePaths, meta?: Record<string, unknown>): Promise<FormComponentsMap> {
     if (this.loadedValidatorDefinitions === null || this.loadedValidatorDefinitions === undefined) {
       // load the validator definitions to be used when constructing the form controls
       this.loadedValidatorDefinitions = this.validatorsSupport.createValidatorDefinitionMapping(redboxClientScript.formValidatorDefinitions);
@@ -188,11 +192,7 @@ export class FormService extends HttpClientService {
 
     // Instantiate the field classes, note these are optional, i.e. components may not have a form bound value
     this.createFormFieldModelInstances(components, formConfig?.enabledValidationGroups, formConfig?.validationGroups);
-    return new FormComponentsMap(components, formConfig);
-  }
-
-  public appendFormFieldType(additionalTypes: AllComponentClassMapType) {
-    _merge(this.compClassMap, additionalTypes);
+    return new FormComponentsMap(components, formConfig, meta);
   }
 
   /**
@@ -632,9 +632,11 @@ export class FormService extends HttpClientService {
       url.searchParams.set('formName', formName?.toString());
     }
 
-    const result = await firstValueFrom(this.http.get<{ data: FormConfigFrame }>(url.href, this.requestOptions));
+    type rawRespType = { data: FormConfigFrame, meta: Record<string, unknown> };
+    const rawResp = this.http.get<rawRespType>(url.href, this.requestOptions);
+    const result = await firstValueFrom(rawResp);
     this.loggerService.info(`Get form fields from url: ${url}`, result);
-    return result?.data;
+    return result;
   }
 
   /**
@@ -812,9 +814,6 @@ export class FormService extends HttpClientService {
 
   /**
    * Reshapes a FormFieldCompMapEntry array into a JSONataQuerySource. Needed to prepare for JSONata queries.
-   *
-   * @param origObject
-   * @returns
    */
   public getJSONataQuerySource(origObject: FormFieldCompMapEntry[], runtimeContext?: JSONataQueryRuntimeContext): JSONataQuerySource {
     let queryDoc: JSONataQuerySourceProperty[] = [];
@@ -956,10 +955,15 @@ export class FormComponentsMap {
    * Mapping of name to angular FormControl. Used to create angular form.
    */
   withFormControl?: { [key: string]: FormControl };
+  /**
+   * Metadata returned with the form config API call.
+   */
+  formConfigMeta?: Record<string, unknown>;
 
-  constructor(components: FormFieldCompMapEntry[], formConfig: FormConfigFrame) {
+  constructor(components: FormFieldCompMapEntry[], formConfig: FormConfigFrame, meta?: Record<string, unknown>) {
     this.components = components;
     this.formConfig = formConfig;
+    this.formConfigMeta = meta;
     this.completeGroupMap = undefined;
     this.withFormControl = undefined;
   }

--- a/angular/projects/researchdatabox/form/src/app/form.service.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.service.ts
@@ -135,7 +135,7 @@ export class FormService extends HttpClientService {
     return this;
   }
 
-  /** *
+  /**
    * Download and consequently loads the form config.
    *
    * Fields can use:

--- a/angular/projects/researchdatabox/form/src/app/form.service.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.service.ts
@@ -17,16 +17,22 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-import { Inject, Injectable, WritableSignal } from '@angular/core';
-import { AbstractControl, FormControl } from '@angular/forms';
-import { isEmpty as _isEmpty, merge as _merge, set as _set, toNumber as _toNumber, isFinite as _isFinite } from 'lodash-es';
+import {Inject, Injectable, WritableSignal} from '@angular/core';
+import {AbstractControl, FormControl} from '@angular/forms';
 import {
-  getStaticComponentClassMap,
-  getStaticModelClassMap,
-  getStaticLayoutClassMap,
+  isEmpty as _isEmpty,
+  isFinite as _isFinite,
+  merge as _merge,
+  set as _set,
+  toNumber as _toNumber
+} from 'lodash-es';
+import {
   AllComponentClassMapType,
-  AllModelClassMapType,
   AllLayoutClassMapType,
+  AllModelClassMapType,
+  getStaticComponentClassMap,
+  getStaticLayoutClassMap,
+  getStaticModelClassMap,
 } from './static-comp-field.dictionary';
 import {
   ConfigService,
@@ -34,32 +40,40 @@ import {
   FormFieldCompMapEntry,
   FormFieldModel,
   HttpClientService,
+  JSONataClientQuerySourceProperty,
   LoggerService,
   TranslationService,
-  UtilityService,
-  JSONataClientQuerySourceProperty
+  UtilityService
 } from '@researchdatabox/portal-ng-common';
-import { PortalNgFormCustomService } from '@researchdatabox/portal-ng-form-custom';
+import {PortalNgFormCustomService} from '@researchdatabox/portal-ng-form-custom';
 import {
-  FormFieldComponentStatus,
+  buildLineagePaths as buildLineagePathsHelper, DynamicScriptResponse,
+  FieldModelDefinitionKind,
   FormComponentDefinitionFrame,
+  FormComponentDefinitionKind,
   FormConfigFrame,
-  FormStatus, FormValidatorComponentErrors, FormValidatorConfig, FormValidatorDefinition,
+  FormFieldComponentStatus,
+  FormFieldValidationGroup,
+  FormModesConfig,
+  FormStatus,
+  FormValidationGroups,
+  FormValidatorComponentErrors,
+  FormValidatorConfig,
+  FormValidatorDefinition,
   FormValidatorSummaryErrors,
-  ValidatorsSupport,
-  LineagePaths,
+  getObjectWithJsonPointer,
+  JSONataQueryRuntimeContext,
   JSONataQuerySource,
   JSONataQuerySourceProperty,
-  buildLineagePaths as buildLineagePathsHelper,
+  KindNameDefaultsMap,
+  KindNameDefaultsMapType,
+  LineagePaths,
   queryJSONata,
-  getObjectWithJsonPointer,
-  FormModesConfig, KindNameDefaultsMap, FieldModelDefinitionKind,
-  FormComponentDefinitionKind, KindNameDefaultsMapType, JSONataQueryRuntimeContext, FormValidationGroups,
-  FormFieldValidationGroup,
+  ValidatorsSupport,
 } from '@researchdatabox/sails-ng-common';
-import { HttpClient } from "@angular/common/http";
-import { APP_BASE_HREF } from "@angular/common";
-import { firstValueFrom } from "rxjs";
+import {HttpClient} from "@angular/common/http";
+import {APP_BASE_HREF} from "@angular/common";
+import {firstValueFrom} from "rxjs";
 import {FormValidationGroupsChangeInitial} from "./form-state";
 
 
@@ -700,16 +714,16 @@ export class FormService extends HttpClientService {
    * @param oid The record id.
    * @param formMode The form mode.
    */
-  public async getDynamicImportFormCompiledItems(recordType: string, oid?: string, formMode?: FormModesConfig) {
+  public async getDynamicImportFormCompiledItems(
+    recordType: string, oid?: string, formMode?: FormModesConfig
+  ): Promise<DynamicScriptResponse> {
     const normalizedRecordType = String(recordType ?? '').trim() || (oid ? 'auto' : '');
     const path = ['dynamicAsset', 'formCompiledItems', normalizedRecordType];
     if (oid) {
       path.push(oid?.toString());
     }
     const params = formMode === "edit" ? { edit: "true" } : undefined;
-    const result = await this.utilityService.getDynamicImport(this.brandingAndPortalUrl, path, params);
-    // TODO add a type for the result -  {evaluate: function(key, context, extra)}
-    return result;
+    return await this.utilityService.getDynamicImport(this.brandingAndPortalUrl, path, params);
   }
 
   /**

--- a/angular/projects/researchdatabox/form/src/app/helpers.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/helpers.spec.ts
@@ -17,7 +17,8 @@ import { APP_BASE_HREF, CommonModule } from "@angular/common";
 import { BrowserModule, Title } from "@angular/platform-browser";
 import { FormService } from "./form.service";
 import {
-  buildKeyString,
+  buildKeyString, DynamicScriptResponse, DynamicScriptResponseEvaluateContext,
+  DynamicScriptResponseEvaluateExtra, DynamicScriptResponseEvaluateKey,
   FormConfigFrame,
   formValidatorsSharedDefinitions,
 } from "@researchdatabox/sails-ng-common";
@@ -253,14 +254,14 @@ export function setUpDynamicAssets(opts?: {
   }
   const utilityService = TestBed.inject(UtilityService);
   spyOn(utilityService, "getDynamicImport").and.callFake(
-    async (brandingAndPortalUrl: string, urlPath: string[], params?: { [key: string]: any }) => {
+    async (brandingAndPortalUrl: string, urlPath: string[], params?: { [key: string]: any }): Promise<DynamicScriptResponse> => {
       const urlKey = `${brandingAndPortalUrl}/${(urlPath ?? []).join("/")}`;
       if (!opts.urlKeyStart || !urlKey.startsWith(opts.urlKeyStart)) {
         throw new Error(`Expected url key '${opts.urlKeyStart}', but got unknown url key: ${urlKey}`);
       }
 
       return {
-        evaluate: (key: (string | number)[], context: any, extra: any) => {
+        evaluate: function(key: DynamicScriptResponseEvaluateKey, context: DynamicScriptResponseEvaluateContext, extra?: DynamicScriptResponseEvaluateExtra): unknown {
           const keyStr = buildKeyString(key as string[]);
           if (opts.callable) {
             return opts.callable(keyStr, key, context, extra);

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/record.service.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/record.service.ts
@@ -20,7 +20,7 @@
 import { map, firstValueFrom } from 'rxjs';
 import { Injectable, Inject } from '@angular/core';
 import { APP_BASE_HREF } from '@angular/common';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { ConfigService } from './config.service';
 import { UtilityService } from './utility.service';
 import { LoggerService } from './logger.service';

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/utility.service.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/utility.service.ts
@@ -425,7 +425,9 @@ export class UtilityService {
    * @param urlPath The path parts.
    * @param params The query string parts.
    */
-  public async getDynamicImport(brandingAndPortalUrl: string, urlPath: string[], params?: { [key: string]: any }) {
+  public async getDynamicImport(
+    brandingAndPortalUrl: string, urlPath: string[], params?: { [key: string]: any }
+  ): Promise<any> {
     if (!brandingAndPortalUrl) {
       throw new Error("Must provide brandingAndPortalUrl");
     }

--- a/packages/redbox-core/src/controllers/RecordController.ts
+++ b/packages/redbox-core/src/controllers/RecordController.ts
@@ -473,7 +473,13 @@ export namespace Controllers {
         if (!_.isEmpty(mergedForm)) {
           return this.sendResp(req, res, {
             data: mergedForm,
-            meta: { formName: formParam, recordType: recordType, oid: oid, contextVariables: contextVariablesMap },
+            meta: {
+              formName: formParam,
+              recordType: recordType,
+              oid: oid,
+              workflow: recordData?.workflow,
+              contextVariables: contextVariablesMap
+            },
           });
         } else {
           const msg = `Failed to get form with name ${formParam} and record type ${recordType} and oid ${oid}`;

--- a/packages/redbox-core/src/model/storage/RecordModel.ts
+++ b/packages/redbox-core/src/model/storage/RecordModel.ts
@@ -28,7 +28,7 @@ export interface RecordModel {
 
   export interface RecordWorkflow {
     stage: string;
-    name: string;
+    stageLabel: string;
   }
 
   export interface StoredRecordAuthorization {

--- a/packages/redbox-core/src/services/FormsService.ts
+++ b/packages/redbox-core/src/services/FormsService.ts
@@ -171,7 +171,6 @@ export namespace Services {
           componentDefinitions: formConfigRaw.componentDefinitions as FormConfigFrame['componentDefinitions'],
           debugValue: formConfigRaw.debugValue as FormConfigFrame['debugValue'],
           attachmentFields: (formConfigRaw.attachmentFields ?? []) as FormConfigFrame['attachmentFields'],
-          contextVariables: formConfigRaw.contextVariables as FormConfigFrame['contextVariables'],
 
           // Deprecated legacy properties (now removed):
           // fields → replaced by componentDefinitions

--- a/packages/redbox-core/src/services/FormsService.ts
+++ b/packages/redbox-core/src/services/FormsService.ts
@@ -654,10 +654,6 @@ export namespace Services {
         }
       }
 
-      if (contextVariablesMap && Object.keys(contextVariablesMap).length > 0) {
-        result.contextVariables = contextVariablesMap;
-      }
-
       return result;
     }
 

--- a/packages/redbox-core/test/services/FormsService.test.ts
+++ b/packages/redbox-core/test/services/FormsService.test.ts
@@ -414,7 +414,7 @@ describe('FormsService', function () {
       expect(templates).to.have.length(expected.length);
     });
 
-    it('should apply context variables and include contextVariables in the returned form', async function () {
+    it('should apply context variables in the returned form', async function () {
       const item: FormConfigFrame = {
         name: 'custom-fields-test',
         componentDefinitions: [
@@ -460,7 +460,7 @@ describe('FormsService', function () {
       const titleConfig = form.componentDefinitions?.[1]?.model?.config as { defaultValue?: string };
 
       expect(contentConfig.content).to.equal('Welcome Alice');
-      expect(form.contextVariables).to.deep.equal(contextVariablesMap);
+      expect(titleConfig.defaultValue).to.equal('Title for Alice');
     });
 
     it('should populate generated view-only metadata display content from the record metadata', async function () {

--- a/packages/redbox-core/test/services/FormsService.test.ts
+++ b/packages/redbox-core/test/services/FormsService.test.ts
@@ -450,17 +450,19 @@ describe('FormsService', function () {
         item,
         'edit',
         [],
-        {},
+        null,
         {},
         'default',
         contextVariablesMap
       );
 
       const contentConfig = form.componentDefinitions?.[0]?.component?.config as { content?: string };
-      const titleConfig = form.componentDefinitions?.[1]?.model?.config as { defaultValue?: string };
+      const titleConfig = form.componentDefinitions?.[1]?.model?.config as { defaultValue?: string, value?: string };
 
       expect(contentConfig.content).to.equal('Welcome Alice');
-      expect(titleConfig.defaultValue).to.equal('Title for Alice');
+      expect(titleConfig.defaultValue).to.be.undefined;
+      expect(titleConfig.value).to.equal('Title for Alice');
+
     });
 
     it('should populate generated view-only metadata display content from the record metadata', async function () {

--- a/packages/sails-ng-common/src/config/form-config.model.ts
+++ b/packages/sails-ng-common/src/config/form-config.model.ts
@@ -34,7 +34,6 @@ export class FormConfig implements FormConfigOutline {
   public behaviours?: FormBehaviourConfigFrame[];
 
   public attachmentFields?: string[];
-  public contextVariables?: Record<string, unknown>;
 
   accept(visitor: FormConfigVisitorOutline): void {
     visitor.visitFormConfig(this);

--- a/packages/sails-ng-common/src/config/form-config.outline.ts
+++ b/packages/sails-ng-common/src/config/form-config.outline.ts
@@ -112,8 +112,6 @@ export interface FormConfigFrame {
    * This is automatically populated by the form config visitor.
    */
   attachmentFields?: string[];
-  // Optional resolved context variables (request scoped variables) available for this form response.
-  contextVariables?: Record<string, unknown>;
 }
 
 export interface FormConfigOutline extends FormConfigFrame, CanVisit {

--- a/packages/sails-ng-common/src/template.outline.ts
+++ b/packages/sails-ng-common/src/template.outline.ts
@@ -42,3 +42,21 @@ export interface TemplateCompileInput extends TemplateCompileItem {
 export function buildKeyString(key: TemplateCompileKey): TemplateCompileKeyFormatted {
     return (key ?? [])?.map(i => i?.toString()?.normalize("NFKC"))?.join('__');
 }
+
+export type DynamicScriptResponseEvaluateKey = TemplateCompileKey;
+export type DynamicScriptResponseEvaluateContext = unknown;
+export type DynamicScriptResponseEvaluateExtra = { libraries?: Record<string, unknown>, [key: string]: unknown };
+export type DynamicScriptResponseEvaluateResult = unknown;
+
+export type DynamicScriptResponseEvaluate = (
+  key: DynamicScriptResponseEvaluateKey,
+  context: DynamicScriptResponseEvaluateContext,
+  extra?: DynamicScriptResponseEvaluateExtra,
+) => DynamicScriptResponseEvaluateResult;
+
+/**
+ * The type of the dynamic script asset response after import.
+ */
+export interface DynamicScriptResponse {
+  evaluate: DynamicScriptResponseEvaluate,
+}


### PR DESCRIPTION
## Summary

Consolidate the various types for dynamic script asset response into one defined type.

Changes made:

* The same API result defined in one place makes maintenance easier.

## Technical implementation details

* Create type `DynamicScriptResponse` and related types.
* Use the type where the result of the API call is used.


