### PR TITLE
Bugfix: Ensure the vocab historical prop is converted to a disabled option

### DIFF
--- a/packages/redbox-core/src/visitor/vocab-inline.visitor.ts
+++ b/packages/redbox-core/src/visitor/vocab-inline.visitor.ts
@@ -156,7 +156,9 @@ export class VocabInlineFormConfigVisitor extends FormConfigVisitor {
       }
       componentConfig.options = entries.map((entry) => ({
         label: String(entry?.label ?? ''),
-        value: String(entry?.value ?? '')
+        value: String(entry?.value ?? ''),
+        // only add disabled if it is true, otherwise set to undefined
+        disabled: entry?.historical === true ? true : undefined,
       }));
     } catch (error) {
       this.logger.warn(

--- a/packages/redbox-core/test/visitor/vocab-inline.visitor.test.ts
+++ b/packages/redbox-core/test/visitor/vocab-inline.visitor.test.ts
@@ -102,6 +102,41 @@ describe('VocabInlineFormConfigVisitor', () => {
         expect(options[0]?.label).to.equal('Local');
     });
 
+    it('sets historical dropdown option to disabled', async () => {
+        const getEntries = async () => ({
+          entries: [{ label: 'Open', value: 'open', historical: true }] });
+        (globalThis as any).VocabularyService = { getEntries };
+
+        const input: FormConfigFrame = {
+            name: 'test',
+            componentDefinitions: [
+                {
+                    name: 'access_type',
+                    component: {
+                        class: 'DropdownInputComponent',
+                        config: {
+                            options: [],
+                            vocabRef: 'access-rights',
+                            inlineVocab: true,
+                        },
+                    },
+                },
+            ],
+        };
+
+        const constructor = new ConstructFormConfigVisitor(logger as any);
+        const constructed = constructor.start({ data: input, formMode: 'edit' });
+
+        const visitor = new VocabInlineFormConfigVisitor(logger);
+        await visitor.resolveVocabs(constructed);
+
+        const radio = constructed.componentDefinitions?.[0] as RadioInputFormComponentDefinitionOutline;
+        const options = radio?.component?.config?.options;
+        expect(options).to.have.length(1);
+        expect(options?.[0]?.label).to.equal('Open');
+        expect(options?.[0]?.disabled).to.be.true;
+    });
+
     it('throws when inline vocab slug cannot be resolved', async () => {
         (globalThis as any).VocabularyService = {
             getEntries: async () => null,


### PR DESCRIPTION
## Summary

Ensure the vocab historical prop is converted to a disabled option.

Changes made:

* The `historical` option set on a vocabulary entry should turn into a disabled dropdown option.

## Technical implementation details

* The `disabled` property is set to true if `historical` is true, otherwise `undefined`, since the default for disabled is false.

## Testing

* Added a test to check the vocab inline visitor converts the property as expected.
