### PR TITLE
chore: resolve some sails warnings

### DIFF
--- a/packages/redbox-core/src/bootstrap.ts
+++ b/packages/redbox-core/src/bootstrap.ts
@@ -1,9 +1,9 @@
 /**
  * Core Bootstrap Function
- * 
+ *
  * This is the main bootstrap logic for ReDBox Portal.
  * Called by the generated config/bootstrap.js shim.
- * 
+ *
  * Hooks can provide additional bootstrap functions via:
  * 1. Add "sails": { "hasBootstrap": true } to package.json
  * 2. Export registerRedboxBootstrap() returning an async function
@@ -28,7 +28,7 @@ export interface BootstrapProvider {
 
 /**
  * Core bootstrap function - initializes all ReDBox services
- * 
+ *
  * This function is called during Sails lift and bootstraps all core services
  * in the correct order. Hook bootstraps run after this completes.
  */
@@ -159,7 +159,7 @@ export async function coreBootstrap(): Promise<void> {
 
 /**
  * Pre-lift configuration setup
- * 
+ *
  * Called before coreBootstrap to configure Sails settings
  * that need to be in place before services bootstrap.
  */
@@ -178,7 +178,7 @@ export function preLiftSetup(): void {
 
     if (sails.config.environment === "production" || sails.config.ng2.force_bundle) {
         sails.config.ng2.use_bundled = true;
-        console.log("Using NG2 Bundled files.......");
+        sails.log.debug("Using NG2 Bundled files.......");
     }
 
     // Update the pino log level to the sails.log.level

--- a/packages/redbox-core/src/config/http.config.ts
+++ b/packages/redbox-core/src/config/http.config.ts
@@ -79,11 +79,8 @@ export interface HttpMiddlewareConfig {
     poweredBy?: MiddlewareFunction;
     redirectNoCacheHeaders?: MiddlewareFunction;
     cacheControl?: MiddlewareFunction;
-    handleBodyParserError?: MiddlewareFunction;
-    startRequestTimer?: MiddlewareFunction;
     cookieParser?: RequestHandler;
     compress?: RequestHandler;
-    methodOverride?: RequestHandler;
     router?: RequestHandler;
     www?: RequestHandler;
     favicon?: RequestHandler;
@@ -472,24 +469,19 @@ export const http: HttpConfig = {
         order: [
             'cacheControl',
             'redirectNoCacheHeaders',
-            'startRequestTimer',
             'cookieParser',
             'redboxSession',
             'passportInit',
             'passportSession',
             'companion',
             'myBodyParser',
-            'handleBodyParserError',
             'compress',
-            'methodOverride',
             'poweredBy',
             'router',
             'translate',
             'brandingAndPortalAwareStaticRouter',
             'www',
             'favicon',
-            '404',
-            '500'
         ],
 
         myBodyParser: function (req: Request, res: Response, next: NextFunction) {

--- a/packages/redbox-core/src/config/routes.config.ts
+++ b/packages/redbox-core/src/config/routes.config.ts
@@ -1,7 +1,7 @@
 /**
  * Routes Config Interface
  * (sails.config.routes)
- * 
+ *
  * URL to controller/action mapping configuration.
  */
 
@@ -174,9 +174,9 @@ export const routes: RoutesConfig = {
     // Auth routes
     'post /user/login_local': 'UserController.localLogin',
     'post /user/login_aaf': { controller: 'UserController', action: 'aafLogin', csrf: false },
-    'get /user/login_oidc': { controller: 'UserController', action: 'openIdConnectLogin', csrf: false },
+    'get /user/login_oidc': { controller: 'UserController', action: 'openIdConnectLogin' },
     'HEAD /user/begin_oidc': { policy: 'disallowedHeadRequestHandler' },
-    'get /user/begin_oidc': { controller: 'UserController', action: 'beginOidc', csrf: false },
+    'get /user/begin_oidc': { controller: 'UserController', action: 'beginOidc' },
     'get /user/info': 'UserController.info',
     'get /:branding/:portal/user/info': 'UserController.info',
     'get /:branding/:portal/user/login': 'UserController.login',
@@ -317,13 +317,13 @@ export const routes: RoutesConfig = {
     'post /:branding/:portal/api/records/harvest/:recordType': { controller: 'webservice/RecordController', action: 'harvest', csrf: false },
     'post /:branding/:portal/api/mint/harvest/:recordType': { controller: 'webservice/RecordController', action: 'legacyHarvest', csrf: false },
     'put /:branding/:portal/api/records/objectmetadata/:oid': { controller: 'webservice/RecordController', action: 'updateObjectMeta', csrf: false },
-    'get /:branding/:portal/api/records/metadata/:oid': { controller: 'webservice/RecordController', action: 'getMeta', csrf: false },
-    'get /:branding/:portal/api/records/audit/:oid': { controller: 'webservice/RecordController', action: 'getRecordAudit', csrf: false },
-    'get /:branding/:portal/api/records/list': { controller: 'webservice/RecordController', action: 'listRecords', csrf: false },
-    'get /:branding/:portal/api/deletedrecords/list': { controller: 'webservice/RecordController', action: 'listDeletedRecords', csrf: false },
+    'get /:branding/:portal/api/records/metadata/:oid': { controller: 'webservice/RecordController', action: 'getMeta' },
+    'get /:branding/:portal/api/records/audit/:oid': { controller: 'webservice/RecordController', action: 'getRecordAudit' },
+    'get /:branding/:portal/api/records/list': { controller: 'webservice/RecordController', action: 'listRecords'},
+    'get /:branding/:portal/api/deletedrecords/list': { controller: 'webservice/RecordController', action: 'listDeletedRecords' },
     'put /:branding/:portal/api/deletedrecords/:oid': { controller: 'webservice/RecordController', action: 'restoreRecord', csrf: false },
     'delete /:branding/:portal/api/deletedrecords/:oid': { controller: 'webservice/RecordController', action: 'destroyDeletedRecord', csrf: false },
-    'get /:branding/:portal/api/records/objectmetadata/:oid': { controller: 'webservice/RecordController', action: 'getObjectMeta', csrf: false },
+    'get /:branding/:portal/api/records/objectmetadata/:oid': { controller: 'webservice/RecordController', action: 'getObjectMeta' },
     'delete /:branding/:portal/api/records/metadata/:oid': { controller: 'webservice/RecordController', action: 'deleteRecord', csrf: false },
 
     // REST API routes - Permissions
@@ -335,49 +335,49 @@ export const routes: RoutesConfig = {
     'delete /:branding/:portal/api/records/permissions/editRole/:oid': { controller: 'webservice/RecordController', action: 'removeRoleEdit', csrf: false },
     'post /:branding/:portal/api/records/permissions/viewRole/:oid': { controller: 'webservice/RecordController', action: 'addRoleView', csrf: false },
     'delete /:branding/:portal/api/records/permissions/viewRole/:oid': { controller: 'webservice/RecordController', action: 'removeRoleView', csrf: false },
-    'get /:branding/:portal/api/records/permissions/:oid': { controller: 'webservice/RecordController', action: 'getPermissions', csrf: false },
+    'get /:branding/:portal/api/records/permissions/:oid': { controller: 'webservice/RecordController', action: 'getPermissions' },
 
     // REST API routes - Datastreams
     'post /:branding/:portal/api/records/datastreams/:oid': { controller: 'webservice/RecordController', action: 'addDataStreams', csrf: false },
-    'get /:branding/:portal/api/records/datastreams/:oid/:datastreamId': { controller: 'webservice/RecordController', action: 'getDataStream', csrf: false },
-    'get /:branding/:portal/api/records/datastreams/:oid': { controller: 'webservice/RecordController', action: 'listDatastreams', csrf: false },
+    'get /:branding/:portal/api/records/datastreams/:oid/:datastreamId': { controller: 'webservice/RecordController', action: 'getDataStream' },
+    'get /:branding/:portal/api/records/datastreams/:oid': { controller: 'webservice/RecordController', action: 'listDatastreams' },
 
     // REST API routes - Workflow
     'post /:branding/:portal/api/records/workflow/step/:targetStep/:oid': { controller: 'webservice/RecordController', action: 'transitionWorkflow', csrf: false },
 
     // REST API routes - Users
-    'get /:branding/:portal/api/users': { controller: 'webservice/UserManagementController', action: 'listUsers', csrf: false },
-    'get /:branding/:portal/api/users/find': { controller: 'webservice/UserManagementController', action: 'getUser', csrf: false },
-    'get /:branding/:portal/api/users/get': { controller: 'webservice/UserManagementController', action: 'getUser', csrf: false },
-    'get /:branding/:portal/api/users/link/candidates': { controller: 'webservice/UserManagementController', action: 'searchLinkCandidates', csrf: false },
-    'get /:branding/:portal/api/users/:id/links': { controller: 'webservice/UserManagementController', action: 'getUserLinks', csrf: false },
-    'get /:branding/:portal/api/users/:id/audit': { controller: 'webservice/UserManagementController', action: 'getUserAudit', csrf: false },
+    'get /:branding/:portal/api/users': { controller: 'webservice/UserManagementController', action: 'listUsers' },
+    'get /:branding/:portal/api/users/find': { controller: 'webservice/UserManagementController', action: 'getUser' },
+    'get /:branding/:portal/api/users/get': { controller: 'webservice/UserManagementController', action: 'getUser' },
+    'get /:branding/:portal/api/users/link/candidates': { controller: 'webservice/UserManagementController', action: 'searchLinkCandidates' },
+    'get /:branding/:portal/api/users/:id/links': { controller: 'webservice/UserManagementController', action: 'getUserLinks' },
+    'get /:branding/:portal/api/users/:id/audit': { controller: 'webservice/UserManagementController', action: 'getUserAudit' },
     'post /:branding/:portal/api/users/link': { controller: 'webservice/UserManagementController', action: 'linkAccounts', csrf: false },
     'put /:branding/:portal/api/users': { controller: 'webservice/UserManagementController', action: 'createUser', csrf: false },
     'post /:branding/:portal/api/users': { controller: 'webservice/UserManagementController', action: 'updateUser', csrf: false },
     'post /:branding/:portal/api/users/:id/disable': { controller: 'webservice/UserManagementController', action: 'disableUser', csrf: false },
     'post /:branding/:portal/api/users/:id/enable': { controller: 'webservice/UserManagementController', action: 'enableUser', csrf: false },
-    'get /:branding/:portal/api/users/token/generate': { controller: 'webservice/UserManagementController', action: 'generateAPIToken', csrf: false },
-    'get /:branding/:portal/api/users/token/revoke': { controller: 'webservice/UserManagementController', action: 'revokeAPIToken', csrf: false },
+    'get /:branding/:portal/api/users/token/generate': { controller: 'webservice/UserManagementController', action: 'generateAPIToken' },
+    'get /:branding/:portal/api/users/token/revoke': { controller: 'webservice/UserManagementController', action: 'revokeAPIToken' },
 
     // REST API routes - Roles
-    'get /:branding/:portal/api/roles': { controller: 'webservice/UserManagementController', action: 'listSystemRoles', csrf: false },
+    'get /:branding/:portal/api/roles': { controller: 'webservice/UserManagementController', action: 'listSystemRoles' },
     'post /:branding/:portal/api/roles/:roleName': { controller: 'webservice/UserManagementController', action: 'createSystemRole', csrf: false },
 
     // REST API routes - Search
-    'get /:branding/:portal/api/search': { controller: 'webservice/SearchController', action: 'search', csrf: false },
-    'get /:branding/:portal/api/search/index': { controller: 'webservice/SearchController', action: 'index', csrf: false },
-    'get /:branding/:portal/api/search/indexAll': { controller: 'webservice/SearchController', action: 'indexAll', csrf: false },
-    'get /:branding/:portal/api/search/removeAll': { controller: 'webservice/SearchController', action: 'removeAll', csrf: false },
+    'get /:branding/:portal/api/search': { controller: 'webservice/SearchController', action: 'search' },
+    'get /:branding/:portal/api/search/index': { controller: 'webservice/SearchController', action: 'index' },
+    'get /:branding/:portal/api/search/indexAll': { controller: 'webservice/SearchController', action: 'indexAll' },
+    'get /:branding/:portal/api/search/removeAll': { controller: 'webservice/SearchController', action: 'removeAll' },
 
     // REST API routes - Forms
-    'get /:branding/:portal/api/forms/get': { controller: 'webservice/FormManagementController', action: 'getForm', csrf: false },
-    'get /:branding/:portal/api/forms': { controller: 'webservice/FormManagementController', action: 'listForms', csrf: false },
+    'get /:branding/:portal/api/forms/get': { controller: 'webservice/FormManagementController', action: 'getForm' },
+    'get /:branding/:portal/api/forms': { controller: 'webservice/FormManagementController', action: 'listForms' },
 
     // REST API routes - Vocabulary
-    'get /:branding/:portal/api/vocabulary': { controller: 'webservice/VocabularyController', action: 'list', csrf: false },
+    'get /:branding/:portal/api/vocabulary': { controller: 'webservice/VocabularyController', action: 'list' },
     'post /:branding/:portal/api/vocabulary/import': { controller: 'webservice/VocabularyController', action: 'import', csrf: false },
-    'get /:branding/:portal/api/vocabulary/:id': { controller: 'webservice/VocabularyController', action: 'get', csrf: false },
+    'get /:branding/:portal/api/vocabulary/:id': { controller: 'webservice/VocabularyController', action: 'get' },
     'post /:branding/:portal/api/vocabulary': { controller: 'webservice/VocabularyController', action: 'create', csrf: false },
     'put /:branding/:portal/api/vocabulary/:id': { controller: 'webservice/VocabularyController', action: 'update', csrf: false },
     'put /:branding/:portal/api/vocabulary/:id/reorder': { controller: 'webservice/VocabularyController', action: 'reorder', csrf: false },
@@ -385,26 +385,26 @@ export const routes: RoutesConfig = {
     'post /:branding/:portal/api/vocabulary/:id/sync': { controller: 'webservice/VocabularyController', action: 'sync', csrf: false },
 
     // REST API routes - Record Types
-    'get /:branding/:portal/api/recordtypes/get': { controller: 'webservice/RecordTypeController', action: 'getRecordType', csrf: false },
-    'get /:branding/:portal/api/recordtypes': { controller: 'webservice/RecordTypeController', action: 'listRecordTypes', csrf: false },
+    'get /:branding/:portal/api/recordtypes/get': { controller: 'webservice/RecordTypeController', action: 'getRecordType' },
+    'get /:branding/:portal/api/recordtypes': { controller: 'webservice/RecordTypeController', action: 'listRecordTypes' },
 
     // REST API routes - Admin
-    'get /:branding/:portal/api/admin/refreshCachedResources': { controller: 'webservice/AdminController', action: 'refreshCachedResources', csrf: false },
+    'get /:branding/:portal/api/admin/refreshCachedResources': { controller: 'webservice/AdminController', action: 'refreshCachedResources' },
     'post /:branding/:portal/api/admin/config/:configKey': { controller: 'webservice/AdminController', action: 'setAppConfig', csrf: false },
-    'get /:branding/:portal/api/admin/config/:configKey': { controller: 'webservice/AdminController', action: 'getAppConfig', csrf: false },
-    'get /:branding/:portal/api/admin/config': { controller: 'webservice/AdminController', action: 'getAppConfig', csrf: false },
+    'get /:branding/:portal/api/admin/config/:configKey': { controller: 'webservice/AdminController', action: 'getAppConfig' },
+    'get /:branding/:portal/api/admin/config': { controller: 'webservice/AdminController', action: 'getAppConfig' },
 
     // REST API routes - Notifications
     'post /:branding/:portal/api/sendNotification': { controller: 'EmailController', action: 'sendNotification', csrf: false },
 
     // REST API routes - Reports
-    'get /:branding/:portal/api/report/namedQuery': { controller: 'webservice/ReportController', action: 'executeNamedQuery', csrf: false },
+    'get /:branding/:portal/api/report/namedQuery': { controller: 'webservice/ReportController', action: 'executeNamedQuery'},
 
     // REST API routes - Export
-    'get /:branding/:portal/api/export/record/download/:format': { controller: 'webservice/ExportController', action: 'downloadRecs', csrf: false },
+    'get /:branding/:portal/api/export/record/download/:format': { controller: 'webservice/ExportController', action: 'downloadRecs' },
 
     // REST API routes - App Config
-    'get /:branding/:portal/api/appconfig/:appConfigId': { controller: 'webservice/AppConfigController', action: 'getAppConfig', csrf: false },
+    'get /:branding/:portal/api/appconfig/:appConfigId': { controller: 'webservice/AppConfigController', action: 'getAppConfig' },
     'post /:branding/:portal/api/appconfig/:appConfigId': { controller: 'webservice/AppConfigController', action: 'saveAppConfig', csrf: false },
 
     // REST API routes - Branding
@@ -413,23 +413,23 @@ export const routes: RoutesConfig = {
     'post /:branding/:portal/api/branding/publish': { controller: 'webservice/BrandingController', action: 'publish', csrf: false },
     'post /:branding/:portal/api/branding/rollback/:versionId': { controller: 'webservice/BrandingController', action: 'rollback', csrf: false },
     'post /:branding/:portal/api/branding/logo': { controller: 'webservice/BrandingController', action: 'logo', csrf: false },
-    'get /:branding/:portal/api/branding/history': { controller: 'webservice/BrandingController', action: 'history', csrf: false },
+    'get /:branding/:portal/api/branding/history': { controller: 'webservice/BrandingController', action: 'history' },
 
     // Translation routes
-    'get /:branding/:portal/locales/:lng/:ns.json': { controller: 'TranslationController', action: 'getNamespace', csrf: false },
-    'get /:branding/:portal/locales/:lng/translation.json': { controller: 'TranslationController', action: 'getNamespace', csrf: false },
-    'get /:branding/:portal/locales': { controller: 'TranslationController', action: 'getLanguages', csrf: false },
+    'get /:branding/:portal/locales/:lng/:ns.json': { controller: 'TranslationController', action: 'getNamespace' },
+    'get /:branding/:portal/locales/:lng/translation.json': { controller: 'TranslationController', action: 'getNamespace' },
+    'get /:branding/:portal/locales': { controller: 'TranslationController', action: 'getLanguages' },
 
     // Workspace routes
     'get /:branding/:portal/workspaces/types/:name': 'WorkspaceTypesController.getOne',
     'get /:branding/:portal/workspaces/types': 'WorkspaceTypesController.get',
 
     // REST API routes - i18n
-    'get /:branding/:portal/api/i18n/entries': { controller: 'webservice/TranslationController', action: 'listEntries', csrf: false },
-    'get /:branding/:portal/api/i18n/entries/:locale/:namespace/:key*': { controller: 'webservice/TranslationController', action: 'getEntry', csrf: false },
+    'get /:branding/:portal/api/i18n/entries': { controller: 'webservice/TranslationController', action: 'listEntries' },
+    'get /:branding/:portal/api/i18n/entries/:locale/:namespace/:key*': { controller: 'webservice/TranslationController', action: 'getEntry' },
     'post /:branding/:portal/api/i18n/entries/:locale/:namespace/:key*': { controller: 'webservice/TranslationController', action: 'setEntry', csrf: false },
     'delete /:branding/:portal/api/i18n/entries/:locale/:namespace/:key*': { controller: 'webservice/TranslationController', action: 'deleteEntry', csrf: false },
-    'get /:branding/:portal/api/i18n/bundles/:locale/:namespace': { controller: 'webservice/TranslationController', action: 'getBundle', csrf: false },
+    'get /:branding/:portal/api/i18n/bundles/:locale/:namespace': { controller: 'webservice/TranslationController', action: 'getBundle' },
     'post /:branding/:portal/api/i18n/bundles/:locale/:namespace': { controller: 'webservice/TranslationController', action: 'setBundle', csrf: false },
 
     // App i18n routes (CSRF enabled)

--- a/packages/redbox-core/src/config/views.config.ts
+++ b/packages/redbox-core/src/config/views.config.ts
@@ -1,13 +1,13 @@
 /**
  * Views Config Interface
  * (sails.config.views)
- * 
+ *
  * View engine configuration for server-side rendering.
  */
 
 export interface ViewsConfig {
     /** Template engine: 'ejs', 'jade', 'handlebars', etc. */
-    engine?: string;
+    extension?: string;
 
     /** Layout template path (relative to views/) or false to disable */
     layout?: string | false;
@@ -23,7 +23,7 @@ export interface ViewsConfig {
 }
 
 export const views: ViewsConfig = {
-    engine: 'ejs',
+    extension: 'ejs',
     layout: 'default/default/layout',
     partials: false,
     noCache: [


### PR DESCRIPTION
## Summary

Resolve some sails warnings.

Changes made:

* Use the current expected approach for configuring the web framework.

## Technical implementation details

Resolved these warnings:

```
debug: The `config.views.engine` config has been deprecated.
debug: In Sails 1.x, use `config.views.extension` to choose your view
debug: extension (defaults to ".ejs"), and use `config.views.getRenderFn`
debug: to configure your template engine or leave it undefined to use
debug: the built-in EJS template support.
````

```
"The `handleBodyParserError` middleware has been removed in Sails 1.0."
"To avoid this message, remove `handleBodyParserError` from "
"the `order` array in `config/http.js`."
"See http://sailsjs.com/upgrading for more info.

"The `methodOverride` middleware has been removed in Sails 1.0."
"To avoid this message, remove `methodOverride` from "
"the `order` array in `config/http.js`."
"See http://sailsjs.com/upgrading for more info.

"The `startRequestTimer` middleware is added to your app automatically in Sails 1.0."
"(ignoring entry in the `sails.config.http.middleware.order` list)"
"See http://sailsjs.com/documentation/reference/request-req/req-start-time for more info.

"The `404` middleware is added to your app automatically in Sails 1.0."
"(ignoring entry in the `sails.config.http.middleware.order` list)"
"If you wish to customize the 404 functionality for your app, you can"
"do so by creating a custom `notFound` response as `api/responses/notFound.js`."
"See http://sailsjs.com/documentation/concepts/custom-responses for more info.

"The `500` middleware is added to your app automatically in Sails 1.0."
"(ignoring entry in the `sails.config.http.middleware.order` list)"
"If you wish to customize the 500 functionality for your app, you can"
"do so by creating a custom `serverError` response as `api/responses/serverError.js`."
"See http://sailsjs.com/documentation/concepts/custom-responses for more info.
```

```
"Ignoring `csrf: false` setting for route `get /user/login_oidc`."
"CSRF protection does not apply to GET, HEAD or OPTIONS routes."
[and similar warnings]
```
