### PR TITLE
Bugfix: Silent update form group status events

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/form-state/behaviours/behaviour-actions.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/behaviours/behaviour-actions.ts
@@ -19,6 +19,7 @@ export interface BehaviourActionExecutionContext {
   eventBus: FormComponentEventBus;
   compiledTemplateEvaluator?: BehaviourCompiledTemplateEvaluator;
   logger: LoggerService;
+  broadcastFormStatus?: () => void;
   fieldResolverContext: BehaviourFieldResolverContext;
   getLogicalFieldEntry: (listName: 'actions' | 'onError', actionIndex: number) => FormFieldCompMapEntry | undefined;
 }
@@ -71,6 +72,7 @@ async function executeSetValueAction(
   const value = await resolveActionValue(action, pipelineContext, ctx);
   resolved.control.setValue(value, { emitEvent: false });
   resolved.control.markAsDirty();
+  ctx.broadcastFormStatus?.();
 }
 
 /**

--- a/angular/projects/researchdatabox/form/src/app/form-state/behaviours/behaviour-handler.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/behaviours/behaviour-handler.ts
@@ -200,6 +200,7 @@ export class BehaviourHandler {
         eventBus: this.ctx.eventBus,
         compiledTemplateEvaluator: this.compiledTemplateEvaluator,
         logger: this.ctx.logger,
+        broadcastFormStatus: () => this.ctx.formComponent.broadcastFormStatus(),
         fieldResolverContext: { formComponent: this.ctx.formComponent },
         getLogicalFieldEntry: (targetListName, targetActionIndex) =>
           this.logicalFieldEntries.get(this.buildActionKey(targetListName, targetActionIndex)),

--- a/angular/projects/researchdatabox/form/src/app/form-state/behaviours/form-behaviour-manager.service.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/behaviours/form-behaviour-manager.service.spec.ts
@@ -96,6 +96,7 @@ describe('FormBehaviourManager', () => {
         },
       }),
       requestParams: () => ({}),
+      broadcastFormStatus: jasmine.createSpy('broadcastFormStatus'),
     } as any;
 
     const setValueSpy = spyOn(targetControl, 'setValue').and.callThrough();
@@ -111,6 +112,7 @@ describe('FormBehaviourManager', () => {
     tick();
 
     expect(setValueSpy).toHaveBeenCalledWith('copied', { emitEvent: false });
+    expect(formComponent.broadcastFormStatus).toHaveBeenCalledTimes(1);
   }));
 
   it('runs fetchMetadata processors and emits onError actions when a processor fails', fakeAsync(() => {

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
@@ -396,6 +396,13 @@ export abstract class FormComponentEventBaseConsumer extends FormComponentEventB
       if (this.control && this.control.value !== targetValue) {
         await setControlValue(this.control, targetValue, { emitEvent: false });
         await syncComponentDisplayFromModel(this.options?.component);
+        // setControlValue with emitEvent:false suppresses Angular's
+        // StatusChangeEvent/PristineChangeEvent. Without an explicit re-broadcast,
+        // listeners like SaveButtonComponent never see that an expression-driven
+        // update flipped the form to valid (e.g. a downstream "required" target
+        // becoming populated), and the Save button stays disabled. Re-emit the
+        // current form status so signal-effect consumers can re-evaluate.
+        this.formComp?.broadcastFormStatus();
       }
     } else if (exprTarget.startsWith(FormExpressionsTargetLayoutPrefix)) {
       const propPath = exprTarget.substring(FormExpressionsTargetLayoutPrefix.length);

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-change-event-consumer.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-change-event-consumer.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { FormControl } from '@angular/forms';
+import { FormControl, Validators } from '@angular/forms';
 import { FormFieldBaseComponent, FormFieldCompMapEntry, LoggerService, ModifyOptions } from '@researchdatabox/portal-ng-common';
 import { FormComponentEventBus } from './form-component-event-bus.service';
 import { FormComponentValueChangeEventConsumer } from './form-component-change-event-consumer';
@@ -27,7 +27,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
     });
 
     eventStream$ = new Subject();
-    eventBus = jasmine.createSpyObj<FormComponentEventBus>('FormComponentEventBus', ['select$']);
+    eventBus = jasmine.createSpyObj<FormComponentEventBus>('FormComponentEventBus', ['select$', 'publish']);
     eventBus.select$.and.returnValue(eventStream$.asObservable());
 
     consumer = TestBed.runInInjectionContext(() => new FormComponentValueChangeEventConsumer(eventBus));
@@ -114,6 +114,45 @@ describe('FormComponentValueChangeEventConsumer', () => {
     expect(control.value).toBe('newValue');
   }));
 
+  it('should broadcast form status after silent model updates', fakeAsync(() => {
+    const expr: FormExpressionsConfigFrame = {
+      name: 'model-update-broadcast-status',
+      config: {
+        target: 'model.value',
+        condition: 'otherField',
+        conditionKind: ExpressionsConditionKind.JSONPointer,
+        template: ''
+      }
+    };
+    const { control, definition, component } = createSetup([expr]);
+    control.addValidators(Validators.required);
+    control.updateValueAndValidity();
+    const formComponent = {
+      getQuerySource: () => undefined,
+      broadcastFormStatus: jasmine.createSpy('broadcastFormStatus')
+    };
+
+    spyOn<any>(consumer, 'getMatchedExpressions').and.returnValue(Promise.resolve([expr]));
+    consumer.formComponent = formComponent as any;
+
+    consumer.bind({ component, definition });
+
+    const event: FieldValueChangedEvent = {
+      type: 'field.value.changed',
+      fieldId: 'otherField',
+      sourceId: 'otherField',
+      value: 'newValue',
+      timestamp: Date.now()
+    };
+
+    eventStream$.next(event);
+    tick();
+
+    expect(control.value).toBe('newValue');
+    expect(control.valid).toBeTrue();
+    expect(formComponent.broadcastFormStatus).toHaveBeenCalledTimes(1);
+  }));
+
   it('should not update model value if unchanged', fakeAsync(() => {
     const expr: FormExpressionsConfigFrame = {
       name: 'model-update',
@@ -126,9 +165,14 @@ describe('FormComponentValueChangeEventConsumer', () => {
     };
     const { control, definition, component } = createSetup([expr]);
     control.setValue('sameValue');
+    const formComponent = {
+      getQuerySource: () => undefined,
+      broadcastFormStatus: jasmine.createSpy('broadcastFormStatus')
+    };
 
     spyOn<any>(consumer, 'getMatchedExpressions').and.returnValue(Promise.resolve([expr]));
     const setValueSpy = spyOn(control, 'setValue').and.callThrough();
+    consumer.formComponent = formComponent as any;
 
     consumer.bind({ component, definition });
 
@@ -144,6 +188,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
     tick();
 
     expect(setValueSpy).not.toHaveBeenCalled();
+    expect(formComponent.broadcastFormStatus).not.toHaveBeenCalled();
   }));
 
   it('should resync component display after silent model updates', fakeAsync(() => {

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-item-select-event-consumer.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-item-select-event-consumer.spec.ts
@@ -112,6 +112,27 @@ describe('FormComponentItemSelectEventConsumer', () => {
     expect(control.touched).toBeTrue();
   });
 
+  it('should broadcast form status after silent item selection updates', async () => {
+    const { options } = createBindOptions('/record/contributors/0/funderName', {
+      rawPath: 'identifier',
+      clearValue: ''
+    });
+    const formComponent = {
+      broadcastFormStatus: jasmine.createSpy('broadcastFormStatus')
+    };
+
+    consumer.bind({ ...options, formComponent } as any);
+
+    emitEvent('/record/contributors/0/funderSearch', {
+      raw: {
+        identifier: 'https://example.org/funder/status'
+      }
+    });
+    await Promise.resolve();
+
+    expect(formComponent.broadcastFormStatus).toHaveBeenCalledTimes(1);
+  });
+
   it('should fall back to selectedItem path when raw path is unavailable', () => {
     const { control, options } = createBindOptions('/record/contributors/0/funderName', {
       rawPath: 'identifier',

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-item-select-event-consumer.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-item-select-event-consumer.ts
@@ -43,6 +43,7 @@ export class FormComponentItemSelectEventConsumer extends FormComponentEventBase
   override bind(options: FormComponentEventBindingOptions): void {
     this.destroy();
     this.options = options;
+    this.formComp = options.formComponent;
 
     const config = options.definition?.compConfigJson?.component?.config;
     this.onItemSelect = config?.onItemSelect;
@@ -110,6 +111,7 @@ export class FormComponentItemSelectEventConsumer extends FormComponentEventBase
       control.markAsDirty();
       control.markAsTouched();
       this.publishParentValueChanged(previousParentValue);
+      this.formComp?.broadcastFormStatus();
       return;
     }
 
@@ -131,6 +133,7 @@ export class FormComponentItemSelectEventConsumer extends FormComponentEventBase
     control.markAsDirty();
     control.markAsTouched();
     this.publishParentValueChanged(previousParentValue);
+    this.formComp?.broadcastFormStatus();
   }
 
   /**

--- a/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
@@ -12,7 +12,7 @@ import {
 } from "./helpers.spec";
 import { FormService } from './form.service';
 import { FormComponentEventBus } from './form-state/events/form-component-event-bus.service';
-import { createFieldValueChangedEvent, createFormDefinitionChangedEvent, createFormSaveExecuteEvent, createFormStatusDirtyRequestEvent, FormComponentEventType } from './form-state/events/form-component-event.types';
+import { createFieldValueChangedEvent, createFormDefinitionChangedEvent, createFormSaveExecuteEvent, createFormStatusDirtyRequestEvent, FormComponentEventType, FormValidationBroadcastEvent } from './form-state/events/form-component-event.types';
 
 describe('FormComponent', () => {
   const setWindowSearch = (search?: string) => {
@@ -171,6 +171,47 @@ describe('FormComponent', () => {
     await fixture.whenStable();
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith(true, 'S1', ["none"]);
+  });
+
+  it('broadcastFormStatus publishes current validation status and refreshes the status signal', async () => {
+    const formConfig: FormConfigFrame = {
+      name: 'broadcast-form-status',
+      debugValue: false,
+      defaultComponentConfig: {
+        defaultComponentCssClasses: 'row',
+      },
+      editCssClasses: 'redbox-form form',
+      componentDefinitions: [
+        {
+          name: 'text_status',
+          model: {
+            class: 'SimpleInputModel',
+            config: {
+              value: 'status value'
+            }
+          },
+          component: {
+            class: 'SimpleInputComponent'
+          }
+        }
+      ]
+    };
+    const { formComponent } = await createFormAndWaitForReady(formConfig);
+    const bus = TestBed.inject(FormComponentEventBus);
+    const events: FormValidationBroadcastEvent[] = [];
+    const sub = bus.select$(FormComponentEventType.FORM_VALIDATION_BROADCAST).subscribe(event => events.push(event));
+
+    try {
+      formComponent.broadcastFormStatus();
+
+      expect(events.length).toBe(1);
+      expect(events[0].isValid).toBe(formComponent.dataStatus.valid);
+      expect(events[0].errors).toBe(formComponent.dataStatus.errors);
+      expect(events[0].status).toEqual(formComponent.dataStatus);
+      expect(formComponent.formGroupStatus()).toEqual(formComponent.dataStatus);
+    } finally {
+      sub.unsubscribe();
+    }
   });
 
   it('allows legacy callers to invoke saveForm directly (Task 17)', async () => {

--- a/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
@@ -12,7 +12,7 @@ import {
 } from "./helpers.spec";
 import { FormService } from './form.service';
 import { FormComponentEventBus } from './form-state/events/form-component-event-bus.service';
-import { createFieldValueChangedEvent, createFormDefinitionChangedEvent, createFormSaveExecuteEvent, createFormStatusDirtyRequestEvent, FormComponentEventType, FormValidationBroadcastEvent } from './form-state/events/form-component-event.types';
+import { createFieldValueChangedEvent, createFormDefinitionChangedEvent, createFormSaveExecuteEvent, createFormStatusDirtyRequestEvent, createFormValidationGroupsChangeRequestEvent, FormComponentEventType, FormValidationBroadcastEvent } from './form-state/events/form-component-event.types';
 
 describe('FormComponent', () => {
   const setWindowSearch = (search?: string) => {
@@ -208,6 +208,63 @@ describe('FormComponent', () => {
       expect(events[0].isValid).toBe(formComponent.dataStatus.valid);
       expect(events[0].errors).toBe(formComponent.dataStatus.errors);
       expect(events[0].status).toEqual(formComponent.dataStatus);
+      expect(formComponent.formGroupStatus()).toEqual(formComponent.dataStatus);
+    } finally {
+      sub.unsubscribe();
+    }
+  });
+
+  it('broadcasts refreshed validation status after validation groups change', async () => {
+    const formConfig: FormConfigFrame = {
+      name: 'validation-group-status-broadcast',
+      debugValue: false,
+      validationGroups: {
+        none: { description: '', initialMembership: 'none' },
+        tester: { description: '' }
+      },
+      enabledValidationGroups: ['none'],
+      defaultComponentConfig: {
+        defaultComponentCssClasses: 'row',
+      },
+      editCssClasses: 'redbox-form form',
+      componentDefinitions: [
+        {
+          name: 'required_when_tester',
+          model: {
+            class: 'SimpleInputModel',
+            config: {
+              value: '',
+              validators: [
+                { class: 'required', groups: { include: ['tester'] } }
+              ]
+            }
+          },
+          component: {
+            class: 'SimpleInputComponent'
+          }
+        }
+      ]
+    };
+    const { fixture, formComponent } = await createFormAndWaitForReady(formConfig);
+    const bus = TestBed.inject(FormComponentEventBus);
+    const events: FormValidationBroadcastEvent[] = [];
+    const sub = bus.select$(FormComponentEventType.FORM_VALIDATION_BROADCAST).subscribe(event => events.push(event));
+
+    try {
+      expect(formComponent.form?.valid).toBeTrue();
+
+      bus.publish(createFormValidationGroupsChangeRequestEvent({
+        initial: 'current',
+        groups: { include: ['tester'] }
+      }));
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(formComponent.enabledValidationGroups).toEqual(['none', 'tester']);
+      expect(formComponent.form?.valid).toBeFalse();
+      expect(events.length).toBeGreaterThanOrEqual(1);
+      expect(events[events.length - 1].isValid).toBeFalse();
+      expect(events[events.length - 1].status).toEqual(formComponent.dataStatus);
       expect(formComponent.formGroupStatus()).toEqual(formComponent.dataStatus);
     } finally {
       sub.unsubscribe();

--- a/angular/projects/researchdatabox/form/src/app/form.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.ts
@@ -574,14 +574,7 @@ export class FormComponent extends BaseComponent implements OnDestroy {
       this.subMaps['formGroupChangesSub'] = this.form.events.subscribe(
         (formGroupEvent: StatusChangeEvent | PristineChangeEvent | ValueChangeEvent<unknown> | unknown) => {
           if (formGroupEvent instanceof StatusChangeEvent || formGroupEvent instanceof PristineChangeEvent) {
-            this.formGroupStatus.set(this.dataStatus);
-            this.eventBus.publish(
-              createFormValidationBroadcastEvent({
-                isValid: this.dataStatus.valid,
-                errors: this.dataStatus.errors,
-                status: this.dataStatus,
-              })
-            );
+            this.broadcastFormStatus();
           }
         }
       );
@@ -604,6 +597,28 @@ export class FormComponent extends BaseComponent implements OnDestroy {
     //     }
     //   });
     // }
+  }
+  /**
+   * Refresh the form group status signal and publish a FORM_VALIDATION_BROADCAST
+   * with the current data status.
+   *
+   * Use this whenever a control value/state has been mutated with `emitEvent: false`
+   * — e.g. expression-driven model updates — so consumers like the Save button
+   * effect can re-evaluate. Without this, silent updates can leave the UI's idea
+   * of validity out of sync with the FormGroup's actual state.
+   */
+  public broadcastFormStatus(): void {
+    if (!this.form) {
+      return;
+    }
+    this.formGroupStatus.set(this.dataStatus);
+    this.eventBus.publish(
+      createFormValidationBroadcastEvent({
+        isValid: this.dataStatus.valid,
+        errors: this.dataStatus.errors,
+        status: this.dataStatus,
+      })
+    );
   }
   /**
    * Create the form group based on the form definition map.

--- a/angular/projects/researchdatabox/form/src/app/form.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.ts
@@ -563,6 +563,7 @@ export class FormComponent extends BaseComponent implements OnDestroy {
         this.componentDefArr?.forEach(mapEntry =>
           this.formService.updateValidators(mapEntry, enabledNames, validationGroups)
         );
+        this.broadcastFormStatus();
 
         this.loggerService.debug(`${this.logName}: Form enabledValidationGroups changed from ${JSON.stringify(originalEnabledValidationGroups)} to ${JSON.stringify(this.enabledValidationGroups)} from event field ${event.fieldId}`);
       });
@@ -611,6 +612,7 @@ export class FormComponent extends BaseComponent implements OnDestroy {
     if (!this.form) {
       return;
     }
+    this.form.updateValueAndValidity({ emitEvent: false });
     this.formGroupStatus.set(this.dataStatus);
     this.eventBus.publish(
       createFormValidationBroadcastEvent({


### PR DESCRIPTION
## Summary

Improves how form validation state is propagated after silent model updates, ensuring UI elements (such as the Save button) accurately reflect the current validity. Introduces a centralized `broadcastFormStatus` mechanism, refactors event handling to use it, and adds tests to validate the behaviour.

---

## Context / Motivation

Angular forms updated with `emitEvent: false` do not trigger value/status change events. This caused:

- UI components not updating (e.g. Save button remaining disabled/enabled incorrectly)
- inconsistent validation state visibility
- duplication of ad-hoc broadcasting logic

This PR ensures validation state is explicitly and consistently broadcast after silent updates.

---

## Key Changes

### Centralised Form Status Broadcasting

- Introduced a new `broadcastFormStatus` method on `FormComponent`

- Responsibilities:
  - refresh the form group status signal
  - emit a `FORM_VALIDATION_BROADCAST` event with current validity

- Ensures:
  - UI consumers are always notified of validation state changes
  - consistent behaviour regardless of how the model is updated

---

### Refactoring of Event Handling

- Replaced duplicated broadcast logic with calls to `broadcastFormStatus`

- Updated:
  - internal `FormComponent` event handling
  - `FormComponentEventBaseConsumer`

- Now:
  - silent model updates explicitly trigger a validation broadcast
  - expression-driven updates correctly propagate state changes

---

### Improved Behaviour for Silent Updates

- After updates using `emitEvent: false`:
  - validation state is now synchronised with UI
  - dependent components (buttons, summaries, etc.) update correctly

- Avoids:
  - stale validation state
  - misleading UI behaviour

---

## Testing

### New and Updated Tests

- Verified:
  - `broadcastFormStatus` is triggered after silent updates
  - it is not called when values remain unchanged
  - correct validation state is published

- Added coverage for:
  - event consumer behaviour
  - `FormComponent` broadcasting logic
  - signal refresh and event emission

---

### Test Setup Improvements

- Updated mocks and imports to support new behaviour
- Improved spying and dependency injection for validation flow testing

---

## Impact

This change:

- fixes UI inconsistencies caused by silent model updates
- centralises validation broadcasting logic
- improves reliability of form state handling
- ensures consistent behaviour across all update pathways
