### PR TITLE
Bugfix: Branding not passed to FormService.getFormByName

### DIFF
--- a/packages/redbox-core/src/services/FormsService.ts
+++ b/packages/redbox-core/src/services/FormsService.ts
@@ -226,8 +226,9 @@ export namespace Services {
 
     public getFormByName = (formName: string, editMode: boolean, brandingId?: string): Observable<FormAttributes | null> => {
       const query: Record<string, unknown> = { name: formName };
-      if (brandingId) {
-        query.branding = brandingId;
+      const resolvedBrandingId = String(brandingId ?? BrandingService.getDefault()?.id ?? '').trim();
+      if (resolvedBrandingId) {
+        query.branding = resolvedBrandingId;
       }
       return super.getObservable<FormAttributes | null>(Form.findOne(query)).pipe(flatMap(form => {
         if (form) {

--- a/packages/redbox-core/src/services/FormsService.ts
+++ b/packages/redbox-core/src/services/FormsService.ts
@@ -226,7 +226,7 @@ export namespace Services {
 
     public getFormByName = (formName: string, editMode: boolean, brandingId?: string): Observable<FormAttributes | null> => {
       const query: Record<string, unknown> = { name: formName };
-      const resolvedBrandingId = String(brandingId ?? BrandingService.getDefault()?.id ?? '').trim();
+      const resolvedBrandingId = brandingId?.trim() || BrandingService.getDefault()?.id?.toString().trim() || '';
       if (resolvedBrandingId) {
         query.branding = resolvedBrandingId;
       }

--- a/packages/redbox-core/src/services/StandardDatastreamService.ts
+++ b/packages/redbox-core/src/services/StandardDatastreamService.ts
@@ -40,13 +40,6 @@ export namespace Services {
 
     protected logHeader: string = 'StandardDatastreamService::';
 
-    private getFormsService(): { getFormByName(formName: string, editMode: boolean, brandingId?: string): Observable<FormLookup | null> } {
-      const svc = FormsService;
-      if (!svc) {
-        throw new Error(`${this.logHeader} FormsService is not available`);
-      }
-      return svc;
-    }
 
     /**
      * Build the storage key for a file: `{oid}/{fileId}`
@@ -98,7 +91,7 @@ export namespace Services {
       const typedRecord = this.coerceRecord(record);
       const typedNewMetadata = this.coerceMetadata(newMetadata);
 
-      return this.getFormsService()
+      return FormsService
         .getFormByName(typedRecord.metaMetadata.form, true, typedRecord.metaMetadata.brandId)
         .pipe(
           mergeMap(form => {

--- a/packages/redbox-core/src/services/StandardDatastreamService.ts
+++ b/packages/redbox-core/src/services/StandardDatastreamService.ts
@@ -14,8 +14,12 @@ type FormLookup = {
   attachmentFields: string[];
 };
 
+declare const FormsService: {
+  getFormByName(formName: string, editMode: boolean, brandingId?: string): Observable<FormLookup | null>;
+};
+
 type RecordWithMetadata = {
-  metaMetadata: { form: string; attachmentFields?: string[] };
+  metaMetadata: { form: string; brandId?: string; attachmentFields?: string[] };
   metadata: Record<string, unknown>;
 };
 
@@ -40,8 +44,8 @@ export namespace Services {
 
     protected logHeader: string = 'StandardDatastreamService::';
 
-    private getFormsService(): { getFormByName(formName: string, editMode: boolean): Observable<FormLookup | null> } {
-      const svc = FormsService as { getFormByName(formName: string, editMode: boolean): Observable<FormLookup | null> };
+    private getFormsService(): { getFormByName(formName: string, editMode: boolean, brandingId?: string): Observable<FormLookup | null> } {
+      const svc = FormsService;
       if (!svc) {
         throw new Error(`${this.logHeader} FormsService is not available`);
       }
@@ -99,7 +103,7 @@ export namespace Services {
       const typedNewMetadata = this.coerceMetadata(newMetadata);
 
       return this.getFormsService()
-        .getFormByName(typedRecord.metaMetadata.form, true)
+        .getFormByName(typedRecord.metaMetadata.form, true, typedRecord.metaMetadata.brandId)
         .pipe(
           mergeMap(form => {
             const safeForm = form ?? { attachmentFields: [] };
@@ -144,11 +148,12 @@ export namespace Services {
       const metaMetadata = rec.metaMetadata as Record<string, unknown> | undefined;
       const metadata = rec.metadata as Record<string, unknown> | undefined;
       const form = typeof metaMetadata?.form === 'string' ? metaMetadata.form : '';
+      const brandId = typeof metaMetadata?.brandId === 'string' ? metaMetadata.brandId : undefined;
       const attachmentFields = Array.isArray(metaMetadata?.attachmentFields)
         ? (metaMetadata?.attachmentFields as string[])
         : undefined;
       return {
-        metaMetadata: { form, attachmentFields },
+        metaMetadata: { form, brandId, attachmentFields },
         metadata: metadata ?? {},
       };
     }

--- a/packages/redbox-core/src/services/StandardDatastreamService.ts
+++ b/packages/redbox-core/src/services/StandardDatastreamService.ts
@@ -91,35 +91,36 @@ export namespace Services {
         .getFormByName(typedRecord.metaMetadata.form, true, typedRecord.metaMetadata.brandId)
         .pipe(
           mergeMap(form => {
-            const safeForm = form ?? { attachmentFields: [] };
+
             const reqs: Promise<unknown>[] = [];
-            typedRecord.metaMetadata.attachmentFields = safeForm.attachmentFields;
+            if (form?.attachmentFields) {
+              typedRecord.metaMetadata.attachmentFields = form.attachmentFields;
 
-            for (const attField of safeForm.attachmentFields) {
-              const perFieldFileIdsAdded: Datastream[] = [];
-              const oldAttachments = this.getAttachments(typedRecord.metadata, attField);
-              const newAttachments = this.getAttachments(typedNewMetadata, attField);
-              const removeIds: Datastream[] = [];
+              for (const attField of form.attachmentFields) {
+                const perFieldFileIdsAdded: Datastream[] = [];
+                const oldAttachments = this.getAttachments(typedRecord.metadata, attField);
+                const newAttachments = this.getAttachments(typedNewMetadata, attField);
+                const removeIds: Datastream[] = [];
 
-              const toRemove = this.diffAttachments(oldAttachments, newAttachments);
-              for (const removeAtt of toRemove) {
-                if (this.isAttachment(removeAtt)) {
-                  removeIds.push(new Datastream(removeAtt));
+                const toRemove = this.diffAttachments(oldAttachments, newAttachments);
+                for (const removeAtt of toRemove) {
+                  if (this.isAttachment(removeAtt)) {
+                    removeIds.push(new Datastream(removeAtt));
+                  }
                 }
-              }
 
-              const toAdd = this.diffAttachments(newAttachments, oldAttachments);
-              for (const addAtt of toAdd) {
-                if (this.isAttachment(addAtt)) {
-                  perFieldFileIdsAdded.push(new Datastream(addAtt));
+                const toAdd = this.diffAttachments(newAttachments, oldAttachments);
+                for (const addAtt of toAdd) {
+                  if (this.isAttachment(addAtt)) {
+                    perFieldFileIdsAdded.push(new Datastream(addAtt));
+                  }
                 }
+
+                fileIdsAdded.push(...perFieldFileIdsAdded);
+
+                reqs.push(this.addAndRemoveDatastreams(oid, perFieldFileIdsAdded, removeIds, stagingDisk));
               }
-
-              fileIdsAdded.push(...perFieldFileIdsAdded);
-
-              reqs.push(this.addAndRemoveDatastreams(oid, perFieldFileIdsAdded, removeIds, stagingDisk));
             }
-
             return of(reqs);
           })
         );

--- a/packages/redbox-core/src/services/StandardDatastreamService.ts
+++ b/packages/redbox-core/src/services/StandardDatastreamService.ts
@@ -10,10 +10,6 @@ import type { Services as StorageManagerServices } from './StorageManagerService
 
 type IDisk = StorageManagerServices.IDisk;
 
-type FormLookup = {
-  attachmentFields: string[];
-};
-
 type RecordWithMetadata = {
   metaMetadata: { form: string; brandId?: string; attachmentFields?: string[] };
   metadata: Record<string, unknown>;

--- a/packages/redbox-core/src/services/StandardDatastreamService.ts
+++ b/packages/redbox-core/src/services/StandardDatastreamService.ts
@@ -14,10 +14,6 @@ type FormLookup = {
   attachmentFields: string[];
 };
 
-declare const FormsService: {
-  getFormByName(formName: string, editMode: boolean, brandingId?: string): Observable<FormLookup | null>;
-};
-
 type RecordWithMetadata = {
   metaMetadata: { form: string; brandId?: string; attachmentFields?: string[] };
   metadata: Record<string, unknown>;

--- a/packages/redbox-core/src/waterline-models/Form.ts
+++ b/packages/redbox-core/src/waterline-models/Form.ts
@@ -23,6 +23,7 @@ export interface FormAttributes extends Sails.WaterlineAttributes {
   name: string;
   branding: string | number | BrandingConfigAttributes;
   configuration?: FormConfigFrame;
+  attachmentFields?: string[];
 }
 
 export interface FormWaterlineModel extends Sails.Model<FormAttributes> {

--- a/packages/redbox-core/test/services/FormsService.test.ts
+++ b/packages/redbox-core/test/services/FormsService.test.ts
@@ -191,6 +191,16 @@ describe('FormsService', function () {
       expect(result).to.deep.equal(form);
     });
 
+    it('should fall back to the default branding when none is provided', async function () {
+      const form = { name: 'form1', fields: [] };
+      mockForm.findOne.returns(createQueryObject(form));
+
+      const result = await FormsService.getFormByName('form1', false).toPromise();
+
+      expect(mockForm.findOne.calledWith({ name: 'form1', branding: 'default-brand' })).to.be.true;
+      expect(result).to.deep.equal(form);
+    });
+
     it('should return null if form not found', async function () {
       mockForm.findOne.returns(createQueryObject(null));
 

--- a/packages/redbox-core/test/services/StandardDatastreamService.test.ts
+++ b/packages/redbox-core/test/services/StandardDatastreamService.test.ts
@@ -344,7 +344,7 @@ describe('StandardDatastreamService', function () {
       const service = new Services.StandardDatastream();
 
       const record = {
-        metaMetadata: { form: 'test-form-1.0-draft' },
+        metaMetadata: { form: 'test-form-1.0-draft', brandId: 'brand-1' },
         metadata: {
           dataLocations: [
             { fileId: 'existing-file', type: 'attachment' },
@@ -367,6 +367,7 @@ describe('StandardDatastreamService', function () {
           // FormsService should have been called
           expect(mockFormsService.getFormByName.calledOnce).to.be.true;
           expect(mockFormsService.getFormByName.firstCall.args[0]).to.equal('test-form-1.0-draft');
+          expect(mockFormsService.getFormByName.firstCall.args[2]).to.equal('brand-1');
 
           // new-file should have been added to fileIdsAdded
           const addedFileIds = fileIdsAdded.map((ds: any) => ds.fileId);

--- a/packages/sails-hook-redbox-storage-mongo/src/services/MongoStorageService.ts
+++ b/packages/sails-hook-redbox-storage-mongo/src/services/MongoStorageService.ts
@@ -794,7 +794,7 @@ export namespace Services {
           `${this.logHeader} updateDatastream requires fileRoot to be a disk name or an IDisk instance with getStream()`
         );
       }
-      return FormsService.getFormByName(record.metaMetadata.form, true).pipe(
+      return FormsService.getFormByName(record.metaMetadata.form, true, record.metaMetadata.brandId).pipe(
         mergeMap(form => {
           const formConfig = form;
           const attachmentFields = _.get(

--- a/packages/sails-hook-redbox-storage-mongo/test/services/MongoStorageService.test.ts
+++ b/packages/sails-hook-redbox-storage-mongo/test/services/MongoStorageService.test.ts
@@ -633,7 +633,7 @@ describe('MongoStorageService', function () {
       service.updateDatastream(
         'oid-1',
         {
-          metaMetadata: { form: 'rdmp' },
+          metaMetadata: { form: 'rdmp', brandId: 'brand-1' },
           metadata: { files: [{ fileId: 'old', type: 'attachment' }] },
         },
         {
@@ -645,6 +645,7 @@ describe('MongoStorageService', function () {
     );
 
     expect((global as any).StorageManagerService.disk.calledOnceWith('staging')).to.be.true;
+    expect((global as any).FormsService.getFormByName.calledOnceWith('rdmp', true, 'brand-1')).to.be.true;
     await Promise.all(result);
     expect(addAndRemoveStub.calledOnce).to.be.true;
     expect(addAndRemoveStub.firstCall.args[1][0].fileId).to.equal('new');


### PR DESCRIPTION
## Summary

Enhances support for brand-specific form retrieval across the application by consistently propagating and resolving `brandId` when fetching forms. Introduces a default branding fallback and updates related services and tests to ensure correct behaviour.

---

## Context / Motivation

ReDBox supports multi-tenant branding, where different institutions or tenants may have customised forms. Previously:

- `brandId` was not consistently passed through all layers
- form retrieval could fall back incorrectly or inconsistently
- some services were unaware of branding context

This PR standardises how branding is handled when retrieving forms.

---

## Key Changes

### Brand-aware Form Retrieval

- Updated `FormsService.getFormByName` to:
  - accept and use `brandId` consistently
  - resolve a default branding when none is provided

- Ensures:
  - the correct branded form is always selected
  - consistent behaviour across all entry points

---

### Propagation of `brandId`

- Updated services to pass `brandId` through the call chain:
  - `StandardDatastreamService`
  - `MongoStorageService`

- `brandId` is now sourced from:
  - `metaMetadata.brandId`

- Internal types and logic updated to support this propagation

---

### Default Branding Fallback

- Introduced fallback behaviour when `brandId` is missing:
  - resolves to a configured default branding

- Prevents:
  - failures due to missing branding
  - inconsistent form selection
---
### Testing Enhancements
- Added and updated tests across:
  - `FormsService`
  - `StandardDatastreamService`
  - `MongoStorageService`

- Coverage includes:
  - correct propagation of `brandId`
  - fallback to default branding
  - correct arguments passed between services

---

## Impact

This change:

- ensures consistent brand-specific form retrieval
- improves reliability in multi-tenant environments
- reduces risk of incorrect form rendering
- strengthens test coverage for branding behaviour