### PR TITLE
Bugfix: Enhance form status broadcasting to ensure UI validity sync after silent model updates

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/action-row-layout.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/action-row-layout.component.ts
@@ -5,7 +5,7 @@ import {
   ViewContainerRef,
   isDevMode,
 } from '@angular/core';
-import { FormFieldBaseComponent, FormFieldCompMapEntry } from '@researchdatabox/portal-ng-common';
+import { FormFieldBaseComponent, FormFieldComponentType, FormFieldCompMapEntry } from '@researchdatabox/portal-ng-common';
 import {
   ActionRowAlignmentOptionsType,
   ActionRowLayoutName,
@@ -33,7 +33,7 @@ import { GroupFieldComponent } from './group.component';
 export class ActionRowLayoutComponent<ValueType> extends FormFieldBaseComponent<ValueType> {
   protected override logName = ActionRowLayoutName;
   public override componentDefinition?: FieldLayoutDefinitionFrame;
-  componentClass?: typeof FormFieldBaseComponent<ValueType>;
+  componentClass?: FormFieldComponentType<ValueType>;
 
   @ViewChild('componentContainer', { read: ViewContainerRef, static: false })
   componentContainer!: ViewContainerRef;
@@ -41,7 +41,7 @@ export class ActionRowLayoutComponent<ValueType> extends FormFieldBaseComponent<
   wrapperComponentRef?: ComponentRef<FormBaseWrapperComponent<ValueType>>;
   protected override setPropertiesFromComponentMapEntry(formFieldCompMapEntry: FormFieldCompMapEntry): void {
     super.setPropertiesFromComponentMapEntry(formFieldCompMapEntry);
-    this.componentClass = formFieldCompMapEntry?.componentClass as typeof FormFieldBaseComponent<ValueType>;
+    this.componentClass = formFieldCompMapEntry?.componentClass as FormFieldComponentType<ValueType>;
     this.componentDefinition = formFieldCompMapEntry?.compConfigJson?.layout;
 
     if (!_isUndefined(this.formFieldCompMapEntry) && !_isNull(this.formFieldCompMapEntry)) {

--- a/angular/projects/researchdatabox/form/src/app/component/base-wrapper.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/base-wrapper.component.ts
@@ -1,8 +1,8 @@
-import { Component, Type, Input, ViewChild, OnDestroy, inject, Injector, Signal, HostBinding } from '@angular/core';
+import { Component, Input, ViewChild, OnDestroy, inject, Injector, Signal, HostBinding } from '@angular/core';
 import { FormBaseWrapperDirective } from './base-wrapper.directive';
 
 import { set as _set, get as _get } from 'lodash-es';
-import { FormFieldBaseComponent, FormFieldCompMapEntry } from '@researchdatabox/portal-ng-common';
+import { FormFieldBaseComponent, FormFieldComponentType, FormFieldCompMapEntry } from '@researchdatabox/portal-ng-common';
 import {
   KeyValueStringNested,
   FormFieldComponentStatus,
@@ -45,7 +45,7 @@ const VALUE_CHANGE_CONSUMER_EXCLUDED_COMPONENTS = new Set<string>([
 })
 export class FormBaseWrapperComponent<ValueType> extends FormFieldBaseComponent<ValueType> implements OnDestroy {
   protected override logName = 'FormBaseWrapperComponent';
-  @Input() componentClass?: typeof FormFieldBaseComponent<ValueType>;
+  @Input() componentClass?: FormFieldComponentType<ValueType>;
   @Input() defaultComponentConfig?: KeyValueStringNested = null;
 
   @ViewChild(FormBaseWrapperDirective, { static: true }) formFieldDirective!: FormBaseWrapperDirective;
@@ -89,7 +89,7 @@ export class FormBaseWrapperComponent<ValueType> extends FormFieldBaseComponent<
     this.formFieldCompMapEntry = formFieldCompMapEntry;
     const componentName = this.formFieldConfigName();
     this.loggerService.debug(`${this.logName}: Starting initWrapperComponent for '${componentName}'.`, this.formFieldCompMapEntry);
-    this.componentClass = this.formFieldCompMapEntry.componentClass as typeof FormFieldBaseComponent<ValueType>;
+    this.componentClass = this.formFieldCompMapEntry.componentClass as FormFieldComponentType<ValueType>;
 
     // If the wrapper has already been initialised, provide the component instance.
     // TODO: Does this make sense, when a different formFieldCompMapEntry might have been provided and set above?
@@ -114,13 +114,12 @@ export class FormBaseWrapperComponent<ValueType> extends FormFieldBaseComponent<
     }
 
     // Select which class to use.
-    const compClass = omitLayout ? this.componentClass : this.formFieldCompMapEntry?.layoutClass || this.componentClass;
-    // TODO: can typescript typeof be converted to angular Type?
-    //       Casting to unknown then to the angular Type is bit odd?
-    const comClassTyped = compClass as unknown as Type<FormFieldBaseComponent<ValueType>>;
+    const compClass = (
+      omitLayout ? this.componentClass : this.formFieldCompMapEntry.layoutClass || this.componentClass
+    ) as FormFieldComponentType<ValueType>;
 
     // Create an instance of the component from the class.
-    const compRef = viewContainerRef.createComponent(comClassTyped);
+    const compRef = viewContainerRef.createComponent(compClass);
 
     // Provide the default css classes to the new component instance.
     if (this.defaultComponentConfig && this.formFieldCompMapEntry?.compConfigJson?.component) {
@@ -136,6 +135,7 @@ export class FormBaseWrapperComponent<ValueType> extends FormFieldBaseComponent<
     } else {
       this.formFieldCompMapEntry.componentRef = compRef;
     }
+    compRef.instance.formEventScopeId = this.getFormComponent.eventScopeId;
 
     // Initialise the component.
     await compRef.instance.initComponent(this.formFieldCompMapEntry);

--- a/angular/projects/researchdatabox/form/src/app/component/date-input.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/date-input.component.spec.ts
@@ -144,4 +144,51 @@ describe('DateInputComponent', () => {
     expect(inputElement.placeholder).toEqual('yyyy/mm/dd');
   });
 
+  it('marks the form dirty and touched when only the time value changes', async () => {
+    const formConfig: FormConfigFrame = {
+      name: 'testing_time_dirty',
+      debugValue: true,
+      defaultComponentConfig: {
+        defaultComponentCssClasses: 'row',
+      },
+      editCssClasses: 'redbox-form form',
+      componentDefinitions: [
+        {
+          name: 'date_test',
+          model: {
+            class: 'DateInputModel',
+            config: {
+              value: new Date('2025-08-10T10:00:00Z')
+            },
+          },
+          component: {
+            class: 'DateInputComponent',
+            config: {
+              enableTimePicker: true,
+            },
+          },
+        },
+      ],
+    };
+
+    const {fixture, formComponent} = await createFormAndWaitForReady(formConfig);
+    const compiled = fixture.nativeElement as HTMLElement;
+    const timeInput = compiled.querySelector('input[type="time"]') as HTMLInputElement;
+    const control = formComponent.form?.get('date_test');
+
+    expect(timeInput).toBeTruthy();
+    expect(control?.dirty).toBeFalse();
+    expect(control?.touched).toBeFalse();
+
+    timeInput.value = '11:30';
+    timeInput.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await Promise.resolve();
+
+    expect(control?.dirty).toBeTrue();
+    expect(control?.touched).toBeTrue();
+    expect(formComponent.form?.dirty).toBeTrue();
+  });
+
 });

--- a/angular/projects/researchdatabox/form/src/app/component/date-input.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/date-input.component.ts
@@ -206,6 +206,8 @@ export class DateInputComponent extends FormFieldBaseComponent<DateInputModelVal
     let timeValue = (event.target as HTMLInputElement).value as string;
     this.loggerService.info(`timeValue ${timeValue}`,'');
     this.model?.setTimeValue(timeValue);
+    this.formControl?.markAsDirty();
+    this.formControl?.markAsTouched();
     try {
       (this.formComponent as { queueFormStatusBroadcast?: () => void } | undefined)?.queueFormStatusBroadcast?.();
     } catch (error) {

--- a/angular/projects/researchdatabox/form/src/app/component/date-input.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/date-input.component.ts
@@ -208,11 +208,6 @@ export class DateInputComponent extends FormFieldBaseComponent<DateInputModelVal
     this.model?.setTimeValue(timeValue);
     this.formControl?.markAsDirty();
     this.formControl?.markAsTouched();
-    try {
-      (this.formComponent as { queueFormStatusBroadcast?: () => void } | undefined)?.queueFormStatusBroadcast?.();
-    } catch (error) {
-      this.loggerService.debug(`${this.logName}: Unable to queue form status broadcast after time change.`, error);
-    }
   }
 
   public get bsConfig(): BsDatepickerConfig {

--- a/angular/projects/researchdatabox/form/src/app/component/date-input.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/date-input.component.ts
@@ -206,6 +206,11 @@ export class DateInputComponent extends FormFieldBaseComponent<DateInputModelVal
     let timeValue = (event.target as HTMLInputElement).value as string;
     this.loggerService.info(`timeValue ${timeValue}`,'');
     this.model?.setTimeValue(timeValue);
+    try {
+      (this.formComponent as { queueFormStatusBroadcast?: () => void } | undefined)?.queueFormStatusBroadcast?.();
+    } catch (error) {
+      this.loggerService.debug(`${this.logName}: Unable to queue form status broadcast after time change.`, error);
+    }
   }
 
   public get bsConfig(): BsDatepickerConfig {

--- a/angular/projects/researchdatabox/form/src/app/component/default-layout.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/default-layout.component.ts
@@ -7,7 +7,7 @@ import {
   FormFieldComponentStatus,
   DefaultLayoutName
 } from "@researchdatabox/sails-ng-common";
-import { FormFieldBaseComponent, FormFieldCompMapEntry } from "@researchdatabox/portal-ng-common";
+import { FormFieldBaseComponent, FormFieldComponentType, FormFieldCompMapEntry } from "@researchdatabox/portal-ng-common";
 import { FormService } from "../form.service";
 
 /**
@@ -77,7 +77,7 @@ import { FormService } from "../form.service";
 export class DefaultLayoutComponent<ValueType> extends FormFieldBaseComponent<ValueType> {
   protected override logName: string = DefaultLayoutName;
   helpTextVisible: boolean = false;
-  componentClass?: typeof FormFieldBaseComponent<ValueType>;
+  componentClass?: FormFieldComponentType<ValueType>;
   public override componentDefinition?: FieldLayoutDefinitionFrame;
 
   @ViewChild('componentContainer', { read: ViewContainerRef, static: false }) componentContainer!: ViewContainerRef;
@@ -102,7 +102,7 @@ export class DefaultLayoutComponent<ValueType> extends FormFieldBaseComponent<Va
    */
   protected override setPropertiesFromComponentMapEntry(formFieldCompMapEntry: FormFieldCompMapEntry): void {
     super.setPropertiesFromComponentMapEntry(formFieldCompMapEntry);
-    this.componentClass = formFieldCompMapEntry?.componentClass as typeof FormFieldBaseComponent<ValueType>;
+    this.componentClass = formFieldCompMapEntry?.componentClass as FormFieldComponentType<ValueType>;
     this.componentDefinition = formFieldCompMapEntry?.compConfigJson?.layout;
     this.tooltip = this.getStringProperty('tooltip');
     if (!_isUndefined(this.formFieldCompMapEntry) && !_isNull(this.formFieldCompMapEntry)) {

--- a/angular/projects/researchdatabox/form/src/app/component/inline-layout.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/inline-layout.component.ts
@@ -7,7 +7,7 @@ import {
   FormFieldComponentStatus,
   InlineLayoutName
 } from "@researchdatabox/sails-ng-common";
-import { FormFieldBaseComponent, FormFieldCompMapEntry } from "@researchdatabox/portal-ng-common";
+import { FormFieldBaseComponent, FormFieldComponentType, FormFieldCompMapEntry } from "@researchdatabox/portal-ng-common";
 import { FormService } from "../form.service";
 
 /**
@@ -77,7 +77,7 @@ import { FormService } from "../form.service";
 export class InlineLayoutComponent<ValueType> extends FormFieldBaseComponent<ValueType> {
   protected override logName: string = InlineLayoutName;
   helpTextVisible: boolean = false;
-  componentClass?: typeof FormFieldBaseComponent<ValueType>;
+  componentClass?: FormFieldComponentType<ValueType>;
   public override componentDefinition?: FieldLayoutDefinitionFrame;
 
   @ViewChild('componentContainer', { read: ViewContainerRef, static: false }) componentContainer!: ViewContainerRef;
@@ -102,7 +102,7 @@ export class InlineLayoutComponent<ValueType> extends FormFieldBaseComponent<Val
    */
   protected override setPropertiesFromComponentMapEntry(formFieldCompMapEntry: FormFieldCompMapEntry): void {
     super.setPropertiesFromComponentMapEntry(formFieldCompMapEntry);
-    this.componentClass = formFieldCompMapEntry?.componentClass as typeof FormFieldBaseComponent<ValueType>;
+    this.componentClass = formFieldCompMapEntry?.componentClass as FormFieldComponentType<ValueType>;
     this.componentDefinition = formFieldCompMapEntry?.compConfigJson?.layout;
     this.tooltip = this.getStringProperty('tooltip');
     if (!_isUndefined(this.formFieldCompMapEntry) && !_isNull(this.formFieldCompMapEntry)) {

--- a/angular/projects/researchdatabox/form/src/app/component/save-button.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/save-button.component.spec.ts
@@ -5,7 +5,7 @@ import {TestBed} from "@angular/core/testing";
 import { Store } from '@ngrx/store';
 import * as FormActions from '../form-state/state/form.actions';
 import {  FormConfigFrame } from '@researchdatabox/sails-ng-common';
-import { FormComponentEventBus } from '../form-state/events';
+import { FormComponentEventBus, FormComponentEventType, FormValidationBroadcastEvent } from '../form-state/events';
 import {TranslationService} from "@researchdatabox/portal-ng-common";
 
 let formConfig: FormConfigFrame;
@@ -132,6 +132,46 @@ describe('SaveButtonComponent', () => {
     expect(saveButton.disabled).toBeFalse();
 
     expect(saveButton.textContent).toEqual("@save-button-default");
+  });
+
+  it('ignores validation broadcasts from another form scope', async () => {
+    const {fixture, formComponent} = await createFormAndWaitForReady(formConfig);
+    const eventBus = TestBed.inject(FormComponentEventBus);
+    const saveButton = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
+    const validDirtyStatus = {
+      ...formComponent.dataStatus,
+      valid: true,
+      invalid: false,
+      dirty: true,
+      pristine: false,
+      status: 'VALID' as const,
+    };
+
+    eventBus.publish<FormValidationBroadcastEvent>({
+      type: FormComponentEventType.FORM_VALIDATION_BROADCAST,
+      sourceId: formComponent.eventScopeId,
+      isValid: true,
+      status: validDirtyStatus,
+    });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(saveButton.disabled).toBeFalse();
+
+    eventBus.publish<FormValidationBroadcastEvent>({
+      type: FormComponentEventType.FORM_VALIDATION_BROADCAST,
+      sourceId: 'another-form-scope',
+      isValid: false,
+      status: {
+        ...validDirtyStatus,
+        valid: false,
+        invalid: true,
+        status: 'INVALID' as const,
+      },
+    });
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(saveButton.disabled).toBeFalse();
   });
 
   it('should not publish save requested when disabled', async () => {

--- a/angular/projects/researchdatabox/form/src/app/component/save-button.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/save-button.component.spec.ts
@@ -137,6 +137,7 @@ describe('SaveButtonComponent', () => {
   it('ignores validation broadcasts from another form scope', async () => {
     const {fixture, formComponent} = await createFormAndWaitForReady(formConfig);
     const eventBus = TestBed.inject(FormComponentEventBus);
+    const store = TestBed.inject(Store);
     const saveButton = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
     const validDirtyStatus = {
       ...formComponent.dataStatus,
@@ -172,6 +173,12 @@ describe('SaveButtonComponent', () => {
     await fixture.whenStable();
 
     expect(saveButton.disabled).toBeFalse();
+
+    store.dispatch(FormActions.formValidationPending());
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(saveButton.disabled).toBeTrue();
   });
 
   it('should not publish save requested when disabled', async () => {

--- a/angular/projects/researchdatabox/form/src/app/component/save-button.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/save-button.component.ts
@@ -1,6 +1,6 @@
 import {Component, inject, effect, signal, Injector} from '@angular/core';
 import { FormFieldBaseComponent } from '@researchdatabox/portal-ng-common';
-import { FormComponent } from '../form.component';
+import { FormComponent, FormGroupStatus } from '../form.component';
 import {SaveButtonComponentName, SaveButtonFieldComponentDefinitionOutline} from '@researchdatabox/sails-ng-common';
 import { FormComponentEventBus, FormComponentEventType, createFormSaveRequestedEvent, FormStateFacade } from '../form-state';
 import {FormService} from "../form.service";
@@ -21,6 +21,7 @@ import {FormService} from "../form.service";
 export class SaveButtonComponent extends FormFieldBaseComponent<undefined> {
   public override logName = SaveButtonComponentName;
   disabled = signal<boolean>(true);
+  private readonly validationStatus = signal<FormGroupStatus | null>(null);
   private readonly eventBus = inject(FormComponentEventBus);
   public override componentDefinition?: SaveButtonFieldComponentDefinitionOutline;
   protected currentLabel = signal<string | undefined>(this.componentDefinition?.config?.label);
@@ -41,11 +42,13 @@ export class SaveButtonComponent extends FormFieldBaseComponent<undefined> {
       const dataStatusEvent = validationSignal();
       const isSaving = this.formStateFacade.isSaving();
       const isValidationPending = this.formStateFacade.isValidationPending();
-      if (dataStatusEvent?.sourceId && dataStatusEvent.sourceId !== this.getFormEventScopeId()) {
-        return;
+      if (!dataStatusEvent?.sourceId || dataStatusEvent.sourceId === this.getFormEventScopeId()) {
+        if (dataStatusEvent?.status) {
+          this.validationStatus.set(dataStatusEvent.status);
+        }
       }
-      if (dataStatusEvent && dataStatusEvent.status) {
-        const dataStatus = dataStatusEvent.status;
+      const dataStatus = this.validationStatus();
+      if (dataStatus) {
         this.loggerService.debug(`SaveButtonComponent effect: validation or pristine signal event: `, dataStatus);
         // Disable when any of the following is true:
         // - form is invalid

--- a/angular/projects/researchdatabox/form/src/app/component/save-button.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/save-button.component.ts
@@ -41,6 +41,9 @@ export class SaveButtonComponent extends FormFieldBaseComponent<undefined> {
       const dataStatusEvent = validationSignal();
       const isSaving = this.formStateFacade.isSaving();
       const isValidationPending = this.formStateFacade.isValidationPending();
+      if (dataStatusEvent?.sourceId && dataStatusEvent.sourceId !== this.getFormEventScopeId()) {
+        return;
+      }
       if (dataStatusEvent && dataStatusEvent.status) {
         const dataStatus = dataStatusEvent.status;
         this.loggerService.debug(`SaveButtonComponent effect: validation or pristine signal event: `, dataStatus);
@@ -81,6 +84,10 @@ export class SaveButtonComponent extends FormFieldBaseComponent<undefined> {
 
   private get getFormComponent(): FormComponent {
     return this.formComponent;
+  }
+
+  private getFormEventScopeId(): string | undefined {
+    return this.formEventScopeId ?? this.getFormComponent.eventScopeId;
   }
 
   private resolveButtonCssClasses(configured: string | undefined, fallbackVariantClass: string): string {

--- a/angular/projects/researchdatabox/form/src/app/form-state/behaviours/behaviour-actions.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/behaviours/behaviour-actions.ts
@@ -19,6 +19,7 @@ export interface BehaviourActionExecutionContext {
   eventBus: FormComponentEventBus;
   compiledTemplateEvaluator?: BehaviourCompiledTemplateEvaluator;
   logger: LoggerService;
+  broadcastFormStatus?: () => void;
   fieldResolverContext: BehaviourFieldResolverContext;
   getLogicalFieldEntry: (listName: 'actions' | 'onError', actionIndex: number) => FormFieldCompMapEntry | undefined;
 }
@@ -71,6 +72,7 @@ async function executeSetValueAction(
   const value = await resolveActionValue(action, pipelineContext, ctx);
   resolved.control.setValue(value, { emitEvent: false });
   resolved.control.markAsDirty();
+  ctx.broadcastFormStatus?.();
 }
 
 /**

--- a/angular/projects/researchdatabox/form/src/app/form-state/behaviours/behaviour-actions.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/behaviours/behaviour-actions.ts
@@ -5,6 +5,7 @@ import { createFieldValueChangedEvent } from '../events/form-component-event.typ
 import { BehaviourCompiledTemplateEvaluator } from './behaviour-compiled-template-evaluator';
 import { BehaviourPipelineContext } from './behaviour-processors';
 import { BehaviourFieldResolverContext, resolveFieldByPointer } from './behaviour-field-resolver';
+import { isEqual as _isEqual } from 'lodash-es';
 
 /**
  * Dependencies shared by action execution.
@@ -69,6 +70,9 @@ async function executeSetValueAction(
   }
 
   const value = await resolveActionValue(action, pipelineContext, ctx);
+  if (_isEqual(resolved.control.value, value)) {
+    return false;
+  }
   resolved.control.setValue(value, { emitEvent: false });
   resolved.control.markAsDirty();
   return true;

--- a/angular/projects/researchdatabox/form/src/app/form-state/behaviours/behaviour-actions.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/behaviours/behaviour-actions.ts
@@ -19,7 +19,6 @@ export interface BehaviourActionExecutionContext {
   eventBus: FormComponentEventBus;
   compiledTemplateEvaluator?: BehaviourCompiledTemplateEvaluator;
   logger: LoggerService;
-  broadcastFormStatus?: () => void;
   fieldResolverContext: BehaviourFieldResolverContext;
   getLogicalFieldEntry: (listName: 'actions' | 'onError', actionIndex: number) => FormFieldCompMapEntry | undefined;
 }
@@ -28,15 +27,15 @@ export async function executeBehaviourAction(
   action: FormBehaviourActionConfig,
   pipelineContext: BehaviourPipelineContext,
   ctx: BehaviourActionExecutionContext
-): Promise<void> {
+): Promise<boolean> {
   switch (action.type) {
     case FormBehaviourActionType.SetValue:
-      await executeSetValueAction(action, pipelineContext, ctx);
-      return;
+      return await executeSetValueAction(action, pipelineContext, ctx);
     case FormBehaviourActionType.EmitEvent:
       await executeEmitEventAction(action, pipelineContext, ctx);
-      return;
+      return false;
   }
+  return false;
 }
 
 /**
@@ -51,7 +50,7 @@ async function executeSetValueAction(
   action: Extract<FormBehaviourActionConfig, { type: 'setValue' }>,
   pipelineContext: BehaviourPipelineContext,
   ctx: BehaviourActionExecutionContext
-): Promise<void> {
+): Promise<boolean> {
   const config = action.config;
   const fieldPathKind = config.fieldPathKind ?? FieldPathKind.ComponentJsonPointer;
   const resolved =
@@ -66,13 +65,13 @@ async function executeSetValueAction(
       listName: ctx.listName,
       fieldPathKind,
     });
-    return;
+    return false;
   }
 
   const value = await resolveActionValue(action, pipelineContext, ctx);
   resolved.control.setValue(value, { emitEvent: false });
   resolved.control.markAsDirty();
-  ctx.broadcastFormStatus?.();
+  return true;
 }
 
 /**

--- a/angular/projects/researchdatabox/form/src/app/form-state/behaviours/behaviour-handler.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/behaviours/behaviour-handler.ts
@@ -200,6 +200,7 @@ export class BehaviourHandler {
         eventBus: this.ctx.eventBus,
         compiledTemplateEvaluator: this.compiledTemplateEvaluator,
         logger: this.ctx.logger,
+        broadcastFormStatus: () => this.ctx.formComponent.broadcastFormStatus(),
         fieldResolverContext: { formComponent: this.ctx.formComponent },
         getLogicalFieldEntry: (targetListName, targetActionIndex) =>
           this.logicalFieldEntries.get(this.buildActionKey(targetListName, targetActionIndex)),

--- a/angular/projects/researchdatabox/form/src/app/form-state/behaviours/behaviour-handler.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/behaviours/behaviour-handler.ts
@@ -188,23 +188,27 @@ export class BehaviourHandler {
     value: unknown,
     event: FormComponentEvent
   ): Promise<void> {
+    let hasSilentSetValueUpdate = false;
     for (const [actionIndex, action] of actions.entries()) {
       const actionKey = this.buildActionKey(listName, actionIndex);
       if (this.permanentlySkippedActions.has(actionKey)) {
         continue;
       }
-      await executeBehaviourAction(action, this.buildPipelineContext(value, event), {
+      const didSilentlyUpdate = await executeBehaviourAction(action, this.buildPipelineContext(value, event), {
         behaviourIndex: this.behaviourIndex,
         actionIndex,
         listName,
         eventBus: this.ctx.eventBus,
         compiledTemplateEvaluator: this.compiledTemplateEvaluator,
         logger: this.ctx.logger,
-        broadcastFormStatus: () => this.ctx.formComponent.broadcastFormStatus(),
         fieldResolverContext: { formComponent: this.ctx.formComponent },
         getLogicalFieldEntry: (targetListName, targetActionIndex) =>
           this.logicalFieldEntries.get(this.buildActionKey(targetListName, targetActionIndex)),
       });
+      hasSilentSetValueUpdate ||= didSilentlyUpdate;
+    }
+    if (hasSilentSetValueUpdate) {
+      this.ctx.formComponent.queueFormStatusBroadcast();
     }
   }
 

--- a/angular/projects/researchdatabox/form/src/app/form-state/behaviours/behaviour-handler.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/behaviours/behaviour-handler.ts
@@ -189,26 +189,29 @@ export class BehaviourHandler {
     event: FormComponentEvent
   ): Promise<void> {
     let hasSilentSetValueUpdate = false;
-    for (const [actionIndex, action] of actions.entries()) {
-      const actionKey = this.buildActionKey(listName, actionIndex);
-      if (this.permanentlySkippedActions.has(actionKey)) {
-        continue;
+    try {
+      for (const [actionIndex, action] of actions.entries()) {
+        const actionKey = this.buildActionKey(listName, actionIndex);
+        if (this.permanentlySkippedActions.has(actionKey)) {
+          continue;
+        }
+        const didSilentlyUpdate = await executeBehaviourAction(action, this.buildPipelineContext(value, event), {
+          behaviourIndex: this.behaviourIndex,
+          actionIndex,
+          listName,
+          eventBus: this.ctx.eventBus,
+          compiledTemplateEvaluator: this.compiledTemplateEvaluator,
+          logger: this.ctx.logger,
+          fieldResolverContext: { formComponent: this.ctx.formComponent },
+          getLogicalFieldEntry: (targetListName, targetActionIndex) =>
+            this.logicalFieldEntries.get(this.buildActionKey(targetListName, targetActionIndex)),
+        });
+        hasSilentSetValueUpdate ||= didSilentlyUpdate;
       }
-      const didSilentlyUpdate = await executeBehaviourAction(action, this.buildPipelineContext(value, event), {
-        behaviourIndex: this.behaviourIndex,
-        actionIndex,
-        listName,
-        eventBus: this.ctx.eventBus,
-        compiledTemplateEvaluator: this.compiledTemplateEvaluator,
-        logger: this.ctx.logger,
-        fieldResolverContext: { formComponent: this.ctx.formComponent },
-        getLogicalFieldEntry: (targetListName, targetActionIndex) =>
-          this.logicalFieldEntries.get(this.buildActionKey(targetListName, targetActionIndex)),
-      });
-      hasSilentSetValueUpdate ||= didSilentlyUpdate;
-    }
-    if (hasSilentSetValueUpdate) {
-      this.ctx.formComponent.queueFormStatusBroadcast();
+    } finally {
+      if (hasSilentSetValueUpdate) {
+        this.ctx.formComponent.queueFormStatusBroadcast();
+      }
     }
   }
 

--- a/angular/projects/researchdatabox/form/src/app/form-state/behaviours/form-behaviour-manager.service.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/behaviours/form-behaviour-manager.service.spec.ts
@@ -133,6 +133,71 @@ describe('FormBehaviourManager', () => {
     expect(formComponent.queueFormStatusBroadcast).toHaveBeenCalledTimes(1);
   }));
 
+  it('does not queue a status broadcast for no-op setValue actions', fakeAsync(() => {
+    const targetControl = new FormControl('copied');
+    const formComponent = {
+      form: { value: { source: 'source', target: 'copied' } },
+      formDefMap: {
+        formConfig: {
+          behaviours: [
+            {
+              name: 'copy-source-noop',
+              condition: '/main/source::field.value.changed',
+              conditionKind: 'jsonpointer',
+              actions: [
+                {
+                  type: 'setValue',
+                  config: {
+                    fieldPath: '/main/target',
+                    fieldPathKind: 'componentJsonPointer',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+      getFormCompiledItems: jasmine.createSpy('getFormCompiledItems').and.resolveTo({
+        evaluate: jasmine.createSpy('evaluate').and.resolveTo('unused'),
+      }),
+      getQuerySource: () => ({
+        queryOrigSource: [],
+        querySource: [],
+        jsonPointerSource: {
+          main: {
+            source: { metadata: { formFieldEntry: { model: { formControl: new FormControl('source') } } } },
+            target: {
+              metadata: {
+                formFieldEntry: {
+                  model: { formControl: targetControl },
+                  lineagePaths: { angularComponentsJsonPointer: '/main/target' },
+                },
+              },
+            },
+          },
+        },
+      }),
+      requestParams: () => ({}),
+      queueFormStatusBroadcast: jasmine.createSpy('queueFormStatusBroadcast'),
+    } as any;
+
+    const setValueSpy = spyOn(targetControl, 'setValue').and.callThrough();
+    manager.bind(formComponent);
+
+    fieldEvents$.next({
+      type: FormComponentEventType.FIELD_VALUE_CHANGED,
+      fieldId: '/main/source',
+      sourceId: '*',
+      value: 'copied',
+      timestamp: Date.now(),
+    } as any);
+    tick();
+
+    expect(setValueSpy).not.toHaveBeenCalled();
+    expect(targetControl.dirty).toBeFalse();
+    expect(formComponent.queueFormStatusBroadcast).not.toHaveBeenCalled();
+  }));
+
   it('runs fetchMetadata processors and emits onError actions when a processor fails', fakeAsync(() => {
     const formComponent = {
       form: { value: { source: 'oid-1' } },

--- a/angular/projects/researchdatabox/form/src/app/form-state/behaviours/form-behaviour-manager.service.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/behaviours/form-behaviour-manager.service.spec.ts
@@ -96,6 +96,7 @@ describe('FormBehaviourManager', () => {
         },
       }),
       requestParams: () => ({}),
+      broadcastFormStatus: jasmine.createSpy('broadcastFormStatus'),
     } as any;
 
     const setValueSpy = spyOn(targetControl, 'setValue').and.callThrough();
@@ -111,6 +112,7 @@ describe('FormBehaviourManager', () => {
     tick();
 
     expect(setValueSpy).toHaveBeenCalledWith('copied', { emitEvent: false });
+    expect(formComponent.broadcastFormStatus).toHaveBeenCalledTimes(1);
   }));
 
   it('runs fetchMetadata processors and emits onError actions when a processor fails', fakeAsync(() => {

--- a/angular/projects/researchdatabox/form/src/app/form-state/behaviours/form-behaviour-manager.service.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/behaviours/form-behaviour-manager.service.spec.ts
@@ -198,6 +198,88 @@ describe('FormBehaviourManager', () => {
     expect(formComponent.queueFormStatusBroadcast).not.toHaveBeenCalled();
   }));
 
+  it('queues a status broadcast when a later behaviour action fails after a silent update', fakeAsync(() => {
+    const targetControl = new FormControl('');
+    const failingTargetControl = new FormControl('');
+    const formComponent = {
+      form: { value: { source: 'source', target: '', failingTarget: '' } },
+      formDefMap: {
+        formConfig: {
+          behaviours: [
+            {
+              name: 'partial-update-then-error',
+              condition: '/main/source::field.value.changed',
+              conditionKind: 'jsonpointer',
+              actions: [
+                {
+                  type: 'setValue',
+                  config: {
+                    fieldPath: '/main/target',
+                    fieldPathKind: 'componentJsonPointer',
+                  },
+                },
+                {
+                  type: 'setValue',
+                  config: {
+                    fieldPath: '/main/failingTarget',
+                    fieldPathKind: 'componentJsonPointer',
+                    hasValueTemplate: true,
+                    valueTemplate: '$error()',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+      getFormCompiledItems: jasmine.createSpy('getFormCompiledItems').and.resolveTo({
+        evaluate: jasmine.createSpy('evaluate').and.rejectWith(new Error('template boom')),
+      }),
+      getQuerySource: () => ({
+        queryOrigSource: [],
+        querySource: [],
+        jsonPointerSource: {
+          main: {
+            source: { metadata: { formFieldEntry: { model: { formControl: new FormControl('source') } } } },
+            target: {
+              metadata: {
+                formFieldEntry: {
+                  model: { formControl: targetControl },
+                  lineagePaths: { angularComponentsJsonPointer: '/main/target' },
+                },
+              },
+            },
+            failingTarget: {
+              metadata: {
+                formFieldEntry: {
+                  model: { formControl: failingTargetControl },
+                  lineagePaths: { angularComponentsJsonPointer: '/main/failingTarget' },
+                },
+              },
+            },
+          },
+        },
+      }),
+      requestParams: () => ({}),
+      queueFormStatusBroadcast: jasmine.createSpy('queueFormStatusBroadcast'),
+    } as any;
+
+    manager.bind(formComponent);
+
+    fieldEvents$.next({
+      type: FormComponentEventType.FIELD_VALUE_CHANGED,
+      fieldId: '/main/source',
+      sourceId: '*',
+      value: 'copied',
+      timestamp: Date.now(),
+    } as any);
+    tick();
+
+    expect(targetControl.value).toBe('copied');
+    expect(failingTargetControl.value).toBe('');
+    expect(formComponent.queueFormStatusBroadcast).toHaveBeenCalledTimes(1);
+  }));
+
   it('runs fetchMetadata processors and emits onError actions when a processor fails', fakeAsync(() => {
     const formComponent = {
       form: { value: { source: 'oid-1' } },

--- a/angular/projects/researchdatabox/form/src/app/form-state/behaviours/form-behaviour-manager.service.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/behaviours/form-behaviour-manager.service.spec.ts
@@ -51,10 +51,11 @@ describe('FormBehaviourManager', () => {
     manager.destroy();
   });
 
-  it('binds behaviours and silently updates target field values', fakeAsync(() => {
+  it('binds behaviours and queues one status broadcast after silent target field updates', fakeAsync(() => {
     const targetControl = new FormControl('');
+    const secondTargetControl = new FormControl('');
     const formComponent = {
-      form: { value: { source: 'source', target: '' } },
+      form: { value: { source: 'source', target: '', secondTarget: '' } },
       formDefMap: {
         formConfig: {
           behaviours: [
@@ -67,6 +68,13 @@ describe('FormBehaviourManager', () => {
                   type: 'setValue',
                   config: {
                     fieldPath: '/main/target',
+                    fieldPathKind: 'componentJsonPointer',
+                  },
+                },
+                {
+                  type: 'setValue',
+                  config: {
+                    fieldPath: '/main/secondTarget',
                     fieldPathKind: 'componentJsonPointer',
                   },
                 },
@@ -92,14 +100,23 @@ describe('FormBehaviourManager', () => {
                 },
               },
             },
+            secondTarget: {
+              metadata: {
+                formFieldEntry: {
+                  model: { formControl: secondTargetControl },
+                  lineagePaths: { angularComponentsJsonPointer: '/main/secondTarget' },
+                },
+              },
+            },
           },
         },
       }),
       requestParams: () => ({}),
-      broadcastFormStatus: jasmine.createSpy('broadcastFormStatus'),
+      queueFormStatusBroadcast: jasmine.createSpy('queueFormStatusBroadcast'),
     } as any;
 
     const setValueSpy = spyOn(targetControl, 'setValue').and.callThrough();
+    const secondSetValueSpy = spyOn(secondTargetControl, 'setValue').and.callThrough();
     manager.bind(formComponent);
 
     fieldEvents$.next({
@@ -112,7 +129,8 @@ describe('FormBehaviourManager', () => {
     tick();
 
     expect(setValueSpy).toHaveBeenCalledWith('copied', { emitEvent: false });
-    expect(formComponent.broadcastFormStatus).toHaveBeenCalledTimes(1);
+    expect(secondSetValueSpy).toHaveBeenCalledWith('copied', { emitEvent: false });
+    expect(formComponent.queueFormStatusBroadcast).toHaveBeenCalledTimes(1);
   }));
 
   it('runs fetchMetadata processors and emits onError actions when a processor fails', fakeAsync(() => {

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
@@ -396,13 +396,7 @@ export abstract class FormComponentEventBaseConsumer extends FormComponentEventB
       if (this.control && this.control.value !== targetValue) {
         await setControlValue(this.control, targetValue, { emitEvent: false });
         await syncComponentDisplayFromModel(this.options?.component);
-        // setControlValue with emitEvent:false suppresses Angular's
-        // StatusChangeEvent/PristineChangeEvent. Without an explicit re-broadcast,
-        // listeners like SaveButtonComponent never see that an expression-driven
-        // update flipped the form to valid (e.g. a downstream "required" target
-        // becoming populated), and the Save button stays disabled. Re-emit the
-        // current form status so signal-effect consumers can re-evaluate.
-        this.formComp?.broadcastFormStatus();
+        this.formComp?.queueFormStatusBroadcast();
       }
     } else if (exprTarget.startsWith(FormExpressionsTargetLayoutPrefix)) {
       const propPath = exprTarget.substring(FormExpressionsTargetLayoutPrefix.length);

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
@@ -396,6 +396,13 @@ export abstract class FormComponentEventBaseConsumer extends FormComponentEventB
       if (this.control && this.control.value !== targetValue) {
         await setControlValue(this.control, targetValue, { emitEvent: false });
         await syncComponentDisplayFromModel(this.options?.component);
+        // setControlValue with emitEvent:false suppresses Angular's
+        // StatusChangeEvent/PristineChangeEvent. Without an explicit re-broadcast,
+        // listeners like SaveButtonComponent never see that an expression-driven
+        // update flipped the form to valid (e.g. a downstream "required" target
+        // becoming populated), and the Save button stays disabled. Re-emit the
+        // current form status so signal-effect consumers can re-evaluate.
+        this.formComp?.broadcastFormStatus();
       }
     } else if (exprTarget.startsWith(FormExpressionsTargetLayoutPrefix)) {
       const propPath = exprTarget.substring(FormExpressionsTargetLayoutPrefix.length);

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-change-event-consumer.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-change-event-consumer.spec.ts
@@ -129,7 +129,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
     control.updateValueAndValidity();
     const formComponent = {
       getQuerySource: () => undefined,
-      broadcastFormStatus: jasmine.createSpy('broadcastFormStatus')
+      queueFormStatusBroadcast: jasmine.createSpy('queueFormStatusBroadcast')
     };
 
     spyOn<any>(consumer, 'getMatchedExpressions').and.returnValue(Promise.resolve([expr]));
@@ -150,7 +150,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
 
     expect(control.value).toBe('newValue');
     expect(control.valid).toBeTrue();
-    expect(formComponent.broadcastFormStatus).toHaveBeenCalledTimes(1);
+    expect(formComponent.queueFormStatusBroadcast).toHaveBeenCalledTimes(1);
   }));
 
   it('should not update model value if unchanged', fakeAsync(() => {
@@ -167,7 +167,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
     control.setValue('sameValue');
     const formComponent = {
       getQuerySource: () => undefined,
-      broadcastFormStatus: jasmine.createSpy('broadcastFormStatus')
+      queueFormStatusBroadcast: jasmine.createSpy('queueFormStatusBroadcast')
     };
 
     spyOn<any>(consumer, 'getMatchedExpressions').and.returnValue(Promise.resolve([expr]));
@@ -188,7 +188,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
     tick();
 
     expect(setValueSpy).not.toHaveBeenCalled();
-    expect(formComponent.broadcastFormStatus).not.toHaveBeenCalled();
+    expect(formComponent.queueFormStatusBroadcast).not.toHaveBeenCalled();
   }));
 
   it('should resync component display after silent model updates', fakeAsync(() => {

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-change-event-consumer.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-change-event-consumer.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { FormControl } from '@angular/forms';
+import { FormControl, Validators } from '@angular/forms';
 import { FormFieldBaseComponent, FormFieldCompMapEntry, LoggerService, ModifyOptions } from '@researchdatabox/portal-ng-common';
 import { FormComponentEventBus } from './form-component-event-bus.service';
 import { FormComponentValueChangeEventConsumer } from './form-component-change-event-consumer';
@@ -27,7 +27,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
     });
 
     eventStream$ = new Subject();
-    eventBus = jasmine.createSpyObj<FormComponentEventBus>('FormComponentEventBus', ['select$']);
+    eventBus = jasmine.createSpyObj<FormComponentEventBus>('FormComponentEventBus', ['select$', 'publish']);
     eventBus.select$.and.returnValue(eventStream$.asObservable());
 
     consumer = TestBed.runInInjectionContext(() => new FormComponentValueChangeEventConsumer(eventBus));
@@ -114,6 +114,45 @@ describe('FormComponentValueChangeEventConsumer', () => {
     expect(control.value).toBe('newValue');
   }));
 
+  it('should broadcast form status after silent model updates', fakeAsync(() => {
+    const expr: FormExpressionsConfigFrame = {
+      name: 'model-update-broadcast-status',
+      config: {
+        target: 'model.value',
+        condition: 'otherField',
+        conditionKind: ExpressionsConditionKind.JSONPointer,
+        template: ''
+      }
+    };
+    const { control, definition, component } = createSetup([expr]);
+    control.addValidators(Validators.required);
+    control.updateValueAndValidity();
+    const formComponent = {
+      getQuerySource: () => undefined,
+      broadcastFormStatus: jasmine.createSpy('broadcastFormStatus')
+    };
+
+    spyOn<any>(consumer, 'getMatchedExpressions').and.returnValue(Promise.resolve([expr]));
+    consumer.formComponent = formComponent as any;
+
+    consumer.bind({ component, definition });
+
+    const event: FieldValueChangedEvent = {
+      type: 'field.value.changed',
+      fieldId: 'otherField',
+      sourceId: 'otherField',
+      value: 'newValue',
+      timestamp: Date.now()
+    };
+
+    eventStream$.next(event);
+    tick();
+
+    expect(control.value).toBe('newValue');
+    expect(control.valid).toBeTrue();
+    expect(formComponent.broadcastFormStatus).toHaveBeenCalledTimes(1);
+  }));
+
   it('should not update model value if unchanged', fakeAsync(() => {
     const expr: FormExpressionsConfigFrame = {
       name: 'model-update',
@@ -126,9 +165,14 @@ describe('FormComponentValueChangeEventConsumer', () => {
     };
     const { control, definition, component } = createSetup([expr]);
     control.setValue('sameValue');
+    const formComponent = {
+      getQuerySource: () => undefined,
+      broadcastFormStatus: jasmine.createSpy('broadcastFormStatus')
+    };
 
     spyOn<any>(consumer, 'getMatchedExpressions').and.returnValue(Promise.resolve([expr]));
     const setValueSpy = spyOn(control, 'setValue').and.callThrough();
+    consumer.formComponent = formComponent as any;
 
     consumer.bind({ component, definition });
 
@@ -144,6 +188,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
     tick();
 
     expect(setValueSpy).not.toHaveBeenCalled();
+    expect(formComponent.broadcastFormStatus).not.toHaveBeenCalled();
   }));
 
   it('should resync component display after silent model updates', fakeAsync(() => {

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-item-select-event-consumer.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-item-select-event-consumer.spec.ts
@@ -112,6 +112,27 @@ describe('FormComponentItemSelectEventConsumer', () => {
     expect(control.touched).toBeTrue();
   });
 
+  it('should broadcast form status after silent item selection updates', async () => {
+    const { options } = createBindOptions('/record/contributors/0/funderName', {
+      rawPath: 'identifier',
+      clearValue: ''
+    });
+    const formComponent = {
+      broadcastFormStatus: jasmine.createSpy('broadcastFormStatus')
+    };
+
+    consumer.bind({ ...options, formComponent } as any);
+
+    emitEvent('/record/contributors/0/funderSearch', {
+      raw: {
+        identifier: 'https://example.org/funder/status'
+      }
+    });
+    await Promise.resolve();
+
+    expect(formComponent.broadcastFormStatus).toHaveBeenCalledTimes(1);
+  });
+
   it('should fall back to selectedItem path when raw path is unavailable', () => {
     const { control, options } = createBindOptions('/record/contributors/0/funderName', {
       rawPath: 'identifier',

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-item-select-event-consumer.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-item-select-event-consumer.spec.ts
@@ -118,10 +118,11 @@ describe('FormComponentItemSelectEventConsumer', () => {
       clearValue: ''
     });
     const formComponent = {
-      broadcastFormStatus: jasmine.createSpy('broadcastFormStatus')
+      queueFormStatusBroadcast: jasmine.createSpy('queueFormStatusBroadcast')
     };
 
-    consumer.bind({ ...options, formComponent } as any);
+    consumer.formComponent = formComponent as any;
+    consumer.bind(options as any);
 
     emitEvent('/record/contributors/0/funderSearch', {
       raw: {
@@ -130,7 +131,7 @@ describe('FormComponentItemSelectEventConsumer', () => {
     });
     await Promise.resolve();
 
-    expect(formComponent.broadcastFormStatus).toHaveBeenCalledTimes(1);
+    expect(formComponent.queueFormStatusBroadcast).toHaveBeenCalledTimes(1);
   });
 
   it('should fall back to selectedItem path when raw path is unavailable', () => {

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-item-select-event-consumer.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-item-select-event-consumer.ts
@@ -43,6 +43,7 @@ export class FormComponentItemSelectEventConsumer extends FormComponentEventBase
   override bind(options: FormComponentEventBindingOptions): void {
     this.destroy();
     this.options = options;
+    this.formComp = options.formComponent;
 
     const config = options.definition?.compConfigJson?.component?.config;
     this.onItemSelect = config?.onItemSelect;
@@ -110,6 +111,7 @@ export class FormComponentItemSelectEventConsumer extends FormComponentEventBase
       control.markAsDirty();
       control.markAsTouched();
       this.publishParentValueChanged(previousParentValue);
+      this.formComp?.broadcastFormStatus();
       return;
     }
 
@@ -131,6 +133,7 @@ export class FormComponentItemSelectEventConsumer extends FormComponentEventBase
     control.markAsDirty();
     control.markAsTouched();
     this.publishParentValueChanged(previousParentValue);
+    this.formComp?.broadcastFormStatus();
   }
 
   /**

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-item-select-event-consumer.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-item-select-event-consumer.ts
@@ -38,12 +38,12 @@ export class FormComponentItemSelectEventConsumer extends FormComponentEventBase
 
   /**
    * Override base bind to skip expression-based consumption.
-    * Instead, subscribe directly and enforce the sibling-only contract in code.
+   * Instead, subscribe directly and enforce the sibling-only contract in code.
    */
   override bind(options: FormComponentEventBindingOptions): void {
     this.destroy();
     this.options = options;
-    this.formComp = options.formComponent;
+    this.formComp = options.formComponent ?? this.formComp;
 
     const config = options.definition?.compConfigJson?.component?.config;
     this.onItemSelect = config?.onItemSelect;
@@ -91,10 +91,10 @@ export class FormComponentItemSelectEventConsumer extends FormComponentEventBase
 
   /**
    * Process a field.item.selected event from a sibling component.
-    *
-    * The control update is intentionally followed by a parent-group rebroadcast
-    * so listeners attached to the containing object see the final selected row
-    * value rather than a piecemeal child-field mutation.
+   *
+   * The control update is intentionally followed by a parent-group rebroadcast
+   * so listeners attached to the containing object see the final selected row
+   * value rather than a piecemeal child-field mutation.
    */
   protected async handleItemSelected(event: FieldItemSelectedEvent): Promise<void> {
     const control = this.control;
@@ -111,7 +111,7 @@ export class FormComponentItemSelectEventConsumer extends FormComponentEventBase
       control.markAsDirty();
       control.markAsTouched();
       this.publishParentValueChanged(previousParentValue);
-      this.formComp?.broadcastFormStatus();
+      this.formComp?.queueFormStatusBroadcast();
       return;
     }
 
@@ -133,7 +133,7 @@ export class FormComponentItemSelectEventConsumer extends FormComponentEventBase
     control.markAsDirty();
     control.markAsTouched();
     this.publishParentValueChanged(previousParentValue);
-    this.formComp?.broadcastFormStatus();
+    this.formComp?.queueFormStatusBroadcast();
   }
 
   /**
@@ -166,10 +166,10 @@ export class FormComponentItemSelectEventConsumer extends FormComponentEventBase
 
   /**
    * Check whether the event's fieldId shares the same parent JSON pointer
-    * as this consumer's own pointer (sibling scope).
-    *
-    * Keeping this boundary strict avoids surprising cross-tree writes for older
-    * form configs that rely on item selection only affecting adjacent fields.
+   * as this consumer's own pointer (sibling scope).
+   *
+   * Keeping this boundary strict avoids surprising cross-tree writes for older
+   * form configs that rely on item selection only affecting adjacent fields.
    */
   private isSiblingEvent(event: FieldItemSelectedEvent): boolean {
     if (!this.ownPointer || !event.fieldId) {

--- a/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
@@ -214,6 +214,72 @@ describe('FormComponent', () => {
     }
   });
 
+  it('queues only one validation refresh for multiple silent update requests', async () => {
+    const formConfig: FormConfigFrame = {
+      name: 'queued-form-status',
+      debugValue: false,
+      componentDefinitions: [
+        {
+          name: 'text_queued_status',
+          model: {
+            class: 'SimpleInputModel',
+            config: {
+              value: 'queued value'
+            }
+          },
+          component: {
+            class: 'SimpleInputComponent'
+          }
+        }
+      ]
+    };
+    const { formComponent } = await createFormAndWaitForReady(formConfig);
+    const spy = spyOn(formComponent, 'broadcastFormStatus').and.callThrough();
+
+    formComponent.queueFormStatusBroadcast();
+    formComponent.queueFormStatusBroadcast();
+    await Promise.resolve();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('publishes status for regular form events without revalidating the full form again', async () => {
+    const formConfig: FormConfigFrame = {
+      name: 'regular-form-status-event',
+      debugValue: false,
+      componentDefinitions: [
+        {
+          name: 'text_regular_status',
+          model: {
+            class: 'SimpleInputModel',
+            config: {
+              value: 'regular value'
+            }
+          },
+          component: {
+            class: 'SimpleInputComponent'
+          }
+        }
+      ]
+    };
+    const { fixture, formComponent } = await createFormAndWaitForReady(formConfig);
+    const bus = TestBed.inject(FormComponentEventBus);
+    const events: FormValidationBroadcastEvent[] = [];
+    const sub = bus.select$(FormComponentEventType.FORM_VALIDATION_BROADCAST).subscribe(event => events.push(event));
+    const updateSpy = spyOn(formComponent.form!, 'updateValueAndValidity').and.callThrough();
+
+    try {
+      formComponent.form?.markAsDirty();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(updateSpy).not.toHaveBeenCalled();
+      expect(events.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      sub.unsubscribe();
+    }
+  });
+
   it('broadcasts refreshed validation status after validation groups change', async () => {
     const formConfig: FormConfigFrame = {
       name: 'validation-group-status-broadcast',

--- a/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
@@ -12,7 +12,7 @@ import {
 } from "./helpers.spec";
 import { FormService } from './form.service';
 import { FormComponentEventBus } from './form-state/events/form-component-event-bus.service';
-import { createFieldValueChangedEvent, createFormDefinitionChangedEvent, createFormSaveExecuteEvent, createFormStatusDirtyRequestEvent, FormComponentEventType } from './form-state/events/form-component-event.types';
+import { createFieldValueChangedEvent, createFormDefinitionChangedEvent, createFormSaveExecuteEvent, createFormStatusDirtyRequestEvent, FormComponentEventType, FormValidationBroadcastEvent } from './form-state/events/form-component-event.types';
 
 describe('FormComponent', () => {
   const setWindowSearch = (search?: string) => {
@@ -171,6 +171,47 @@ describe('FormComponent', () => {
     await fixture.whenStable();
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith(true, 'S1', ["none"]);
+  });
+
+  it('broadcastFormStatus publishes current validation status and refreshes the status signal', async () => {
+    const formConfig: FormConfigFrame = {
+      name: 'broadcast-form-status',
+      debugValue: false,
+      defaultComponentConfig: {
+        defaultComponentCssClasses: 'row',
+      },
+      editCssClasses: 'redbox-form form',
+      componentDefinitions: [
+        {
+          name: 'text_status',
+          model: {
+            class: 'SimpleInputModel',
+            config: {
+              value: 'status value'
+            }
+          },
+          component: {
+            class: 'SimpleInputComponent'
+          }
+        }
+      ]
+    };
+    const { formComponent } = await createFormAndWaitForReady(formConfig);
+    const bus = TestBed.inject(FormComponentEventBus);
+    const events: FormValidationBroadcastEvent[] = [];
+    const sub = bus.select$(FormComponentEventType.FORM_VALIDATION_BROADCAST).subscribe(event => events.push(event));
+
+    try {
+      formComponent.broadcastFormStatus();
+
+      expect(events.length).toBe(1);
+      expect(events[0].isValid).toBe(formComponent.dataStatus.valid);
+      expect(events[0].errors).toBe(formComponent.dataStatus.errors);
+      expect(events[0].status).toEqual(formComponent.dataStatus);
+      expect(formComponent.formGroupStatus()).toEqual(formComponent.dataStatus);
+    } finally {
+      sub.unsubscribe();
+    }
   });
 
   it('allows legacy callers to invoke saveForm directly (Task 17)', async () => {

--- a/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
@@ -208,6 +208,7 @@ describe('FormComponent', () => {
       expect(events[0].isValid).toBe(formComponent.dataStatus.valid);
       expect(events[0].errors).toBe(formComponent.dataStatus.errors);
       expect(events[0].status).toEqual(formComponent.dataStatus);
+      expect(events[0].sourceId).toBe(formComponent.eventScopeId);
       expect(formComponent.formGroupStatus()).toEqual(formComponent.dataStatus);
     } finally {
       sub.unsubscribe();
@@ -304,6 +305,7 @@ describe('FormComponent', () => {
 
       expect(updateSpy).not.toHaveBeenCalled();
       expect(events.length).toBeGreaterThanOrEqual(1);
+      expect(events[events.length - 1].sourceId).toBe(formComponent.eventScopeId);
     } finally {
       sub.unsubscribe();
     }
@@ -360,6 +362,7 @@ describe('FormComponent', () => {
       expect(events.length).toBeGreaterThanOrEqual(1);
       expect(events[events.length - 1].isValid).toBeFalse();
       expect(events[events.length - 1].status).toEqual(formComponent.dataStatus);
+      expect(events[events.length - 1].sourceId).toBe(formComponent.eventScopeId);
       expect(formComponent.formGroupStatus()).toEqual(formComponent.dataStatus);
     } finally {
       sub.unsubscribe();

--- a/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
@@ -243,6 +243,35 @@ describe('FormComponent', () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
+  it('does not publish a queued validation refresh after destroy', async () => {
+    const formConfig: FormConfigFrame = {
+      name: 'queued-form-status-destroy',
+      debugValue: false,
+      componentDefinitions: [
+        {
+          name: 'text_queued_destroy',
+          model: {
+            class: 'SimpleInputModel',
+            config: {
+              value: 'queued destroy value'
+            }
+          },
+          component: {
+            class: 'SimpleInputComponent'
+          }
+        }
+      ]
+    };
+    const { formComponent } = await createFormAndWaitForReady(formConfig);
+    const spy = spyOn(formComponent, 'broadcastFormStatus').and.callThrough();
+
+    formComponent.queueFormStatusBroadcast();
+    formComponent.ngOnDestroy();
+    await Promise.resolve();
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
   it('publishes status for regular form events without revalidating the full form again', async () => {
     const formConfig: FormConfigFrame = {
       name: 'regular-form-status-event',

--- a/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
@@ -12,7 +12,7 @@ import {
 } from "./helpers.spec";
 import { FormService } from './form.service';
 import { FormComponentEventBus } from './form-state/events/form-component-event-bus.service';
-import { createFieldValueChangedEvent, createFormDefinitionChangedEvent, createFormSaveExecuteEvent, createFormStatusDirtyRequestEvent, FormComponentEventType, FormValidationBroadcastEvent } from './form-state/events/form-component-event.types';
+import { createFieldValueChangedEvent, createFormDefinitionChangedEvent, createFormSaveExecuteEvent, createFormStatusDirtyRequestEvent, createFormValidationGroupsChangeRequestEvent, FormComponentEventType, FormValidationBroadcastEvent } from './form-state/events/form-component-event.types';
 
 describe('FormComponent', () => {
   const setWindowSearch = (search?: string) => {
@@ -208,6 +208,63 @@ describe('FormComponent', () => {
       expect(events[0].isValid).toBe(formComponent.dataStatus.valid);
       expect(events[0].errors).toBe(formComponent.dataStatus.errors);
       expect(events[0].status).toEqual(formComponent.dataStatus);
+      expect(formComponent.formGroupStatus()).toEqual(formComponent.dataStatus);
+    } finally {
+      sub.unsubscribe();
+    }
+  });
+
+  it('broadcasts refreshed validation status after validation groups change', async () => {
+    const formConfig: FormConfigFrame = {
+      name: 'validation-group-status-broadcast',
+      debugValue: false,
+      validationGroups: {
+        none: { description: '', initialMembership: 'none' },
+        tester: { description: '' }
+      },
+      enabledValidationGroups: ['none'],
+      defaultComponentConfig: {
+        defaultComponentCssClasses: 'row',
+      },
+      editCssClasses: 'redbox-form form',
+      componentDefinitions: [
+        {
+          name: 'required_when_tester',
+          model: {
+            class: 'SimpleInputModel',
+            config: {
+              value: '',
+              validators: [
+                { class: 'required', groups: { include: ['tester'] } }
+              ]
+            }
+          },
+          component: {
+            class: 'SimpleInputComponent'
+          }
+        }
+      ]
+    };
+    const { fixture, formComponent } = await createFormAndWaitForReady(formConfig);
+    const bus = TestBed.inject(FormComponentEventBus);
+    const events: FormValidationBroadcastEvent[] = [];
+    const sub = bus.select$(FormComponentEventType.FORM_VALIDATION_BROADCAST).subscribe(event => events.push(event));
+
+    try {
+      expect(formComponent.form?.valid).toBeTrue();
+
+      bus.publish(createFormValidationGroupsChangeRequestEvent({
+        initial: 'current',
+        groups: { include: ['tester'] }
+      }));
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(formComponent.enabledValidationGroups).toEqual(['none', 'tester']);
+      expect(formComponent.form?.valid).toBeFalse();
+      expect(events.length).toBeGreaterThanOrEqual(1);
+      expect(events[events.length - 1].isValid).toBeFalse();
+      expect(events[events.length - 1].status).toEqual(formComponent.dataStatus);
       expect(formComponent.formGroupStatus()).toEqual(formComponent.dataStatus);
     } finally {
       sub.unsubscribe();

--- a/angular/projects/researchdatabox/form/src/app/form.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.ts
@@ -574,14 +574,7 @@ export class FormComponent extends BaseComponent implements OnDestroy {
       this.subMaps['formGroupChangesSub'] = this.form.events.subscribe(
         (formGroupEvent: StatusChangeEvent | PristineChangeEvent | ValueChangeEvent<unknown> | unknown) => {
           if (formGroupEvent instanceof StatusChangeEvent || formGroupEvent instanceof PristineChangeEvent) {
-            this.formGroupStatus.set(this.dataStatus);
-            this.eventBus.publish(
-              createFormValidationBroadcastEvent({
-                isValid: this.dataStatus.valid,
-                errors: this.dataStatus.errors,
-                status: this.dataStatus,
-              })
-            );
+            this.broadcastFormStatus();
           }
         }
       );
@@ -604,6 +597,28 @@ export class FormComponent extends BaseComponent implements OnDestroy {
     //     }
     //   });
     // }
+  }
+  /**
+   * Refresh the form group status signal and publish a FORM_VALIDATION_BROADCAST
+   * with the current data status.
+   *
+   * Use this whenever a control value/state has been mutated with `emitEvent: false`
+   * — e.g. expression-driven model updates — so consumers like the Save button
+   * effect can re-evaluate. Without this, silent updates can leave the UI's idea
+   * of validity out of sync with the FormGroup's actual state.
+   */
+  public broadcastFormStatus(): void {
+    if (!this.form) {
+      return;
+    }
+    this.formGroupStatus.set(this.dataStatus);
+    this.eventBus.publish(
+      createFormValidationBroadcastEvent({
+        isValid: this.dataStatus.valid,
+        errors: this.dataStatus.errors,
+        status: this.dataStatus,
+      })
+    );
   }
   /**
    * Create the form group based on the form definition map.

--- a/angular/projects/researchdatabox/form/src/app/form.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.ts
@@ -199,6 +199,7 @@ export class FormComponent extends BaseComponent implements OnDestroy {
   private eventBus = inject(FormComponentEventBus);
   private focusRequestCoordinator = inject(FormComponentFocusRequestCoordinator);
   private formStatusBroadcastQueued = false;
+  private isDestroyed = false;
   public readonly eventScopeId = `form-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
   /**
    * Status of the form, derived from the facade as signal
@@ -623,12 +624,15 @@ export class FormComponent extends BaseComponent implements OnDestroy {
    * `emitEvent: false` writes for one user action.
    */
   public queueFormStatusBroadcast(): void {
-    if (this.formStatusBroadcastQueued) {
+    if (this.isDestroyed || this.formStatusBroadcastQueued) {
       return;
     }
     this.formStatusBroadcastQueued = true;
     void Promise.resolve().then(() => {
       this.formStatusBroadcastQueued = false;
+      if (this.isDestroyed) {
+        return;
+      }
       this.broadcastFormStatus();
     });
   }
@@ -1164,6 +1168,8 @@ export class FormComponent extends BaseComponent implements OnDestroy {
   }
 
   override ngOnDestroy(): void {
+    this.isDestroyed = true;
+    this.formStatusBroadcastQueued = false;
     super.ngOnDestroy();
     // Clean up subscriptions
     Object.values(this.subMaps).forEach(sub => sub.unsubscribe());

--- a/angular/projects/researchdatabox/form/src/app/form.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.ts
@@ -647,6 +647,7 @@ export class FormComponent extends BaseComponent implements OnDestroy {
         isValid: this.dataStatus.valid,
         errors: this.dataStatus.errors,
         status: this.dataStatus,
+        sourceId: this.eventScopeId,
       })
     );
   }

--- a/angular/projects/researchdatabox/form/src/app/form.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.ts
@@ -198,6 +198,7 @@ export class FormComponent extends BaseComponent implements OnDestroy {
    */
   private eventBus = inject(FormComponentEventBus);
   private focusRequestCoordinator = inject(FormComponentFocusRequestCoordinator);
+  private formStatusBroadcastQueued = false;
   public readonly eventScopeId = `form-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
   /**
    * Status of the form, derived from the facade as signal
@@ -575,7 +576,7 @@ export class FormComponent extends BaseComponent implements OnDestroy {
       this.subMaps['formGroupChangesSub'] = this.form.events.subscribe(
         (formGroupEvent: StatusChangeEvent | PristineChangeEvent | ValueChangeEvent<unknown> | unknown) => {
           if (formGroupEvent instanceof StatusChangeEvent || formGroupEvent instanceof PristineChangeEvent) {
-            this.broadcastFormStatus();
+            this.publishFormStatus();
           }
         }
       );
@@ -613,6 +614,29 @@ export class FormComponent extends BaseComponent implements OnDestroy {
       return;
     }
     this.form.updateValueAndValidity({ emitEvent: false });
+    this.publishFormStatus();
+  }
+
+  /**
+   * Coalesce silent form updates into a single full-form refresh and validation
+   * broadcast. Use this from event/behaviour pipelines that may perform several
+   * `emitEvent: false` writes for one user action.
+   */
+  public queueFormStatusBroadcast(): void {
+    if (this.formStatusBroadcastQueued) {
+      return;
+    }
+    this.formStatusBroadcastQueued = true;
+    void Promise.resolve().then(() => {
+      this.formStatusBroadcastQueued = false;
+      this.broadcastFormStatus();
+    });
+  }
+
+  private publishFormStatus(): void {
+    if (!this.form) {
+      return;
+    }
     this.formGroupStatus.set(this.dataStatus);
     this.eventBus.publish(
       createFormValidationBroadcastEvent({

--- a/angular/projects/researchdatabox/form/src/app/form.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.ts
@@ -563,6 +563,7 @@ export class FormComponent extends BaseComponent implements OnDestroy {
         this.componentDefArr?.forEach(mapEntry =>
           this.formService.updateValidators(mapEntry, enabledNames, validationGroups)
         );
+        this.broadcastFormStatus();
 
         this.loggerService.debug(`${this.logName}: Form enabledValidationGroups changed from ${JSON.stringify(originalEnabledValidationGroups)} to ${JSON.stringify(this.enabledValidationGroups)} from event field ${event.fieldId}`);
       });
@@ -611,6 +612,7 @@ export class FormComponent extends BaseComponent implements OnDestroy {
     if (!this.form) {
       return;
     }
+    this.form.updateValueAndValidity({ emitEvent: false });
     this.formGroupStatus.set(this.dataStatus);
     this.eventBus.publish(
       createFormValidationBroadcastEvent({

--- a/angular/projects/researchdatabox/form/src/app/form.service.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.service.ts
@@ -37,6 +37,7 @@ import {
 import {
   ConfigService,
   FormFieldBaseComponent,
+  FormFieldComponentType,
   FormFieldCompMapEntry,
   FormFieldModel,
   HttpClientService,
@@ -236,8 +237,8 @@ export class FormService extends HttpClientService {
       const isModuleCustom = componentConfig.module === 'custom';
 
       let modelClass: typeof FormFieldModel<unknown> | undefined = undefined;
-      let componentClass: typeof FormFieldBaseComponent<unknown> | undefined = undefined;
-      let layoutClass: typeof FormFieldBaseComponent<unknown> | undefined = undefined;
+      let componentClass: FormFieldComponentType | undefined = undefined;
+      let layoutClass: FormFieldComponentType | undefined = undefined;
 
       const modelClassName = componentConfig.model?.class || '';
       const componentClassName = componentConfig.component?.class || '';

--- a/angular/projects/researchdatabox/form/src/app/static-comp-field.dictionary.ts
+++ b/angular/projects/researchdatabox/form/src/app/static-comp-field.dictionary.ts
@@ -38,7 +38,7 @@ import {
 } from './component/publish-data-location-selector.component';
 import { PublishDataLocationRefreshComponent } from './component/publish-data-location-refresh.component';
 import { RecordMetadataRetrieverComponent } from './component/record-metadata-retriever.component';
-import { FormFieldBaseComponent, FormFieldModel } from '@researchdatabox/portal-ng-common';
+import { FormFieldBaseComponent, FormFieldComponentType, FormFieldModel } from '@researchdatabox/portal-ng-common';
 import {
   StaticComponentClassMapGenType,
   StaticModelClassMapGenType,
@@ -108,8 +108,8 @@ import {
  * The Component classes.
  */
 
-export type StaticComponentClassMapType = StaticComponentClassMapGenType<typeof FormFieldBaseComponent<unknown>>;
-export type AllComponentClassMapType = StaticClassMapType<string, typeof FormFieldBaseComponent<unknown>>;
+export type StaticComponentClassMapType = StaticComponentClassMapGenType<FormFieldComponentType>;
+export type AllComponentClassMapType = StaticClassMapType<string, FormFieldComponentType>;
 export const getStaticComponentClassMap = (): StaticComponentClassMapType => ({
   [RepeatableComponentName]: RepeatableComponent,
   [GroupFieldComponentName]: GroupFieldComponent,
@@ -178,8 +178,8 @@ export const getStaticModelClassMap = (): StaticModelClassMapType => ({
  * The Layout classes.
  */
 
-export type StaticLayoutClassMapType = StaticLayoutClassMapGenType<typeof FormFieldBaseComponent<unknown> | null>;
-export type AllLayoutClassMapType = StaticClassMapType<string, typeof FormFieldBaseComponent<unknown> | null>;
+export type StaticLayoutClassMapType = StaticLayoutClassMapGenType<FormFieldComponentType | null>;
+export type AllLayoutClassMapType = StaticClassMapType<string, FormFieldComponentType | null>;
 export const getStaticLayoutClassMap = (): StaticLayoutClassMapType => ({
   [DefaultLayoutName]: DefaultLayoutComponent,
   [ActionRowLayoutName]: ActionRowLayoutComponent,

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/form/form-field-base.component.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/form/form-field-base.component.ts
@@ -3,7 +3,7 @@ import { FormControl } from '@angular/forms';
 import {
   Directive, HostBinding, ViewChild, signal, inject, TemplateRef,
   ViewContainerRef, ComponentRef, AfterViewInit, effect,
-  EffectRef, Injector, ApplicationRef
+  EffectRef, Injector, ApplicationRef, Type
 } from '@angular/core';
 import { LoggerService } from '../logger.service';
 import {  isEmpty as _isEmpty, get as _get } from 'lodash-es';
@@ -37,6 +37,7 @@ export class FormFieldBaseComponent<ValueType> implements AfterViewInit {
   public model?: FormFieldModel<ValueType>;
   public componentDefinition?: FormFieldComponentOrLayoutDefinition;
   public formFieldCompMapEntry?: FormFieldCompMapEntry;
+  public formEventScopeId?: string;
   public hostBindingCssClasses?: string;
   // The status of the component
   public status = signal<FormFieldComponentStatus>(FormFieldComponentStatus.INIT);
@@ -381,6 +382,8 @@ export class FormFieldBaseComponent<ValueType> implements AfterViewInit {
   }
 }
 
+export type FormFieldComponentType<ValueType = unknown> = Type<FormFieldBaseComponent<ValueType>>;
+
 /**
  * The complete metadata data structure describing a form field component, including the necessary constructors to create and init the component and model.
  *
@@ -390,8 +393,8 @@ export class FormFieldBaseComponent<ValueType> implements AfterViewInit {
 export interface FormFieldCompMapEntry {
   name?: string;
   modelClass?: typeof FormFieldModel<unknown>;
-  layoutClass?: typeof FormFieldBaseComponent<unknown>;
-  componentClass?: typeof FormFieldBaseComponent<unknown>;
+  layoutClass?: FormFieldComponentType;
+  componentClass?: FormFieldComponentType;
   compConfigJson: FormComponentDefinitionFrame;
   model?: FormFieldModel<unknown>;
   component?: FormFieldBaseComponent<unknown>;

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/form/resolver.interface.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/form/resolver.interface.ts
@@ -1,8 +1,8 @@
-import { FormFieldBaseComponent } from "./form-field-base.component";
+import { FormFieldComponentType } from "./form-field-base.component";
 import { FormFieldModel } from "./base.model";
 
 export interface FormComponentResolver {
-  getComponentClass(componentName: string): Promise<typeof FormFieldBaseComponent<unknown>>;
+  getComponentClass(componentName: string): Promise<FormFieldComponentType>;
 }
 
 export interface FormFieldResolver {


### PR DESCRIPTION
## Summary

Improves how form validation state is propagated after silent model updates, ensuring UI elements (such as the Save button) accurately reflect the current validity. Introduces a centralized `broadcastFormStatus` mechanism, refactors event handling to use it, and adds tests to validate the behaviour.

---

## Context / Motivation

Angular forms updated with `emitEvent: false` do not trigger value/status change events. This caused:

- UI components not updating (e.g. Save button remaining disabled/enabled incorrectly)
- inconsistent validation state visibility
- duplication of ad-hoc broadcasting logic

This PR ensures validation state is explicitly and consistently broadcast after silent updates.

---

## Key Changes

### Centralised Form Status Broadcasting

- Introduced a new `broadcastFormStatus` method on `FormComponent`

- Responsibilities:
  - refresh the form group status signal
  - emit a `FORM_VALIDATION_BROADCAST` event with current validity

- Ensures:
  - UI consumers are always notified of validation state changes
  - consistent behaviour regardless of how the model is updated

---

### Refactoring of Event Handling

- Replaced duplicated broadcast logic with calls to `broadcastFormStatus`

- Updated:
  - internal `FormComponent` event handling
  - `FormComponentEventBaseConsumer`

- Now:
  - silent model updates explicitly trigger a validation broadcast
  - expression-driven updates correctly propagate state changes

---

### Improved Behaviour for Silent Updates

- After updates using `emitEvent: false`:
  - validation state is now synchronised with UI
  - dependent components (buttons, summaries, etc.) update correctly

- Avoids:
  - stale validation state
  - misleading UI behaviour

---

## Testing

### New and Updated Tests

- Verified:
  - `broadcastFormStatus` is triggered after silent updates
  - it is not called when values remain unchanged
  - correct validation state is published

- Added coverage for:
  - event consumer behaviour
  - `FormComponent` broadcasting logic
  - signal refresh and event emission

---

### Test Setup Improvements

- Updated mocks and imports to support new behaviour
- Improved spying and dependency injection for validation flow testing

---

## Impact

This change:

- fixes UI inconsistencies caused by silent model updates
- centralises validation broadcasting logic
- improves reliability of form state handling
- ensures consistent behaviour across all update pathways

---

## Future Work

- Extend broadcasting pattern to other derived state (e.g. dirty/touched summaries)
- Consider batching broadcasts for performance in large forms
- Explore signal-driven validation propagation to reduce event bus reliance