### PR TITLE
feature: set component disabled state by updating angular formControl

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/date-input.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/date-input.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, ViewChild } from '@angular/core';
-import { FormFieldBaseComponent, FormFieldCompMapEntry, FormFieldModel } from "@researchdatabox/portal-ng-common";
+import { FormFieldBaseComponent, FormFieldCompMapEntry, FormFieldModel, ModifyOptions } from "@researchdatabox/portal-ng-common";
 import {
   DateInputFieldComponentConfigFrame,
   DateInputFieldComponentConfig,
@@ -63,9 +63,9 @@ export class DateInputModel extends FormFieldModel<DateInputModelValueType> {
     return normalizeDateInputValue(this.fieldConfig.config?.value) ?? null;
   }
 
-  public override setValue(value: DateInputModelValueType): void {
+  public override setValue(value: DateInputModelValueType, opts?: ModifyOptions): void {
     const normalizedValue = normalizeDateInputValue(value);
-    super.setValue((normalizedValue ?? value) as DateInputModelValueType);
+    super.setValue((normalizedValue ?? value) as DateInputModelValueType, opts);
   }
 
   public override patchValue(value: DateInputModelValueType): void {
@@ -73,17 +73,12 @@ export class DateInputModel extends FormFieldModel<DateInputModelValueType> {
     super.patchValue((normalizedValue ?? value) as DateInputModelValueType);
   }
 
-  public override setValueDontEmitEvent(value: DateInputModelValueType): void {
-    const normalizedValue = normalizeDateInputValue(value);
-    super.setValueDontEmitEvent((normalizedValue ?? value) as DateInputModelValueType);
-  }
-
   public setTimeValue(timeValue: string): void {
     if(this.enableTimePicker) {
       //TODO: Implementation of time input requires more work to handle timezones properly and this will be done in a later PR if/when required
       let isoDts:string = `${this.stripTimeFromJSDate(this.formControl?.value as Date)}T${timeValue}:00.000Z`;
       let jsDate = DateTime.fromISO(isoDts).toJSDate();
-      this.setValueDontEmitEvent(jsDate);
+      this.setValue(jsDate, {emitEvent: false});
     }
   }
 

--- a/angular/projects/researchdatabox/form/src/app/component/date-input.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/date-input.component.ts
@@ -68,9 +68,9 @@ export class DateInputModel extends FormFieldModel<DateInputModelValueType> {
     super.setValue((normalizedValue ?? value) as DateInputModelValueType, opts);
   }
 
-  public override patchValue(value: DateInputModelValueType): void {
+  public override patchValue(value: DateInputModelValueType, opts?: ModifyOptions): void {
     const normalizedValue = normalizeDateInputValue(value);
-    super.patchValue((normalizedValue ?? value) as DateInputModelValueType);
+    super.patchValue((normalizedValue ?? value) as DateInputModelValueType, opts);
   }
 
   public setTimeValue(timeValue: string): void {

--- a/angular/projects/researchdatabox/form/src/app/component/repeatable.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/repeatable.component.ts
@@ -1,6 +1,6 @@
 import { Component, ComponentRef, inject, ViewChild, ViewContainerRef, TemplateRef } from '@angular/core';
 import { FormArray, AbstractControl } from '@angular/forms';
-import { FormFieldBaseComponent, FormFieldModel, FormFieldCompMapEntry } from '@researchdatabox/portal-ng-common';
+import { FormFieldBaseComponent, FormFieldModel, FormFieldCompMapEntry, ModifyOptions } from '@researchdatabox/portal-ng-common';
 import {
   ContentComponentName,
   FormConfigFrame,
@@ -19,7 +19,7 @@ import { createFormDefinitionChangeRequestEvent, createFormStatusDirtyRequestEve
 import { CustomSetValueControl } from '../form-state/custom-set-value.control';
 import {FormComponent} from "../form.component";
 
-type RepeatableSetValueOptions = { emitEvent?: boolean; onlySelf?: boolean };
+type RepeatableSetValueOptions = ModifyOptions;
 
 class RepeatableFormArray
   extends FormArray<AbstractControl<unknown>>

--- a/angular/projects/researchdatabox/form/src/app/component/simple-input.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/simple-input.component.spec.ts
@@ -108,4 +108,47 @@ describe('SimpleInputComponent', () => {
     expect(inputComp?.showValidState).toBeTrue();
   });
 
+  it('should be possible to disable the form control', async () => {
+    const formConfig: FormConfigFrame = {
+      name: 'testing',
+      debugValue: true,
+      defaultComponentConfig: {
+        defaultComponentCssClasses: 'row',
+      },
+      editCssClasses: "redbox-form form",
+      componentDefinitions: [
+        {
+          name: 'text_1',
+          model: {class: 'SimpleInputModel', config: {value: 'valid value'}},
+          component: {class: 'SimpleInputComponent', config: {}}
+        }
+      ]
+    };
+
+    const {fixture, formComponent} = await createFormAndWaitForReady(formConfig);
+    const inputComp = formComponent.componentDefArr[0]?.component as SimpleInputComponent | undefined;
+    expect(inputComp?.isDisabled).toBeFalse();
+    expect(formComponent.form?.value).toEqual({text_1: 'valid value'});
+
+    inputComp?.setDisabled(true, {onlySelf: true});
+
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(inputComp?.isDisabled).toBeTrue();
+    expect(formComponent.form?.controls['text_1']?.disabled).toEqual(true);
+    expect(formComponent.form?.controls['text_1']).toEqual(inputComp?.model?.formControl);
+
+    // The form by default would be disabled when all the controls in the form are disabled.
+    // However, by passing 'onlySelf: true', the form remains enabled.
+    expect(formComponent.form?.disabled).toBeFalse();
+    // TODO: We expect the form value to not include the value for the disabled control, but 'text_1' is still present.
+    //       This is because if all a control's nested controls are disabled, then all the control values are included.
+    //       This is the case regardless of whether the parent control itself is disabled or enabled.
+    // expect(formComponent.form?.value).toEqual({});
+
+    inputComp?.setDisabled(false);
+    expect(inputComp?.isDisabled).toBeFalse();
+    expect(formComponent.form?.value).toEqual({text_1: 'valid value'});
+  });
 });

--- a/angular/projects/researchdatabox/form/src/app/form-state/custom-set-value.control.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/custom-set-value.control.ts
@@ -1,8 +1,9 @@
 import { AbstractControl } from '@angular/forms';
 import {FormValidationGroupsChangeRequestEvent} from "./events";
+import {ModifyOptions} from "@researchdatabox/portal-ng-common";
 import {guessType} from "@researchdatabox/sails-ng-common";
 
-export type ControlSetValueOptions = { emitEvent?: boolean; onlySelf?: boolean };
+export type ControlSetValueOptions = ModifyOptions;
 
 export interface CustomSetValueControl<ValueType = unknown> {
   setCustomValue(value: ValueType, options?: ControlSetValueOptions): Promise<void> | void;

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
@@ -377,17 +377,11 @@ export abstract class FormComponentEventBaseConsumer extends FormComponentEventB
         await syncComponentDisplayFromModel(this.options?.component);
       }
     } else if (exprTarget.startsWith(FormExpressionsTargetLayoutPrefix)) {
-      const layoutPath = exprTarget.substring(FormExpressionsTargetLayoutPrefix.length);
-      const container = this.options?.definition?.layout?.componentDefinition?.config;
-      if (container) {
-        _set(container, layoutPath, targetValue);
-      }
+      const propPath = exprTarget.substring(FormExpressionsTargetLayoutPrefix.length);
+      await this.setTargetComponentProp(targetValue, propPath, "layout");
     } else if (exprTarget.startsWith(FormExpressionsTargetComponentPrefix)) {
-      const componentPath = exprTarget.substring(FormExpressionsTargetComponentPrefix.length);
-      const container = this.options?.definition?.component?.componentDefinition?.config;
-      if (container) {
-        _set(container, componentPath, targetValue);
-      }
+      const propPath = exprTarget.substring(FormExpressionsTargetComponentPrefix.length);
+      await this.setTargetComponentProp(targetValue, propPath, "component");
     } else if (exprTarget === FormExpressionsTargetValidationGroups) {
       if (isTypeFormValidationGroupsChangeRequestInfo(targetValue)) {
         // Only publish an event in response to scoped change events, don't need to respond to the broadcast events.
@@ -412,6 +406,39 @@ export abstract class FormComponentEventBaseConsumer extends FormComponentEventB
         expression
       );
     }
+
+  }
+
+  protected async setTargetComponentProp(
+    targetValue: unknown, propPath: string, targetKind: "component" | "layout"
+  ) {
+
+    if (targetKind === "component" && propPath !== 'disabled') {
+      const config = this.options?.definition?.component?.componentDefinition?.config;
+      if (config && propPath) {
+        _set(config, propPath, targetValue);
+      }
+      return;
+    }
+
+    if (targetKind === "layout" && propPath !== 'disabled') {
+      const config = this.options?.definition?.layout?.componentDefinition?.config;
+      if (config && propPath) {
+        _set(config, propPath, targetValue);
+      }
+    }
+
+    if (propPath === 'disabled' && typeof targetValue === 'boolean') {
+      const component = this.options?.component;
+      if (component) {
+        component.setDisabled(targetValue);
+      }
+      return;
+    }
+
+    this.loggerService.warn(
+      `FormComponentBaseEventConsumer: Unknown target ${targetKind} property path '${propPath}' value '${targetValue}' in expression config.`
+    );
   }
 
   /**

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
@@ -11,7 +11,7 @@ import {
   ExpressionsConditionKind,
   ExpressionsConditionKindType,
   FormExpressionsTargetModelValue, FormExpressionsTargetLayoutPrefix, FormExpressionsTargetComponentPrefix,
-  FormExpressionsTargetValidationGroups, DynamicScriptResponse,
+  FormExpressionsTargetValidationGroups, DynamicScriptResponse, guessType,
 } from '@researchdatabox/sails-ng-common';
 import jsonata from 'jsonata';
 import { isEmpty as _isEmpty, set as _set } from 'lodash-es';
@@ -413,6 +413,7 @@ export abstract class FormComponentEventBaseConsumer extends FormComponentEventB
     targetValue: unknown, propPath: string, targetKind: "component" | "layout"
   ) {
 
+    // For a component, all config properties except 'disabled' can be set directly.
     if (targetKind === "component" && propPath !== 'disabled') {
       const config = this.options?.definition?.component?.componentDefinition?.config;
       if (config && propPath) {
@@ -421,14 +422,8 @@ export abstract class FormComponentEventBaseConsumer extends FormComponentEventB
       return;
     }
 
-    if (targetKind === "layout" && propPath !== 'disabled') {
-      const config = this.options?.definition?.layout?.componentDefinition?.config;
-      if (config && propPath) {
-        _set(config, propPath, targetValue);
-      }
-    }
-
-    if (propPath === 'disabled' && typeof targetValue === 'boolean') {
+    // For a component, the disabled property must be handled specially to satisfy angular.
+    if (targetKind === "component" && propPath === 'disabled' && typeof targetValue === 'boolean') {
       const component = this.options?.component;
       if (component) {
         component.setDisabled(targetValue);
@@ -436,8 +431,17 @@ export abstract class FormComponentEventBaseConsumer extends FormComponentEventB
       return;
     }
 
+    // For a layout, there is no need for specific handling of the 'disabled' property.
+    // This is because the 'disabled' property has no general meaning and is specific to each layout.
+    if (targetKind === "layout") {
+      const config = this.options?.definition?.layout?.componentDefinition?.config;
+      if (config && propPath) {
+        _set(config, propPath, targetValue);
+      }
+    }
+
     this.loggerService.warn(
-      `FormComponentBaseEventConsumer: Unknown target ${targetKind} property path '${propPath}' value '${targetValue}' in expression config.`
+      `FormComponentBaseEventConsumer: Don't know what to do with target '${targetKind}' property path '${propPath}' value '${targetValue}' (type ${guessType(targetValue)}) in expression config.`
     );
   }
 

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
@@ -11,7 +11,7 @@ import {
   ExpressionsConditionKind,
   ExpressionsConditionKindType,
   FormExpressionsTargetModelValue, FormExpressionsTargetLayoutPrefix, FormExpressionsTargetComponentPrefix,
-  FormExpressionsTargetValidationGroups, DynamicScriptResponse, guessType,
+  FormExpressionsTargetValidationGroups, DynamicScriptResponse, guessType, toBoolean,
 } from '@researchdatabox/sails-ng-common';
 import jsonata from 'jsonata';
 import { isEmpty as _isEmpty, set as _set } from 'lodash-es';
@@ -423,10 +423,10 @@ export abstract class FormComponentEventBaseConsumer extends FormComponentEventB
     }
 
     // For a component, the disabled property must be handled specially to satisfy angular.
-    if (targetKind === "component" && propPath === 'disabled' && typeof targetValue === 'boolean') {
+    if (targetKind === "component" && propPath === 'disabled') {
       const component = this.options?.component;
       if (component) {
-        component.setDisabled(targetValue);
+        component.setDisabled(toBoolean(targetValue));
       }
       return;
     }

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
@@ -438,6 +438,7 @@ export abstract class FormComponentEventBaseConsumer extends FormComponentEventB
       if (config && propPath) {
         _set(config, propPath, targetValue);
       }
+      return;
     }
 
     this.loggerService.warn(

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-change-event-consumer.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-change-event-consumer.spec.ts
@@ -223,7 +223,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
     const expr: FormExpressionsConfigFrame = {
       name: 'layout-update',
       config: {
-        target: 'layout.someProp',
+        target: 'layout.disabled',
         condition: 'otherField',
         template: ''
       }
@@ -246,7 +246,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
     tick();
 
     const config = definition.layout?.componentDefinition?.config as Record<string, unknown>;
-    expect(config['someProp']).toBe('red');
+    expect(config['disabled']).toBe('red');
   }));
 
   it('should update component config when target starts with "component."', fakeAsync(() => {
@@ -277,6 +277,37 @@ describe('FormComponentValueChangeEventConsumer', () => {
 
     const config = definition.component?.componentDefinition?.config as Record<string, unknown>;
     expect(config['someSetting']).toBe('enabled');
+  }));
+
+  it('should update component config and formControl.disabled when target is "component.disabled"', fakeAsync(() => {
+    const expr: FormExpressionsConfigFrame = {
+      name: 'component-update',
+      config: {
+        target: 'component.disabled',
+        condition: 'otherField',
+        template: ''
+      }
+    };
+    const { control, definition, component } = createSetup([expr]);
+
+    spyOn<any>(consumer, 'getMatchedExpressions').and.returnValue(Promise.resolve([expr]));
+
+    consumer.bind({ component, definition });
+
+    const event: FieldValueChangedEvent = {
+      type: 'field.value.changed',
+      fieldId: 'otherField',
+      sourceId: 'otherField',
+      value: 'enabled',
+      timestamp: Date.now()
+    };
+
+    eventStream$.next(event);
+    tick();
+
+    const config = definition.component?.componentDefinition?.config as Record<string, unknown>;
+    expect(config['disabled']).toBe(true);
+    expect(control.disabled).toBe(true);
   }));
 
   it('should use template evaluation when hasTemplate is true', fakeAsync(() => {

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-change-event-consumer.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-change-event-consumer.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { FormControl } from '@angular/forms';
-import { FormFieldBaseComponent, FormFieldCompMapEntry, LoggerService } from '@researchdatabox/portal-ng-common';
+import { FormFieldBaseComponent, FormFieldCompMapEntry, LoggerService, ModifyOptions } from '@researchdatabox/portal-ng-common';
 import { FormComponentEventBus } from './form-component-event-bus.service';
 import { FormComponentValueChangeEventConsumer } from './form-component-change-event-consumer';
 import {
@@ -29,7 +29,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
     eventStream$ = new Subject();
     eventBus = jasmine.createSpyObj<FormComponentEventBus>('FormComponentEventBus', ['select$']);
     eventBus.select$.and.returnValue(eventStream$.asObservable());
-    
+
     consumer = TestBed.runInInjectionContext(() => new FormComponentValueChangeEventConsumer(eventBus));
   });
 
@@ -39,20 +39,32 @@ describe('FormComponentValueChangeEventConsumer', () => {
 
   function createSetup(expressions: FormExpressionsConfigFrame[]) {
     const control = new FormControl('');
-    const definition = {
-      model: { formControl: control },
-      expressions: expressions,
-      lineagePaths: { formConfig: ['root'] },
-      layout: { componentDefinition: { config: {} } },
-      component: { componentDefinition: { config: {} } }
-    } as unknown as FormFieldCompMapEntry;
-    
     const component = {
       formFieldConfigName: () => 'test-field',
-      model: { formControl: control }
+      model: {formControl: control},
+      componentDefinition: {config: {}},
+      setDisabled: function (
+        this: FormFieldBaseComponent<unknown>, disabled: boolean, opts?: ModifyOptions
+      ): void {
+        if (disabled) {
+          this.model?.formControl?.disable(opts);
+        } else {
+          this.model?.formControl?.enable(opts);
+        }
+        if (this?.componentDefinition?.config) {
+          this.componentDefinition.config.disabled = disabled;
+        }
+      }
     } as unknown as FormFieldBaseComponent<unknown>;
+    const definition = {
+      model: {formControl: control},
+      expressions: expressions,
+      lineagePaths: {formConfig: ['root']},
+      layout: {componentDefinition: {config: {}}},
+      component: component,
+    } as unknown as FormFieldCompMapEntry;
 
-    return { control, definition, component };
+    return {control, definition, component};
   }
 
   it('should subscribe to FIELD_VALUE_CHANGED events when bound', () => {
@@ -545,7 +557,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
     };
 
     const matched = await (consumer as any).getMatchedExpressions(event, [exprUndefined, exprNull]);
-    
+
     expect(matched).toBeTruthy();
     expect(matched.length).toBe(2);
     expect(matched).toContain(exprUndefined);
@@ -568,7 +580,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
 
     // Subsequent events should not be processed
     spyOn<any>(consumer, 'consumeEvent');
-    
+
     const event: FieldValueChangedEvent = {
       type: 'field.value.changed',
       fieldId: 'otherField',

--- a/angular/projects/researchdatabox/form/src/app/form.service.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.service.ts
@@ -41,7 +41,7 @@ import {
   FormFieldModel,
   HttpClientService,
   JSONataClientQuerySourceProperty,
-  LoggerService,
+  LoggerService, ModifyOptions,
   TranslationService,
   UtilityService
 } from '@researchdatabox/portal-ng-common';
@@ -566,7 +566,7 @@ export class FormService extends HttpClientService {
     validators?: FormValidatorConfig[] | null,
     enabledValidationGroups?: string[] | null,
     validationGroups?: FormValidationGroups | null,
-    updateValueAndValidityOpts?: { doUpdate?: boolean, onlySelf?: boolean, emitEvent?: boolean },
+    updateValueAndValidityOpts?: { doUpdate?: boolean } & ModifyOptions,
   ): void {
     if (!formControl) {
       this.loggerService.warn(`${this.logName}: Cannot set validators because formControl was not provided.`);
@@ -589,10 +589,12 @@ export class FormService extends HttpClientService {
     const enabledValidators = this.validatorsSupport.enabledValidators(availableGroups, enabledValidationGroups, validators);
     const validatorFns = this.validatorsSupport.createFormValidatorInstancesFromMapping(defMap, enabledValidators) ?? [];
 
+    // For debugging:
+    // this.loggerService.debug(`${this.logName}: setting validators to formControl`,
+    //   {definedValidators: validators, enabledValidators, formControlValue: formControl.value});
+
     // Set validators to the form control.
     // This may setValidators with an empty array - that is ok, and is necessary to remove existing validators.
-    this.loggerService.debug(`${this.logName}: setting validators to formControl`,
-      {definedValidators: validators, enabledValidators, formControlValue: formControl.value});
     formControl.setValidators(validatorFns);
     if (updateValueAndValidityOpts?.doUpdate !== false) {
       // TODO: Store the first created validator functions per formControl, and use that in .hasValidator.
@@ -942,7 +944,8 @@ export class FormService extends HttpClientService {
       }
     }
 
-    this.loggerService.debug(`${this.logName}: Calculated validation groups ${JSON.stringify(enabledNames)} from currentValidationGroups ${JSON.stringify(currentValidationGroups)} validationGroups ${JSON.stringify(validationGroups)} initial ${initial} groups ${JSON.stringify(groups)}`);
+    // For debugging:
+    // this.loggerService.debug(`${this.logName}: Calculated validation groups ${JSON.stringify(enabledNames)} from currentValidationGroups ${JSON.stringify(currentValidationGroups)} validationGroups ${JSON.stringify(validationGroups)} initial ${initial} groups ${JSON.stringify(groups)}`);
 
     return enabledNames;
   }

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/form/base.model.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/form/base.model.ts
@@ -170,7 +170,7 @@ export class FormFieldModel<ValueType> extends FormModel<ValueType, FieldModelDe
    * @param disabled Set the disabled status.
    * @param opts The modify options.
    */
-  public setDisabled(disabled: boolean, opts?: ModifyOptions) {
+  public setDisabled(disabled: boolean, opts?: ModifyOptions): void {
     const isDisabled = this.formControl?.disabled;
     if (isDisabled === undefined) {
       return;

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/form/base.model.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/form/base.model.ts
@@ -2,6 +2,26 @@ import {cloneDeep as _cloneDeep} from 'lodash-es';
 import {AbstractControl, FormControl} from '@angular/forms';
 import {FieldModelDefinitionFrame, FormValidatorConfig, guessType} from "@researchdatabox/sails-ng-common";
 
+
+/**
+ * Common angular modify options.
+ */
+export type ModifyOptions = {
+  /**
+   * When true or not supplied the statusChanges, valueChanges and events observables
+   * emit events with the latest status and value when the control is updated.
+   * When false, no events are emitted.
+   *
+   * Default true.
+   */
+  emitEvent?: boolean,
+  /**
+   * When true, mark only this control.
+   * When false or not supplied, marks all direct ancestors. Default is false.
+   */
+  onlySelf?: boolean
+};
+
 /**
  * Core model for form elements.
  */
@@ -117,14 +137,6 @@ export class FormFieldModel<ValueType> extends FormModel<ValueType, FieldModelDe
   }
 
   /**
-   * Set the value of the field
-   * @param value the value to set
-   */
-  public setValueDontEmitEvent(value: ValueType): void {
-    this.formControl?.setValue(value, { emitEvent: false });
-  }
-
-  /**
    * Primitive implementation returns the form control.
    * Complex implementations should override this method to create complex form controls.
    * @returns the form control
@@ -137,8 +149,35 @@ export class FormFieldModel<ValueType> extends FormModel<ValueType, FieldModelDe
     }
   }
 
+  /**
+   * Get all the validators initially set on this model.
+   */
   get validators(): FormValidatorConfig[] {
     return this.initConfig?.config?.validators ?? [];
+  }
+
+  /**
+   * True if this model is disabled, false if enabled.
+   */
+  public isDisabled(): boolean {
+    return this.formControl?.disabled ?? false;
+  }
+
+  /**
+   * Set this model to be disabled or enabled.
+   * @param disabled Set the disabled status.
+   * @param opts The modify options.
+   */
+  public setDisabled(disabled: boolean, opts?: ModifyOptions) {
+    const isDisabled = this.formControl?.disabled;
+    if (isDisabled === undefined) {
+      return;
+    }
+    if (!disabled && isDisabled) {
+      this.formControl?.enable(opts);
+    } else if (disabled && !isDisabled) {
+      this.formControl?.disable(opts);
+    }
   }
 }
 

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/form/base.model.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/form/base.model.ts
@@ -103,8 +103,9 @@ export class FormFieldModel<ValueType> extends FormModel<ValueType, FieldModelDe
   /**
    * Set the value of the field
    * @param value the value to set
+   * @param opts The modify options.
    */
-  public setValue(value: ValueType): void {
+  public setValue(value: ValueType, opts?: ModifyOptions): void {
     // NOTE: There are some form configs or form modes that will throw an error when setting the value.
     // This can occur when a repeatable (FormArray) or group (FormGroup) component has no controls that have a model.
     // Use the 'controls' property to check if there are any controls before trying to set the value.
@@ -125,15 +126,16 @@ export class FormFieldModel<ValueType> extends FormModel<ValueType, FieldModelDe
       }
     }
 
-    this.formControl?.setValue(value);
+    this.formControl?.setValue(value, opts);
   }
 
   /**
    * Set the value of the field if it is provided in value, otherwise keeps the existing value.
    * @param value The new form field value.
+   * @param opts The modify options.
    */
-  public patchValue(value: ValueType): void {
-    this.formControl?.patchValue(value);
+  public patchValue(value: ValueType, opts?: ModifyOptions): void {
+    this.formControl?.patchValue(value, opts);
   }
 
   /**

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/form/base.model.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/form/base.model.ts
@@ -161,7 +161,7 @@ export class FormFieldModel<ValueType> extends FormModel<ValueType, FieldModelDe
   /**
    * True if this model is disabled, false if enabled.
    */
-  public isDisabled(): boolean {
+  public get isDisabled(): boolean {
     return this.formControl?.disabled ?? false;
   }
 

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/form/form-field-base.component.spec.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/form/form-field-base.component.spec.ts
@@ -1,14 +1,20 @@
-import { TestBed } from '@angular/core/testing';
-import { FormFieldComponentStatus } from '@researchdatabox/sails-ng-common';
-import { LoggerService } from '../logger.service';
-import { UtilityService } from '../utility.service';
-import { FormFieldBaseComponent } from './form-field-base.component';
+import {TestBed} from '@angular/core/testing';
+import {FormFieldComponentStatus} from '@researchdatabox/sails-ng-common';
+import {LoggerService} from '../logger.service';
+import {UtilityService} from '../utility.service';
+import {FormFieldBaseComponent} from './form-field-base.component';
+import {FormFieldModel} from "./base.model";
 
 class TestFormFieldBaseComponent extends FormFieldBaseComponent<unknown> {
   public waitForViewReady(): Promise<void> {
     return this.untilViewIsInitialised();
   }
 }
+
+class TestFormFieldModel extends FormFieldModel<unknown> {
+  protected override logName = "TestFormFieldModel";
+}
+
 
 describe('FormFieldBaseComponent', () => {
   let component: TestFormFieldBaseComponent;
@@ -40,5 +46,21 @@ describe('FormFieldBaseComponent', () => {
     } finally {
       jasmine.clock().uninstall();
     }
+  });
+  it('should set formControl to disabled', async () => {
+    await component.initComponent({
+      modelClass: TestFormFieldModel,
+      model: new TestFormFieldModel({class: "SimpleInputModel"}),
+      compConfigJson: {
+        name: "testing-component-model-disabled",
+        component: {class: "SimpleInputComponent", config: {}}
+      }
+    });
+    expect(component.isDisabled).toBeFalse();
+
+    component.setDisabled(true);
+    expect(component.isDisabled).toBeTrue();
+
+    expect(component.model?.isDisabled).toBeTrue();
   });
 });

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/form/form-field-base.component.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/form/form-field-base.component.ts
@@ -6,28 +6,21 @@ import {
   EffectRef, Injector, ApplicationRef
 } from '@angular/core';
 import { LoggerService } from '../logger.service';
-import {  isEmpty as _isEmpty } from 'lodash-es';
+import {  isEmpty as _isEmpty, get as _get } from 'lodash-es';
 import { UtilityService } from "../utility.service";
 import {
   FormComponentDefinitionFrame,
-  FieldComponentDefinitionFrame,
-  FieldLayoutDefinitionFrame,
   FormFieldComponentStatus,
   LineagePaths,
   JSONataQuerySourceProperty,
   FormExpressionsConfigOutline,
-  ExtractPropertyNamesOfType
+  FormFieldComponentOrLayoutDefinition,
 } from '@researchdatabox/sails-ng-common';
 
-export type FormFieldComponentOrLayoutDefinition = FieldComponentDefinitionFrame | FieldLayoutDefinitionFrame;
-export type FormFieldComponentOrLayoutConfig = NonNullable<FormFieldComponentOrLayoutDefinition['config']>;
 export interface FormFieldFocusRequestOptions {
   scroll?: boolean;
   scrollOptions?: ScrollIntoViewOptions;
 }
-type FormFieldComponentOrLayoutStringKeys = NonNullable<ExtractPropertyNamesOfType<FormFieldComponentOrLayoutConfig, string | undefined>>;
-type FormFieldComponentOrLayoutBooleanKeys = NonNullable<ExtractPropertyNamesOfType<FormFieldComponentOrLayoutConfig, boolean | undefined>>;
-
 
 /**
  * Base class for form components. Data binding to a form field is optional.
@@ -133,12 +126,12 @@ export class FormFieldBaseComponent<ValueType> implements AfterViewInit {
     return this.status() === FormFieldComponentStatus.INIT_VIEW_READY || this.status() === FormFieldComponentStatus.READY;
   }
 
-  public getBooleanProperty(name: FormFieldComponentOrLayoutBooleanKeys, defaultValue: boolean): boolean {
-    return this.componentDefinition?.config?.[name] ?? defaultValue;
+  public getBooleanProperty(name: string, defaultValue: boolean): boolean {
+    return _get(this.componentDefinition?.config, name, defaultValue);
   }
 
-  public getStringProperty(name: FormFieldComponentOrLayoutStringKeys) {
-    return this.componentDefinition?.config?.[name] ?? '';
+  public getStringProperty(name: string): string {
+    return _get(this.componentDefinition?.config, name, '');
   }
 
   get isVisible(): boolean {

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/form/form-field-base.component.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/form/form-field-base.component.ts
@@ -148,7 +148,7 @@ export class FormFieldBaseComponent<ValueType> implements AfterViewInit {
    * NOTE: Do not use isDisabled for HTML elements that are associated with an angular formControl (e.g. [disabled]="isDisabled").
    *       The formControl sets the disabled state on the HTML element DOM.
    */
-  get isDisabled(): boolean {
+  public get isDisabled(): boolean {
     return this.componentDefinition?.config?.disabled ?? false;
   }
 

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/form/form-field-base.component.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/form/form-field-base.component.ts
@@ -164,10 +164,12 @@ export class FormFieldBaseComponent<ValueType> implements AfterViewInit {
       if (this.componentDefinition?.config) {
         this.componentDefinition.config.disabled = disabled;
       }
-    } catch {
+    } catch (error) {
       if (this.componentDefinition?.config) {
         this.componentDefinition.config.disabled = current;
       }
+      this.loggerService.error(
+        `Could not set model disabled state with value ${disabled} and opts ${opts}.`, error);
     }
   }
 

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/form/form-field-base.component.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/form/form-field-base.component.ts
@@ -1,4 +1,4 @@
-import { FormFieldModel } from './base.model';
+import {FormFieldModel, ModifyOptions} from './base.model';
 import { FormControl } from '@angular/forms';
 import {
   Directive, HostBinding, ViewChild, signal, inject, TemplateRef,
@@ -6,26 +6,28 @@ import {
   EffectRef, Injector, ApplicationRef
 } from '@angular/core';
 import { LoggerService } from '../logger.service';
-import { get as _get,  isEmpty as _isEmpty } from 'lodash-es';
+import {  isEmpty as _isEmpty } from 'lodash-es';
 import { UtilityService } from "../utility.service";
 import {
   FormComponentDefinitionFrame,
-  FieldComponentConfigFrame,
   FieldComponentDefinitionFrame,
   FieldLayoutDefinitionFrame,
-  FieldLayoutConfigFrame,
   FormFieldComponentStatus,
   LineagePaths,
   JSONataQuerySourceProperty,
-  FormExpressionsConfigOutline
+  FormExpressionsConfigOutline,
+  ExtractPropertyNamesOfType
 } from '@researchdatabox/sails-ng-common';
 
 export type FormFieldComponentOrLayoutDefinition = FieldComponentDefinitionFrame | FieldLayoutDefinitionFrame;
-export type FormFieldComponentOrLayoutConfig = FieldComponentConfigFrame | FieldLayoutConfigFrame;
+export type FormFieldComponentOrLayoutConfig = NonNullable<FormFieldComponentOrLayoutDefinition['config']>;
 export interface FormFieldFocusRequestOptions {
   scroll?: boolean;
   scrollOptions?: ScrollIntoViewOptions;
 }
+type FormFieldComponentOrLayoutStringKeys = NonNullable<ExtractPropertyNamesOfType<FormFieldComponentOrLayoutConfig, string | undefined>>;
+type FormFieldComponentOrLayoutBooleanKeys = NonNullable<ExtractPropertyNamesOfType<FormFieldComponentOrLayoutConfig, boolean | undefined>>;
+
 
 /**
  * Base class for form components. Data binding to a form field is optional.
@@ -131,12 +133,12 @@ export class FormFieldBaseComponent<ValueType> implements AfterViewInit {
     return this.status() === FormFieldComponentStatus.INIT_VIEW_READY || this.status() === FormFieldComponentStatus.READY;
   }
 
-  public getBooleanProperty(name: string, defaultValue: boolean): boolean {
-    return _get(this.componentDefinition?.config, name, defaultValue);
+  public getBooleanProperty(name: FormFieldComponentOrLayoutBooleanKeys, defaultValue: boolean): boolean {
+    return this.componentDefinition?.config?.[name] ?? defaultValue;
   }
 
-  public getStringProperty(name: string) {
-    return _get(this.componentDefinition?.config, name, '');
+  public getStringProperty(name: FormFieldComponentOrLayoutStringKeys) {
+    return this.componentDefinition?.config?.[name] ?? '';
   }
 
   get isVisible(): boolean {
@@ -147,12 +149,37 @@ export class FormFieldBaseComponent<ValueType> implements AfterViewInit {
     return this.componentDefinition?.config?.readonly ?? false;
   }
 
+  /**
+   * Get whether this component is disabled or not.
+   *
+   * NOTE: Do not use isDisabled for HTML elements that are associated with an angular formControl (e.g. [disabled]="isDisabled").
+   *       The formControl sets the disabled state on the HTML element DOM.
+   */
   get isDisabled(): boolean {
     return this.componentDefinition?.config?.disabled ?? false;
   }
 
+  /**
+   * Set this component to be disabled or enabled.
+   * @param disabled True for disabled, false for enabled.
+   * @param opts The modify options.
+   */
+  public setDisabled(disabled: boolean, opts?: ModifyOptions) {
+    const current = this.isDisabled;
+    try {
+      this.model?.setDisabled(disabled, opts);
+      if (this.componentDefinition?.config) {
+        this.componentDefinition.config.disabled = disabled;
+      }
+    } catch {
+      if (this.componentDefinition?.config) {
+        this.componentDefinition.config.disabled = current;
+      }
+    }
+  }
+
   get label(): string {
-    return _get(this.componentDefinition?.config, 'label', '');
+    return this.componentDefinition?.config?.label ?? '';
   }
 
   /**

--- a/packages/redbox-core/src/services/VocabService.ts
+++ b/packages/redbox-core/src/services/VocabService.ts
@@ -24,6 +24,7 @@ import { VocabQueryConfig } from '../model/config/VocabQueryConfig';
 import { BrandingModel } from '../model/storage/BrandingModel';
 import { Services as services } from '../CoreService';
 import axios, { AxiosResponse } from 'axios';
+import {toBoolean} from "@researchdatabox/sails-ng-common";
 
 
 export namespace Services {
@@ -384,19 +385,8 @@ export namespace Services {
         uri: String(entry.identifier ?? entry.value ?? ''),
         notation: String(entry.value ?? ''),
         label: String(entry.label ?? ''),
-        historical: this.toBoolean(entry.historical)
+        historical: toBoolean(entry.historical)
       }));
-    }
-
-    private toBoolean(value: unknown): boolean {
-      if (typeof value === 'boolean') {
-        return value;
-      }
-      if (typeof value === 'number') {
-        return value !== 0;
-      }
-      const normalized = String(value ?? '').trim().toLowerCase();
-      return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on';
     }
 
     // have to do this since ANDS endpoint ignores _pageSize

--- a/packages/redbox-core/src/services/VocabularyService.ts
+++ b/packages/redbox-core/src/services/VocabularyService.ts
@@ -3,6 +3,7 @@ import { VocabularyAttributes, VocabularyEntryAttributes } from '../waterline-mo
 import { runWithOptionalTransaction } from '../utilities/TransactionUtils';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import {toBoolean} from "@researchdatabox/sails-ng-common";
 
 export namespace Services {
   type VocabType = 'flat' | 'tree';
@@ -189,17 +190,6 @@ export namespace Services {
       }
 
       return brandingString;
-    }
-
-    private toBoolean(value: unknown): boolean {
-      if (typeof value === 'boolean') {
-        return value;
-      }
-      if (typeof value === 'number') {
-        return value !== 0;
-      }
-      const normalized = String(value ?? '').trim().toLowerCase();
-      return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on';
     }
 
     public async list(options: VocabularyListOptions): Promise<{ data: VocabularyAttributes[]; meta: { total: number; limit: number; offset: number } }> {
@@ -577,7 +567,7 @@ export namespace Services {
         ...entry,
         label: String(entry.label ?? '').trim(),
         value: String(entry.value ?? '').trim(),
-        historical: this.toBoolean(entry.historical)
+        historical: toBoolean(entry.historical)
       };
     }
 
@@ -899,7 +889,7 @@ export namespace Services {
         label: String(entry.label ?? '').trim(),
         value: String(entry.value ?? '').trim(),
         order: typeof entry.order === 'number' ? entry.order : index,
-        historical: typeof entry.historical === 'undefined' ? false : this.toBoolean(entry.historical)
+        historical: typeof entry.historical === 'undefined' ? false : toBoolean(entry.historical)
       };
 
       if (typeof entry.identifier === 'string' && entry.identifier.trim()) {

--- a/packages/redbox-core/src/waterline-models/VocabularyEntry.ts
+++ b/packages/redbox-core/src/waterline-models/VocabularyEntry.ts
@@ -10,6 +10,7 @@ import {
   toWaterlineModelDef
 } from '../decorators';
 import type { VocabularyAttributes } from './Vocabulary';
+import {toBoolean} from "@researchdatabox/sails-ng-common";
 
 const normalize = (record: Record<string, unknown>, isCreate: boolean): void => {
   // On create, the record.label must be present and be a non-empty string.
@@ -44,17 +45,6 @@ const normalize = (record: Record<string, unknown>, isCreate: boolean): void => 
   if (Object.hasOwn(record, 'historical')) {
     record.historical = toBoolean(record.historical);
   }
-};
-
-const toBoolean = (value: unknown): boolean => {
-  if (typeof value === 'boolean') {
-    return value;
-  }
-  if (typeof value === 'number') {
-    return value !== 0;
-  }
-  const normalized = String(value ?? '').trim().toLowerCase();
-  return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on';
 };
 
 const validateParent = async (record: Record<string, unknown>): Promise<void> => {

--- a/packages/sails-ng-common/src/config/dictionary.outline.ts
+++ b/packages/sails-ng-common/src/config/dictionary.outline.ts
@@ -8,11 +8,7 @@ import { SaveButtonTypes } from './component/save-button.outline';
 import { SaveStatusTypes } from './component/save-status.outline';
 import { TextAreaTypes } from './component/text-area.outline';
 import { ContentTypes } from './component/content.outline';
-import {
-  SimpleInputFormComponentDefinitionFrame,
-  SimpleInputFormComponentDefinitionOutline,
-  SimpleInputTypes,
-} from './component/simple-input.outline';
+import { SimpleInputTypes} from './component/simple-input.outline';
 import { ValidationSummaryTypes } from './component/validation-summary.outline';
 import {
   TabContentFormComponentDefinitionOutline,
@@ -26,28 +22,17 @@ import { InlineLayoutTypes } from './component/inline-layout.outline';
 import { ActionRowLayoutTypes } from './component/action-row-layout.outline';
 
 import {
+  FieldComponentDefinitionFrameKindType,
   FieldLayoutDefinitionFrameKindType,
   FieldLayoutDefinitionKindType,
   FormComponentDefinitionFrameKindType,
   FormComponentDefinitionKindType,
 } from './shared.outline';
-import {
-  CheckboxInputFormComponentDefinitionFrame,
-  CheckboxInputFormComponentDefinitionOutline,
-  CheckboxInputTypes,
-} from './component/checkbox-input.outline';
+import {  CheckboxInputTypes} from './component/checkbox-input.outline';
 import { DropdownInputTypes } from './component/dropdown-input.outline';
-import {
-  RadioInputFormComponentDefinitionFrame,
-  RadioInputFormComponentDefinitionOutline,
-  RadioInputTypes,
-} from './component/radio-input.outline';
+import {  RadioInputTypes} from './component/radio-input.outline';
 import { DateInputTypes } from './component/date-input.outline';
-import {
-  ReusableFormComponentDefinitionFrame,
-  ReusableFormComponentDefinitionOutline,
-  ReusableTypes,
-} from './component/reusable.outline';
+import {  ReusableTypes} from './component/reusable.outline';
 import { QuestionTreeTypes } from './component/question-tree.outline';
 import { CheckboxTreeTypes } from './component/checkbox-tree.outline';
 import { RecordSelectorTypes } from './component/record-selector.outline';
@@ -147,6 +132,9 @@ export type AllFormComponentDefinitionOutlines = Extract<
     kind: FormComponentDefinitionKindType;
   }
 >['class'];
+
+export type AllFieldComponentDefinitionFrames = Extract<AllTypes, {kind:FieldComponentDefinitionFrameKindType}>['class'];
+export type AllFieldLayoutDefinitionFrames = Extract<AllTypes, {kind:FieldLayoutDefinitionFrameKindType}>['class'];
 
 /**
  * The form component definition outlines available for use in any list of form components.

--- a/packages/sails-ng-common/src/config/dictionary.outline.ts
+++ b/packages/sails-ng-common/src/config/dictionary.outline.ts
@@ -48,6 +48,8 @@ import { PublishDataLocationSelectorTypes } from './component/publish-data-locat
 import { CancelButtonTypes } from './component/cancel-button.outline';
 import { TabNavButtonTypes } from './component/tab-nav-button.outline';
 import { DeleteButtonTypes } from './component/delete-button.outline';
+import {FieldComponentDefinitionFrame} from "./field-component.outline";
+import {FieldLayoutDefinitionFrame} from "./field-layout.outline";
 
 /**
  * The static type union of all available interfaces that provides typing for the object literal and schema.
@@ -133,8 +135,25 @@ export type AllFormComponentDefinitionOutlines = Extract<
   }
 >['class'];
 
+/**
+ * All possible field component definition frames.
+ */
 export type AllFieldComponentDefinitionFrames = Extract<AllTypes, {kind:FieldComponentDefinitionFrameKindType}>['class'];
+
+/**
+ * All possible field layout definition frames.
+ */
 export type AllFieldLayoutDefinitionFrames = Extract<AllTypes, {kind:FieldLayoutDefinitionFrameKindType}>['class'];
+
+/**
+ * All possible field component and field layout definition frames, including the non-component specific frames.
+ */
+export type FormFieldComponentOrLayoutDefinition =
+  | FieldComponentDefinitionFrame
+  | FieldLayoutDefinitionFrame
+  | AllFieldComponentDefinitionFrames
+  | AllFieldLayoutDefinitionFrames
+  ;
 
 /**
  * The form component definition outlines available for use in any list of form components.

--- a/packages/sails-ng-common/src/config/helpers.ts
+++ b/packages/sails-ng-common/src/config/helpers.ts
@@ -103,3 +103,8 @@ function valueProtoInfo(value: any) {
         isValueProtoCtorFuncObj,
     };
 }
+
+/**
+ * Extract all properties of the type T that are of the type U.
+ */
+export type ExtractPropertyNamesOfType<T, U> = { [K in keyof T]: T[K] extends U ? K : never }[keyof T];

--- a/packages/sails-ng-common/src/config/helpers.ts
+++ b/packages/sails-ng-common/src/config/helpers.ts
@@ -105,6 +105,22 @@ function valueProtoInfo(value: any) {
 }
 
 /**
+ * Apply conventions to convert a value to a boolean.
+ * @param value A value to convert to boolean.
+ */
+export function toBoolean(value: unknown): boolean {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+  const normalized = String(value ?? '').trim().toLowerCase();
+  const trueValues = ["true", "t", "1", "yes", "y", "on", "enable", "enabled"];
+  return trueValues.includes(normalized);
+}
+
+/**
  * Extract all properties of the type T that are of the type U.
  */
 export type ExtractPropertyNamesOfType<T, U> = { [K in keyof T]: T[K] extends U ? K : never }[keyof T];

--- a/packages/sails-ng-common/src/config/helpers.ts
+++ b/packages/sails-ng-common/src/config/helpers.ts
@@ -113,7 +113,7 @@ export function toBoolean(value: unknown): boolean {
     return value;
   }
   if (typeof value === 'number') {
-    return value !== 0;
+    return !Number.isNaN(value) && value !== 0;
   }
   const normalized = String(value ?? '').trim().toLowerCase();
   const trueValues = ["true", "t", "1", "yes", "y", "on", "enable", "enabled"];

--- a/packages/sails-ng-common/src/config/helpers.ts
+++ b/packages/sails-ng-common/src/config/helpers.ts
@@ -108,3 +108,18 @@ function valueProtoInfo(value: any) {
  * Extract all properties of the type T that are of the type U.
  */
 export type ExtractPropertyNamesOfType<T, U> = { [K in keyof T]: T[K] extends U ? K : never }[keyof T];
+
+/**
+ * Extract all properties from each of the types in the union type T, where the properties are of type U.
+ * This uses the distributive feature of conditional types (T extends T ? ...).
+ */
+export type ExtractPropertyNamesOfTypeFromTypeUnion<T, U> = T extends T ? ExtractPropertyNamesOfType<T, U> : never;
+
+// TODO: consider trying to type the access to the config properties.
+// type FormFieldComponentOrLayoutDefinitionConfig = FormFieldComponentOrLayoutDefinition['config'];
+// type FormFieldComponentOrLayoutStringKeys = NonNullable<ExtractPropertyNamesOfTypeFromTypeUnion<
+//   FormFieldComponentOrLayoutDefinitionConfig, string | undefined | null
+// >>;
+// type FormFieldComponentOrLayoutBooleanKeys = NonNullable<ExtractPropertyNamesOfTypeFromTypeUnion<
+//   FormFieldComponentOrLayoutDefinitionConfig, boolean | undefined | null
+// >>;

--- a/packages/sails-ng-common/src/validation/helpers.ts
+++ b/packages/sails-ng-common/src/validation/helpers.ts
@@ -1,5 +1,6 @@
 import {get as _get} from "lodash";
 import {FormValidatorCreateConfig} from "./form.model";
+import {toBoolean} from "../config/helpers";
 
 
 /**
@@ -61,11 +62,7 @@ export function formValidatorGetDefinitionBoolean(
   defaultValue: boolean | undefined = undefined,
 ) {
   const value = formValidatorGetDefinitionItem(config, key, defaultValue);
-  if (typeof value === "boolean") {
-    return value;
-  }
-  const valueString = value?.toString()?.toLowerCase() ?? "";
-  return ["true", "t", "1", "yes", "y"].includes(valueString);
+  return toBoolean(value);
 }
 
 export function formValidatorGetDefinitionRegexp(

--- a/support/specs/form-control-disabled-readonly/design.md
+++ b/support/specs/form-control-disabled-readonly/design.md
@@ -10,17 +10,19 @@ This design is concerned with readonly and disabled.
 
 ### Interactions:
 
-Common:
-
-- can't be edited
-- are not included in validation
-- cannot be marked as required
 
 #### readonly
+
+Note a difference in HTML and angular for `readonly`:
+- the readonly attribute does not impact the angular validation
+- a readonly HTML element *does not* participate in constraint validation
 
 HTML API
 Ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/readonly
 
+- be edited: no
+- included in validation: no
+- can be marked as required: no
 - can be focused: yes
 - can receive events like mouse click: yes
 - supported by: input, textarea
@@ -31,15 +33,23 @@ participate in focus and events,
 and still part of the form and included in form submission.
 
 Angular API
+Ref:
 
+- be edited: no
+- included in validation: yes
+- can be marked as required: yes
 - not part of the angular forms API
 - needs to be implemented using angular property binding to a property in the model
+- readonly does not affect the angular validation
 
 #### disabled
 
 HTML API
 Ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/disabled
 
+- be edited: no
+- included in validation: no
+- can be marked as required: no
 - can be focused: no
 - can receive events like mouse click: no
 - supported by: input, textarea, select, option, optgroup, fieldset, button
@@ -51,8 +61,14 @@ not be focused and not have events,
 and not included in form submission.
 
 Angular API
+Ref: https://v20.angular.dev/api/forms/FormControl#disabled
 
+- be edited: no
+- included in validation: no ("disabled controls are exempt from validation checks")
+- can be marked as required: no
 - is part of the angular forms API
+- disabled controls are exempt from validation checks
+- disabled controls are not included in the aggregate value of their ancestor controls
 - angular warns when using property binding for disabled:
 
 ```

--- a/support/specs/form-control-disabled-readonly/design.md
+++ b/support/specs/form-control-disabled-readonly/design.md
@@ -1,0 +1,73 @@
+# Overview of design choices and approach for form control disabled and readonly states
+
+## Background
+
+The availability or access to form fields can be changed in a few ways.
+
+The main ways are enabled / disabled, readonly / editable, and visible / hidden.
+
+This design is concerned with readonly and disabled.
+
+### Interactions:
+
+Common:
+
+- can't be edited
+- are not included in validation
+- cannot be marked as required
+
+#### readonly
+
+HTML API
+Ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/readonly
+
+- can be focused: yes
+- can receive events like mouse click: yes
+- supported by: input, textarea
+
+Use readonly when a field should be shown,
+not be able to be changed by the user,
+participate in focus and events,
+and still part of the form and included in form submission.
+
+Angular API
+
+- not part of the angular forms API
+- needs to be implemented using angular property binding to a property in the model
+
+#### disabled
+
+HTML API
+Ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/disabled
+
+- can be focused: no
+- can receive events like mouse click: no
+- supported by: input, textarea, select, option, optgroup, fieldset, button
+- children form fields are also disabled
+
+Use disabled when a field should be shown,
+not be able to be changed by the user,
+not be focused and not have events,
+and not included in form submission.
+
+Angular API
+
+- is part of the angular forms API
+- angular warns when using property binding for disabled:
+
+```
+It looks like you're using the disabled attribute with a reactive form directive. If you set disabled to true
+when you set up this control in your component class, the disabled attribute will actually be set in the DOM for
+you. We recommend using this approach to avoid 'changed after checked' errors.
+
+Example:
+// Specify the `disabled` property at control creation time:
+form = new FormGroup({
+  first: new FormControl({value: 'Nancy', disabled: true}, Validators.required),
+  last: new FormControl('Drew', Validators.required)
+});
+
+// Controls can also be enabled/disabled after creation:
+form.get('first')?.enable();
+form.get('last')?.disable();
+```


### PR DESCRIPTION
## Summary

Set component disabled state by updating angular formControl.

Partial work for #3671 and #3632.

Changes made:

* Allow form fields to be disabled and enabled as part of the form configuration.

## Context / related work

* Addresses current gaps in the form field config and event production and consumption.

## Technical implementation details

* This takes advantage of the built-in angular support for managing the disabled state. Trying to set the HTML disabled attribute for `input` tags triggers an angular console warning.
* Extracted duplicate `toBoolean` conversions to a shared helper function.
* Only applies to the component. The layout has a `disabled` property, but the meaning of disabling a layout is specific to each layout.
* Consolidates multiple definitions of the angular `emitEvent` and `onlySelf` options into a common definition. Also allows the options to be included in more places to have control over how changes trigger events.

## Testing

* Added test for `component.disabled` to ensure it sets both the form config and `formControl.disabled`.

## Future work

* Consider the `readonly` attribute usage and fix it up and make the usage consistent.
* Are there other angular formControl properties or HTML attributes that need similar treatment?
