### PR TITLE
chore: cache the result of translations in memory only

### DIFF
--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/translation.service.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/translation.service.ts
@@ -84,6 +84,8 @@ export class TranslationService extends HttpClientService implements Service {
     }
   };
 
+  private readonly translationKeyValueCache: Map<string, TranslationResult> = new Map();
+
   constructor(
     @Inject(HttpClient) protected override http: HttpClient,
     @Inject(APP_BASE_HREF) public override rootContext: string,
@@ -184,21 +186,34 @@ export class TranslationService extends HttpClientService implements Service {
       return '';
     }
 
+    const cacheKey = Array.isArray(key) ? key.join('][') : String(key);
+
+    if (this.translationKeyValueCache.has(cacheKey)) {
+      return this.translationKeyValueCache.get(cacheKey);
+    }
+
     // Guess at whether the key is a natural language string.
     // If it likely is natural langauge, just return it.
     if (!Array.isArray(key) && isLikelyNaturalLanguage(key)) {
+      this.translationKeyValueCache.set(cacheKey, key);
       return key;
     }
 
     if (typeof defaultValueOrOptions === 'string') {
-      return this.i18NextService.t(key, defaultValueOrOptions, options);
+      const result = this.i18NextService.t(key, defaultValueOrOptions, options);
+      this.translationKeyValueCache.set(cacheKey, result);
+      return result;
     }
 
     if (defaultValueOrOptions === undefined) {
-      return this.i18NextService.t(key);
+      const result = this.i18NextService.t(key);
+      this.translationKeyValueCache.set(cacheKey, result);
+      return result;
     }
 
-    return this.i18NextService.t(key, defaultValueOrOptions);
+    const result = this.i18NextService.t(key, defaultValueOrOptions);
+    this.translationKeyValueCache.set(cacheKey, result);
+    return result;
   }
 
   /** Change the current language and reload resources */


### PR DESCRIPTION
## Summary

Cache the output of translations to reduce the number of logs from missing translations.

This is needed to reduce the overwhelming number of log entries.

Closes #3852 

Changes made:

* Reduce unnecessary repeated work in the web app.

## Technical implementation details

* Added an in-memory per-page cache. This is intentionally not caching between pages for now.

## Future work

* If we want a cache that is shared between pages, we should look into the [built-in i18next caching options](https://www.i18next.com/how-to/caching).
