### PR TITLE
Feature: Checkbox Tree Component Expand on Label Click

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/checkbox-tree.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/checkbox-tree.component.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 import { FormConfigFrame } from "@researchdatabox/sails-ng-common";
-import {createFormAndWaitForReady, createTestbedModule, setUpDynamicAssets} from "../helpers.spec";
+import { createFormAndWaitForReady, createTestbedModule, setUpDynamicAssets } from "../helpers.spec";
 import { CheckboxTreeComponent } from "./checkbox-tree.component";
 import { VocabTreeService } from "../service/vocab-tree.service";
 
@@ -73,6 +73,58 @@ describe("CheckboxTreeComponent", () => {
     const checkboxes = compiled.querySelectorAll('input[type="checkbox"]');
     expect(checkboxes.length).toBe(1);
     expect((compiled.textContent ?? "").includes("Leaf")).toBeTrue();
+  });
+
+  it("expands parent nodes when their label is clicked instead of toggling the parent checkbox", async () => {
+    const formConfig: FormConfigFrame = {
+      name: "testing",
+      componentDefinitions: [
+        {
+          name: "anzsrc",
+          component: {
+            class: "CheckboxTreeComponent",
+            config: {
+              inlineVocab: true,
+              leafOnly: false,
+              treeData: [
+                {
+                  id: "root",
+                  label: "Root",
+                  value: "01",
+                  notation: "01",
+                  hasChildren: true,
+                  children: [
+                    { id: "leaf", label: "Leaf", value: "0101", notation: "0101", hasChildren: false }
+                  ]
+                }
+              ]
+            }
+          },
+          model: {
+            class: "CheckboxTreeModel",
+            config: {
+              value: []
+            }
+          }
+        }
+      ]
+    };
+
+    const { fixture } = await createFormAndWaitForReady(formConfig);
+    const compiled = fixture.nativeElement as HTMLElement;
+    const parentLabel = compiled.querySelector(".rb-tree-label") as HTMLLabelElement;
+    const parentCheckbox = compiled.querySelector('input[type="checkbox"]') as HTMLInputElement;
+
+    expect(compiled.querySelectorAll('[role="treeitem"]').length).toBe(1);
+
+    parentLabel.click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(compiled.querySelectorAll('[role="treeitem"]').length).toBe(2);
+    expect((compiled.textContent ?? "").includes("Leaf")).toBeTrue();
+    expect(parentCheckbox.checked).toBeFalse();
   });
 
   it("renders templated visible labels and updates selected item label value", async () => {

--- a/angular/projects/researchdatabox/form/src/app/component/checkbox-tree.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/checkbox-tree.component.ts
@@ -61,11 +61,15 @@ export class CheckboxTreeModel extends FormFieldModel<CheckboxTreeModelValueType
                 [checked]="isSelected(node)"
                 [indeterminate]="isIndeterminate(node)"
                 [attr.aria-checked]="getAriaChecked(node)"
+                [attr.aria-label]="node.displayLabel"
                 [id]="getCheckboxId(node)"
                 (change)="onNodeChecked(node, $any($event.target).checked)"
               />
             }
-            <label class="rb-tree-label" [class.rb-tree-label-root]="level === 1" [attr.for]="isSelectable(node) ? getCheckboxId(node) : null">{{ node.displayLabel }}</label>
+            <label class="rb-tree-label"
+              [class.rb-tree-label-root]="level === 1"
+              [attr.for]="isSelectable(node) && !canExpand(node, level) ? getCheckboxId(node) : null"
+              (click)="onLabelClick($event, node, level)">{{ node.displayLabel }}</label>
           </div>
           @if (loadErrors.has(node.id)) {
             <div class="rb-tree-status rb-tree-status-error rb-tree-status-nested">{{ loadErrors.get(node.id) }}</div>
@@ -338,6 +342,15 @@ export class CheckboxTreeComponent extends FormFieldBaseComponent<CheckboxTreeMo
     if (!this.inlineVocab && node.hasChildren && (node.children?.length ?? 0) === 0 && !this.loadedNodeIds.has(node.id)) {
       await this.loadChildren(node);
     }
+  }
+
+  public onLabelClick(event: MouseEvent, node: CheckboxTreeRenderNode, level: number): void {
+    this.focusedNodeId = node.id;
+    if (!this.canExpand(node, level)) {
+      return;
+    }
+    event.preventDefault();
+    void this.toggleExpand(node, level);
   }
 
   public onNodeChecked(node: CheckboxTreeRenderNode, checked: boolean): void {


### PR DESCRIPTION
## Summary

Improves the usability and accessibility of the `CheckboxTreeComponent` by changing how parent node labels behave. Parent labels now expand or collapse nodes instead of toggling checkboxes, reducing accidental selections and aligning with common tree UI patterns.

---

## Context / Motivation

Previously:

- Clicking a parent node label would toggle its checkbox
- This often caused accidental selection when users intended to expand/collapse
- Behaviour did not align with standard tree component UX patterns
- Accessibility could be improved

This PR refines interaction behaviour to make the component more intuitive and accessible.

---

## Key Changes

### Improved Parent Node Interaction

- Clicking a parent node label now:
  - expands or collapses the node
  - does not toggle the checkbox

- Introduced dedicated handling for label clicks on expandable nodes

- Results in:
  - clearer separation between navigation (expand/collapse) and selection
  - reduced accidental interactions

---

### Label Behaviour Refinement

- The label `for` attribute is now:
  - only applied to selectable, non-expandable nodes

- Ensures:
  - parent labels no longer trigger checkbox toggling
  - leaf nodes retain expected click-to-select behaviour

---

### Accessibility Enhancements

- Added `aria-label` to checkbox inputs using the node’s display label

- Improves:
  - screen reader support
  - clarity for assistive technologies

---

### Testing Enhancements

- Added tests to verify:
  - parent label click expands/collapses nodes
  - checkbox state is not affected by label click on parent nodes

- Ensures behaviour is stable and regression-safe

---

## Impact

This change:

- improves usability of tree-based selection components
- aligns behaviour with standard UI patterns
- reduces accidental checkbox toggling
- enhances accessibility for assistive technology users
- increases confidence through improved test coverage