### PR TITLE
Provide Validators To Client

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/suggested-validation-summary.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/suggested-validation-summary.component.ts
@@ -12,7 +12,7 @@ import { ValidationSummaryFieldComponent } from './validation-summary.component'
 @Component({
   selector: 'redbox-suggested-validation-summary-field',
   template: `
-    @let validationList = (allValidationErrorsDisplay() | async) ?? [];
+    @let validationList = (validationErrorsDisplay$ | async) ?? [];
     @if (validationList.length === 0 && showWhenValid) {
       <div class="alert alert-info" role="alert">
         {{ '@dmpt-form-suggested-validation-summary-complete' | i18next }}
@@ -104,17 +104,8 @@ export class SuggestedValidationSummaryFieldComponent extends ValidationSummaryF
 
   private readonly suggestedFormService = inject(FormService);
 
-  override async allValidationErrorsDisplay(): Promise<FormValidatorSummaryErrors[]> {
-    const mapEntries = this.formComponent.componentDefArr ?? [];
-    const result: FormValidatorSummaryErrors[] = [];
-    for (const mapEntry of mapEntries) {
-      await this.suggestedFormService.getSuggestedValidatorSummaryErrors(
-        mapEntry,
-        this.enabledValidationGroups,
-        this.formComponent.validationGroups
-      )
-    }
-    return result;
+  override allValidationErrorsDisplay(): Promise<FormValidatorSummaryErrors[]> {
+    return Promise.resolve(this.validationErrorsDisplay$.value);
   }
 
   override trackValidationError(error: FormValidatorComponentErrors, errorIndex: number): string {
@@ -123,6 +114,19 @@ export class SuggestedValidationSummaryFieldComponent extends ValidationSummaryF
 
   public get header(): string {
     return this.suggestedConfig.header ?? '@dmpt-form-suggested-validation-summary-header';
+  }
+
+  protected override async refreshValidationErrors(): Promise<void> {
+    const mapEntries = this.formComponent.componentDefArr ?? [];
+    const result: FormValidatorSummaryErrors[] = [];
+    for (const mapEntry of mapEntries) {
+      result.push(...await this.suggestedFormService.getSuggestedValidatorSummaryErrors(
+        mapEntry,
+        this.enabledValidationGroups,
+        this.formComponent.validationGroups
+      ));
+    }
+    this.validationErrorsDisplay$.next(result);
   }
 
   private get enabledValidationGroups(): string[] {

--- a/angular/projects/researchdatabox/form/src/app/component/validation-summary.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/validation-summary.component.spec.ts
@@ -152,6 +152,69 @@ describe('ValidationSummaryFieldComponent', () => {
     ]);
   });
 
+  it('should remove a validation summary item when the field becomes valid while the form remains invalid', async () => {
+    const formConfig: FormConfigFrame = {
+      name: 'testing',
+      debugValue: true,
+      domElementType: 'form',
+      defaultComponentConfig: {
+        defaultComponentCssClasses: 'row',
+      },
+      editCssClasses: "redbox-form form",
+      componentDefinitions: [
+        {
+          name: 'text_1_event',
+          model: {
+            class: 'SimpleInputModel',
+            config: {
+              value: '',
+              validators: [
+                { class: 'required' },
+              ]
+            }
+          },
+          component: {
+            class: 'SimpleInputComponent'
+          }
+        },
+        {
+          name: 'text_2_event',
+          model: {
+            class: 'SimpleInputModel',
+            config: {
+              value: '',
+              validators: [
+                { class: 'required' },
+              ]
+            }
+          },
+          component: {
+            class: 'SimpleInputComponent'
+          }
+        },
+        {
+          name: 'validation_summary_1',
+          component: { class: "ValidationSummaryComponent" }
+        },
+      ]
+    };
+
+    const { fixture, formComponent } = await createFormAndWaitForReady(formConfig);
+    const validationSummary = fixture.componentInstance.componentDefArr[2].component as ValidationSummaryFieldComponent;
+    const initialSummaryErrors = await validationSummary.allValidationErrorsDisplay();
+    expect(initialSummaryErrors.map((summary) => summary.id)).toContain('form-item-id-text-1-event');
+    expect(initialSummaryErrors.map((summary) => summary.id)).toContain('form-item-id-text-2-event');
+
+    formComponent.form?.get('text_1_event')?.setValue('Valid project name');
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const updatedSummaryErrors = await validationSummary.allValidationErrorsDisplay();
+    expect(formComponent.form?.status).toBe('INVALID');
+    expect(updatedSummaryErrors.map((summary) => summary.id)).not.toContain('form-item-id-text-1-event');
+    expect(updatedSummaryErrors.map((summary) => summary.id)).toContain('form-item-id-text-2-event');
+  });
+
   it('should produce unique error track keys across summaries for matching errors', async () => {
     // arrange
     const formConfig: FormConfigFrame = {

--- a/angular/projects/researchdatabox/form/src/app/component/validation-summary.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/validation-summary.component.ts
@@ -1,7 +1,8 @@
-import { Component, inject, Injector, Input } from '@angular/core';
+import { ChangeDetectorRef, Component, DestroyRef, inject, Injector, Input } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import { FormFieldBaseComponent, FormFieldCompMapEntry } from "@researchdatabox/portal-ng-common";
-import { FormComponent } from "../form.component";
+import { TranslationService } from "@researchdatabox/portal-ng-common";
+import type { FormComponent } from "../form.component";
 import { TabComponent } from './tab.component';
 import {
   FormValidatorComponentErrors,
@@ -15,14 +16,15 @@ import {
   ValidationSummaryComponentName,
 } from "@researchdatabox/sails-ng-common";
 import { FormComponentEventBus } from '../form-state/events/form-component-event-bus.service';
-import { createLineageFieldFocusRequestEvent } from '../form-state/events/form-component-event.types';
-import { FormService } from "../form.service";
+import { createLineageFieldFocusRequestEvent, FormComponentEventType } from '../form-state/events/form-component-event.types';
+import { BehaviorSubject, merge } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 
 @Component({
   selector: 'redbox-validation-summary-field',
   template: `
-    @let validationList = (allValidationErrorsDisplay() | async) ?? [];
+    @let validationList = (validationErrorsDisplay$ | async) ?? [];
     @if (validationList.length === 0 && showWhenValid) {
       <div class="alert alert-info" role="alert">
         {{ '@dmpt-form-validation-summary-valid' | i18next }}
@@ -121,7 +123,11 @@ export class ValidationSummaryFieldComponent extends FormFieldBaseComponent<stri
   private _injector = inject(Injector);
   private readonly eventBus = inject(FormComponentEventBus);
   private readonly doc = inject(DOCUMENT);
-  private readonly formService = inject(FormService);
+  private readonly translationService = inject(TranslationService);
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+  private readonly destroyRef = inject(DestroyRef);
+  public readonly validationErrorsDisplay$ = new BehaviorSubject<FormValidatorSummaryErrors[]>([]);
+  private validationRefreshQueued = false;
   private readonly focusableSelector = [
     'input:not([type="hidden"]):not([disabled])',
     'select:not([disabled])',
@@ -131,8 +137,40 @@ export class ValidationSummaryFieldComponent extends FormFieldBaseComponent<stri
     '[tabindex]:not([tabindex="-1"])',
   ].join(',');
 
-  public async allValidationErrorsDisplay(): Promise<FormValidatorSummaryErrors[]> {
-    return this.getFormComponent.getValidationErrors() ?? [];
+  public allValidationErrorsDisplay(): Promise<FormValidatorSummaryErrors[]> {
+    return Promise.resolve(this.validationErrorsDisplay$.value);
+  }
+
+  protected override async initEventHandlers(): Promise<void> {
+    await super.initEventHandlers();
+    this.refreshValidationErrors();
+
+    const form = this.getFormComponent.form;
+    if (form) {
+      merge(form.valueChanges, form.statusChanges)
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe(() => this.queueValidationErrorsRefresh());
+    }
+
+    this.eventBus.select$(FormComponentEventType.FORM_VALIDATION_BROADCAST)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.queueValidationErrorsRefresh());
+  }
+
+  protected queueValidationErrorsRefresh(): void {
+    if (this.validationRefreshQueued) {
+      return;
+    }
+    this.validationRefreshQueued = true;
+    queueMicrotask(() => {
+      this.validationRefreshQueued = false;
+      this.refreshValidationErrors();
+    });
+  }
+
+  protected async refreshValidationErrors(): Promise<void> {
+    this.validationErrorsDisplay$.next(this.getFormComponent.getValidationErrors() ?? []);
+    this.changeDetectorRef.markForCheck();
   }
 
   public trackValidationError(error: FormValidatorComponentErrors, errorIndex: number): string {
@@ -384,7 +422,11 @@ export class ValidationSummaryFieldComponent extends FormFieldBaseComponent<stri
   }
 
   private translate(key: string): string {
-    return this.formService.translate(key);
+    const translated = this.translationService.t(key);
+    if (translated === undefined || translated === null || translated === '') {
+      return key;
+    }
+    return translated.toString();
   }
 
   private findComponentEntryFromLineage(angularPath: Array<string | number>): FormFieldCompMapEntry | undefined {

--- a/angular/projects/researchdatabox/form/src/app/component/validation-summary.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/validation-summary.component.ts
@@ -143,7 +143,7 @@ export class ValidationSummaryFieldComponent extends FormFieldBaseComponent<stri
 
   protected override async initEventHandlers(): Promise<void> {
     await super.initEventHandlers();
-    this.refreshValidationErrors();
+    this.triggerValidationErrorsRefresh('init');
 
     const form = this.getFormComponent.form;
     if (form) {
@@ -164,7 +164,13 @@ export class ValidationSummaryFieldComponent extends FormFieldBaseComponent<stri
     this.validationRefreshQueued = true;
     queueMicrotask(() => {
       this.validationRefreshQueued = false;
-      this.refreshValidationErrors();
+      this.triggerValidationErrorsRefresh('queue');
+    });
+  }
+
+  private triggerValidationErrorsRefresh(source: 'init' | 'queue'): void {
+    void this.refreshValidationErrors().catch((error) => {
+      this.loggerService.error(`${this.logName}: Failed to refresh validation errors during ${source}.`, error);
     });
   }
 

--- a/angular/projects/researchdatabox/form/src/app/form.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.ts
@@ -391,7 +391,9 @@ export class FormComponent extends BaseComponent implements OnDestroy {
     this.componentDefArr = this.formDefMap.components;
     if (this.shouldRefreshDebugSnapshots()) {
       this.refreshTranslatedConfigDebugInfo(true);
-      this.refreshComponentDebugInfo();
+      if (this.shouldRefreshComponentDebugInfo()) {
+        this.refreshComponentDebugInfo();
+      }
     }
     const compContainerRef: ViewContainerRef | undefined = this.componentsContainer;
     if (!compContainerRef) {
@@ -452,11 +454,12 @@ export class FormComponent extends BaseComponent implements OnDestroy {
    * Initialize reactive effects
    */
   protected initEffects() {
-    // Keep the expensive debug snapshots lazy. Large hook configs can make the
-    // initial render unusable if we deep-clone the full form tree while the
-    // panel is still collapsed.
+    // Keep the expensive component tree snapshot lazy while still maintaining
+    // form/model snapshots whenever debug mode is enabled.
     effect(() => {
-      if (this.shouldRefreshDebugSnapshots()) {
+      const shouldRefreshSnapshots = this.shouldRefreshDebugSnapshots();
+      this.shouldRefreshComponentDebugInfo();
+      if (shouldRefreshSnapshots) {
         untracked(() => this.refreshAllDebugInfo());
       }
     });
@@ -536,7 +539,9 @@ export class FormComponent extends BaseComponent implements OnDestroy {
           return;
         }
         this.refreshTranslatedConfigDebugInfo(false);
-        this.refreshComponentDebugInfo();
+        if (this.shouldRefreshComponentDebugInfo()) {
+          this.refreshComponentDebugInfo();
+        }
       });
     this.subMaps['formStatusDirtyRequestSub'] = this.eventBus
       .select$(FormComponentEventType.FORM_STATUS_DIRTY_REQUEST)
@@ -816,12 +821,19 @@ export class FormComponent extends BaseComponent implements OnDestroy {
     }
     this.refreshTranslatedConfigDebugInfo(!!opts?.resetConfigInitial);
     this.refreshModelDebugInfo(!!opts?.captureModelPrevious);
-    this.refreshComponentDebugInfo();
+    if (this.shouldRefreshComponentDebugInfo()) {
+      this.refreshComponentDebugInfo();
+    }
     this.debugState.setFormValueSnapshots(this.getDebugFormValue(), this.getDebugRawFormValue());
   }
 
   private shouldRefreshDebugSnapshots(): boolean {
-    return this.debugState.isDebugEnabled() && (!this.debugState.panelCollapsed() || this.debugState.isDebugPopoutWindow());
+    return this.debugState.isDebugEnabled();
+  }
+
+  private shouldRefreshComponentDebugInfo(): boolean {
+    return this.debugState.isDebugEnabled() &&
+      (!this.debugState.panelCollapsed() || this.debugState.isDebugPopoutWindow());
   }
 
   private refreshTranslatedConfigDebugInfo(resetInitial: boolean) {

--- a/angular/projects/researchdatabox/form/src/app/form.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.ts
@@ -26,6 +26,7 @@ import {
   model,
   OnDestroy,
   signal,
+  untracked,
   ViewChild,
   ViewContainerRef,
   ViewEncapsulation,
@@ -388,8 +389,10 @@ export class FormComponent extends BaseComponent implements OnDestroy {
       this.formDefMap = await this.formService.createFormComponentsMap(formConfig, parentLineagePaths);
     }
     this.componentDefArr = this.formDefMap.components;
-    this.refreshTranslatedConfigDebugInfo(true);
-    this.refreshComponentDebugInfo();
+    if (this.shouldRefreshDebugSnapshots()) {
+      this.refreshTranslatedConfigDebugInfo(true);
+      this.refreshComponentDebugInfo();
+    }
     const compContainerRef: ViewContainerRef | undefined = this.componentsContainer;
     if (!compContainerRef) {
       throw new Error(`${this.logName}: No component container found. Cannot load components.`);
@@ -449,9 +452,13 @@ export class FormComponent extends BaseComponent implements OnDestroy {
    * Initialize reactive effects
    */
   protected initEffects() {
-    // This is needed to update the debugging info when form status changes.
+    // Keep the expensive debug snapshots lazy. Large hook configs can make the
+    // initial render unusable if we deep-clone the full form tree while the
+    // panel is still collapsed.
     effect(() => {
-      this.getDebugInfo();
+      if (this.shouldRefreshDebugSnapshots()) {
+        untracked(() => this.refreshAllDebugInfo());
+      }
     });
 
     // Monitor async validation state and dispatch actions (R16.3, AC56)
@@ -525,6 +532,9 @@ export class FormComponent extends BaseComponent implements OnDestroy {
     this.subMaps['formDefinitionChangedDebugSub'] = this.eventBus
       .select$(FormComponentEventType.FORM_DEFINITION_CHANGED)
       .subscribe(() => {
+        if (!this.shouldRefreshDebugSnapshots()) {
+          return;
+        }
         this.refreshTranslatedConfigDebugInfo(false);
         this.refreshComponentDebugInfo();
       });
@@ -582,6 +592,9 @@ export class FormComponent extends BaseComponent implements OnDestroy {
 
       this.subMaps['formValueChangesSub']?.unsubscribe();
       this.subMaps['formValueChangesSub'] = this.form.valueChanges.subscribe(() => {
+        if (!this.shouldRefreshDebugSnapshots()) {
+          return;
+        }
         this.refreshAllDebugInfo({ captureModelPrevious: true });
       });
     }
@@ -798,10 +811,17 @@ export class FormComponent extends BaseComponent implements OnDestroy {
   }
 
   private refreshAllDebugInfo(opts?: { captureModelPrevious?: boolean; resetConfigInitial?: boolean }) {
+    if (!this.shouldRefreshDebugSnapshots()) {
+      return;
+    }
     this.refreshTranslatedConfigDebugInfo(!!opts?.resetConfigInitial);
     this.refreshModelDebugInfo(!!opts?.captureModelPrevious);
     this.refreshComponentDebugInfo();
     this.debugState.setFormValueSnapshots(this.getDebugFormValue(), this.getDebugRawFormValue());
+  }
+
+  private shouldRefreshDebugSnapshots(): boolean {
+    return this.debugState.isDebugEnabled() && (!this.debugState.panelCollapsed() || this.debugState.isDebugPopoutWindow());
   }
 
   private refreshTranslatedConfigDebugInfo(resetInitial: boolean) {

--- a/angular/projects/researchdatabox/form/src/app/form.service.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.service.spec.ts
@@ -10,10 +10,10 @@ import {
   TranslationService,
   UtilityService
 } from "@researchdatabox/portal-ng-common";
-import {APP_BASE_HREF} from "@angular/common";
-import {Title} from "@angular/platform-browser";
-import {HttpContext, provideHttpClient} from "@angular/common/http";
-import {HttpTestingController, provideHttpClientTesting} from "@angular/common/http/testing";
+import { APP_BASE_HREF } from "@angular/common";
+import { Title } from "@angular/platform-browser";
+import { HttpContext, provideHttpClient } from "@angular/common/http";
+import { HttpTestingController, provideHttpClientTesting } from "@angular/common/http/testing";
 import {
   FormConfigFrame,
   FormFieldValidationGroup,
@@ -23,9 +23,9 @@ import {
   FormValidatorSummaryErrors,
   LineagePaths
 } from "@researchdatabox/sails-ng-common";
-import {FormValidationGroupsChangeInitial} from "./form-state";
-import {setUpDynamicAssets} from "./helpers.spec";
-import {FormControl} from "@angular/forms";
+import { FormValidationGroupsChangeInitial } from "./form-state";
+import { setUpDynamicAssets } from "./helpers.spec";
+import { FormControl } from "@angular/forms";
 
 
 describe('The FormService', () => {
@@ -78,13 +78,13 @@ describe('The FormService', () => {
     const componentDefinitions = [
       {
         name: 'accordion_1',
-        component: {class: 'AccordionComponent', config: {panels: []}},
-        layout: {class: 'AccordionLayout'},
+        component: { class: 'AccordionComponent', config: { panels: [] } },
+        layout: { class: 'AccordionLayout' },
       },
       {
         name: 'accordion_panel_1',
-        component: {class: 'AccordionPanelComponent', config: {componentDefinitions: []}},
-        layout: {class: 'AccordionPanelLayout'},
+        component: { class: 'AccordionPanelComponent', config: { componentDefinitions: [] } },
+        layout: { class: 'AccordionPanelLayout' },
       },
     ] as any;
 
@@ -108,9 +108,9 @@ describe('The FormService', () => {
       pointer: string,
       children: FormFieldCompMapEntry[] = []
     ): FormFieldCompMapEntry => ({
-      compConfigJson: {name},
-      lineagePaths: {angularComponentsJsonPointer: pointer} as any,
-      component: {formFieldCompMapEntries: children} as any
+      compConfigJson: { name },
+      lineagePaths: { angularComponentsJsonPointer: pointer } as any,
+      component: { formFieldCompMapEntries: children } as any
     } as unknown as FormFieldCompMapEntry);
 
     it('transformIntoJSONataProperty should include nested children metadata', () => {
@@ -320,6 +320,25 @@ describe('The FormService', () => {
         { edit: 'true' }
       );
     });
+
+    it('should use the provided form mode when building compiled validator imports', async () => {
+      const getDynamicImportFormCompiledItemsSpy = spyOn(service, 'getDynamicImportFormCompiledItems').and.resolveTo({ evaluate: () => '' } as any);
+      const formConfig: FormConfigFrame = {
+        name: 'testing',
+        type: 'rdmp',
+        componentDefinitions: []
+      };
+      const parentLineagePaths = service.buildLineagePaths({
+        angularComponents: [],
+        dataModel: [],
+        formConfig: [],
+        layout: []
+      });
+
+      await service.createFormComponentsMap(formConfig, parentLineagePaths, undefined, 'view');
+
+      expect(getDynamicImportFormCompiledItemsSpy).toHaveBeenCalledWith('rdmp', undefined, 'view');
+    });
   });
 
   describe('calculate enabled validation groups', async () => {
@@ -332,66 +351,66 @@ describe('The FormService', () => {
         groups?: FormFieldValidationGroup
       };
       expected: string[];
-    }[] =[
-      {
-        title: "be empty with empty parameters",
-        args: {currentValidationGroups:[], validationGroups: {} },
-        expected: [],
-      },
-      {
-        title: "add included group to current groups",
-        args: {
-          currentValidationGroups: ["none"],
-          validationGroups: {
-            "none": {description: "", initialMembership:"none"},
-            "tester": {description: ""}
-          },
-          initial: "current",
-          groups:{include: ["tester"]},
+    }[] = [
+        {
+          title: "be empty with empty parameters",
+          args: { currentValidationGroups: [], validationGroups: {} },
+          expected: [],
         },
-        expected: ["none", "tester"],
-      },
-      {
-        title: "remove excluded group from current groups",
-        args: {
-          currentValidationGroups: ["none"],
-          validationGroups: {
-            "none": {description: "", initialMembership:"none"},
-            "tester": {description: ""}
+        {
+          title: "add included group to current groups",
+          args: {
+            currentValidationGroups: ["none"],
+            validationGroups: {
+              "none": { description: "", initialMembership: "none" },
+              "tester": { description: "" }
+            },
+            initial: "current",
+            groups: { include: ["tester"] },
           },
-          initial: "current",
-          groups:{exclude: ["none"]},
+          expected: ["none", "tester"],
         },
-        expected: [],
-      },
-      {
-        title: "remove excluded group from all groups",
-        args: {
-          currentValidationGroups: [],
-          validationGroups: {
-            "none": {description: "", initialMembership:"none"},
-            "tester": {description: ""}
+        {
+          title: "remove excluded group from current groups",
+          args: {
+            currentValidationGroups: ["none"],
+            validationGroups: {
+              "none": { description: "", initialMembership: "none" },
+              "tester": { description: "" }
+            },
+            initial: "current",
+            groups: { exclude: ["none"] },
           },
-          initial: "all",
-          groups:{exclude: ["tester"]},
+          expected: [],
         },
-        expected: ["none"],
-      },
-      {
-        title: "set included group with initial none",
-        args: {
-          currentValidationGroups: ["none"],
-          validationGroups: {
-            "none": {description: "", initialMembership:"none"},
-            "tester": {description: ""}
+        {
+          title: "remove excluded group from all groups",
+          args: {
+            currentValidationGroups: [],
+            validationGroups: {
+              "none": { description: "", initialMembership: "none" },
+              "tester": { description: "" }
+            },
+            initial: "all",
+            groups: { exclude: ["tester"] },
           },
-          initial: "none",
-          groups:{include: ["tester"]},
+          expected: ["none"],
         },
-        expected: ["tester"],
-      },
-    ];
-    cases.forEach(({title, args, expected}) => {
+        {
+          title: "set included group with initial none",
+          args: {
+            currentValidationGroups: ["none"],
+            validationGroups: {
+              "none": { description: "", initialMembership: "none" },
+              "tester": { description: "" }
+            },
+            initial: "none",
+            groups: { include: ["tester"] },
+          },
+          expected: ["tester"],
+        },
+      ];
+    cases.forEach(({ title, args, expected }) => {
       it(`should ${title}`, async function () {
         const results = service.calculateValidationGroups(args.currentValidationGroups, args.validationGroups, args.initial, args.groups);
         expect(results).toEqual(expected);
@@ -427,8 +446,8 @@ describe('The FormService', () => {
       ]
     };
     const meta: Record<string, unknown> = {
-      workflow: {stage: 'draft', stageLabel: 'Draft'},
-      contextVariables: {'one': 1},
+      workflow: { stage: 'draft', stageLabel: 'Draft' },
+      contextVariables: { 'one': 1 },
     };
     setUpDynamicAssets();
     const oid = "oid", recordType = "auto", editMode = false, formName = "", modulePaths: string[] = [];
@@ -436,7 +455,7 @@ describe('The FormService', () => {
     const req = httpTesting.expectOne((request) =>
       request.url.startsWith(`http://localhost/default/rdmp/record/form/${recordType}/${oid}`));
     expect(req.request.method).toBe('GET');
-    req.flush({data: basicFormConfig, meta: meta});
+    req.flush({ data: basicFormConfig, meta: meta });
     expect((await result).formConfigMeta).toEqual(meta);
   });
 });

--- a/angular/projects/researchdatabox/form/src/app/form.service.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.service.spec.ts
@@ -19,6 +19,7 @@ import {
   FormFieldValidationGroup,
   FormModesConfig,
   FormValidationGroups,
+  FormValidatorConfig,
   FormValidatorSummaryErrors,
   LineagePaths
 } from "@researchdatabox/sails-ng-common";
@@ -32,6 +33,7 @@ describe('The FormService', () => {
   const translationService = getStubTranslationService();
   let service: FormService;
   let httpTesting: HttpTestingController;
+  const waitForAsyncValidation = () => new Promise(resolve => setTimeout(resolve, 0));
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
@@ -192,14 +194,14 @@ describe('The FormService', () => {
           layoutJsonPointer: "/text_7-layout",
         },
       };
-      const enabledValidationGroups: string[] = [];
+      const enabledValidationGroups: string[] = ["all"];
       const validationGroups: FormValidationGroups = {};
       const expected: FormValidatorSummaryErrors[] = [
         {
           errors: [
             {
               message: "@validator-error-jsonata-expression",
-              class: "jsonata-expressions",
+              class: "jsonata-expression",
               params: {
                 actual: "hello world 2!",
                 description: "the description",
@@ -207,8 +209,8 @@ describe('The FormService', () => {
               },
             },
           ],
-          id: "text_7",
-          message: "TextField with default wrapper defined",
+          id: "form-item-id-text-7",
+          message: null,
           lineagePaths: {
             formConfig: ["componentDefinitions", "0"],
             dataModel: ["text_7"],
@@ -221,6 +223,57 @@ describe('The FormService', () => {
       ];
       const actual = await service.getSuggestedValidatorSummaryErrors(mapEntry, enabledValidationGroups, validationGroups);
       expect(actual).toEqual(expected);
+    });
+
+    it('should attach jsonata-expression as a hard async validator failure', async () => {
+      const control = new FormControl("hello world 2!");
+      const validators: FormValidatorConfig[] = [{
+        class: 'jsonata-expression',
+        config: {
+          description: "the description",
+          expression: "$ = 45",
+        },
+      }];
+      const mapEntry = {
+        lineagePaths: {
+          formConfig: ["componentDefinitions", "0"],
+        },
+      } as unknown as FormFieldCompMapEntry;
+
+      service.setValidators(control, validators, ["all"], {}, { doUpdate: true }, mapEntry);
+      await waitForAsyncValidation();
+
+      expect(control.invalid).toBeTrue();
+      expect(control.errors?.['jsonata-expression']).toEqual({
+        message: "@validator-error-jsonata-expression",
+        params: {
+          actual: "hello world 2!",
+          description: "the description",
+          expression: "$ = 45",
+        },
+      });
+    });
+
+    it('should attach jsonata-expression as a hard async validator pass', async () => {
+      const control = new FormControl(45);
+      const validators: FormValidatorConfig[] = [{
+        class: 'jsonata-expression',
+        config: {
+          description: "the description",
+          expression: "$ = 45",
+        },
+      }];
+      const mapEntry = {
+        lineagePaths: {
+          formConfig: ["componentDefinitions", "0"],
+        },
+      } as unknown as FormFieldCompMapEntry;
+
+      service.setValidators(control, validators, ["all"], {}, { doUpdate: true }, mapEntry);
+      await waitForAsyncValidation();
+
+      expect(control.valid).toBeTrue();
+      expect(control.errors).toBeNull();
     });
   });
 

--- a/angular/projects/researchdatabox/form/src/app/form.service.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.service.ts
@@ -17,8 +17,8 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-import {Inject, Injectable, WritableSignal} from '@angular/core';
-import {AbstractControl, FormControl} from '@angular/forms';
+import { Inject, Injectable, WritableSignal } from '@angular/core';
+import { AbstractControl, FormControl } from '@angular/forms';
 import {
   isEmpty as _isEmpty,
   isFinite as _isFinite,
@@ -45,7 +45,7 @@ import {
   TranslationService,
   UtilityService
 } from '@researchdatabox/portal-ng-common';
-import {PortalNgFormCustomService} from '@researchdatabox/portal-ng-form-custom';
+import { PortalNgFormCustomService } from '@researchdatabox/portal-ng-form-custom';
 import {
   buildLineagePaths as buildLineagePathsHelper,
   DynamicScriptResponse,
@@ -64,6 +64,7 @@ import {
   FormValidatorFns,
   FormValidatorSummaryErrors,
   getObjectWithJsonPointer, jsonataEvaluateFunc,
+  jsonataLibrary,
   JSONataQueryRuntimeContext,
   JSONataQuerySource,
   JSONataQuerySourceProperty,
@@ -74,10 +75,10 @@ import {
   queryJSONata,
   ValidatorsSupport,
 } from '@researchdatabox/sails-ng-common';
-import {HttpClient} from "@angular/common/http";
-import {APP_BASE_HREF} from "@angular/common";
-import {firstValueFrom} from "rxjs";
-import {FormValidationGroupsChangeInitial} from "./form-state";
+import { HttpClient } from "@angular/common/http";
+import { APP_BASE_HREF } from "@angular/common";
+import { firstValueFrom } from "rxjs";
+import { FormValidationGroupsChangeInitial } from "./form-state";
 
 // redboxClientScript.formValidatorDefinitions is provided from index.bundle.js, via client-script.js
 declare var redboxClientScript: { formValidatorDefinitions: FormValidatorDefinition[] };
@@ -112,6 +113,7 @@ export class FormService extends HttpClientService {
 
   private requestOptions: Record<string, unknown> = {};
   private loadedValidatorDefinitions?: Map<string, FormValidatorDefinition>;
+  private formCompiledItems?: Promise<DynamicScriptResponse>;
   // Suggested validation is read from template getters, so cache by control to avoid rebuilding validators on every change detection pass.
   private suggestedValidatorSummaryCache = new WeakMap<AbstractControl, SuggestedValidatorSummaryCacheEntry>();
 
@@ -208,6 +210,9 @@ export class FormService extends HttpClientService {
       this.loadedValidatorDefinitions = this.validatorsSupport.createValidatorDefinitionMapping(validatorDefinitions);
       this.loggerService.debug(`Loaded validator definitions`, this.loadedValidatorDefinitions);
     }
+    this.formCompiledItems = formConfig?.type
+      ? this.getDynamicImportFormCompiledItems(formConfig.type, undefined, "edit")
+      : undefined;
 
     const componentDefinitions = Array.isArray(formConfig?.componentDefinitions) ? formConfig?.componentDefinitions : [];
 
@@ -373,7 +378,7 @@ export class FormService extends HttpClientService {
       compMapEntry.model = new ModelType(modelConfig);
       const formControl = compMapEntry.model.formControl;
       const validators = compMapEntry.model.validators;
-      this.setValidators(formControl, validators, enabledValidationGroups, validationGroups);
+      this.setValidators(formControl, validators, enabledValidationGroups, validationGroups, undefined, compMapEntry);
       return compMapEntry.model;
     }
 
@@ -524,7 +529,7 @@ export class FormService extends HttpClientService {
     if (formControl && !formControl.disabled && lineagePaths && validators.length > 0) {
       const errors = await this.getCachedSuggestedValidatorComponentErrors(
         formControl,
-        validators,
+        this.prepareValidatorConfigs(validators, mapEntry),
         enabledValidationGroups,
         validationGroups
       );
@@ -690,6 +695,7 @@ export class FormService extends HttpClientService {
     enabledValidationGroups?: string[] | null,
     validationGroups?: FormValidationGroups | null,
     updateValueAndValidityOpts?: { doUpdate?: boolean } & ModifyOptions,
+    mapEntry?: FormFieldCompMapEntry,
   ): void {
     if (!formControl) {
       this.loggerService.warn(`${this.logName}: Cannot set validators because formControl was not provided.`);
@@ -707,11 +713,7 @@ export class FormService extends HttpClientService {
       enabledValidationGroups = [];
     }
 
-    // ensure jsonata-expression validators can be evaluated
-    this.validatorsSupport.assignJsonataEvaluators(validators, function (validator: FormValidatorConfig, index: number): unknown {
-      // TODO: create evaluator function from validator index using lineage path
-      return null;
-    });
+    validators = this.prepareValidatorConfigs(validators, mapEntry);
 
     // Filter the validator configs to the enabled ones.
     const enabledValidators = this.validatorsSupport.enabledValidators(availableGroups, enabledValidationGroups, validators);
@@ -750,7 +752,7 @@ export class FormService extends HttpClientService {
       const formControl = mapEntry?.model?.formControl;
       const validators = mapEntry?.model?.validators;
       const updateValueAndValidityOpts = { doUpdate: true, onlySelf: true, emitEvent: false };
-      this.setValidators(formControl, validators, enabledValidationGroups, validationGroups, updateValueAndValidityOpts);
+      this.setValidators(formControl, validators, enabledValidationGroups, validationGroups, updateValueAndValidityOpts, mapEntry);
     }
 
     // Set the validators for any child controls.
@@ -1007,11 +1009,11 @@ export class FormService extends HttpClientService {
     validationGroups: FormValidationGroups,
     initial?: FormValidationGroupsChangeInitial,
     groups?: FormFieldValidationGroup
-  ): string[]{
+  ): string[] {
     let enabledNames = [...currentValidationGroups];
     // Initial is 'current' by default.
     initial = initial ?? "current";
-    switch(initial) {
+    switch (initial) {
       case "all":
         enabledNames = Object.keys(validationGroups);
         break;
@@ -1085,8 +1087,63 @@ export class FormService extends HttpClientService {
   }
 
   public getValidatorInstances(enabledValidators: FormValidatorConfig[]) {
-    const defMap = this.loadedValidatorDefinitions ?? new Map<string, FormValidatorDefinition>();
+    if (this.loadedValidatorDefinitions === null || this.loadedValidatorDefinitions === undefined) {
+      const validatorDefinitions = redboxClientScript.formValidatorDefinitions;
+      this.loadedValidatorDefinitions = this.validatorsSupport.createValidatorDefinitionMapping(validatorDefinitions);
+    }
+    const defMap = this.loadedValidatorDefinitions;
     return this.validatorsSupport.createFormValidatorInstancesFromMapping(defMap, enabledValidators) ?? [];
+  }
+
+  private prepareValidatorConfigs(validators: FormValidatorConfig[], mapEntry?: FormFieldCompMapEntry): FormValidatorConfig[] {
+    const prepared = validators.map(validator => ({
+      ...validator,
+      config: validator.config ? { ...validator.config } : undefined,
+    }));
+    this.validatorsSupport.assignJsonataEvaluators(prepared, (validator: FormValidatorConfig, index: number): unknown => {
+      const expression = validator?.config?.['expression']?.toString() ?? "";
+      const keys = this.getValidatorCompiledItemKeys(mapEntry, index);
+      return async (value: unknown) => {
+        if (this.formCompiledItems && keys.length > 0) {
+          try {
+            const compiledItems = await this.formCompiledItems;
+            for (const key of keys) {
+              const result = await compiledItems.evaluate(key, value, { libraries: jsonataLibrary });
+              if (result !== undefined) {
+                return result;
+              }
+            }
+          } catch (error) {
+            this.loggerService.warn(`${this.logName}: Could not evaluate compiled jsonata validator.`, error);
+            return null;
+          }
+        }
+        return await jsonataEvaluateFunc(expression)(value);
+      };
+    });
+    return prepared;
+  }
+
+  private getValidatorCompiledItemKeys(mapEntry: FormFieldCompMapEntry | undefined, index: number): string[][] {
+    const rootKey = ['validators', index.toString(), 'config', 'expression'];
+    const formConfigPath = mapEntry?.lineagePaths?.formConfig ?? [];
+    if (formConfigPath.length === 0) {
+      return [rootKey];
+    }
+
+    const parentPath = formConfigPath.map(path => path.toString());
+    const normalizedParentPath = this.normalizeValidatorFormConfigPath(parentPath);
+    const canonicalKey = [...normalizedParentPath, 'config', 'validators', index.toString(), 'config', 'expression'];
+    const legacyKey = [...parentPath, 'model', 'config', 'validators', index.toString(), 'config', 'expression'];
+
+    return [canonicalKey, legacyKey];
+  }
+
+  private normalizeValidatorFormConfigPath(path: string[]): string[] {
+    if (path.length > 0 && path[0] === 'formConfig') {
+      return path.slice(1);
+    }
+    return path;
   }
 }
 

--- a/angular/projects/researchdatabox/form/src/app/form.service.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.service.ts
@@ -114,6 +114,7 @@ export class FormService extends HttpClientService {
   private requestOptions: Record<string, unknown> = {};
   private loadedValidatorDefinitions?: Map<string, FormValidatorDefinition>;
   private formCompiledItems?: Promise<DynamicScriptResponse>;
+  private currentFormMode: FormModesConfig = 'edit';
   // Suggested validation is read from template getters, so cache by control to avoid rebuilding validators on every change detection pass.
   private suggestedValidatorSummaryCache = new WeakMap<AbstractControl, SuggestedValidatorSummaryCacheEntry>();
 
@@ -191,7 +192,8 @@ export class FormService extends HttpClientService {
     });
 
     // Resolve the field and component pairs
-    return this.createFormComponentsMap(formConfig, parentLineagePaths, formConfigMeta);
+    const formMode: FormModesConfig = editMode ? 'edit' : 'view';
+    return this.createFormComponentsMap(formConfig, parentLineagePaths, formConfigMeta, formMode);
   }
 
   /**
@@ -203,7 +205,12 @@ export class FormService extends HttpClientService {
    * @returns The config and the components built from the config.
    */
   public async createFormComponentsMap(
-    formConfig: FormConfigFrame, parentLineagePaths: LineagePaths, meta?: Record<string, unknown>): Promise<FormComponentsMap> {
+    formConfig: FormConfigFrame,
+    parentLineagePaths: LineagePaths,
+    meta?: Record<string, unknown>,
+    formMode?: FormModesConfig
+  ): Promise<FormComponentsMap> {
+    this.currentFormMode = formMode ?? this.currentFormMode ?? 'edit';
     if (this.loadedValidatorDefinitions === null || this.loadedValidatorDefinitions === undefined) {
       // load the validator definitions to be used when constructing the form controls
       const validatorDefinitions = redboxClientScript.formValidatorDefinitions;
@@ -211,7 +218,7 @@ export class FormService extends HttpClientService {
       this.loggerService.debug(`Loaded validator definitions`, this.loadedValidatorDefinitions);
     }
     this.formCompiledItems = formConfig?.type
-      ? this.getDynamicImportFormCompiledItems(formConfig.type, undefined, "edit")
+      ? this.getDynamicImportFormCompiledItems(formConfig.type, undefined, this.currentFormMode)
       : undefined;
 
     const componentDefinitions = Array.isArray(formConfig?.componentDefinitions) ? formConfig?.componentDefinitions : [];
@@ -1086,7 +1093,7 @@ export class FormService extends HttpClientService {
     return undefined;
   }
 
-  public getValidatorInstances(enabledValidators: FormValidatorConfig[]) {
+  private getValidatorInstances(enabledValidators: FormValidatorConfig[]) {
     if (this.loadedValidatorDefinitions === null || this.loadedValidatorDefinitions === undefined) {
       const validatorDefinitions = redboxClientScript.formValidatorDefinitions;
       this.loadedValidatorDefinitions = this.validatorsSupport.createValidatorDefinitionMapping(validatorDefinitions);

--- a/angular/projects/researchdatabox/form/src/app/helpers.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/helpers.spec.ts
@@ -46,7 +46,7 @@ import { FormDebugConfigTabComponent } from "./form-debug/form-debug-config-tab.
 import { FormDebugEventsTabComponent } from "./form-debug/form-debug-events-tab.component";
 import { ConfirmationDialogComponent } from "./component/confirmation-dialog.component";
 import { ConfirmationDialogService } from "./confirmation-dialog.service";
-import {ApplicationRef, ComponentRef} from "@angular/core";
+import { ApplicationRef, ComponentRef } from "@angular/core";
 import isSpy = jasmine.isSpy;
 
 // provide to test the same way as provided to browser
@@ -277,7 +277,14 @@ export function setUpDynamicAssets(opts?: DynamicAssetOptions) {
     }): Promise<DynamicScriptResponse> => {
       const urlKey = `${brandingAndPortalUrl}/${(urlPath ?? []).join("/")}`;
 
-      const entries = opts?.entries ?? [];
+      const entries = opts?.entries?.length
+        ? opts.entries
+        : [{
+          urlKeyStart: "http://localhost/default/rdmp/dynamicAsset/formCompiledItems/rdmp/oid-generated-",
+          callable: (_keyStr: string) => {
+            throw new Error(`Unknown key: ${_keyStr}`);
+          }
+        }];
 
       for (const entry of entries) {
         if (!entry.urlKeyStart || !urlKey.startsWith(entry.urlKeyStart)) {
@@ -295,6 +302,6 @@ export function setUpDynamicAssets(opts?: DynamicAssetOptions) {
         };
       }
 
-      throw new Error(`Url key '${urlKey}' did not match any available keys ${entries?.map(i => i.urlKeyStart)}`);
+      throw new Error(`Url key '${urlKey}' did not match any available keys ${entries.map(i => i.urlKeyStart)}`);
     });
 }

--- a/packages/redbox-core/src/controllers/RecordController.ts
+++ b/packages/redbox-core/src/controllers/RecordController.ts
@@ -319,7 +319,7 @@ export namespace Controllers {
                   metadata: {}
                 } as unknown as Parameters<typeof FormRecordConsistencyService.mergeRecordClientFormConfig>[0];
 
-                const filteredRecord = FormRecordConsistencyService.mergeRecordClientFormConfig(
+                const filteredRecord = await FormRecordConsistencyService.mergeRecordClientFormConfig(
                   emptyOriginal,
                   record as unknown as Parameters<typeof FormRecordConsistencyService.mergeRecordClientFormConfig>[1],
                   clientFormConfig,
@@ -385,7 +385,7 @@ export namespace Controllers {
           displayErrors: [{ detail: `Form configuration not found for record type: ${recordType}` }],
         });
       }
-      const modelDataDefault = FormRecordConsistencyService.buildDataModelDefaultForFormConfig(formConfig, formMode, reusableFormDefs);
+      const modelDataDefault = await FormRecordConsistencyService.buildDataModelDefaultForFormConfig(formConfig, formMode, reusableFormDefs);
 
       // return the matching format, return the model data as json
       return this.sendResp(req, res, {

--- a/packages/redbox-core/src/services/FormRecordConsistencyService.ts
+++ b/packages/redbox-core/src/services/FormRecordConsistencyService.ts
@@ -128,7 +128,7 @@ export namespace Services {
             const clientFormConfig = await FormsService.buildClientFormConfig(formConfig, formMode, userRoles, recordMetadata, reusableFormDefs);
 
             // merge the original and changed records using the client form config to know which changes to include
-            return this.mergeRecordClientFormConfig(original as unknown as BasicRedboxRecord, changed, clientFormConfig, formMode, reusableFormDefs);
+            return await this.mergeRecordClientFormConfig(original as unknown as BasicRedboxRecord, changed, clientFormConfig, formMode, reusableFormDefs);
         }
 
         /**
@@ -149,15 +149,15 @@ export namespace Services {
          * @param reusableFormDefs The reusable form definitions.
          * @return The merged record.
          */
-        public mergeRecordClientFormConfig(
+        public async mergeRecordClientFormConfig(
             original: BasicRedboxRecord,
             changed: BasicRedboxRecord,
             clientFormConfig: FormConfigFrame,
             formMode: FormModesConfig,
             reusableFormDefs?: ReusableFormDefinitions
-        ): BasicRedboxRecord {
+        ): Promise<BasicRedboxRecord> {
             const schemaFormConfig = this.stripModelValuesFromFormConfig(clientFormConfig);
-            const permittedChanges = this.buildSchemaForFormConfig(schemaFormConfig, formMode, reusableFormDefs);
+            const permittedChanges = await this.buildSchemaForFormConfig(schemaFormConfig, formMode, reusableFormDefs);
             const originalMetadata = original?.metadata ?? {};
             const changedMetadata = changed?.metadata ?? {};
             const changes = this.compareRecords(original, changed);

--- a/packages/redbox-core/src/visitor/attachment-fields.visitor.ts
+++ b/packages/redbox-core/src/visitor/attachment-fields.visitor.ts
@@ -38,7 +38,7 @@ export class AttachmentFieldsVisitor extends FormConfigVisitor {
     async visitFormConfig(item: FormConfigOutline): Promise<void> {
         // Visit all components
         for (const component of item.componentDefinitions) {
-          await component.accept(this);
+            await component.accept(this);
         }
         // Populate the attachmentFields property
         item.attachmentFields = this.attachmentFields;
@@ -70,7 +70,9 @@ export class AttachmentFieldsVisitor extends FormConfigVisitor {
     }
 
     async visitGroupFieldComponentDefinition(item: GroupFieldComponentDefinitionOutline): Promise<void> {
-        item.config?.componentDefinitions?.forEach(def => def.accept(this));
+        for (const def of item.config?.componentDefinitions ?? []) {
+            await def.accept(this);
+        }
     }
 
     // Tab
@@ -79,7 +81,9 @@ export class AttachmentFieldsVisitor extends FormConfigVisitor {
     }
 
     async visitTabFieldComponentDefinition(item: TabFieldComponentDefinitionOutline): Promise<void> {
-        item.config?.tabs?.forEach(tab => tab.accept(this));
+        for (const tab of item.config?.tabs ?? []) {
+            await tab.accept(this);
+        }
     }
 
     // Accordion
@@ -88,7 +92,9 @@ export class AttachmentFieldsVisitor extends FormConfigVisitor {
     }
 
     async visitAccordionFieldComponentDefinition(item: AccordionFieldComponentDefinitionOutline): Promise<void> {
-        item.config?.panels?.forEach(panel => panel.accept(this));
+        for (const panel of item.config?.panels ?? []) {
+            await panel.accept(this);
+        }
     }
 
     // Accordion Panel
@@ -97,7 +103,9 @@ export class AttachmentFieldsVisitor extends FormConfigVisitor {
     }
 
     async visitAccordionPanelFieldComponentDefinition(item: AccordionPanelFieldComponentDefinitionOutline): Promise<void> {
-        item.config?.componentDefinitions?.forEach(def => def.accept(this));
+        for (const def of item.config?.componentDefinitions ?? []) {
+            await def.accept(this);
+        }
     }
 
     // Tab Content
@@ -106,9 +114,9 @@ export class AttachmentFieldsVisitor extends FormConfigVisitor {
     }
 
     async visitTabContentFieldComponentDefinition(item: TabContentFieldComponentDefinitionOutline): Promise<void> {
-      for (const def of item.config?.componentDefinitions ?? []) {
-        await def.accept(this)
-      }
+        for (const def of item.config?.componentDefinitions ?? []) {
+            await def.accept(this);
+        }
     }
 
     // Repeatable

--- a/packages/redbox-core/src/visitor/client.visitor.ts
+++ b/packages/redbox-core/src/visitor/client.visitor.ts
@@ -394,15 +394,14 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
 
     this.removePropsUndefined(item);
     const items: AvailableFormComponentDefinitionOutlines[] = [];
-    const that = this;
-    (item?.componentDefinitions ?? []).forEach((componentDefinition, index) => {
+    for (const [index, componentDefinition] of (item?.componentDefinitions ?? []).entries()) {
       items.push(componentDefinition);
       // Visit children
-      that.formPathHelper.acceptFormPath(
+      await this.formPathHelper.acceptFormPath(
         componentDefinition,
-        that.formPathHelper.lineagePathsForFormConfigComponentDefinition(componentDefinition, index)
+        this.formPathHelper.lineagePathsForFormConfigComponentDefinition(componentDefinition, index)
       );
-    });
+    }
     item.componentDefinitions = items.filter(i => this.hasObjectProps(i));
 
     // if there are no components, this is an invalid form
@@ -423,7 +422,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitSimpleInputFormComponentDefinition(item: SimpleInputFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
   }
 
@@ -434,7 +433,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitContentFormComponentDefinition(item: ContentFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
   }
 
@@ -445,7 +444,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
 
     const componentDefinition = item?.config?.elementTemplate;
     if (componentDefinition) {
-      this.formPathHelper.acceptFormPath(
+      await this.formPathHelper.acceptFormPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForRepeatableFieldComponentDefinition(componentDefinition)
       );
@@ -461,7 +460,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitRepeatableFormComponentDefinition(item: RepeatableFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
 
     // if the element template is empty, this is an invalid component
@@ -484,7 +483,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitValidationSummaryFormComponentDefinition(item: ValidationSummaryFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
   }
 
@@ -493,7 +492,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitSuggestedValidationSummaryFormComponentDefinition(item: SuggestedValidationSummaryFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
   }
 
@@ -502,7 +501,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitSaveStatusFormComponentDefinition(item: SaveStatusFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
   }
 
@@ -512,14 +511,13 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
     this.processFieldComponentDefinition(item);
 
     const items: AvailableFormComponentDefinitionOutlines[] = [];
-    const that = this;
-    (item?.config?.componentDefinitions ?? []).forEach((componentDefinition, index) => {
+    for (const [index, componentDefinition] of (item?.config?.componentDefinitions ?? []).entries()) {
       items.push(componentDefinition);
-      that.formPathHelper.acceptFormPath(
+      await this.formPathHelper.acceptFormPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForGroupFieldComponentDefinition(componentDefinition, index)
       );
-    });
+    }
     if (item.config) {
       item.config.componentDefinitions = items.filter(i => this.hasObjectProps(i));
     }
@@ -530,7 +528,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitGroupFormComponentDefinition(item: GroupFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
 
     // if there are no components, this is an invalid component
@@ -545,13 +543,13 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   async visitTabFieldComponentDefinition(item: TabFieldComponentDefinitionOutline): Promise<void> {
     this.processFieldComponentDefinition(item);
 
-    (item.config?.tabs ?? []).forEach((componentDefinition, index) => {
+    for (const [index, componentDefinition] of (item.config?.tabs ?? []).entries()) {
       // Visit children
-      this.formPathHelper.acceptFormPath(
+      await this.formPathHelper.acceptFormPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForTabFieldComponentDefinition(componentDefinition, index)
       );
-    });
+    }
   }
 
   async visitTabFieldLayoutDefinition(item: TabFieldLayoutDefinitionOutline): Promise<void> {
@@ -559,7 +557,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitTabFormComponentDefinition(item: TabFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
 
     // if there are no tabs, this is an invalid component
@@ -574,12 +572,12 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   async visitAccordionFieldComponentDefinition(item: AccordionFieldComponentDefinitionOutline): Promise<void> {
     this.processFieldComponentDefinition(item);
 
-    (item.config?.panels ?? []).forEach((componentDefinition, index) => {
-      this.formPathHelper.acceptFormPath(
+    for (const [index, componentDefinition] of (item.config?.panels ?? []).entries()) {
+      await this.formPathHelper.acceptFormPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForAccordionFieldComponentDefinition(componentDefinition, index)
       );
-    });
+    }
   }
 
   async visitAccordionFieldLayoutDefinition(item: AccordionFieldLayoutDefinitionOutline): Promise<void> {
@@ -587,7 +585,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitAccordionFormComponentDefinition(item: AccordionFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
 
     if ((item.component?.config?.panels ?? [])?.length === 0) {
@@ -599,13 +597,13 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
     this.processFieldComponentDefinition(item);
 
     const items: AvailableFormComponentDefinitionOutlines[] = [];
-    (item.config?.componentDefinitions ?? []).forEach((componentDefinition, index) => {
+    for (const [index, componentDefinition] of (item.config?.componentDefinitions ?? []).entries()) {
       items.push(componentDefinition);
-      this.formPathHelper.acceptFormPath(
+      await this.formPathHelper.acceptFormPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForAccordionPanelFieldComponentDefinition(componentDefinition, index)
       );
-    });
+    }
     if (item.config) {
       item.config.componentDefinitions = items.filter(i => this.hasObjectProps(i));
     }
@@ -616,7 +614,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitAccordionPanelFormComponentDefinition(item: AccordionPanelFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
 
     if ((item.component?.config?.componentDefinitions ?? []).length === 0) {
@@ -630,14 +628,14 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
     this.processFieldComponentDefinition(item);
 
     const items: AvailableFormComponentDefinitionOutlines[] = [];
-    (item.config?.componentDefinitions ?? []).forEach((componentDefinition, index) => {
+    for (const [index, componentDefinition] of (item.config?.componentDefinitions ?? []).entries()) {
       items.push(componentDefinition);
       // Visit children
-      this.formPathHelper.acceptFormPath(
+      await this.formPathHelper.acceptFormPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForTabContentFieldComponentDefinition(componentDefinition, index)
       );
-    });
+    }
     if (item.config) {
       item.config.componentDefinitions = items.filter(i => this.hasObjectProps(i));
     }
@@ -648,7 +646,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitTabContentFormComponentDefinition(item: TabContentFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
 
     // if there are no components, this is an invalid component
@@ -665,7 +663,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitSaveButtonFormComponentDefinition(item: SaveButtonFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
   }
 
@@ -676,7 +674,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitCancelButtonFormComponentDefinition(item: CancelButtonFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
   }
 
@@ -685,7 +683,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitDeleteButtonFormComponentDefinition(item: DeleteButtonFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
   }
 
@@ -696,7 +694,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitTabNavButtonFormComponentDefinition(item: TabNavButtonFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
   }
 
@@ -711,7 +709,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitTextAreaFormComponentDefinition(item: TextAreaFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
   }
 
@@ -732,7 +730,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitCheckboxInputFormComponentDefinition(item: CheckboxInputFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
   }
 
@@ -747,7 +745,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitCheckboxTreeFormComponentDefinition(item: CheckboxTreeFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
   }
 
@@ -762,7 +760,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitRecordSelectorFormComponentDefinition(item: RecordSelectorFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
   }
 
@@ -777,7 +775,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitDropdownInputFormComponentDefinition(item: DropdownInputFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
   }
 
@@ -792,7 +790,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitTypeaheadInputFormComponentDefinition(item: TypeaheadInputFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
   }
 
@@ -807,7 +805,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitRichTextEditorFormComponentDefinition(item: RichTextEditorFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
   }
 
@@ -822,7 +820,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitMapFormComponentDefinition(item: MapFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
   }
 
@@ -837,7 +835,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitFileUploadFormComponentDefinition(item: FileUploadFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
   }
 
@@ -852,7 +850,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitPDFListFormComponentDefinition(item: PDFListFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
   }
 
@@ -867,7 +865,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   async visitRecordMetadataRetrieverFormComponentDefinition(
     item: RecordMetadataRetrieverFormComponentDefinitionOutline
   ): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
   }
 
@@ -882,7 +880,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitDataLocationFormComponentDefinition(item: DataLocationFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
   }
 
@@ -897,7 +895,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   async visitPublishDataLocationRefreshFormComponentDefinition(
     item: PublishDataLocationRefreshFormComponentDefinitionOutline
   ): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
   }
 
@@ -916,7 +914,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   async visitPublishDataLocationSelectorFormComponentDefinition(
     item: PublishDataLocationSelectorFormComponentDefinitionOutline
   ): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
   }
 
@@ -931,7 +929,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitRadioInputFormComponentDefinition(item: RadioInputFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
   }
 
@@ -946,7 +944,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitDateInputFormComponentDefinition(item: DateInputFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
   }
 
@@ -956,13 +954,13 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
     this.processFieldComponentDefinition(item);
 
     const items: AvailableFormComponentDefinitionOutlines[] = [];
-    (item?.config?.componentDefinitions ?? []).forEach((componentDefinition, index) => {
+    for (const [index, componentDefinition] of (item?.config?.componentDefinitions ?? []).entries()) {
       items.push(componentDefinition);
-      this.formPathHelper.acceptFormPath(
+      await this.formPathHelper.acceptFormPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForQuestionTreeFieldComponentDefinition(componentDefinition, index)
       );
-    });
+    }
     if (item.config) {
       item.config.componentDefinitions = items.filter(i => this.hasObjectProps(i));
     }
@@ -973,7 +971,7 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitQuestionTreeFormComponentDefinition(item: QuestionTreeFormComponentDefinitionOutline): Promise<void> {
-    this.acceptCheckConstraintsCurrentPath(item);
+    await this.acceptCheckConstraintsCurrentPath(item);
     this.processFormComponentDefinition(item);
 
     if ((item.component?.config?.componentDefinitions ?? [])?.length === 0) {
@@ -999,17 +997,20 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
     // Expressions must be compiled on the server, then retrieved by the client.
     // The raw expressions must not be available to the client.
     if ('expressions' in item) {
-      // Loop through the expressions and remove `template` if defined and set the `hasTemplate` flag
-      item.expressions?.forEach(expr => {
-        expr.config.hasTemplate = 'template' in expr?.config && expr.config?.template !== undefined && expr.config?.template !== null;
-        this.removePropsUndefined(expr);
-        this.removePropsUndefined(expr.config);
-      });
+      this.processFormComponentExpressions(item);
       if (item.expressions?.length === 0) {
         delete item['expressions'];
       }
     }
     this.removePropsUndefined(item);
+  }
+
+  protected processFormComponentExpressions(item: Pick<FormComponentDefinitionOutline, 'expressions'>) {
+    item.expressions?.forEach(expr => {
+      expr.config.hasTemplate = expr.config?.template !== undefined && expr.config?.template !== null;
+      this.removePropsUndefined(expr);
+      this.removePropsUndefined(expr.config);
+    });
   }
 
   protected processFieldComponentDefinition(item: FieldComponentDefinitionOutline) {

--- a/packages/redbox-core/src/visitor/construct.visitor.ts
+++ b/packages/redbox-core/src/visitor/construct.visitor.ts
@@ -493,19 +493,19 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
     );
 
     // Visit the components
-    currentData.componentDefinitions.forEach((componentDefinition, index) => {
+    for (const [index, componentDefinition] of currentData.componentDefinitions.entries()) {
       const formComponent = this.constructFormComponent(componentDefinition);
 
       // Visit children
       const testing = this.formPathHelper.lineagePathsForFormConfigComponentDefinition(formComponent, index);
-      this.formPathHelper.acceptFormPath(formComponent, testing);
+      await this.formPathHelper.acceptFormPath(formComponent, testing);
 
       // After the construction is done, apply any transforms
       const itemTransformed = this.applyConstructPhaseTransform(formComponent);
 
       // Store the instance on the item
       item.componentDefinitions.push(itemTransformed);
-    });
+    }
   }
 
   /* SimpleInput */
@@ -547,7 +547,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitSimpleInputFormComponentDefinition(item: SimpleInputFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* Content */
@@ -575,7 +575,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
 
   async visitContentFormComponentDefinition(item: ContentFormComponentDefinitionOutline): Promise<void> {
     // TODO: does the content component require the data model?
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* Repeatable  */
@@ -640,7 +640,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
     const formComponent = this.constructFormComponent(frame.elementTemplate);
 
     // Continue the construction
-    this.formPathHelper.acceptFormPath(
+    await this.formPathHelper.acceptFormPath(
       formComponent,
       this.formPathHelper.lineagePathsForRepeatableFieldComponentDefinition(formComponent)
     );
@@ -694,7 +694,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitRepeatableFormComponentDefinition(item: RepeatableFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* Validation Summary */
@@ -723,7 +723,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitValidationSummaryFormComponentDefinition(item: ValidationSummaryFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   async visitSuggestedValidationSummaryFieldComponentDefinition(item: SuggestedValidationSummaryFieldComponentDefinitionOutline): Promise<void> {
@@ -750,7 +750,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitSuggestedValidationSummaryFormComponentDefinition(item: SuggestedValidationSummaryFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* Save Status */
@@ -770,7 +770,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitSaveStatusFormComponentDefinition(item: SaveStatusFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* Group */
@@ -796,11 +796,11 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
     );
 
     // Visit the components
-    frame.componentDefinitions.forEach((componentDefinition, index) => {
+    for (const [index, componentDefinition] of frame.componentDefinitions.entries()) {
       const formComponent = this.constructFormComponent(componentDefinition);
 
       // Continue the construction
-      this.formPathHelper.acceptFormPath(
+      await this.formPathHelper.acceptFormPath(
         formComponent,
         this.formPathHelper.lineagePathsForGroupFieldComponentDefinition(formComponent, index)
       );
@@ -810,7 +810,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
 
       // Store the instance on the item
       item.config?.componentDefinitions.push(itemTransformed);
-    });
+    }
   }
 
   async visitGroupFieldModelDefinition(item: GroupFieldModelDefinitionOutline): Promise<void> {
@@ -831,7 +831,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitGroupFormComponentDefinition(item: GroupFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* Tab  */
@@ -865,7 +865,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
     frame.tabs = tabs;
 
     // Visit the components
-    frame?.tabs.forEach((componentDefinition, index) => {
+    for (const [index, componentDefinition] of (frame?.tabs ?? []).entries()) {
       if (
         isTypeFormComponentDefinitionName<TabContentFormComponentDefinitionFrame>(
           componentDefinition,
@@ -875,7 +875,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
         const formComponent = this.constructFormComponent(componentDefinition);
 
         // Continue the construction
-        this.formPathHelper.acceptFormPath(
+        await this.formPathHelper.acceptFormPath(
           formComponent,
           this.formPathHelper.lineagePathsForTabFieldComponentDefinition(formComponent, index)
         );
@@ -889,7 +889,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
         // Store the instance on the item
         item.config?.tabs.push(itemTransformed);
       }
-    });
+    }
   }
 
   async visitTabFieldLayoutDefinition(item: TabFieldLayoutDefinitionOutline): Promise<void> {
@@ -917,7 +917,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitTabFormComponentDefinition(item: TabFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* Accordion */
@@ -954,7 +954,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
     }
     frame.panels = panels;
 
-    frame.panels.forEach((componentDefinition, index) => {
+    for (const [index, componentDefinition] of frame.panels.entries()) {
       if (
         isTypeFormComponentDefinitionName<AccordionPanelFormComponentDefinitionFrame>(
           componentDefinition,
@@ -962,7 +962,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
         )
       ) {
         const formComponent = this.constructFormComponent(componentDefinition);
-        this.formPathHelper.acceptFormPath(
+        await this.formPathHelper.acceptFormPath(
           formComponent,
           this.formPathHelper.lineagePathsForAccordionFieldComponentDefinition(formComponent, index)
         );
@@ -973,7 +973,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
 
         item.config?.panels.push(itemTransformed);
       }
-    });
+    }
   }
 
   async visitAccordionFieldLayoutDefinition(item: AccordionFieldLayoutDefinitionOutline): Promise<void> {
@@ -990,7 +990,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitAccordionFormComponentDefinition(item: AccordionFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   async visitAccordionPanelFieldComponentDefinition(item: AccordionPanelFieldComponentDefinitionOutline): Promise<void> {
@@ -1012,16 +1012,16 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
       this.reusableFormDefs
     );
 
-    config.componentDefinitions.forEach((componentDefinition, index) => {
+    for (const [index, componentDefinition] of config.componentDefinitions.entries()) {
       const formComponent = this.constructFormComponent(componentDefinition);
-      this.formPathHelper.acceptFormPath(
+      await this.formPathHelper.acceptFormPath(
         formComponent,
         this.formPathHelper.lineagePathsForAccordionPanelFieldComponentDefinition(formComponent, index)
       );
 
       const itemTransformed = this.applyConstructPhaseTransform(formComponent);
       item.config?.componentDefinitions.push(itemTransformed);
-    });
+    }
   }
 
   async visitAccordionPanelFieldLayoutDefinition(item: AccordionPanelFieldLayoutDefinitionOutline): Promise<void> {
@@ -1039,7 +1039,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitAccordionPanelFormComponentDefinition(item: AccordionPanelFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* Tab Content */
@@ -1067,7 +1067,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
     );
 
     // Visit the components
-    config?.componentDefinitions.forEach((componentDefinition, index) => {
+    for (const [index, componentDefinition] of (config?.componentDefinitions ?? []).entries()) {
       let formComponent: AllFormComponentDefinitionOutlines;
       try {
         formComponent = this.constructFormComponent(componentDefinition);
@@ -1079,7 +1079,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
       }
 
       // Continue the construction
-      this.formPathHelper.acceptFormPath(
+      await this.formPathHelper.acceptFormPath(
         formComponent,
         this.formPathHelper.lineagePathsForTabContentFieldComponentDefinition(formComponent, index)
       );
@@ -1089,7 +1089,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
 
       // Store the instance on the item
       item.config?.componentDefinitions.push(itemTransformed);
-    });
+    }
   }
 
   async visitTabContentFieldLayoutDefinition(item: TabContentFieldLayoutDefinitionOutline): Promise<void> {
@@ -1111,7 +1111,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitTabContentFormComponentDefinition(item: TabContentFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* Save Button  */
@@ -1138,7 +1138,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitSaveButtonFormComponentDefinition(item: SaveButtonFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* Cancel Button  */
@@ -1166,7 +1166,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitCancelButtonFormComponentDefinition(item: CancelButtonFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* Delete Button  */
@@ -1195,7 +1195,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitDeleteButtonFormComponentDefinition(item: DeleteButtonFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* Tab Nav Button  */
@@ -1222,7 +1222,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitTabNavButtonFormComponentDefinition(item: TabNavButtonFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* Text Area */
@@ -1265,7 +1265,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitTextAreaFormComponentDefinition(item: TextAreaFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* Rich Text Editor */
@@ -1308,7 +1308,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitRichTextEditorFormComponentDefinition(item: RichTextEditorFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
     await this.ensureRichTextViewOverride(item);
   }
 
@@ -1354,7 +1354,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitMapFormComponentDefinition(item: MapFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* File Upload */
@@ -1396,7 +1396,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitFileUploadFormComponentDefinition(item: FileUploadFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* PDF List */
@@ -1443,7 +1443,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitPDFListFormComponentDefinition(item: PDFListFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* Record Metadata Retriever */
@@ -1470,7 +1470,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   async visitRecordMetadataRetrieverFormComponentDefinition(
     item: RecordMetadataRetrieverFormComponentDefinitionOutline
   ): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* Data Location */
@@ -1531,7 +1531,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitDataLocationFormComponentDefinition(item: DataLocationFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   // Construct the refresh trigger as a pure component definition. The click
@@ -1558,7 +1558,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   async visitPublishDataLocationRefreshFormComponentDefinition(
     item: PublishDataLocationRefreshFormComponentDefinitionOutline
   ): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   async visitPublishDataLocationSelectorFieldComponentDefinition(
@@ -1622,7 +1622,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   async visitPublishDataLocationSelectorFormComponentDefinition(
     item: PublishDataLocationSelectorFormComponentDefinitionOutline
   ): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* Default Layout  */
@@ -1717,7 +1717,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitCheckboxInputFormComponentDefinition(item: CheckboxInputFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* Checkbox Tree */
@@ -1764,7 +1764,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitCheckboxTreeFormComponentDefinition(item: CheckboxTreeFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* Record Selector */
@@ -1805,7 +1805,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitRecordSelectorFormComponentDefinition(item: RecordSelectorFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* Dropdown Input */
@@ -1852,7 +1852,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitDropdownInputFormComponentDefinition(item: DropdownInputFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* Typeahead Input */
@@ -1939,7 +1939,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitTypeaheadInputFormComponentDefinition(item: TypeaheadInputFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* Radio Input */
@@ -1983,7 +1983,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitRadioInputFormComponentDefinition(item: RadioInputFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* Date Input */
@@ -2029,7 +2029,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitDateInputFormComponentDefinition(item: DateInputFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* Question Tree */
@@ -2061,9 +2061,9 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
       this.formOverride.applyOverridesReusable(configFrame?.componentDefinitions ?? [], this.reusableFormDefs)
     );
 
-    configFrame.componentDefinitions.forEach((componentDefinition, index) => {
+    for (const [index, componentDefinition] of configFrame.componentDefinitions.entries()) {
       const formComponent = this.constructFormComponent(componentDefinition);
-      this.formPathHelper.acceptFormPath(
+      await this.formPathHelper.acceptFormPath(
         formComponent,
         this.formPathHelper.lineagePathsForQuestionTreeFieldComponentDefinition(formComponent, index)
       );
@@ -2076,7 +2076,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
 
       // Store the instance on the item
       item.config?.componentDefinitions.push(itemTransformed);
-    });
+    }
   }
 
   async visitQuestionTreeFieldModelDefinition(item: QuestionTreeFieldModelDefinitionOutline): Promise<void> {
@@ -2093,7 +2093,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitQuestionTreeFormComponentDefinition(item: QuestionTreeFormComponentDefinitionOutline): Promise<void> {
-    this.populateFormComponent(item);
+    await this.populateFormComponent(item);
   }
 
   /* Shared */

--- a/packages/redbox-core/src/visitor/context-variables.visitor.ts
+++ b/packages/redbox-core/src/visitor/context-variables.visitor.ts
@@ -61,41 +61,41 @@ export class ContextVariablesFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitFormConfig(item: FormConfigOutline): Promise<void> {
-    item.componentDefinitions?.forEach(component => {
-      component.accept(this);
-    });
+    for (const component of item.componentDefinitions ?? []) {
+      await component.accept(this);
+    }
   }
 
   async visitSimpleInputFormComponentDefinition(item: SimpleInputFormComponentDefinitionOutline): Promise<void> {
-    item.model?.accept(this);
+    await item.model?.accept(this);
   }
 
   async visitTextAreaFormComponentDefinition(item: TextAreaFormComponentDefinitionOutline): Promise<void> {
-    item.model?.accept(this);
+    await item.model?.accept(this);
   }
 
   async visitCheckboxInputFormComponentDefinition(item: CheckboxInputFormComponentDefinitionOutline): Promise<void> {
-    item.model?.accept(this);
+    await item.model?.accept(this);
   }
 
   async visitRadioInputFormComponentDefinition(item: RadioInputFormComponentDefinitionOutline): Promise<void> {
-    item.model?.accept(this);
+    await item.model?.accept(this);
   }
 
   async visitDropdownInputFormComponentDefinition(item: DropdownInputFormComponentDefinitionOutline): Promise<void> {
-    item.model?.accept(this);
+    await item.model?.accept(this);
   }
 
   async visitTypeaheadInputFormComponentDefinition(item: TypeaheadInputFormComponentDefinitionOutline): Promise<void> {
-    item.model?.accept(this);
+    await item.model?.accept(this);
   }
 
   async visitDateInputFormComponentDefinition(item: DateInputFormComponentDefinitionOutline): Promise<void> {
-    item.model?.accept(this);
+    await item.model?.accept(this);
   }
 
   async visitRichTextEditorFormComponentDefinition(item: RichTextEditorFormComponentDefinitionOutline): Promise<void> {
-    item.model?.accept(this);
+    await item.model?.accept(this);
   }
 
   async visitContentFormComponentDefinition(item: ContentFormComponentDefinitionOutline): Promise<void> {
@@ -103,7 +103,7 @@ export class ContextVariablesFormConfigVisitor extends FormConfigVisitor {
   }
   async visitGroupFormComponentDefinition(item: GroupFormComponentDefinitionOutline): Promise<void> {
     await item.component?.accept(this);
-    item.model?.accept(this);
+    await item.model?.accept(this);
   }
 
   async visitTabFormComponentDefinition(item: TabFormComponentDefinitionOutline): Promise<void> {
@@ -124,7 +124,7 @@ export class ContextVariablesFormConfigVisitor extends FormConfigVisitor {
 
   async visitRepeatableFormComponentDefinition(item: RepeatableFormComponentDefinitionOutline): Promise<void> {
     await item.component?.accept(this);
-    item.model?.accept(this);
+    await item.model?.accept(this);
   }
 
   async visitGroupFieldModelDefinition(item: GroupFieldModelDefinitionOutline): Promise<void> {
@@ -173,23 +173,33 @@ export class ContextVariablesFormConfigVisitor extends FormConfigVisitor {
     }
   }
   async visitGroupFieldComponentDefinition(item: GroupFieldComponentDefinitionOutline): Promise<void> {
-    item.config?.componentDefinitions?.forEach(def => def.accept(this));
+    for (const def of item.config?.componentDefinitions ?? []) {
+      await def.accept(this);
+    }
   }
 
   async visitTabFieldComponentDefinition(item: TabFieldComponentDefinitionOutline): Promise<void> {
-    item.config?.tabs?.forEach(tab => tab.accept(this));
+    for (const tab of item.config?.tabs ?? []) {
+      await tab.accept(this);
+    }
   }
 
   async visitTabContentFieldComponentDefinition(item: TabContentFieldComponentDefinitionOutline): Promise<void> {
-    item.config?.componentDefinitions?.forEach(def => def.accept(this));
+    for (const def of item.config?.componentDefinitions ?? []) {
+      await def.accept(this);
+    }
   }
 
   async visitAccordionFieldComponentDefinition(item: AccordionFieldComponentDefinitionOutline): Promise<void> {
-    item.config?.panels?.forEach(panel => panel.accept(this));
+    for (const panel of item.config?.panels ?? []) {
+      await panel.accept(this);
+    }
   }
 
   async visitAccordionPanelFieldComponentDefinition(item: AccordionPanelFieldComponentDefinitionOutline): Promise<void> {
-    item.config?.componentDefinitions?.forEach(def => def.accept(this));
+    for (const def of item.config?.componentDefinitions ?? []) {
+      await def.accept(this);
+    }
   }
 
   async visitRepeatableFieldComponentDefinition(item: RepeatableFieldComponentDefinitionOutline): Promise<void> {

--- a/packages/redbox-core/src/visitor/data-value.visitor.ts
+++ b/packages/redbox-core/src/visitor/data-value.visitor.ts
@@ -202,13 +202,13 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   /* Form Config */
 
   async visitFormConfig(item: FormConfigOutline): Promise<void> {
-    (item?.componentDefinitions ?? []).forEach((componentDefinition, index) => {
+    for (const [index, componentDefinition] of (item?.componentDefinitions ?? []).entries()) {
       // Visit children
-      this.formPathHelper.acceptFormPath(
+      await this.formPathHelper.acceptFormPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForFormConfigComponentDefinition(componentDefinition, index)
       );
-    });
+    }
   }
 
   /* SimpleInput */
@@ -220,7 +220,7 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitSimpleInputFormComponentDefinition(item: SimpleInputFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   /* Content */
@@ -228,7 +228,7 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   async visitContentFieldComponentDefinition(_item: ContentFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitContentFormComponentDefinition(item: ContentFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   /* Repeatable  */
@@ -246,7 +246,7 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   async visitRepeatableElementFieldLayoutDefinition(_item: RepeatableElementFieldLayoutDefinitionOutline): Promise<void> { }
 
   async visitRepeatableFormComponentDefinition(item: RepeatableFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   /* Validation Summary */
@@ -254,31 +254,31 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   async visitValidationSummaryFieldComponentDefinition(_item: ValidationSummaryFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitValidationSummaryFormComponentDefinition(item: ValidationSummaryFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   async visitSuggestedValidationSummaryFieldComponentDefinition(_item: SuggestedValidationSummaryFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitSuggestedValidationSummaryFormComponentDefinition(item: SuggestedValidationSummaryFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   async visitSaveStatusFieldComponentDefinition(_item: SaveStatusFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitSaveStatusFormComponentDefinition(item: SaveStatusFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   /* Group */
 
   async visitGroupFieldComponentDefinition(item: GroupFieldComponentDefinitionOutline): Promise<void> {
-    (item.config?.componentDefinitions ?? []).forEach((componentDefinition, index) => {
+    for (const [index, componentDefinition] of (item.config?.componentDefinitions ?? []).entries()) {
       // Visit children
-      this.formPathHelper.acceptFormPath(
+      await this.formPathHelper.acceptFormPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForGroupFieldComponentDefinition(componentDefinition, index)
       );
-    });
+    }
   }
 
   async visitGroupFieldModelDefinition(item: GroupFieldModelDefinitionOutline): Promise<void> {
@@ -286,75 +286,75 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitGroupFormComponentDefinition(item: GroupFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   /* Tab  */
 
   async visitTabFieldComponentDefinition(item: TabFieldComponentDefinitionOutline): Promise<void> {
-    (item.config?.tabs ?? []).forEach((componentDefinition, index) => {
+    for (const [index, componentDefinition] of (item.config?.tabs ?? []).entries()) {
       // Visit children
-      this.formPathHelper.acceptFormPath(
+      await this.formPathHelper.acceptFormPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForTabFieldComponentDefinition(componentDefinition, index)
       );
-    });
+    }
   }
 
   async visitTabFieldLayoutDefinition(_item: TabFieldLayoutDefinitionOutline): Promise<void> { }
 
   async visitTabFormComponentDefinition(item: TabFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   /* Accordion */
 
   async visitAccordionFieldComponentDefinition(item: AccordionFieldComponentDefinitionOutline): Promise<void> {
-    (item.config?.panels ?? []).forEach((componentDefinition, index) => {
-      this.formPathHelper.acceptFormPath(
+    for (const [index, componentDefinition] of (item.config?.panels ?? []).entries()) {
+      await this.formPathHelper.acceptFormPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForAccordionFieldComponentDefinition(componentDefinition, index)
       );
-    });
+    }
   }
 
   async visitAccordionFieldLayoutDefinition(_item: AccordionFieldLayoutDefinitionOutline): Promise<void> { }
 
   async visitAccordionFormComponentDefinition(item: AccordionFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   async visitAccordionPanelFieldComponentDefinition(item: AccordionPanelFieldComponentDefinitionOutline): Promise<void> {
-    (item.config?.componentDefinitions ?? []).forEach((componentDefinition, index) => {
-      this.formPathHelper.acceptFormPath(
+    for (const [index, componentDefinition] of (item.config?.componentDefinitions ?? []).entries()) {
+      await this.formPathHelper.acceptFormPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForAccordionPanelFieldComponentDefinition(componentDefinition, index)
       );
-    });
+    }
   }
 
   async visitAccordionPanelFieldLayoutDefinition(_item: AccordionPanelFieldLayoutDefinitionOutline): Promise<void> { }
 
   async visitAccordionPanelFormComponentDefinition(item: AccordionPanelFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   /*  Tab Content */
 
   async visitTabContentFieldComponentDefinition(item: TabContentFieldComponentDefinitionOutline): Promise<void> {
-    (item.config?.componentDefinitions ?? []).forEach((componentDefinition, index) => {
+    for (const [index, componentDefinition] of (item.config?.componentDefinitions ?? []).entries()) {
       // Visit children
-      this.formPathHelper.acceptFormPath(
+      await this.formPathHelper.acceptFormPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForTabContentFieldComponentDefinition(componentDefinition, index)
       );
-    });
+    }
   }
 
   async visitTabContentFieldLayoutDefinition(_item: TabContentFieldLayoutDefinitionOutline): Promise<void> { }
 
   async visitTabContentFormComponentDefinition(item: TabContentFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   /* Save Button  */
@@ -362,7 +362,7 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   async visitSaveButtonFieldComponentDefinition(_item: SaveButtonFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitSaveButtonFormComponentDefinition(item: SaveButtonFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   /* Cancel Button  */
@@ -370,13 +370,13 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   async visitCancelButtonFieldComponentDefinition(_item: CancelButtonFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitCancelButtonFormComponentDefinition(item: CancelButtonFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   async visitDeleteButtonFieldComponentDefinition(_item: DeleteButtonFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitDeleteButtonFormComponentDefinition(item: DeleteButtonFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   /* Tab Nav Button  */
@@ -384,7 +384,7 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   async visitTabNavButtonFieldComponentDefinition(_item: TabNavButtonFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitTabNavButtonFormComponentDefinition(item: TabNavButtonFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   /* Text Area */
@@ -396,7 +396,7 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitTextAreaFormComponentDefinition(item: TextAreaFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   /* Default Layout  */
@@ -412,7 +412,7 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitCheckboxInputFormComponentDefinition(item: CheckboxInputFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   /* Checkbox Tree */
@@ -424,7 +424,7 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitCheckboxTreeFormComponentDefinition(item: CheckboxTreeFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   /* Record Selector */
@@ -436,7 +436,7 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitRecordSelectorFormComponentDefinition(item: RecordSelectorFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   /* Dropdown Input */
@@ -448,7 +448,7 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitDropdownInputFormComponentDefinition(item: DropdownInputFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   /* Typeahead Input */
@@ -460,7 +460,7 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitTypeaheadInputFormComponentDefinition(item: TypeaheadInputFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   /* Rich Text Editor */
@@ -472,7 +472,7 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitRichTextEditorFormComponentDefinition(item: RichTextEditorFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   /* Map */
@@ -484,7 +484,7 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitMapFormComponentDefinition(item: MapFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   /* File Upload */
@@ -496,7 +496,7 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitFileUploadFormComponentDefinition(item: FileUploadFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   async visitPDFListFieldComponentDefinition(_item: PDFListFieldComponentDefinitionOutline): Promise<void> { }
@@ -506,13 +506,13 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitPDFListFormComponentDefinition(item: PDFListFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   async visitRecordMetadataRetrieverFieldComponentDefinition(_item: RecordMetadataRetrieverFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitRecordMetadataRetrieverFormComponentDefinition(item: RecordMetadataRetrieverFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   /* Data Location */
@@ -524,7 +524,7 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitDataLocationFormComponentDefinition(item: DataLocationFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   // No stored field value exists for the refresh trigger, so the data-value
@@ -532,7 +532,7 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   async visitPublishDataLocationRefreshFieldComponentDefinition(_item: PublishDataLocationRefreshFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitPublishDataLocationRefreshFormComponentDefinition(item: PublishDataLocationRefreshFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   async visitPublishDataLocationSelectorFieldComponentDefinition(_item: PublishDataLocationSelectorFieldComponentDefinitionOutline): Promise<void> { }
@@ -542,7 +542,7 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitPublishDataLocationSelectorFormComponentDefinition(item: PublishDataLocationSelectorFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   /* Radio Input */
@@ -554,7 +554,7 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitRadioInputFormComponentDefinition(item: RadioInputFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   /* Date Input */
@@ -566,18 +566,18 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitDateInputFormComponentDefinition(item: DateInputFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   /* Question Tree */
 
   async visitQuestionTreeFieldComponentDefinition(item: QuestionTreeFieldComponentDefinitionOutline): Promise<void> {
-    (item.config?.componentDefinitions ?? []).forEach((componentDefinition, index) => {
-      this.formPathHelper.acceptFormPath(
+    for (const [index, componentDefinition] of (item.config?.componentDefinitions ?? []).entries()) {
+      await this.formPathHelper.acceptFormPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForQuestionTreeFieldComponentDefinition(componentDefinition, index)
       );
-    });
+    }
   }
 
   async visitQuestionTreeFieldModelDefinition(item: QuestionTreeFieldModelDefinitionOutline): Promise<void> {
@@ -585,7 +585,7 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitQuestionTreeFormComponentDefinition(item: QuestionTreeFormComponentDefinitionOutline): Promise<void> {
-    this.acceptFormComponentDefinition(item);
+    await this.acceptFormComponentDefinition(item);
   }
 
   /* Shared */

--- a/packages/redbox-core/src/visitor/json-type-def.visitor.ts
+++ b/packages/redbox-core/src/visitor/json-type-def.visitor.ts
@@ -199,14 +199,14 @@ export class JsonTypeDefSchemaFormConfigVisitor extends FormConfigVisitor {
   /* Form Config */
 
   async visitFormConfig(item: FormConfigOutline): Promise<void> {
-    (item?.componentDefinitions ?? []).forEach((componentDefinition, index) => {
+    for (const [index, componentDefinition] of (item?.componentDefinitions ?? []).entries()) {
       // Visit children
-      this.acceptJsonTypeDefPath(
+      await this.acceptJsonTypeDefPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForFormConfigComponentDefinition(componentDefinition, index),
         ['properties']
       );
-    });
+    }
   }
 
   /* SimpleInput */
@@ -277,14 +277,14 @@ export class JsonTypeDefSchemaFormConfigVisitor extends FormConfigVisitor {
   /* Group */
 
   async visitGroupFieldComponentDefinition(item: GroupFieldComponentDefinitionOutline): Promise<void> {
-    (item.config?.componentDefinitions ?? []).forEach((componentDefinition, index) => {
+    for (const [index, componentDefinition] of (item.config?.componentDefinitions ?? []).entries()) {
       // Visit children
-      this.acceptJsonTypeDefPath(
+      await this.acceptJsonTypeDefPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForGroupFieldComponentDefinition(componentDefinition, index),
         ['properties']
       );
-    });
+    }
   }
 
   async visitGroupFieldModelDefinition(_item: GroupFieldModelDefinitionOutline): Promise<void> {
@@ -300,13 +300,13 @@ export class JsonTypeDefSchemaFormConfigVisitor extends FormConfigVisitor {
   /* Tab  */
 
   async visitTabFieldComponentDefinition(item: TabFieldComponentDefinitionOutline): Promise<void> {
-    (item.config?.tabs ?? []).forEach((componentDefinition, index) => {
+    for (const [index, componentDefinition] of (item.config?.tabs ?? []).entries()) {
       // Visit children
-      this.acceptJsonTypeDefPath(
+      await this.acceptJsonTypeDefPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForTabFieldComponentDefinition(componentDefinition, index)
       );
-    });
+    }
   }
 
   async visitTabFieldLayoutDefinition(_item: TabFieldLayoutDefinitionOutline): Promise<void> { }
@@ -318,12 +318,12 @@ export class JsonTypeDefSchemaFormConfigVisitor extends FormConfigVisitor {
   /* Accordion */
 
   async visitAccordionFieldComponentDefinition(item: AccordionFieldComponentDefinitionOutline): Promise<void> {
-    (item.config?.panels ?? []).forEach((componentDefinition, index) => {
-      this.acceptJsonTypeDefPath(
+    for (const [index, componentDefinition] of (item.config?.panels ?? []).entries()) {
+      await this.acceptJsonTypeDefPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForAccordionFieldComponentDefinition(componentDefinition, index)
       );
-    });
+    }
   }
 
   async visitAccordionFieldLayoutDefinition(_item: AccordionFieldLayoutDefinitionOutline): Promise<void> { }
@@ -333,12 +333,12 @@ export class JsonTypeDefSchemaFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitAccordionPanelFieldComponentDefinition(item: AccordionPanelFieldComponentDefinitionOutline): Promise<void> {
-    (item.config?.componentDefinitions ?? []).forEach((componentDefinition, index) => {
-      this.acceptJsonTypeDefPath(
+    for (const [index, componentDefinition] of (item.config?.componentDefinitions ?? []).entries()) {
+      await this.acceptJsonTypeDefPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForAccordionPanelFieldComponentDefinition(componentDefinition, index)
       );
-    });
+    }
   }
 
   async visitAccordionPanelFieldLayoutDefinition(_item: AccordionPanelFieldLayoutDefinitionOutline): Promise<void> { }
@@ -350,13 +350,13 @@ export class JsonTypeDefSchemaFormConfigVisitor extends FormConfigVisitor {
   /*  Tab Content */
 
   async visitTabContentFieldComponentDefinition(item: TabContentFieldComponentDefinitionOutline): Promise<void> {
-    (item.config?.componentDefinitions ?? []).forEach((componentDefinition, index) => {
+    for (const [index, componentDefinition] of (item.config?.componentDefinitions ?? []).entries()) {
       // Visit children
-      this.acceptJsonTypeDefPath(
+      await this.acceptJsonTypeDefPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForTabContentFieldComponentDefinition(componentDefinition, index)
       );
-    });
+    }
   }
 
   async visitTabContentFieldLayoutDefinition(_item: TabContentFieldLayoutDefinitionOutline): Promise<void> { }
@@ -625,13 +625,13 @@ export class JsonTypeDefSchemaFormConfigVisitor extends FormConfigVisitor {
   /* Question Tree */
 
   async visitQuestionTreeFieldComponentDefinition(item: QuestionTreeFieldComponentDefinitionOutline): Promise<void> {
-    (item.config?.componentDefinitions ?? []).forEach((componentDefinition, index) => {
-      this.acceptJsonTypeDefPath(
+    for (const [index, componentDefinition] of (item.config?.componentDefinitions ?? []).entries()) {
+      await this.acceptJsonTypeDefPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForQuestionTreeFieldComponentDefinition(componentDefinition, index),
         ['properties']
       );
-    });
+    }
   }
 
   async visitQuestionTreeFieldModelDefinition(_item: QuestionTreeFieldModelDefinitionOutline): Promise<void> {
@@ -686,7 +686,7 @@ export class JsonTypeDefSchemaFormConfigVisitor extends FormConfigVisitor {
     const originalPath = [...this.jsonTypeDefPath];
     try {
       this.jsonTypeDefPath = [...originalPath, ...(jsonTypeDefPathKeys ?? [])];
-      this.formPathHelper.acceptFormPath(item, more);
+      await this.formPathHelper.acceptFormPath(item, more);
     } finally {
       this.jsonTypeDefPath = originalPath;
     }

--- a/packages/redbox-core/src/visitor/migrate-config-v4-v5.visitor.ts
+++ b/packages/redbox-core/src/visitor/migrate-config-v4-v5.visitor.ts
@@ -2313,7 +2313,7 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     const original = [...(this.v4FormPath ?? [])];
     try {
       this.v4FormPath = [...original, ...(v4FormPath ?? [])];
-      this.formPathHelper.acceptFormPath(item, more);
+      await this.formPathHelper.acceptFormPath(item, more);
     } finally {
       this.v4FormPath = original;
     }

--- a/packages/redbox-core/src/visitor/migrate-config-v4-v5.visitor.ts
+++ b/packages/redbox-core/src/visitor/migrate-config-v4-v5.visitor.ts
@@ -1256,10 +1256,10 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
 
     const fields: Record<string, unknown>[] = field?.definition?.fields ?? [];
     // this.logger.info(`Processing '${item.class}': with ${fields.length} fields at ${JSON.stringify(this.v4FormPath)}.`);
-    fields.forEach((field, index) => {
+    for (const [index, field] of fields.entries()) {
       const v4FormPathMore = ['definition', 'fields', index.toString()];
       if (this.shouldOmitLegacyField(field, v4FormPathMore)) {
-        return;
+        continue;
       }
 
       // TODO: Does this approach to mapping the tab content component lose data?
@@ -1276,7 +1276,7 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
         )
       ) {
         // Visit children
-        this.acceptV4FormConfigPath(
+        await this.acceptV4FormConfigPath(
           formComponent,
           this.formPathHelper.lineagePathsForTabFieldComponentDefinition(formComponent, index),
           v4FormPathMore
@@ -1285,7 +1285,7 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
         // Store the instance on the item
         config.tabs.push(formComponent);
       }
-    });
+    }
   }
 
   async visitTabFieldLayoutDefinition(item: TabFieldLayoutDefinitionOutline): Promise<void> {

--- a/packages/redbox-core/src/visitor/template.visitor.ts
+++ b/packages/redbox-core/src/visitor/template.visitor.ts
@@ -1,4 +1,4 @@
-import {FormConfigVisitor, FormValidatorConfig} from '@researchdatabox/sails-ng-common';
+import { FormConfigVisitor, FormValidatorConfig } from '@researchdatabox/sails-ng-common';
 import { FormConfigOutline } from '@researchdatabox/sails-ng-common';
 import { TemplateCompileInput } from '@researchdatabox/sails-ng-common';
 import {
@@ -193,18 +193,18 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
     await this.extractExpressions(item.expressions);
     await this.extractBehaviours(item.behaviours);
     await this.extractValidators(item.validators);
-    (item?.componentDefinitions ?? []).forEach((componentDefinition, index) => {
+    for (const [index, componentDefinition] of (item?.componentDefinitions ?? []).entries()) {
       // Visit children
-      this.formPathHelper.acceptFormPath(
+      await this.formPathHelper.acceptFormPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForFormConfigComponentDefinition(componentDefinition, index)
       );
-    });
+    }
   }
 
   /* SimpleInput */
 
-  async visitSimpleInputFieldComponentDefinition(_item: SimpleInputFieldComponentDefinitionOutline): Promise<void> {}
+  async visitSimpleInputFieldComponentDefinition(_item: SimpleInputFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitSimpleInputFieldModelDefinition(item: SimpleInputFieldModelDefinitionOutline): Promise<void> {
     await this.extractValidators(item.config?.validators);
@@ -236,7 +236,7 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
   async visitRepeatableFieldComponentDefinition(item: RepeatableFieldComponentDefinitionOutline): Promise<void> {
     const componentDefinition = item.config?.elementTemplate;
     if (componentDefinition) {
-      this.formPathHelper.acceptFormPath(
+      await this.formPathHelper.acceptFormPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForRepeatableFieldComponentDefinition(componentDefinition)
       );
@@ -247,7 +247,7 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
     await this.extractValidators(item.config?.validators);
   }
 
-  async visitRepeatableElementFieldLayoutDefinition(_item: RepeatableElementFieldLayoutDefinitionOutline): Promise<void> {}
+  async visitRepeatableElementFieldLayoutDefinition(_item: RepeatableElementFieldLayoutDefinitionOutline): Promise<void> { }
 
   async visitRepeatableFormComponentDefinition(item: RepeatableFormComponentDefinitionOutline): Promise<void> {
     await this.acceptFormComponentDefinition(item);
@@ -255,19 +255,19 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
 
   /* Validation Summary */
 
-  async visitValidationSummaryFieldComponentDefinition(_item: ValidationSummaryFieldComponentDefinitionOutline): Promise<void> {}
+  async visitValidationSummaryFieldComponentDefinition(_item: ValidationSummaryFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitValidationSummaryFormComponentDefinition(item: ValidationSummaryFormComponentDefinitionOutline): Promise<void> {
     await this.acceptFormComponentDefinition(item);
   }
 
-  async visitSuggestedValidationSummaryFieldComponentDefinition(_item: SuggestedValidationSummaryFieldComponentDefinitionOutline): Promise<void> {}
+  async visitSuggestedValidationSummaryFieldComponentDefinition(_item: SuggestedValidationSummaryFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitSuggestedValidationSummaryFormComponentDefinition(item: SuggestedValidationSummaryFormComponentDefinitionOutline): Promise<void> {
     await this.acceptFormComponentDefinition(item);
   }
 
-  async visitSaveStatusFieldComponentDefinition(_item: SaveStatusFieldComponentDefinitionOutline): Promise<void> {}
+  async visitSaveStatusFieldComponentDefinition(_item: SaveStatusFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitSaveStatusFormComponentDefinition(item: SaveStatusFormComponentDefinitionOutline): Promise<void> {
     await this.acceptFormComponentDefinition(item);
@@ -276,13 +276,13 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
   /* Group */
 
   async visitGroupFieldComponentDefinition(item: GroupFieldComponentDefinitionOutline): Promise<void> {
-    (item.config?.componentDefinitions ?? []).forEach((componentDefinition, index) => {
+    for (const [index, componentDefinition] of (item.config?.componentDefinitions ?? []).entries()) {
       // Visit children
-      this.formPathHelper.acceptFormPath(
+      await this.formPathHelper.acceptFormPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForGroupFieldComponentDefinition(componentDefinition, index)
       );
-    });
+    }
   }
 
   async visitGroupFieldModelDefinition(item: GroupFieldModelDefinitionOutline): Promise<void> {
@@ -296,16 +296,16 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
   /* Tab  */
 
   async visitTabFieldComponentDefinition(item: TabFieldComponentDefinitionOutline): Promise<void> {
-    (item.config?.tabs ?? []).forEach((componentDefinition, index) => {
+    for (const [index, componentDefinition] of (item.config?.tabs ?? []).entries()) {
       // Visit children
-      this.formPathHelper.acceptFormPath(
+      await this.formPathHelper.acceptFormPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForTabFieldComponentDefinition(componentDefinition, index)
       );
-    });
+    }
   }
 
-  async visitTabFieldLayoutDefinition(_item: TabFieldLayoutDefinitionOutline): Promise<void> {}
+  async visitTabFieldLayoutDefinition(_item: TabFieldLayoutDefinitionOutline): Promise<void> { }
 
   async visitTabFormComponentDefinition(item: TabFormComponentDefinitionOutline): Promise<void> {
     await this.acceptFormComponentDefinition(item);
@@ -314,30 +314,30 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
   /* Accordion */
 
   async visitAccordionFieldComponentDefinition(item: AccordionFieldComponentDefinitionOutline): Promise<void> {
-    (item.config?.panels ?? []).forEach((componentDefinition, index) => {
-      this.formPathHelper.acceptFormPath(
+    for (const [index, componentDefinition] of (item.config?.panels ?? []).entries()) {
+      await this.formPathHelper.acceptFormPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForAccordionFieldComponentDefinition(componentDefinition, index)
       );
-    });
+    }
   }
 
-  async visitAccordionFieldLayoutDefinition(_item: AccordionFieldLayoutDefinitionOutline): Promise<void> {}
+  async visitAccordionFieldLayoutDefinition(_item: AccordionFieldLayoutDefinitionOutline): Promise<void> { }
 
   async visitAccordionFormComponentDefinition(item: AccordionFormComponentDefinitionOutline): Promise<void> {
     await this.acceptFormComponentDefinition(item);
   }
 
   async visitAccordionPanelFieldComponentDefinition(item: AccordionPanelFieldComponentDefinitionOutline): Promise<void> {
-    (item.config?.componentDefinitions ?? []).forEach((componentDefinition, index) => {
-      this.formPathHelper.acceptFormPath(
+    for (const [index, componentDefinition] of (item.config?.componentDefinitions ?? []).entries()) {
+      await this.formPathHelper.acceptFormPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForAccordionPanelFieldComponentDefinition(componentDefinition, index)
       );
-    });
+    }
   }
 
-  async visitAccordionPanelFieldLayoutDefinition(_item: AccordionPanelFieldLayoutDefinitionOutline): Promise<void> {}
+  async visitAccordionPanelFieldLayoutDefinition(_item: AccordionPanelFieldLayoutDefinitionOutline): Promise<void> { }
 
   async visitAccordionPanelFormComponentDefinition(item: AccordionPanelFormComponentDefinitionOutline): Promise<void> {
     await this.acceptFormComponentDefinition(item);
@@ -346,16 +346,16 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
   /*  Tab Content */
 
   async visitTabContentFieldComponentDefinition(item: TabContentFieldComponentDefinitionOutline): Promise<void> {
-    (item.config?.componentDefinitions ?? []).forEach((componentDefinition, index) => {
+    for (const [index, componentDefinition] of (item.config?.componentDefinitions ?? []).entries()) {
       // Visit children
-      this.formPathHelper.acceptFormPath(
+      await this.formPathHelper.acceptFormPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForTabContentFieldComponentDefinition(componentDefinition, index)
       );
-    });
+    }
   }
 
-  async visitTabContentFieldLayoutDefinition(_item: TabContentFieldLayoutDefinitionOutline): Promise<void> {}
+  async visitTabContentFieldLayoutDefinition(_item: TabContentFieldLayoutDefinitionOutline): Promise<void> { }
 
   async visitTabContentFormComponentDefinition(item: TabContentFormComponentDefinitionOutline): Promise<void> {
     await this.acceptFormComponentDefinition(item);
@@ -363,7 +363,7 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
 
   /* Save Button  */
 
-  async visitSaveButtonFieldComponentDefinition(_item: SaveButtonFieldComponentDefinitionOutline): Promise<void> {}
+  async visitSaveButtonFieldComponentDefinition(_item: SaveButtonFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitSaveButtonFormComponentDefinition(item: SaveButtonFormComponentDefinitionOutline): Promise<void> {
     await this.acceptFormComponentDefinition(item);
@@ -371,7 +371,7 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
 
   /* Cancel Button  */
 
-  async visitCancelButtonFieldComponentDefinition(_item: CancelButtonFieldComponentDefinitionOutline): Promise<void> {}
+  async visitCancelButtonFieldComponentDefinition(_item: CancelButtonFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitCancelButtonFormComponentDefinition(item: CancelButtonFormComponentDefinitionOutline): Promise<void> {
     await this.acceptFormComponentDefinition(item);
@@ -394,7 +394,7 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
 
   /* Tab Nav Button  */
 
-  async visitTabNavButtonFieldComponentDefinition(_item: TabNavButtonFieldComponentDefinitionOutline): Promise<void> {}
+  async visitTabNavButtonFieldComponentDefinition(_item: TabNavButtonFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitTabNavButtonFormComponentDefinition(item: TabNavButtonFormComponentDefinitionOutline): Promise<void> {
     await this.acceptFormComponentDefinition(item);
@@ -402,7 +402,7 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
 
   /* Text Area */
 
-  async visitTextAreaFieldComponentDefinition(_item: TextAreaFieldComponentDefinitionOutline): Promise<void> {}
+  async visitTextAreaFieldComponentDefinition(_item: TextAreaFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitTextAreaFieldModelDefinition(item: TextAreaFieldModelDefinitionOutline): Promise<void> {
     await this.extractValidators(item.config?.validators);
@@ -414,11 +414,11 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
 
   /* Default Layout  */
 
-  async visitDefaultFieldLayoutDefinition(_item: DefaultFieldLayoutDefinitionOutline): Promise<void> {}
+  async visitDefaultFieldLayoutDefinition(_item: DefaultFieldLayoutDefinitionOutline): Promise<void> { }
 
   /* Checkbox Input */
 
-  async visitCheckboxInputFieldComponentDefinition(_item: CheckboxInputFieldComponentDefinitionOutline): Promise<void> {}
+  async visitCheckboxInputFieldComponentDefinition(_item: CheckboxInputFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitCheckboxInputFieldModelDefinition(item: CheckboxInputFieldModelDefinitionOutline): Promise<void> {
     await this.extractValidators(item.config?.validators);
@@ -451,7 +451,7 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
 
   /* Record Selector */
 
-  async visitRecordSelectorFieldComponentDefinition(_item: RecordSelectorFieldComponentDefinitionOutline): Promise<void> {}
+  async visitRecordSelectorFieldComponentDefinition(_item: RecordSelectorFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitRecordSelectorFieldModelDefinition(item: RecordSelectorFieldModelDefinitionOutline): Promise<void> {
     await this.extractValidators(item.config?.validators);
@@ -463,7 +463,7 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
 
   /* Dropdown Input */
 
-  async visitDropdownInputFieldComponentDefinition(_item: DropdownInputFieldComponentDefinitionOutline): Promise<void> {}
+  async visitDropdownInputFieldComponentDefinition(_item: DropdownInputFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitDropdownInputFieldModelDefinition(item: DropdownInputFieldModelDefinitionOutline): Promise<void> {
     await this.extractValidators(item.config?.validators);
@@ -496,7 +496,7 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
 
   /* Rich Text Editor */
 
-  async visitRichTextEditorFieldComponentDefinition(_item: RichTextEditorFieldComponentDefinitionOutline): Promise<void> {}
+  async visitRichTextEditorFieldComponentDefinition(_item: RichTextEditorFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitRichTextEditorFieldModelDefinition(item: RichTextEditorFieldModelDefinitionOutline): Promise<void> {
     await this.extractValidators(item.config?.validators);
@@ -508,7 +508,7 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
 
   /* Map */
 
-  async visitMapFieldComponentDefinition(_item: MapFieldComponentDefinitionOutline): Promise<void> {}
+  async visitMapFieldComponentDefinition(_item: MapFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitMapFieldModelDefinition(item: MapFieldModelDefinitionOutline): Promise<void> {
     await this.extractValidators(item.config?.validators);
@@ -520,7 +520,7 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
 
   /* File Upload */
 
-  async visitFileUploadFieldComponentDefinition(_item: FileUploadFieldComponentDefinitionOutline): Promise<void> {}
+  async visitFileUploadFieldComponentDefinition(_item: FileUploadFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitFileUploadFieldModelDefinition(item: FileUploadFieldModelDefinitionOutline): Promise<void> {
     await this.extractValidators(item.config?.validators);
@@ -551,7 +551,7 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
 
   async visitRecordMetadataRetrieverFieldComponentDefinition(
     _item: RecordMetadataRetrieverFieldComponentDefinitionOutline
-  ): Promise<void> {}
+  ): Promise<void> { }
 
   async visitRecordMetadataRetrieverFormComponentDefinition(
     item: RecordMetadataRetrieverFormComponentDefinitionOutline
@@ -561,7 +561,7 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
 
   /* Data Location */
 
-  async visitDataLocationFieldComponentDefinition(_item: DataLocationFieldComponentDefinitionOutline): Promise<void> {}
+  async visitDataLocationFieldComponentDefinition(_item: DataLocationFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitDataLocationFieldModelDefinition(item: DataLocationFieldModelDefinitionOutline): Promise<void> {
     await this.extractValidators(item.config?.validators);
@@ -574,7 +574,7 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
   // The refresh trigger has no template-bearing fields of its own.
   async visitPublishDataLocationRefreshFieldComponentDefinition(
     _item: PublishDataLocationRefreshFieldComponentDefinitionOutline
-  ): Promise<void> {}
+  ): Promise<void> { }
 
   async visitPublishDataLocationRefreshFormComponentDefinition(
     item: PublishDataLocationRefreshFormComponentDefinitionOutline
@@ -584,7 +584,7 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
 
   async visitPublishDataLocationSelectorFieldComponentDefinition(
     _item: PublishDataLocationSelectorFieldComponentDefinitionOutline
-  ): Promise<void> {}
+  ): Promise<void> { }
 
   async visitPublishDataLocationSelectorFieldModelDefinition(item: PublishDataLocationSelectorFieldModelDefinitionOutline): Promise<void> {
     await this.extractValidators(item.config?.validators);
@@ -598,7 +598,7 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
 
   /* Radio Input */
 
-  async visitRadioInputFieldComponentDefinition(_item: RadioInputFieldComponentDefinitionOutline): Promise<void> {}
+  async visitRadioInputFieldComponentDefinition(_item: RadioInputFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitRadioInputFieldModelDefinition(item: RadioInputFieldModelDefinitionOutline): Promise<void> {
     await this.extractValidators(item.config?.validators);
@@ -610,7 +610,7 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
 
   /* Date Input */
 
-  async visitDateInputFieldComponentDefinition(_item: DateInputFieldComponentDefinitionOutline): Promise<void> {}
+  async visitDateInputFieldComponentDefinition(_item: DateInputFieldComponentDefinitionOutline): Promise<void> { }
 
   async visitDateInputFieldModelDefinition(item: DateInputFieldModelDefinitionOutline): Promise<void> {
     await this.extractValidators(item.config?.validators);
@@ -623,12 +623,12 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
   /* Question Tree */
 
   async visitQuestionTreeFieldComponentDefinition(item: QuestionTreeFieldComponentDefinitionOutline): Promise<void> {
-    (item.config?.componentDefinitions ?? []).forEach((componentDefinition, index) => {
-      this.formPathHelper.acceptFormPath(
+    for (const [index, componentDefinition] of (item.config?.componentDefinitions ?? []).entries()) {
+      await this.formPathHelper.acceptFormPath(
         componentDefinition,
         this.formPathHelper.lineagePathsForQuestionTreeFieldComponentDefinition(componentDefinition, index)
       );
-    });
+    }
   }
 
   async visitQuestionTreeFieldModelDefinition(item: QuestionTreeFieldModelDefinitionOutline): Promise<void> {
@@ -757,13 +757,24 @@ export class TemplateFormConfigVisitor extends FormConfigVisitor {
       if (validator.class === "jsonata-expression") {
         const value = validator.config?.expression?.toString() ?? "";
         if (value) {
+          const parentKey = this.normalizeValidatorTemplateParentKey(this.formPathHelper.formPath.formConfig ?? []);
+          const key = parentKey.length > 0
+            ? [...parentKey, 'config', 'validators', index.toString(), 'config', 'expression']
+            : ['validators', index.toString(), 'config', 'expression'];
           this.templates?.push({
-            key: ['validators', index, "config", "expression"],
+            key,
             value: value,
             kind: 'jsonata',
           });
         }
       }
     });
+  }
+
+  private normalizeValidatorTemplateParentKey(path: Array<string | number>): Array<string | number> {
+    if (path[0] === 'formConfig') {
+      return path.slice(1);
+    }
+    return path;
   }
 }

--- a/packages/redbox-core/src/visitor/validator.visitor.ts
+++ b/packages/redbox-core/src/visitor/validator.visitor.ts
@@ -186,18 +186,18 @@ export class ValidatorFormConfigVisitor extends FormConfigVisitor {
     /* Form Config */
 
     async visitFormConfig(item: FormConfigOutline): Promise<void> {
-        (item?.componentDefinitions ?? []).forEach((componentDefinition, index) => {
+        for (const [index, componentDefinition] of (item?.componentDefinitions ?? []).entries()) {
             // Visit children
-            this.formPathHelper.acceptFormPath(
+            await this.formPathHelper.acceptFormPath(
                 componentDefinition,
                 this.formPathHelper.lineagePathsForFormConfigComponentDefinition(componentDefinition, index),
             );
-        });
+        }
 
         // Run form-level validators using the full form data model.
         // There are various reasons a validator is at form level, e.g. they involve more than one field.
         const dataValueVisitor = new DataValueFormConfigVisitor(this.logger);
-        const value = dataValueVisitor.start({ form: item });
+        const value = await dataValueVisitor.start({ form: item });
         const itemName = item?.name ?? "";
         this.validationErrors.push(...await this.validateFormComponent(itemName, value, item?.validators));
     }
@@ -264,13 +264,13 @@ export class ValidatorFormConfigVisitor extends FormConfigVisitor {
     /* Group */
 
     async visitGroupFieldComponentDefinition(item: GroupFieldComponentDefinitionOutline): Promise<void> {
-        (item.config?.componentDefinitions ?? []).forEach((componentDefinition, index) => {
+        for (const [index, componentDefinition] of (item.config?.componentDefinitions ?? []).entries()) {
             // Visit children
-            this.formPathHelper.acceptFormPath(
+            await this.formPathHelper.acceptFormPath(
                 componentDefinition,
                 this.formPathHelper.lineagePathsForGroupFieldComponentDefinition(componentDefinition, index),
             );
-        });
+        }
     }
 
     async visitGroupFieldModelDefinition(_item: GroupFieldModelDefinitionOutline): Promise<void> {
@@ -283,13 +283,13 @@ export class ValidatorFormConfigVisitor extends FormConfigVisitor {
     /* Tab  */
 
     async visitTabFieldComponentDefinition(item: TabFieldComponentDefinitionOutline): Promise<void> {
-        (item.config?.tabs ?? []).forEach((componentDefinition, index) => {
+        for (const [index, componentDefinition] of (item.config?.tabs ?? []).entries()) {
             // Visit children
-            this.formPathHelper.acceptFormPath(
+            await this.formPathHelper.acceptFormPath(
                 componentDefinition,
                 this.formPathHelper.lineagePathsForTabFieldComponentDefinition(componentDefinition, index),
             );
-        });
+        }
     }
 
     async visitTabFieldLayoutDefinition(_item: TabFieldLayoutDefinitionOutline): Promise<void> {
@@ -302,12 +302,12 @@ export class ValidatorFormConfigVisitor extends FormConfigVisitor {
     /* Accordion */
 
     async visitAccordionFieldComponentDefinition(item: AccordionFieldComponentDefinitionOutline): Promise<void> {
-        (item.config?.panels ?? []).forEach((componentDefinition, index) => {
-            this.formPathHelper.acceptFormPath(
+        for (const [index, componentDefinition] of (item.config?.panels ?? []).entries()) {
+            await this.formPathHelper.acceptFormPath(
                 componentDefinition,
                 this.formPathHelper.lineagePathsForAccordionFieldComponentDefinition(componentDefinition, index)
             );
-        });
+        }
     }
 
     async visitAccordionFieldLayoutDefinition(_item: AccordionFieldLayoutDefinitionOutline): Promise<void> {
@@ -318,12 +318,12 @@ export class ValidatorFormConfigVisitor extends FormConfigVisitor {
     }
 
     async visitAccordionPanelFieldComponentDefinition(item: AccordionPanelFieldComponentDefinitionOutline): Promise<void> {
-        (item.config?.componentDefinitions ?? []).forEach((componentDefinition, index) => {
-            this.formPathHelper.acceptFormPath(
+        for (const [index, componentDefinition] of (item.config?.componentDefinitions ?? []).entries()) {
+            await this.formPathHelper.acceptFormPath(
                 componentDefinition,
                 this.formPathHelper.lineagePathsForAccordionPanelFieldComponentDefinition(componentDefinition, index)
             );
-        });
+        }
     }
 
     async visitAccordionPanelFieldLayoutDefinition(_item: AccordionPanelFieldLayoutDefinitionOutline): Promise<void> {
@@ -336,13 +336,13 @@ export class ValidatorFormConfigVisitor extends FormConfigVisitor {
     /*  Tab Content */
 
     async visitTabContentFieldComponentDefinition(item: TabContentFieldComponentDefinitionOutline): Promise<void> {
-        (item.config?.componentDefinitions ?? []).forEach((componentDefinition, index) => {
+        for (const [index, componentDefinition] of (item.config?.componentDefinitions ?? []).entries()) {
             // Visit children
-            this.formPathHelper.acceptFormPath(
+            await this.formPathHelper.acceptFormPath(
                 componentDefinition,
                 this.formPathHelper.lineagePathsForTabContentFieldComponentDefinition(componentDefinition, index),
             );
-        });
+        }
     }
 
     async visitTabContentFieldLayoutDefinition(_item: TabContentFieldLayoutDefinitionOutline): Promise<void> {
@@ -418,12 +418,12 @@ export class ValidatorFormConfigVisitor extends FormConfigVisitor {
     /* Question Tree */
 
     async visitQuestionTreeFieldComponentDefinition(item: QuestionTreeFieldComponentDefinitionOutline): Promise<void> {
-        (item.config?.componentDefinitions ?? []).forEach((componentDefinition, index) => {
-            this.formPathHelper.acceptFormPath(
+        for (const [index, componentDefinition] of (item.config?.componentDefinitions ?? []).entries()) {
+            await this.formPathHelper.acceptFormPath(
                 componentDefinition,
                 this.formPathHelper.lineagePathsForQuestionTreeFieldComponentDefinition(componentDefinition, index)
             );
-        });
+        }
     }
 
     async visitQuestionTreeFieldModelDefinition(_item: QuestionTreeFieldModelDefinitionOutline): Promise<void> {

--- a/packages/redbox-core/src/visitor/vocab-inline.visitor.ts
+++ b/packages/redbox-core/src/visitor/vocab-inline.visitor.ts
@@ -74,9 +74,9 @@ export class VocabInlineFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitFormConfig(item: FormConfigOutline): Promise<void> {
-    item.componentDefinitions.forEach((component) => {
-      component.accept(this);
-    });
+    for (const component of item.componentDefinitions) {
+      await component.accept(this);
+    }
   }
 
   async visitDropdownInputFormComponentDefinition(item: DropdownInputFormComponentDefinitionOutline): Promise<void> {
@@ -100,7 +100,9 @@ export class VocabInlineFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitGroupFieldComponentDefinition(item: GroupFieldComponentDefinitionOutline): Promise<void> {
-    item.config?.componentDefinitions?.forEach((def) => def.accept(this));
+    for (const def of item.config?.componentDefinitions ?? []) {
+      await def.accept(this);
+    }
   }
 
   async visitTabFormComponentDefinition(item: TabFormComponentDefinitionOutline): Promise<void> {
@@ -108,7 +110,9 @@ export class VocabInlineFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitTabFieldComponentDefinition(item: TabFieldComponentDefinitionOutline): Promise<void> {
-    item.config?.tabs?.forEach((tab) => tab.accept(this));
+    for (const tab of item.config?.tabs ?? []) {
+      await tab.accept(this);
+    }
   }
 
   async visitAccordionFormComponentDefinition(item: AccordionFormComponentDefinitionOutline): Promise<void> {
@@ -116,7 +120,9 @@ export class VocabInlineFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitAccordionFieldComponentDefinition(item: AccordionFieldComponentDefinitionOutline): Promise<void> {
-    item.config?.panels?.forEach((panel) => panel.accept(this));
+    for (const panel of item.config?.panels ?? []) {
+      await panel.accept(this);
+    }
   }
 
   async visitAccordionPanelFormComponentDefinition(item: AccordionPanelFormComponentDefinitionOutline): Promise<void> {
@@ -124,7 +130,9 @@ export class VocabInlineFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitAccordionPanelFieldComponentDefinition(item: AccordionPanelFieldComponentDefinitionOutline): Promise<void> {
-    item.config?.componentDefinitions?.forEach((def) => def.accept(this));
+    for (const def of item.config?.componentDefinitions ?? []) {
+      await def.accept(this);
+    }
   }
 
   async visitTabContentFormComponentDefinition(item: TabContentFormComponentDefinitionOutline): Promise<void> {
@@ -132,7 +140,9 @@ export class VocabInlineFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitTabContentFieldComponentDefinition(item: TabContentFieldComponentDefinitionOutline): Promise<void> {
-    item.config?.componentDefinitions?.forEach((def) => def.accept(this));
+    for (const def of item.config?.componentDefinitions ?? []) {
+      await def.accept(this);
+    }
   }
 
   async visitRepeatableFormComponentDefinition(item: RepeatableFormComponentDefinitionOutline): Promise<void> {
@@ -140,7 +150,7 @@ export class VocabInlineFormConfigVisitor extends FormConfigVisitor {
   }
 
   async visitRepeatableFieldComponentDefinition(item: RepeatableFieldComponentDefinitionOutline): Promise<void> {
-    item.config?.elementTemplate?.accept(this);
+    await item.config?.elementTemplate?.accept(this);
   }
 
   private async enqueueIfInlineVocab(
@@ -227,7 +237,11 @@ export class VocabInlineFormConfigVisitor extends FormConfigVisitor {
     componentConfig: ComponentConfigWithInlineVocab,
     treeMode: boolean
   ): Promise<VocabularyEntryAttributes[]> {
-    return entries.filter(async (entry) => {
+    const selectedValues = treeMode
+      ? await this.selectedTreeValuesFromModelValue(definition?.model?.config?.value)
+      : await this.selectedValuesFromModelValue(definition?.model?.config?.value);
+
+    return entries.filter((entry) => {
       if (!this.isHistorical(entry)) {
         return true;
       }
@@ -237,10 +251,6 @@ export class VocabInlineFormConfigVisitor extends FormConfigVisitor {
       if (this.shouldDisableHistoricalEntry(entry, componentConfig)) {
         return true;
       }
-
-      const selectedValues = treeMode
-        ? await this.selectedTreeValuesFromModelValue(definition?.model?.config?.value)
-        : await this.selectedValuesFromModelValue(definition?.model?.config?.value);
       return this.entryMatchesSelectedValue(entry, selectedValues, treeMode);
     });
   }

--- a/packages/redbox-core/test/services/FormRecordConsistencyService.test.ts
+++ b/packages/redbox-core/test/services/FormRecordConsistencyService.test.ts
@@ -77,7 +77,7 @@ describe('FormRecordConsistencyService', function () {
   });
 
   describe('mergeRecordClientFormConfig', function () {
-    it('should delegate to mergeRecordMetadataPermitted', function () {
+    it('should delegate to mergeRecordMetadataPermitted', async function () {
       const original = { redboxOid: 'oid', metadata: { a: 1 } };
       const changed = { redboxOid: 'oid', metadata: { a: 2 } };
       const config = {};
@@ -86,12 +86,12 @@ describe('FormRecordConsistencyService', function () {
       sinon.stub(FormRecordConsistencyService, 'compareRecords').returns([]);
       sinon.stub(FormRecordConsistencyService, 'mergeRecordMetadataPermitted').returns({ merged: true });
 
-      const result = FormRecordConsistencyService.mergeRecordClientFormConfig(original, changed, config, 'edit');
+      const result = await FormRecordConsistencyService.mergeRecordClientFormConfig(original, changed, config, 'edit');
 
       expect(result.metadata).to.deep.equal({ merged: true });
     });
 
-    it('should strip hydrated model values before building schema', function () {
+    it('should strip hydrated model values before building schema', async function () {
       const original = { redboxOid: 'oid', metadata: { title: 'before' } };
       const changed = { redboxOid: 'oid', metadata: { title: 'after' } };
       const config = {
@@ -126,7 +126,7 @@ describe('FormRecordConsistencyService', function () {
       sinon.stub(FormRecordConsistencyService, 'compareRecords').returns([]);
       sinon.stub(FormRecordConsistencyService, 'mergeRecordMetadataPermitted').returns({ merged: true });
 
-      FormRecordConsistencyService.mergeRecordClientFormConfig(original, changed, config, 'edit');
+      await FormRecordConsistencyService.mergeRecordClientFormConfig(original, changed, config, 'edit');
 
       const schemaInput = buildSchemaStub.firstCall.args[0];
       const strippedTopLevel = schemaInput.componentDefinitions?.[0]?.model?.config?.value;

--- a/packages/redbox-core/test/services/FormsService.test.ts
+++ b/packages/redbox-core/test/services/FormsService.test.ts
@@ -411,7 +411,7 @@ describe('FormsService', function () {
       expect(form).to.have.property('name');
       expect(form.name).to.eql(item.name);
 
-      const templates = visitor.start({ form });
+      const templates = await visitor.start({ form });
 
       const expected = [
         { kind: "handlebars" }, { kind: "jsonata" },

--- a/packages/redbox-core/test/unit/attachment-fields.visitor.test.ts
+++ b/packages/redbox-core/test/unit/attachment-fields.visitor.test.ts
@@ -27,7 +27,7 @@ let expect: Chai.ExpectStatic;
 import("chai").then(mod => expect = mod.expect);
 
 describe("AttachmentFieldsVisitor", () => {
-    it("should identify top-level FileUpload component", () => {
+    it("should identify top-level FileUpload component", async () => {
         const formConfig = new FormConfig();
         const fileUpload = new FileUploadFormComponentDefinition();
         fileUpload.name = "fileUpload1";
@@ -36,13 +36,13 @@ describe("AttachmentFieldsVisitor", () => {
         formConfig.componentDefinitions = [fileUpload];
 
         const visitor = new AttachmentFieldsVisitor(logger);
-        visitor.start(formConfig);
+        await visitor.start(formConfig);
 
         expect(formConfig.attachmentFields).to.include("fileUpload1");
         expect(formConfig.attachmentFields?.length).to.equal(1);
     });
 
-    it("should identify nested FileUpload component in Group", () => {
+    it("should identify nested FileUpload component in Group", async () => {
         const formConfig = new FormConfig();
         const group = new GroupFormComponentDefinition();
         group.name = "group1";
@@ -58,13 +58,13 @@ describe("AttachmentFieldsVisitor", () => {
         formConfig.componentDefinitions = [group];
 
         const visitor = new AttachmentFieldsVisitor(logger);
-        visitor.start(formConfig);
+        await visitor.start(formConfig);
 
         expect(formConfig.attachmentFields).to.include("fileUploadInGroup");
         expect(formConfig.attachmentFields?.length).to.equal(1);
     });
 
-    it("should identify nested FileUpload component in Tab", () => {
+    it("should identify nested FileUpload component in Tab", async () => {
         const formConfig = new FormConfig();
         const tab = new TabFormComponentDefinition();
         tab.name = "tab1";
@@ -86,13 +86,13 @@ describe("AttachmentFieldsVisitor", () => {
         formConfig.componentDefinitions = [tab];
 
         const visitor = new AttachmentFieldsVisitor(logger);
-        visitor.start(formConfig);
+        await visitor.start(formConfig);
 
         expect(formConfig.attachmentFields).to.include("fileUploadInTab");
         expect(formConfig.attachmentFields?.length).to.equal(1);
     });
 
-    it("should identify FileUpload component in Repeatable elementTemplate", () => {
+    it("should identify FileUpload component in Repeatable elementTemplate", async () => {
         const formConfig = new FormConfig();
         const repeatable = new RepeatableFormComponentDefinition();
         repeatable.name = "repeatable1";
@@ -108,13 +108,13 @@ describe("AttachmentFieldsVisitor", () => {
         formConfig.componentDefinitions = [repeatable];
 
         const visitor = new AttachmentFieldsVisitor(logger);
-        visitor.start(formConfig);
+        await visitor.start(formConfig);
 
         expect(formConfig.attachmentFields).to.include("fileUploadInRepeatable");
         expect(formConfig.attachmentFields?.length).to.equal(1);
     });
 
-    it("should identify multiple FileUpload components", () => {
+    it("should identify multiple FileUpload components", async () => {
         const formConfig = new FormConfig();
 
         const fileUpload1 = new FileUploadFormComponentDefinition();
@@ -137,25 +137,25 @@ describe("AttachmentFieldsVisitor", () => {
         formConfig.componentDefinitions = [fileUpload1, group];
 
         const visitor = new AttachmentFieldsVisitor(logger);
-        visitor.start(formConfig);
+        await visitor.start(formConfig);
 
         expect(formConfig.attachmentFields).to.include("fileUpload1");
         expect(formConfig.attachmentFields).to.include("fileUpload2");
         expect(formConfig.attachmentFields?.length).to.equal(2);
     });
 
-    it("should initialize attachmentFields as empty array if no attachments found", () => {
+    it("should initialize attachmentFields as empty array if no attachments found", async () => {
         const formConfig = new FormConfig();
         formConfig.componentDefinitions = [];
 
         const visitor = new AttachmentFieldsVisitor(logger);
-        visitor.start(formConfig);
+        await visitor.start(formConfig);
 
         expect(formConfig.attachmentFields).to.be.an("array");
         expect(formConfig.attachmentFields?.length).to.equal(0);
     });
 
-    it("should identify top-level DataLocation component", () => {
+    it("should identify top-level DataLocation component", async () => {
         const formConfig = new FormConfig();
         const dataLocation = new DataLocationFormComponentDefinition();
         dataLocation.name = "dataLocations";
@@ -164,7 +164,7 @@ describe("AttachmentFieldsVisitor", () => {
         formConfig.componentDefinitions = [dataLocation];
 
         const visitor = new AttachmentFieldsVisitor(logger);
-        visitor.start(formConfig);
+        await visitor.start(formConfig);
 
         expect(formConfig.attachmentFields).to.include("dataLocations");
         expect(formConfig.attachmentFields?.length).to.equal(1);

--- a/packages/redbox-core/test/unit/client.visitor.test.ts
+++ b/packages/redbox-core/test/unit/client.visitor.test.ts
@@ -44,14 +44,14 @@ describe("Client Visitor", async () => {
       };
 
       const constructor = new ConstructFormConfigVisitor(logger);
-      const constructed = constructor.start({
+      const constructed = await constructor.start({
         data: args,
         formMode: "edit",
         reusableFormDefs: reusableFormDefinitions,
       });
 
       const visitor = new ClientFormConfigVisitor(logger);
-      const actual = visitor.start({form: constructed});
+      const actual = await visitor.start({form: constructed});
       const repeatableConfig = actual.componentDefinitions[0].component.config as RepeatableFieldComponentConfigFrame;
 
       expect(repeatableConfig.addButtonShow).to.equal(false);
@@ -59,7 +59,7 @@ describe("Client Visitor", async () => {
       expect(repeatableConfig.hideWhenZeroRows).to.equal(true);
     });
 
-    it('should propagate syncSources through sharedPopulateFieldComponentConfig', () => {
+    it('should propagate syncSources through sharedPopulateFieldComponentConfig', async () => {
       const args: FormConfigFrame = {
         name: 'repeatable-sync-sources-preserve',
         componentDefinitions: [
@@ -96,14 +96,14 @@ describe("Client Visitor", async () => {
       };
 
       const constructor = new ConstructFormConfigVisitor(logger);
-      const constructed = constructor.start({
+      const constructed = await constructor.start({
         data: args,
         formMode: 'edit',
         reusableFormDefs: reusableFormDefinitions,
       });
 
       const visitor = new ClientFormConfigVisitor(logger);
-      const actual = visitor.start({form: constructed});
+      const actual = await visitor.start({form: constructed});
       const repeatableConfig = actual.componentDefinitions[0].component.config as RepeatableFieldComponentConfigFrame;
 
       expect(repeatableConfig.syncSources).to.deep.equal([
@@ -222,14 +222,14 @@ describe("Client Visitor", async () => {
       };
 
       const constructor = new ConstructFormConfigVisitor(logger);
-      const constructed = constructor.start({
+      const constructed = await constructor.start({
         data: args,
         formMode: 'edit',
         reusableFormDefs: reusableFormDefinitions,
       });
 
       const visitor = new ClientFormConfigVisitor(logger);
-      const actual = visitor.start({form: constructed});
+      const actual = await visitor.start({form: constructed});
       const value = actual.componentDefinitions?.[0]?.model?.config?.value as any[];
 
       expect(value).to.have.length(1);
@@ -297,14 +297,14 @@ describe("Client Visitor", async () => {
       };
 
       const constructor = new ConstructFormConfigVisitor(logger);
-      const constructed = constructor.start({
+      const constructed = await constructor.start({
         data: args,
         formMode: 'edit',
         reusableFormDefs: reusableFormDefinitions,
       });
 
       const visitor = new ClientFormConfigVisitor(logger);
-      const actual = visitor.start({form: constructed});
+      const actual = await visitor.start({form: constructed});
       const value = actual.componentDefinitions?.[0]?.model?.config?.value as any[];
 
       expect(value).to.have.length(1);
@@ -366,14 +366,14 @@ describe("Client Visitor", async () => {
       };
 
       const constructor = new ConstructFormConfigVisitor(logger);
-      const constructed = constructor.start({
+      const constructed = await constructor.start({
         data: args,
         formMode: 'edit',
         reusableFormDefs: reusableFormDefinitions,
       });
 
       const visitor = new ClientFormConfigVisitor(logger);
-      const actual = visitor.start({form: constructed});
+      const actual = await visitor.start({form: constructed});
       const repeatable = actual.componentDefinitions?.[0];
 
       expect(repeatable.component?.config?.visible).to.equal(false);
@@ -424,14 +424,14 @@ describe("Client Visitor", async () => {
       };
 
       const constructor = new ConstructFormConfigVisitor(logger);
-      const constructed = constructor.start({
+      const constructed = await constructor.start({
         data: args,
         formMode: 'edit',
         reusableFormDefs: reusableFormDefinitions,
       });
 
       const visitor = new ClientFormConfigVisitor(logger);
-      const actual = visitor.start({form: constructed});
+      const actual = await visitor.start({form: constructed});
       const repeatable = actual.componentDefinitions?.[0];
       const repeatableValue = repeatable?.model?.config?.value as unknown[] | undefined;
       const repeatableConfig = repeatable?.component?.config as RepeatableFieldComponentConfigFrame | undefined;
@@ -486,7 +486,7 @@ describe("Client Visitor", async () => {
       };
 
       const constructor = new ConstructFormConfigVisitor(logger);
-      const constructed = constructor.start({
+      const constructed = await constructor.start({
         data: args,
         reusableFormDefs: reusableFormDefinitions,
         formMode: 'edit',
@@ -499,7 +499,7 @@ describe("Client Visitor", async () => {
       });
 
       const visitor = new ClientFormConfigVisitor(logger);
-      const actual = visitor.start({
+      const actual = await visitor.start({
         form: constructed,
         reusableFormDefs: reusableFormDefinitions,
         formMode: 'edit',
@@ -549,14 +549,14 @@ describe("Client Visitor", async () => {
     const args = formConfigExample1;
 
     const constructor = new ConstructFormConfigVisitor(logger);
-    const constructed = constructor.start({
+    const constructed = await constructor.start({
       data: args,
       formMode: "edit",
       reusableFormDefs: reusableFormDefinitions,
     });
 
     const visitor = new ClientFormConfigVisitor(logger);
-    const actual = visitor.start({form: constructed});
+    const actual = await visitor.start({form: constructed});
 
     const stringified = JSON.stringify(actual);
 
@@ -1178,10 +1178,10 @@ describe("Client Visitor", async () => {
   cases.forEach(({title, args, expected}) => {
     it(`should ${title}`, async function () {
       const constructor = new ConstructFormConfigVisitor(logger);
-      const constructed = constructor.start({data: args, formMode: "edit"});
+      const constructed = await constructor.start({data: args, formMode: "edit"});
 
       const visitor = new ClientFormConfigVisitor(logger);
-      const actual = visitor.start({form: constructed});
+      const actual = await visitor.start({form: constructed});
       expect(actual).to.eql(expected);
     });
   });
@@ -1226,14 +1226,14 @@ describe("Client Visitor", async () => {
     };
 
     const constructor = new ConstructFormConfigVisitor(logger);
-    const constructed = constructor.start({
+    const constructed = await constructor.start({
       data: formConfig,
       formMode: "edit",
       record: {text_2: "text_2_value"}
     });
 
     const visitor = new ClientFormConfigVisitor(logger);
-    const actual = visitor.start({
+    const actual = await visitor.start({
       form: constructed,
       formMode: "view",
       userRoles: ["Librarian"],
@@ -1243,7 +1243,7 @@ describe("Client Visitor", async () => {
 
   it(`should keep transformed accordion in view mode`, async function () {
     const constructor = new ConstructFormConfigVisitor(logger);
-    const constructed = constructor.start({
+    const constructed = await constructor.start({
       formMode: "view",
       data: {
         name: "form",
@@ -1271,13 +1271,13 @@ describe("Client Visitor", async () => {
     });
 
     const visitor = new ClientFormConfigVisitor(logger);
-    const actual = visitor.start({ form: constructed, formMode: "view" });
+    const actual = await visitor.start({ form: constructed, formMode: "view" });
     expect(actual.componentDefinitions[0].component.class).to.eql("AccordionComponent");
   });
 
   it(`should prune edit-only repeatables nested in transformed tabs for view mode`, async function () {
     const constructor = new ConstructFormConfigVisitor(logger);
-    const constructed = constructor.start({
+    const constructed = await constructor.start({
       formMode: "view",
       record: { finalKeywords: ["alpha", "beta"] },
       data: {
@@ -1330,7 +1330,7 @@ describe("Client Visitor", async () => {
     });
 
     const visitor = new ClientFormConfigVisitor(logger);
-    const actual = visitor.start({ form: constructed, formMode: "view" });
+    const actual = await visitor.start({ form: constructed, formMode: "view" });
     const accordion = actual.componentDefinitions[0];
     expect(accordion.component.class).to.eql("AccordionComponent");
     const panel = (accordion.component.config as any).panels?.[0];
@@ -1340,7 +1340,7 @@ describe("Client Visitor", async () => {
 
   it(`should keep explicit view repeatables in view mode`, async function () {
     const constructor = new ConstructFormConfigVisitor(logger);
-    const constructed = constructor.start({
+    const constructed = await constructor.start({
       formMode: "view",
       record: { actions: ["Edit this plan", "Create a data record from this plan"] },
       data: {
@@ -1371,13 +1371,13 @@ describe("Client Visitor", async () => {
     });
 
     const visitor = new ClientFormConfigVisitor(logger);
-    const actual = visitor.start({ form: constructed, formMode: "view" });
+    const actual = await visitor.start({ form: constructed, formMode: "view" });
     expect(actual.componentDefinitions[0].component.class).to.eql("RepeatableComponent");
   });
 
   it(`should prune edit-only repeatables in view mode before view transforms`, async function () {
     const constructor = new ConstructFormConfigVisitor(logger);
-    const constructed = constructor.start({
+    const constructed = await constructor.start({
       formMode: "view",
       data: {
         name: "form",
@@ -1427,13 +1427,13 @@ describe("Client Visitor", async () => {
     });
 
     const visitor = new ClientFormConfigVisitor(logger);
-    const actual = visitor.start({ form: constructed, formMode: "view" });
+    const actual = await visitor.start({ form: constructed, formMode: "view" });
     expect(actual.componentDefinitions ?? []).to.have.length(0);
   });
 
   it(`should omit non-renderable fields from group view transforms`, async function () {
     const constructor = new ConstructFormConfigVisitor(logger);
-    const constructed = constructor.start({
+    const constructed = await constructor.start({
       formMode: "view",
       data: {
         name: "form",
@@ -1484,7 +1484,7 @@ describe("Client Visitor", async () => {
     });
 
     const visitor = new ClientFormConfigVisitor(logger);
-    const actual = visitor.start({ form: constructed, formMode: "view" });
+    const actual = await visitor.start({ form: constructed, formMode: "view" });
     const transformed = actual.componentDefinitions[0];
 
     expect(transformed.component.class).to.equal("ContentComponent");
@@ -1499,7 +1499,7 @@ describe("Client Visitor", async () => {
 
   it(`should keep action row groups in view mode`, async function () {
     const constructor = new ConstructFormConfigVisitor(logger);
-    const constructed = constructor.start({
+    const constructed = await constructor.start({
       formMode: "view",
       data: {
         name: "form",
@@ -1534,14 +1534,14 @@ describe("Client Visitor", async () => {
     });
 
     const visitor = new ClientFormConfigVisitor(logger);
-    const actual = visitor.start({ form: constructed, formMode: "view" });
+    const actual = await visitor.start({ form: constructed, formMode: "view" });
     expect(actual.componentDefinitions[0].component.class).to.eql("GroupComponent");
     expect(actual.componentDefinitions[0].layout?.class).to.eql("ActionRowLayout");
   });
 
   it(`should keep tab in edit mode`, async function () {
     const constructor = new ConstructFormConfigVisitor(logger);
-    const constructed = constructor.start({
+    const constructed = await constructor.start({
       formMode: "edit",
       data: {
         name: "form",
@@ -1569,7 +1569,7 @@ describe("Client Visitor", async () => {
     });
 
     const visitor = new ClientFormConfigVisitor(logger);
-    const actual = visitor.start({ form: constructed, formMode: "edit" });
+    const actual = await visitor.start({ form: constructed, formMode: "edit" });
     expect(actual.componentDefinitions[0].component.class).to.eql("TabComponent");
   });
 
@@ -1801,16 +1801,24 @@ describe("Client Visitor", async () => {
     };
 
     const constructor = new ConstructFormConfigVisitor(logger);
-    const constructed = constructor.start({
+    const constructed = await constructor.start({
       data: formConfig,
       formMode: "edit",
       reusableFormDefs: reusableFormDefinitions,
     });
 
     const visitor = new ClientFormConfigVisitor(logger);
-    const actual = visitor.start({form: constructed});
+    const actual = await visitor.start({form: constructed});
 
     expect(actual).to.containSubset(expected);
+    const questionTree = actual.componentDefinitions[0] as QuestionTreeFormComponentDefinitionOutline;
+    for (const componentDefinition of questionTree.component.config?.componentDefinitions ?? []) {
+      for (const expression of componentDefinition.expressions ?? []) {
+        if (expression.config.template !== undefined) {
+          expect(expression.config.hasTemplate, expression.name).to.equal(true);
+        }
+      }
+    }
   });
 
   it("should transform question tree answers to content in view mode", async () => {
@@ -1869,7 +1877,7 @@ describe("Client Visitor", async () => {
     };
 
     const constructor = new ConstructFormConfigVisitor(logger);
-    const constructed = constructor.start({
+    const constructed = await constructor.start({
       data: formConfig,
       formMode: "view",
       reusableFormDefs: reusableFormDefinitions,
@@ -1896,7 +1904,7 @@ describe("Client Visitor", async () => {
     }
 
     const visitor = new ClientFormConfigVisitor(logger);
-    const actual = visitor.start({ form: constructed, formMode: "view" });
+    const actual = await visitor.start({ form: constructed, formMode: "view" });
     const transformed = actual.componentDefinitions[0];
 
     expect(transformed.component.class).to.equal("ContentComponent");
@@ -2105,7 +2113,7 @@ describe("Client Visitor", async () => {
 
 
       const constructor = new ConstructFormConfigVisitor(logger);
-      const constructed = constructor.start({
+      const constructed = await constructor.start({
         data: serverFormConfig,
         formMode: "edit",
         reusableFormDefs: reusableFormDefinitions,
@@ -2115,7 +2123,7 @@ describe("Client Visitor", async () => {
       await vocabVisitor.resolveVocabs(constructed, 'default');
 
       const visitor = new ClientFormConfigVisitor(logger);
-      const result = visitor.start({form: constructed});
+      const result = await visitor.start({form: constructed});
       expect(result.componentDefinitions).to.have.length(3);
       const qt = result.componentDefinitions[0] as QuestionTreeFormComponentDefinitionOutline;
       expect(qt.component.config?.componentDefinitions).to.have.length(4);
@@ -2232,7 +2240,7 @@ describe("Client Visitor", async () => {
     };
 
     const constructVisitor = new ConstructFormConfigVisitor(logger);
-    const constructForm = constructVisitor.start({
+    const constructForm = await constructVisitor.start({
       data,
       formMode: 'edit',
       reusableFormDefs: reusableFormDefinitions,
@@ -2240,7 +2248,7 @@ describe("Client Visitor", async () => {
     // expect(constructForm).to.containSubset(expected);
 
     const clientFormVisitor = new ClientFormConfigVisitor(logger);
-    const clientForm = clientFormVisitor.start({
+    const clientForm = await clientFormVisitor.start({
       form: constructForm,
       formMode: 'edit',
       reusableFormDefs: reusableFormDefinitions,

--- a/packages/redbox-core/test/unit/construct.visitor.test.ts
+++ b/packages/redbox-core/test/unit/construct.visitor.test.ts
@@ -30,6 +30,19 @@ import("chai").then(mod => expect = mod.expect);
 
 const normalizeTemplate = (template: string): string => template.replace(/\s+/g, " ").trim();
 
+async function expectRejects(errorFunc: () => Promise<unknown>, message?: string): Promise<void> {
+    let actualError: unknown = null;
+    try {
+        await errorFunc();
+    } catch (error) {
+        actualError = error;
+    }
+    expect(actualError).to.be.instanceOf(Error);
+    if (message) {
+        expect((actualError as Error).message).to.contain(message);
+    }
+}
+
 describe("Construct Visitor", async () => {
     describe("basic constructing", async () => {
         const cases: {
@@ -212,7 +225,7 @@ describe("Construct Visitor", async () => {
         cases.forEach(({ title, args, expected }) => {
             it(`should ${title}`, async function () {
                 const visitor = new ConstructFormConfigVisitor(logger);
-                const actual = visitor.start({ data: args, formMode: "edit" });
+                const actual = await visitor.start({ data: args, formMode: "edit" });
                 expect(actual).to.deep.include({ name: expected.name });
 
                 const expectedDefs = expected.componentDefinitions ?? [];
@@ -233,7 +246,7 @@ describe("Construct Visitor", async () => {
 
         it("should retain checkbox tree labelTemplate config", async function () {
             const visitor = new ConstructFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 formMode: "edit",
                 data: {
                     name: "test",
@@ -259,7 +272,7 @@ describe("Construct Visitor", async () => {
 
         it("should set typeahead namedQuery defaults and cache behaviour", async function () {
             const visitor = new ConstructFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 formMode: "edit",
                 data: {
                     name: "test",
@@ -287,7 +300,7 @@ describe("Construct Visitor", async () => {
 
         it("should preserve external typeahead provider config", async function () {
             const visitor = new ConstructFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 formMode: "edit",
                 data: {
                     name: "test",
@@ -320,7 +333,7 @@ describe("Construct Visitor", async () => {
 
         it("should preserve service typeahead config and disable caching by default", async function () {
             const visitor = new ConstructFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 formMode: "edit",
                 data: {
                     name: "test",
@@ -349,7 +362,7 @@ describe("Construct Visitor", async () => {
 
         it("should normalize repeatable elementTemplate layout to RepeatableElementLayout", async function () {
             const visitor = new ConstructFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 formMode: "edit",
                 data: {
                     name: "repeatable-layout-normalization",
@@ -385,7 +398,7 @@ describe("Construct Visitor", async () => {
                 warn: (message: unknown) => warnings.push(String(message ?? ""))
             };
             const visitor = new ConstructFormConfigVisitor(testLogger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 formMode: "edit",
                 data: {
                     name: "test",
@@ -415,7 +428,7 @@ describe("Construct Visitor", async () => {
 
         it("should not apply default view transform when allowModes explicitly includes view", async function () {
             const visitor = new ConstructFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 formMode: "view",
                 data: {
                     name: "test",
@@ -447,7 +460,7 @@ describe("Construct Visitor", async () => {
 
         it("should apply an explicit content view transform for rich text fields constrained to view mode", async function () {
             const visitor = new ConstructFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 formMode: "view",
                 data: {
                     name: "test",
@@ -484,7 +497,7 @@ describe("Construct Visitor", async () => {
     describe("record metadata retriever", async () => {
         it("should construct RecordMetadataRetrieverComponent definitions with operation expressions and no model", async () => {
             const visitor = new ConstructFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 formMode: "edit",
                 data: {
                     name: "form",
@@ -529,7 +542,7 @@ describe("Construct Visitor", async () => {
             // This locks in the design decision that the refresh trigger remains
             // stateless in V5 and only participates through behaviour events.
             const visitor = new ConstructFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 formMode: "edit",
                 data: {
                     name: "form",
@@ -621,7 +634,7 @@ describe("Construct Visitor", async () => {
         cases.forEach(({ title, args, expected }) => {
             it(`should ${title}`, async function () {
                 const visitor = new ConstructFormConfigVisitor(logger);
-                const actual = visitor.start({
+                const actual = await visitor.start({
                     data: args.formConfig,
                     formMode: args.formMode,
                     reusableFormDefs: args.reusableFormDefs
@@ -654,9 +667,9 @@ describe("Construct Visitor", async () => {
     });
     describe("expected errors", async () => {
         it("should fail when duplicate expression name is found", async () => {
-            const errorFunc = function () {
+            const errorFunc = async function () {
                 const visitor = new ConstructFormConfigVisitor(logger);
-                visitor.start({
+                return await visitor.start({
                     data: {
                         name: "form",
                         componentDefinitions: [
@@ -672,12 +685,12 @@ describe("Construct Visitor", async () => {
                     }
                 });
             };
-            expect(errorFunc).to.throw(Error, 'Duplicate name in expression: exp1');
+            await expectRejects(errorFunc, 'Duplicate name in expression: exp1');
         });
         it("should fail when repeatable elementTemplate is invalid", async () => {
-            const errorFunc = function () {
+            const errorFunc = async function () {
                 const visitor = new ConstructFormConfigVisitor(logger);
-                visitor.start({
+                return await visitor.start({
                     data: {
                         name: "form",
                         componentDefinitions: [
@@ -698,12 +711,12 @@ describe("Construct Visitor", async () => {
                     }, formMode: "edit", reusableFormDefs: reusableFormDefinitionsExample2
                 });
             };
-            expect(errorFunc).to.throw(Error, `Repeatable element template overrides must result in exactly one item, got 3`);
+            await expectRejects(errorFunc, `Repeatable element template overrides must result in exactly one item, got 3`);
         });
         it("should fail when repeatable elementTemplate has defaultValue", async () => {
-            const errorFunc = function () {
+            const errorFunc = async function () {
                 const visitor = new ConstructFormConfigVisitor(logger);
-                visitor.start({
+                return await visitor.start({
                     data: {
                         name: "form",
                         componentDefinitions: [
@@ -724,12 +737,12 @@ describe("Construct Visitor", async () => {
                     }, formMode: "edit", reusableFormDefs: reusableFormDefinitionsExample2
                 });
             };
-            expect(errorFunc).to.throw(Error, "Set the repeatable elementTemplate new item default using 'elementTemplate.model.config.newEntryValue', not 'elementTemplate.model.config.defaultValue', set the repeatable default in 'repeatable.model.config.defaultValue'");
+            await expectRejects(errorFunc, "Set the repeatable elementTemplate new item default using 'elementTemplate.model.config.newEntryValue', not 'elementTemplate.model.config.defaultValue', set the repeatable default in 'repeatable.model.config.defaultValue'");
         });
         it("should fail when repeatable elementTemplate has descendant with defaultValue", async () => {
-            const errorFunc = function () {
+            const errorFunc = async function () {
                 const visitor = new ConstructFormConfigVisitor(logger);
-                visitor.start({
+                return await visitor.start({
                     data: {
                         name: "form",
                         componentDefinitions: [
@@ -763,13 +776,13 @@ describe("Construct Visitor", async () => {
                     }, formMode: "edit", reusableFormDefs: reusableFormDefinitionsExample2
                 });
             };
-            expect(errorFunc).to.throw(Error, "Set the repeatable elementTemplate descendant component new item default using 'elementTemplate.model.config.newEntryValue', set the repeatable default in 'repeatable.model.config.defaultValue', not the descendant components");
+            await expectRejects(errorFunc, "Set the repeatable elementTemplate descendant component new item default using 'elementTemplate.model.config.newEntryValue', set the repeatable default in 'repeatable.model.config.defaultValue', not the descendant components");
         });
         it("should fail when component class is not available", async () => {
-            const errorFunc = function () {
+            const errorFunc = async function () {
                 const visitor = new ConstructFormConfigVisitor(logger);
 
-                visitor.start({
+                return await visitor.start({
                     data: {
                         name: "form",
                         componentDefinitions: [
@@ -792,13 +805,13 @@ describe("Construct Visitor", async () => {
                     }, formMode: "edit", reusableFormDefs: reusableFormDefinitionsExample2
                 });
             };
-            expect(errorFunc).to.throw(Error, "Could not find class for form component class name 'NotAClass'");
+            await expectRejects(errorFunc, "Could not find class for form component class name 'NotAClass'");
         });
         it("should fail when form component is invalid", async () => {
-            const errorFunc = function () {
+            const errorFunc = async function () {
                 const visitor = new ConstructFormConfigVisitor(logger);
 
-                visitor.start({
+                return await visitor.start({
                     data: {
                         name: "form",
                         componentDefinitions: [
@@ -820,13 +833,13 @@ describe("Construct Visitor", async () => {
                     }, formMode: "edit", reusableFormDefs: reusableFormDefinitionsExample2
                 });
             };
-            expect(errorFunc).to.throw(Error);
+            await expectRejects(errorFunc);
         });
         it("should fail when override has both reusable form name and other property", async () => {
-            const errorFunc = function () {
+            const errorFunc = async function () {
                 const visitor = new ConstructFormConfigVisitor(logger);
 
-                visitor.start({
+                return await visitor.start({
                     data: {
                         name: "form",
                         componentDefinitions: [
@@ -850,15 +863,15 @@ describe("Construct Visitor", async () => {
                     }, formMode: "edit", reusableFormDefs: reusableFormDefinitionsExample2
                 });
             };
-            expect(errorFunc).to.throw(Error, "Invalid usage of reusable form config. " +
+            await expectRejects(errorFunc, "Invalid usage of reusable form config. " +
                 "Override for component name '' class 'ReusableComponent' must contain only 'reusableFormName', " +
                 "it cannot be combined with other properties '{\"reusableFormName\":\"standard-contributor-field\",\"replaceName\":\"new_name\"}'");
         });
         it("should fail when override for reusable form is invalid", async () => {
-            const errorFunc1 = function () {
+            const errorFunc1 = async function () {
                 const visitor = new ConstructFormConfigVisitor(logger);
 
-                visitor.start({
+                return await visitor.start({
                     data: {
                         name: "form",
                         componentDefinitions: [
@@ -882,12 +895,12 @@ describe("Construct Visitor", async () => {
                     }, formMode: "edit", reusableFormDefs: reusableFormDefinitionsExample2
                 });
             };
-            expect(errorFunc1).to.throw(Error, "Invalid usage of reusable form config. Component class 'ReusableComponent' must be 'ReusableComponent' and reusableFormName");
+            await expectRejects(errorFunc1, "Invalid usage of reusable form config. Component class 'ReusableComponent' must be 'ReusableComponent' and reusableFormName");
 
-            const errorFunc2 = function () {
+            const errorFunc2 = async function () {
                 const visitor = new ConstructFormConfigVisitor(logger);
 
-                visitor.start({
+                return await visitor.start({
                     data: {
                         name: "form",
                         componentDefinitions: [
@@ -911,13 +924,13 @@ describe("Construct Visitor", async () => {
                     }, formMode: "edit", reusableFormDefs: reusableFormDefinitionsExample2
                 });
             };
-            expect(errorFunc2).to.throw(Error, "Invalid usage of reusable form config. Component class 'TextAreaComponent' must be 'ReusableComponent' and reusableFormName");
+            await expectRejects(errorFunc2, "Invalid usage of reusable form config. Component class 'TextAreaComponent' must be 'ReusableComponent' and reusableFormName");
         });
         it("should fail when override reusable form config tries to override a component that does not exist", async () => {
-            const errorFunc = function () {
+            const errorFunc = async function () {
                 const visitor = new ConstructFormConfigVisitor(logger);
 
-                visitor.start({
+                return await visitor.start({
                     data: {
                         name: "form",
                         componentDefinitions: [
@@ -943,15 +956,15 @@ describe("Construct Visitor", async () => {
                     }, formMode: "edit", reusableFormDefs: reusableFormDefinitionsExample2
                 });
             };
-            expect(errorFunc).to.throw(Error, "Invalid usage of reusable form config. " +
+            await expectRejects(errorFunc, "Invalid usage of reusable form config. " +
                 "Each item in the ReusableComponent componentDefinitions must have a name that matches an item in the reusable form config 'standard-contributor-field'. " +
                 "Names 'a_name' did not match any reusable form config items. Available names ");
         });
         it("should fail when override reusable form config override does not have unique names", async () => {
-            const errorFunc = function () {
+            const errorFunc = async function () {
                 const visitor = new ConstructFormConfigVisitor(logger);
 
-                visitor.start({
+                return await visitor.start({
                     data: {
                         name: "form",
                         componentDefinitions: [
@@ -985,15 +998,15 @@ describe("Construct Visitor", async () => {
                 });
             }
                 ;
-            expect(errorFunc).to.throw(Error, "Invalid usage of reusable form config. " +
+            await expectRejects(errorFunc, "Invalid usage of reusable form config. " +
                 "Each item in the ReusableComponent componentDefinitions must have a unique name. " +
                 "These names were not unique 'name'.");
         });
         it("should fail when reusable form config override tries to change the class name in the component definition", async () => {
-            const errorFunc = function () {
+            const errorFunc = async function () {
                 const visitor = new ConstructFormConfigVisitor(logger);
 
-                visitor.start({
+                return await visitor.start({
                     data: {
                         name: "form",
                         componentDefinitions: [
@@ -1019,7 +1032,7 @@ describe("Construct Visitor", async () => {
                     }, formMode: "edit", reusableFormDefs: reusableFormDefinitionsExample2
                 });
             };
-            expect(errorFunc).to.throw(Error, "Invalid usage of reusable form config. " +
+            await expectRejects(errorFunc, "Invalid usage of reusable form config. " +
                 "The class must match the reusable form config. " +
                 "To change the class, use 'formModeClasses'. " +
                 "The component class in reusable form config 'standard-contributor-field' item 'name' is 'SimpleInputComponent' given class was 'CheckboxInputComponent'");
@@ -1028,7 +1041,7 @@ describe("Construct Visitor", async () => {
     describe("model data special cases", async () => {
         it("should populate content component from record", async () => {
             const visitor = new ConstructFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 data: {
                     name: "form",
                     componentDefinitions: [
@@ -1070,7 +1083,7 @@ describe("Construct Visitor", async () => {
         });
         it("should populate transformed content component from record", async () => {
             const visitor = new ConstructFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 data: {
                     name: "form",
                     componentDefinitions: [
@@ -1163,7 +1176,7 @@ describe("Construct Visitor", async () => {
 
         it("should transform data location components to content in view mode", async function () {
             const visitor = new ConstructFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 data: {
                     name: "form",
                     componentDefinitions: [
@@ -1220,7 +1233,7 @@ describe("Construct Visitor", async () => {
 
         it("should preserve data location placeholder config in edit mode", async function () {
             const visitor = new ConstructFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 data: {
                     name: "form",
                     componentDefinitions: [
@@ -1252,7 +1265,7 @@ describe("Construct Visitor", async () => {
 
         it("should transform publish data location selector components to content in view mode", async function () {
             const visitor = new ConstructFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 data: {
                     name: "form",
                     componentDefinitions: [
@@ -1317,7 +1330,7 @@ describe("Construct Visitor", async () => {
 
         it("should populate transformed dropdown content component from record array values", async () => {
             const visitor = new ConstructFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 data: {
                     name: "form",
                     componentDefinitions: [
@@ -1362,7 +1375,7 @@ describe("Construct Visitor", async () => {
     describe("accordion transformations", async () => {
         it("should transform tab to accordion in view mode", async () => {
             const visitor = new ConstructFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 formMode: "view",
                 data: {
                     name: "form",
@@ -1400,7 +1413,7 @@ describe("Construct Visitor", async () => {
 
         it("should transform empty tabs to accordion with zero panels in view mode", async () => {
             const visitor = new ConstructFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 formMode: "view",
                 data: {
                     name: "form",
@@ -1424,7 +1437,7 @@ describe("Construct Visitor", async () => {
 
         it("should apply transformed panel label fallback chain", async () => {
             const visitor = new ConstructFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 formMode: "view",
                 data: {
                     name: "form",
@@ -1471,7 +1484,7 @@ describe("Construct Visitor", async () => {
                 warn: (message: unknown) => warnings.push(String(message ?? ""))
             };
             const visitor = new ConstructFormConfigVisitor(testLogger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 formMode: "view",
                 data: {
                     name: "form",
@@ -1500,7 +1513,7 @@ describe("Construct Visitor", async () => {
 
         it("should keep tab in edit mode", async () => {
             const visitor = new ConstructFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 formMode: "edit",
                 data: {
                     name: "form",
@@ -1522,7 +1535,7 @@ describe("Construct Visitor", async () => {
 
         it("should construct direct accordion with default startingOpenMode", async () => {
             const visitor = new ConstructFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 formMode: "view",
                 data: {
                     name: "form",
@@ -1562,7 +1575,7 @@ describe("Construct Visitor", async () => {
             };
 
             const visitor = new ConstructFormConfigVisitor(testLogger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 formMode: "edit",
                 data: {
                     name: "form",
@@ -1612,7 +1625,7 @@ describe("Construct Visitor", async () => {
                     }
                 ]
             };
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 formMode: "view",
                 reusableFormDefs,
                 data: {
@@ -1634,7 +1647,7 @@ describe("Construct Visitor", async () => {
 
         it("should keep repeatable and group components untransformed in view mode during construct phase", async () => {
             const visitor = new ConstructFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 formMode: "view",
                 data: {
                     name: "form",
@@ -1756,7 +1769,7 @@ describe("Construct Visitor", async () => {
 
         it("should set model values as expected", async () => {
             const visitor = new ConstructFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 formMode: "view",
                 reusableFormDefs: reusableFormDefinitions,
                 data: {
@@ -1877,7 +1890,7 @@ describe("Construct Visitor", async () => {
 
         it("should set group model value from record metadata for tab descendants", async () => {
             const visitor = new ConstructFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 formMode: "edit",
                 record: {
                     contributor_ci: {
@@ -1973,7 +1986,7 @@ describe("Construct Visitor", async () => {
 
         it("should set group model value from record metadata for reusable contributor group with title", async () => {
             const visitor = new ConstructFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 formMode: "edit",
                 record: {
                     contributor_ci: {
@@ -2076,7 +2089,7 @@ describe("Construct Visitor", async () => {
 
         it("should preserve expressions on reusable wrapper fields that expand to a single component", async () => {
             const visitor = new ConstructFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 formMode: "edit",
                 reusableFormDefs: {
                     "single-group": [

--- a/packages/redbox-core/test/unit/data-value.visitor.test.ts
+++ b/packages/redbox-core/test/unit/data-value.visitor.test.ts
@@ -229,24 +229,24 @@ describe("Data Value Visitor", async () => {
     cases.forEach(({title, args, expected}) => {
         it(`should ${title}`, async function () {
             const constructor = new ConstructFormConfigVisitor(logger);
-            const constructed = constructor.start({
+            const constructed = await constructor.start({
               data: args,
               formMode:"edit",
               reusableFormDefs: reusableFormDefinitions,
             });
 
             const visitor = new DataValueFormConfigVisitor(logger);
-            const actual = visitor.start({form: constructed});
+            const actual = await visitor.start({form: constructed});
             expect(actual).to.eql(expected);
 
             // Confirm that using an empty record gives empty data value result
             const constructorEmpty = new ConstructFormConfigVisitor(logger);
-            const constructedEmpty = constructorEmpty.start({
+            const constructedEmpty = await constructorEmpty.start({
               data: args, formMode:"edit", record: {}, reusableFormDefs: reusableFormDefinitions,
             });
 
             const visitorEmpty = new DataValueFormConfigVisitor(logger);
-            const actualEmpty = visitorEmpty.start({form: constructedEmpty});
+            const actualEmpty = await visitorEmpty.start({form: constructedEmpty});
             expect(actualEmpty).to.eql({});
 
         });

--- a/packages/redbox-core/test/unit/form-behaviour.visitor.test.ts
+++ b/packages/redbox-core/test/unit/form-behaviour.visitor.test.ts
@@ -61,19 +61,19 @@ describe('Form behaviour visitors', () => {
     ],
   } as FormConfigFrame & { behaviours: unknown[] };
 
-  it('construct visitor preserves behaviours on form config', () => {
+  it('construct visitor preserves behaviours on form config', async () => {
     const visitor = new ConstructFormConfigVisitor(logger);
-    const constructed = visitor.start({ data: formConfig, formMode: 'edit' });
+    const constructed = await visitor.start({ data: formConfig, formMode: 'edit' });
 
     expect((constructed as any).behaviours).to.deep.equal(formConfig.behaviours);
   });
 
-  it('template visitor extracts compiled behaviour templates', () => {
+  it('template visitor extracts compiled behaviour templates', async () => {
     const constructor = new ConstructFormConfigVisitor(logger);
-    const constructed = constructor.start({ data: formConfig, formMode: 'edit' });
+    const constructed = await constructor.start({ data: formConfig, formMode: 'edit' });
     const visitor = new TemplateFormConfigVisitor(logger);
 
-    const actual = visitor.start({ form: constructed });
+    const actual = await visitor.start({ form: constructed });
 
     expect(actual).to.deep.equal([
       {
@@ -104,12 +104,12 @@ describe('Form behaviour visitors', () => {
     ]);
   });
 
-  it('client visitor strips behaviour template source and sets flags', () => {
+  it('client visitor strips behaviour template source and sets flags', async () => {
     const constructor = new ConstructFormConfigVisitor(logger);
-    const constructed = constructor.start({ data: formConfig, formMode: 'edit' });
+    const constructed = await constructor.start({ data: formConfig, formMode: 'edit' });
     const visitor = new ClientFormConfigVisitor(logger);
 
-    const actual = visitor.start({ form: constructed });
+    const actual = await visitor.start({ form: constructed });
     const behaviour = (actual as any).behaviours?.[0];
     const processor = behaviour?.processors?.[0];
     const action = behaviour?.actions?.[0];

--- a/packages/redbox-core/test/unit/json-type-def.visitor.test.ts
+++ b/packages/redbox-core/test/unit/json-type-def.visitor.test.ts
@@ -348,12 +348,12 @@ describe("JSON Type Def Schema Visitor", async () => {
     cases.forEach(({title, args, expected}) => {
         it(`should ${title}`, async function () {
             const constructor = new ConstructFormConfigVisitor(logger);
-            const constructed = constructor.start({
+            const constructed = await constructor.start({
               data: args, formMode: "edit", reusableFormDefs: reusableFormDefinitions,
             });
 
             const visitor = new JsonTypeDefSchemaFormConfigVisitor(logger);
-            const actual = visitor.start({form: constructed});
+            const actual = await visitor.start({form: constructed});
             expect(actual).to.eql(expected);
         });
     });

--- a/packages/redbox-core/test/unit/migrate-config-v4-v5.visitor.test.ts
+++ b/packages/redbox-core/test/unit/migrate-config-v4-v5.visitor.test.ts
@@ -75,7 +75,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it("maps MarkdownTextArea to RichTextEditor with markdown output format", async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "rich-text-migration",
                 fields: [
@@ -103,7 +103,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it("normalizes legacy top-level form css classes to rb-form classes", async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "legacy-css-migration",
                 viewCssClasses: "row col-md-offset-1 col-md-10",
@@ -123,7 +123,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
             warn: (message: unknown) => warnings.push(String(message ?? ''))
         };
         const visitor = new MigrationV4ToV5FormConfigVisitor(testLogger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
           data: {
             name: 'checkbox-tree-edge',
             fields: [
@@ -161,7 +161,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it('omits boolean defaults for legacy toggle fields migrated to CheckboxInput', async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: 'legacy-toggle-migration',
                 fields: [
@@ -198,7 +198,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it('maps LinkValueComponent to ContentComponent with a legacy-compatible link template', async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: 'link-value-migration',
                 fields: [
@@ -245,7 +245,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it('defaults migrated LinkValueComponent link targets to _blank when the legacy definition omits target', async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: 'link-value-default-target-migration',
                 fields: [
@@ -274,7 +274,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it('maps HtmlRawComponent to ContentComponent', async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: 'html-raw-migration',
                 fields: [
@@ -305,7 +305,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
             warn: (message: unknown) => warnings.push(String(message ?? ''))
         };
         const visitor = new MigrationV4ToV5FormConfigVisitor(testLogger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "typeahead-edge",
                 fields: [
@@ -344,7 +344,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it('migrates static typeahead options and prefers legacy options over staticOptions', async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "typeahead-static-options",
                 fields: [
@@ -390,7 +390,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
             warn: (message: unknown) => warnings.push(String(message ?? ''))
         };
         const visitor = new MigrationV4ToV5FormConfigVisitor(testLogger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: 'parameter-retriever-migration',
                 fields: [
@@ -421,7 +421,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it('maps legacy RecordMetadataRetriever subscriptions into fetch expressions and downstream listeners', async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: 'record-metadata-retriever-migration',
                 fields: [
@@ -517,7 +517,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it('migrates legacy PDFList fields to PDFListComponent and survives visitor verification', async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: 'pdf-list-migration',
                 fields: [
@@ -566,7 +566,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it('maps legacy RecordMetadataRetriever request-param fetch expressions inside tab content containers', async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: 'record-metadata-retriever-tab-migration',
                 fields: [
@@ -727,7 +727,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it('omits the form-ready RecordMetadataRetriever fetch expression when parameter metadata is missing', async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: 'record-metadata-retriever-without-parameter',
                 fields: [
@@ -754,7 +754,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it('maps RepeatableVocabComponent to RepeatableComponent with Typeahead elementTemplate', async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "repeatable-vocab-edge",
                 fields: [
@@ -804,7 +804,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it('maps legacy external VocabField to external TypeaheadInput config', async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "typeahead-external",
                 fields: [
@@ -837,7 +837,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it('maps RepeatableContributor layout label from definition name when label is missing on both parent and child', async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "repeatable-contributor-label-fallback",
                 fields: [
@@ -871,7 +871,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it('maps RepeatableContributor layout label from inner field label when parent label is missing', async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "repeatable-contributor-label-inner-fallback",
                 fields: [
@@ -906,7 +906,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it('maps legacy ContributorField with forceLookupOnly to the lookup-only reusable definition', async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "contributor-force-lookup-only",
                 fields: [
@@ -960,7 +960,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it("maps legacy MapField to MapComponent and normalizes config/value", async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "map-migration",
                 fields: [
@@ -1005,7 +1005,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it("migrates ButtonBarContainer as expected", async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "button-bar-migration",
                 fields: [
@@ -1059,7 +1059,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it("migrates SaveButton targetStep into the v5 component config", async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "save-button-target-step-migration",
                 fields: [
@@ -1082,7 +1082,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it("maps AnchorOrButton links to ContentComponent anchor links with InlineLayout", async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "anchor-or-button-migration",
                 fields: [
@@ -1123,7 +1123,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it("maps legacy delete button redirectLocation tokens to a Handlebars template", async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "delete-button-migration",
                 fields: [
@@ -1151,7 +1151,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it("maps legacy form-inline groups to ActionRowLayout with InlineLayout children", async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "inline-group-migration",
                 fields: [
@@ -1199,7 +1199,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it("uses Handlebars translation helper for migrated TextBlock translation keys", async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "text-block-translation-key",
                 fields: [
@@ -1224,7 +1224,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it("uses heading wrapper from TextBlock type for heading content", async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "text-block-heading-type",
                 fields: [
@@ -1250,7 +1250,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it("binds TextBlock heading content from formData when value is missing and definition.name is present", async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "text-block-heading-name-binding",
                 fields: [
@@ -1289,7 +1289,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it("maps view-only markdown text areas to ContentComponent in view overrides", async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "markdown-view-only",
                 fields: [
@@ -1314,7 +1314,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it("keeps plain text TextBlock values as non-translated content templates", async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "text-block-plain-text",
                 fields: [
@@ -1339,7 +1339,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it("promotes legacy TextBlock span label/help blocks into layout label config", async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "text-block-span-label-help",
                 fields: [
@@ -1370,7 +1370,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it("populates attachmentFields from FileUpload components", async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "attachment-fields-migration",
                 fields: [
@@ -1407,7 +1407,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it("maps legacy DataLocation to DataLocationComponent with config fields", async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "data-location-migration",
                 fields: [
@@ -1457,7 +1457,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it("maps legacy PublishDataLocationSelector to the v5 selector component", async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "publish-data-location-selector-migration",
                 fields: [
@@ -1531,7 +1531,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it("uses the enclosing container path for migrated publish data location selector expressions", async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "publish-data-location-selector-nested-migration",
                 fields: [
@@ -1590,7 +1590,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
 
     it("resolves cross-tab publish data location selector sources to their real component path", async function () {
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "publish-data-location-selector-cross-tab-migration",
                 fields: [
@@ -1674,7 +1674,7 @@ describe("Migrate v4 to v5 Visitor", async () => {
         // The migrated output must keep the button semantics without carrying
         // forward the old imperative-fetch implementation details.
         const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = visitor.start({
+        const migrated = await visitor.start({
             data: {
                 name: "publish-data-location-refresh-migration",
                 fields: [

--- a/packages/redbox-core/test/unit/template.visitor.test.ts
+++ b/packages/redbox-core/test/unit/template.visitor.test.ts
@@ -5,9 +5,9 @@ import {
 import { ConstructFormConfigVisitor } from "../../src/visitor/construct.visitor";
 import { TemplateFormConfigVisitor } from "../../src/visitor/template.visitor";
 
-import {formConfigExample1} from "./example-data";
+import { formConfigExample1 } from "./example-data";
 import { logger } from "./helpers";
-import {reusableFormDefinitions} from "../../src";
+import { reusableFormDefinitions } from "../../src";
 
 let expect: Chai.ExpectStatic;
 import("chai").then(mod => expect = mod.expect);
@@ -18,176 +18,223 @@ describe("Template Visitor", async () => {
         args: FormConfigFrame;
         expected: TemplateCompileInput[];
     }[] = [
-        {
-            title: "create empty item",
-            args: { name: "", componentDefinitions: [] },
-            expected: []
-        },
-        {
-            title: "create full example",
-            args: formConfigExample1,
-            expected: [
-                {
-                    key: ["componentDefinitions", "0", "component", "config", "tabs", "0", "component", "config", "componentDefinitions", "0", "component", "config", "template"],
-                    kind: "handlebars",
-                    value: '<h3>{{content}}</h3>',
-                },
-                {
-                    key: ["componentDefinitions", "0", "component", "config", "tabs", "0", "component", "config", "componentDefinitions", "10", "expressions", "0", "config", "template"],
-                    kind: "jsonata",
-                    value: `value & "__suffix"`,
-                },
-                {
-                    key: ["componentDefinitions", "0", "component", "config", "tabs", "0", "component", "config", "componentDefinitions", "12", "expressions", "0", "config", "template"],
-                    kind: "jsonata",
-                    value: `value = "hide text_2_component_event"`,
-                },
-                {
-                    key: ["componentDefinitions", "0", "component", "config", "tabs", "0", "component", "config", "componentDefinitions", "14", "expressions", "0", "config", "template"],
-                    kind: "jsonata",
-                    value: `value = "hide text_3_layout_event"`,
-                },
-                {
-                    key: ["componentDefinitions", "0", "component", "config", "tabs", "1", "component", "config", "componentDefinitions", "0", "expressions", "0", "config", "template"],
-                    kind: "jsonata",
-                    value: `value = "hide group_1_component"`,
-                },
-                {
-                    key: ["componentDefinitions", "0", "component", "config", "tabs", "1", "component", "config", "componentDefinitions", "1", "expressions", "0", "config", "template"],
-                    kind: "jsonata",
-                    value: `value = "hide repeatable_textfield_1"`,
-                },
-                {
-                  // layout.visible
-                    key: ["componentDefinitions", "0", "component", "config", "tabs", "1", "component", "config", "componentDefinitions","2", "component", "config", "componentDefinitions", "1", "expressions", "0", "config", "template"],
-                    kind: "jsonata",
-                    value: '$count(formData.`questiontree_1`.`question_1`[][$ in ["no"]]) > 0',
-                },
-                {
-                  // component.visible
-                    key: ["componentDefinitions", "0", "component", "config", "tabs", "1", "component", "config", "componentDefinitions","2", "component", "config", "componentDefinitions", "1", "expressions", "1", "config", "template"],
-                    kind: "jsonata",
-                    value: '$count(formData.`questiontree_1`.`question_1`[][$ in ["no"]]) > 0',
-                },
-                {
-                  key: ["componentDefinitions", "0", "component", "config", "tabs", "1", "component", "config", "componentDefinitions", "2", "component", "config", "componentDefinitions", "1", "expressions", "2", "config", "template",],
-                  kind: "jsonata",
-                  value: "($count(formData.`questiontree_1`.`question_1`[][$ in [\"no\"]]) > 0 ? formData.`questiontree_1`.`question_2` : null)",
-                },
-            ]
-        },
-        {
-            title: "extract checkbox tree label template",
-            args: {
-                name: "test",
-                componentDefinitions: [
+            {
+                title: "create empty item",
+                args: { name: "", componentDefinitions: [] },
+                expected: []
+            },
+            {
+                title: "create full example",
+                args: formConfigExample1,
+                expected: [
                     {
-                        name: "anzsrc",
-                        component: {
-                            class: "CheckboxTreeComponent",
-                            config: {
-                                labelTemplate: "{{notation}} - {{label}}"
-                            }
-                        },
-                        model: { class: "CheckboxTreeModel", config: {} }
-                    }
+                        key: ["componentDefinitions", "0", "component", "config", "tabs", "0", "component", "config", "componentDefinitions", "0", "component", "config", "template"],
+                        kind: "handlebars",
+                        value: '<h3>{{content}}</h3>',
+                    },
+                    {
+                        key: ["componentDefinitions", "0", "component", "config", "tabs", "0", "component", "config", "componentDefinitions", "10", "expressions", "0", "config", "template"],
+                        kind: "jsonata",
+                        value: `value & "__suffix"`,
+                    },
+                    {
+                        key: ["componentDefinitions", "0", "component", "config", "tabs", "0", "component", "config", "componentDefinitions", "12", "expressions", "0", "config", "template"],
+                        kind: "jsonata",
+                        value: `value = "hide text_2_component_event"`,
+                    },
+                    {
+                        key: ["componentDefinitions", "0", "component", "config", "tabs", "0", "component", "config", "componentDefinitions", "14", "expressions", "0", "config", "template"],
+                        kind: "jsonata",
+                        value: `value = "hide text_3_layout_event"`,
+                    },
+                    {
+                        key: ["componentDefinitions", "0", "component", "config", "tabs", "1", "component", "config", "componentDefinitions", "0", "expressions", "0", "config", "template"],
+                        kind: "jsonata",
+                        value: `value = "hide group_1_component"`,
+                    },
+                    {
+                        key: ["componentDefinitions", "0", "component", "config", "tabs", "1", "component", "config", "componentDefinitions", "1", "expressions", "0", "config", "template"],
+                        kind: "jsonata",
+                        value: `value = "hide repeatable_textfield_1"`,
+                    },
+                    {
+                        // layout.visible
+                        key: ["componentDefinitions", "0", "component", "config", "tabs", "1", "component", "config", "componentDefinitions", "2", "component", "config", "componentDefinitions", "1", "expressions", "0", "config", "template"],
+                        kind: "jsonata",
+                        value: '$count(formData.`questiontree_1`.`question_1`[][$ in ["no"]]) > 0',
+                    },
+                    {
+                        // component.visible
+                        key: ["componentDefinitions", "0", "component", "config", "tabs", "1", "component", "config", "componentDefinitions", "2", "component", "config", "componentDefinitions", "1", "expressions", "1", "config", "template"],
+                        kind: "jsonata",
+                        value: '$count(formData.`questiontree_1`.`question_1`[][$ in ["no"]]) > 0',
+                    },
+                    {
+                        key: ["componentDefinitions", "0", "component", "config", "tabs", "1", "component", "config", "componentDefinitions", "2", "component", "config", "componentDefinitions", "1", "expressions", "2", "config", "template",],
+                        kind: "jsonata",
+                        value: "($count(formData.`questiontree_1`.`question_1`[][$ in [\"no\"]]) > 0 ? formData.`questiontree_1`.`question_2` : null)",
+                    },
                 ]
             },
-            expected: [
-                {
-                    key: ["componentDefinitions", "0", "component", "config", "labelTemplate"],
-                    kind: "handlebars",
-                    value: "{{notation}} - {{label}}"
-                }
-            ]
-        },
-        {
-            title: "extract typeahead label template",
-            args: {
-                name: "test",
-                componentDefinitions: [
-                    {
-                        name: "person_lookup",
-                        component: {
-                            class: "TypeaheadInputComponent",
-                            config: {
-                                sourceType: "namedQuery",
-                                queryId: "people",
-                                labelTemplate: "{{raw.title}} ({{raw.code}})"
-                            }
-                        },
-                        model: { class: "TypeaheadInputModel", config: {} }
-                    }
-                ]
-            },
-            expected: [
-                {
-                    key: ["componentDefinitions", "0", "component", "config", "labelTemplate"],
-                    kind: "handlebars",
-                    value: "{{raw.title}} ({{raw.code}})"
-                }
-            ]
-        },
-        {
-            title: "allow data location components without additional template extraction",
-            args: {
-                name: "test",
-                componentDefinitions: [
-                    {
-                        name: "dataLocations",
-                        component: {
-                            class: "DataLocationComponent",
-                            config: {
-                                label: "Data locations",
-                                dataTypes: [
-                                    { value: "url", label: "URL" }
-                                ]
-                            }
-                        },
-                        model: {
-                            class: "DataLocationModel",
-                            config: {}
+            {
+                title: "extract checkbox tree label template",
+                args: {
+                    name: "test",
+                    componentDefinitions: [
+                        {
+                            name: "anzsrc",
+                            component: {
+                                class: "CheckboxTreeComponent",
+                                config: {
+                                    labelTemplate: "{{notation}} - {{label}}"
+                                }
+                            },
+                            model: { class: "CheckboxTreeModel", config: {} }
                         }
+                    ]
+                },
+                expected: [
+                    {
+                        key: ["componentDefinitions", "0", "component", "config", "labelTemplate"],
+                        kind: "handlebars",
+                        value: "{{notation}} - {{label}}"
                     }
                 ]
             },
-            expected: []
-        },
-        {
-            title: "extract delete button redirectLocation template",
-            args: {
-                name: "test",
-                componentDefinitions: [
+            {
+                title: "extract typeahead label template",
+                args: {
+                    name: "test",
+                    componentDefinitions: [
+                        {
+                            name: "person_lookup",
+                            component: {
+                                class: "TypeaheadInputComponent",
+                                config: {
+                                    sourceType: "namedQuery",
+                                    queryId: "people",
+                                    labelTemplate: "{{raw.title}} ({{raw.code}})"
+                                }
+                            },
+                            model: { class: "TypeaheadInputModel", config: {} }
+                        }
+                    ]
+                },
+                expected: [
                     {
-                        name: "delete_button",
-                        component: {
-                            class: "DeleteButtonComponent",
-                            config: {
-                                redirectLocation: '{{concat "/" branding "/" portal "/dashboard/" oid}}'
+                        key: ["componentDefinitions", "0", "component", "config", "labelTemplate"],
+                        kind: "handlebars",
+                        value: "{{raw.title}} ({{raw.code}})"
+                    }
+                ]
+            },
+            {
+                title: "allow data location components without additional template extraction",
+                args: {
+                    name: "test",
+                    componentDefinitions: [
+                        {
+                            name: "dataLocations",
+                            component: {
+                                class: "DataLocationComponent",
+                                config: {
+                                    label: "Data locations",
+                                    dataTypes: [
+                                        { value: "url", label: "URL" }
+                                    ]
+                                }
+                            },
+                            model: {
+                                class: "DataLocationModel",
+                                config: {}
                             }
                         }
+                    ]
+                },
+                expected: []
+            },
+            {
+                title: "extract delete button redirectLocation template",
+                args: {
+                    name: "test",
+                    componentDefinitions: [
+                        {
+                            name: "delete_button",
+                            component: {
+                                class: "DeleteButtonComponent",
+                                config: {
+                                    redirectLocation: '{{concat "/" branding "/" portal "/dashboard/" oid}}'
+                                }
+                            }
+                        }
+                    ]
+                },
+                expected: [
+                    {
+                        key: ["componentDefinitions", "0", "component", "config", "redirectLocation"],
+                        kind: "handlebars",
+                        value: '{{concat "/" branding "/" portal "/dashboard/" oid}}'
                     }
                 ]
             },
-            expected: [
-                {
-                    key: ["componentDefinitions", "0", "component", "config", "redirectLocation"],
-                    kind: "handlebars",
-                    value: '{{concat "/" branding "/" portal "/dashboard/" oid}}'
-                }
-            ]
-        }
-    ];
+            {
+                title: "extract jsonata validator expression keys for form and component validators",
+                args: {
+                    name: "test",
+                    validators: [
+                        {
+                            class: "jsonata-expression",
+                            config: {
+                                expression: "$count(formData) > 0"
+                            }
+                        }
+                    ],
+                    componentDefinitions: [
+                        {
+                            name: "text_1",
+                            model: {
+                                class: "SimpleInputModel",
+                                config: {
+                                    validators: [
+                                        {
+                                            class: "jsonata-expression",
+                                            config: {
+                                                expression: "$ = \"ok\""
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            component: {
+                                class: "SimpleInputComponent"
+                            }
+                        }
+                    ]
+                },
+                expected: [
+                    {
+                        key: ["validators", "0", "config", "expression"],
+                        kind: "jsonata",
+                        value: "$count(formData) > 0"
+                    },
+                    {
+                        key: ["componentDefinitions", "0", "model", "config", "validators", "0", "config", "expression"],
+                        kind: "jsonata",
+                        value: "$ = \"ok\""
+                    }
+                ]
+            }
+        ];
 
     cases.forEach(({ title, args, expected }) => {
         it(`should ${title}`, async function () {
             const constructor = new ConstructFormConfigVisitor(logger);
-            const constructed = constructor.start({
-              data: args, formMode: "edit", reusableFormDefs: reusableFormDefinitions,
+            const constructed = await constructor.start({
+                data: args, formMode: "edit", reusableFormDefs: reusableFormDefinitions,
             });
 
             const visitor = new TemplateFormConfigVisitor(logger);
-            const actual = visitor.start({ form: constructed });
+            const actual = await visitor.start({ form: constructed });
 
             expect(actual).to.eql(expected);
         });

--- a/packages/redbox-core/test/unit/validator.visitor.test.ts
+++ b/packages/redbox-core/test/unit/validator.visitor.test.ts
@@ -102,10 +102,10 @@ describe("Validator Visitor", async () => {
         ];
 
         const constructor = new ConstructFormConfigVisitor(logger);
-        const constructed = constructor.start({ data: formConfig, formMode: "edit" });
+        const constructed = await constructor.start({ data: formConfig, formMode: "edit" });
 
         const visitor = new ValidatorFormConfigVisitor(logger);
-        const actual = visitor.start({
+        const actual = await visitor.start({
             form: constructed,
             enabledValidationGroups: ["minimumCreate", "minimumUpdate"],
             validatorDefinitions: formValidatorsSharedDefinitions
@@ -197,10 +197,10 @@ describe("Validator Visitor", async () => {
         ];
 
         const constructor = new ConstructFormConfigVisitor(logger);
-        const constructed = constructor.start({ data: formConfig, formMode: "edit" });
+        const constructed = await constructor.start({ data: formConfig, formMode: "edit" });
 
         const visitor = new ValidatorFormConfigVisitor(logger);
-        const actual = visitor.start({
+        const actual = await visitor.start({
             form: constructed,
             enabledValidationGroups: ["transitionDraftToSubmitted"],
             validatorDefinitions: formValidatorsSharedDefinitions
@@ -275,10 +275,10 @@ describe("Validator Visitor", async () => {
         ];
 
         const constructor = new ConstructFormConfigVisitor(logger);
-        const constructed = constructor.start({ data: formConfig, formMode: "edit", record });
+        const constructed = await constructor.start({ data: formConfig, formMode: "edit", record });
 
         const visitor = new ValidatorFormConfigVisitor(logger);
-        const actual = visitor.start({
+        const actual = await visitor.start({
             form: constructed,
             enabledValidationGroups: ["all"],
             validatorDefinitions: formValidatorsSharedDefinitions,
@@ -437,12 +437,12 @@ describe("Validator Visitor", async () => {
         ];
 
         const constructor = new ConstructFormConfigVisitor(logger);
-        const constructed = constructor.start({
+        const constructed = await constructor.start({
           data: args, formMode: "edit", record, reusableFormDefs: reusableFormDefinitions
         });
 
         const visitor = new ValidatorFormConfigVisitor(logger);
-        const actual = visitor.start({
+        const actual = await visitor.start({
             form: constructed,
             enabledValidationGroups: ["all"],
             validatorDefinitions: formValidatorsSharedDefinitions,
@@ -452,7 +452,7 @@ describe("Validator Visitor", async () => {
 
     it("should report typeahead configuration errors for unsupported/invalid config", async function () {
         const constructor = new ConstructFormConfigVisitor(logger);
-        const constructed = constructor.start({
+        const constructed = await constructor.start({
             data: {
                 name: "typeahead-validator",
                 componentDefinitions: [
@@ -474,7 +474,7 @@ describe("Validator Visitor", async () => {
         });
 
         const visitor = new ValidatorFormConfigVisitor(logger);
-        const actual = visitor.start({
+        const actual = await visitor.start({
             form: constructed,
             enabledValidationGroups: ["all"],
             validatorDefinitions: formValidatorsSharedDefinitions
@@ -486,7 +486,7 @@ describe("Validator Visitor", async () => {
 
     it("should report external typeahead provider requirement", async function () {
         const constructor = new ConstructFormConfigVisitor(logger);
-        const constructed = constructor.start({
+        const constructed = await constructor.start({
             data: {
                 name: "typeahead-external-validator",
                 componentDefinitions: [
@@ -507,7 +507,7 @@ describe("Validator Visitor", async () => {
         });
 
         const visitor = new ValidatorFormConfigVisitor(logger);
-        const actual = visitor.start({
+        const actual = await visitor.start({
             form: constructed,
             enabledValidationGroups: ["all"],
             validatorDefinitions: formValidatorsSharedDefinitions
@@ -518,7 +518,7 @@ describe("Validator Visitor", async () => {
 
     it("should report service typeahead serviceId requirement", async function () {
         const constructor = new ConstructFormConfigVisitor(logger);
-        const constructed = constructor.start({
+        const constructed = await constructor.start({
             data: {
                 name: "typeahead-service-validator",
                 componentDefinitions: [
@@ -539,7 +539,7 @@ describe("Validator Visitor", async () => {
         });
 
         const visitor = new ValidatorFormConfigVisitor(logger);
-        const actual = visitor.start({
+        const actual = await visitor.start({
             form: constructed,
             enabledValidationGroups: ["all"],
             validatorDefinitions: formValidatorsSharedDefinitions
@@ -590,7 +590,7 @@ describe("Validator Visitor", async () => {
             const constructor = new ConstructFormConfigVisitor(logger);
             let constructed;
             try {
-                constructed = constructor.start({
+                constructed = await constructor.start({
                   data: formConfig, formMode: "edit",
                   reusableFormDefs: reusableFormDefinitions,
                 });
@@ -605,7 +605,7 @@ describe("Validator Visitor", async () => {
             (globalThis as any).sails = (global as any).sails;
 
             const visitor = new ValidatorFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 form: constructed,
                 enabledValidationGroups: ["all"],
                 validatorDefinitions: formValidatorsSharedDefinitions
@@ -637,7 +637,7 @@ describe("Validator Visitor", async () => {
             };
 
             const constructor = new ConstructFormConfigVisitor(logger);
-            const constructed = constructor.start({
+            const constructed = await constructor.start({
               data: formConfig, formMode: "edit",
               reusableFormDefs: reusableFormDefinitions,
             });
@@ -647,7 +647,7 @@ describe("Validator Visitor", async () => {
             (globalThis as any).sails = (global as any).sails;
 
             const visitor = new ValidatorFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 form: constructed,
                 enabledValidationGroups: ["all"],
                 validatorDefinitions: formValidatorsSharedDefinitions
@@ -678,7 +678,7 @@ describe("Validator Visitor", async () => {
             };
 
             const constructor = new ConstructFormConfigVisitor(logger);
-            const constructed = constructor.start({
+            const constructed = await constructor.start({
               data: formConfig, formMode: "edit",
               reusableFormDefs: reusableFormDefinitions,
             });
@@ -687,7 +687,7 @@ describe("Validator Visitor", async () => {
             (globalThis as any).sails = (global as any).sails;
 
             const visitor = new ValidatorFormConfigVisitor(logger);
-            const actual = visitor.start({
+            const actual = await visitor.start({
                 form: constructed,
                 enabledValidationGroups: ["all"],
                 validatorDefinitions: formValidatorsSharedDefinitions
@@ -747,7 +747,7 @@ describe("Validator Visitor", async () => {
           errors: [
             {
               message: "@validator-error-jsonata-expression",
-              class: "jsonata-expressions",
+              class: "jsonata-expression",
               params: {
                 actual: "hello world 2!",
                 description: "the description",
@@ -777,10 +777,10 @@ describe("Validator Visitor", async () => {
       ];
 
       const constructor = new ConstructFormConfigVisitor(logger);
-      const constructed = constructor.start({ data: formConfig, formMode: "edit" });
+      const constructed = await constructor.start({ data: formConfig, formMode: "edit" });
 
       const visitor = new ValidatorFormConfigVisitor(logger);
-      const actual = visitor.start({
+      const actual = await visitor.start({
         form: constructed,
         enabledValidationGroups: ["all"],
         validatorDefinitions: formValidatorsSharedDefinitions

--- a/packages/redbox-core/test/visitor/context-variables.visitor.test.ts
+++ b/packages/redbox-core/test/visitor/context-variables.visitor.test.ts
@@ -21,7 +21,7 @@ describe('ContextVariablesFormConfigVisitor', () => {
     blank: () => undefined,
   };
 
-  it('replaces tokens only in scoped fields and supports overlapping keys', () => {
+  it('replaces tokens only in scoped fields and supports overlapping keys', async () => {
     const input: FormConfigFrame = {
       name: 'test',
       expressions: [{
@@ -106,7 +106,7 @@ describe('ContextVariablesFormConfigVisitor', () => {
     };
 
     const constructor = new ConstructFormConfigVisitor(logger as any);
-    const constructed = constructor.start({ data: input, formMode: 'edit' });
+    const constructed = await constructor.start({ data: input, formMode: 'edit' });
 
     const visitor = new ContextVariablesFormConfigVisitor(logger);
     visitor.applyContextVariables(constructed, { '@user': 'U', '@user_name': 'User Name', '@user_email': 'user@example.com' });

--- a/packages/redbox-core/test/visitor/context-variables.visitor.test.ts
+++ b/packages/redbox-core/test/visitor/context-variables.visitor.test.ts
@@ -109,7 +109,7 @@ describe('ContextVariablesFormConfigVisitor', () => {
     const constructed = await constructor.start({ data: input, formMode: 'edit' });
 
     const visitor = new ContextVariablesFormConfigVisitor(logger);
-    visitor.applyContextVariables(constructed, { '@user': 'U', '@user_name': 'User Name', '@user_email': 'user@example.com' });
+    await visitor.applyContextVariables(constructed, { '@user': 'U', '@user_name': 'User Name', '@user_email': 'user@example.com' });
 
     const content = constructed.componentDefinitions?.[0]?.component?.config as { content?: string };
     const inputComponent = constructed.componentDefinitions?.[1] as {

--- a/packages/redbox-core/test/visitor/vocab-inline.visitor.test.ts
+++ b/packages/redbox-core/test/visitor/vocab-inline.visitor.test.ts
@@ -59,7 +59,7 @@ describe('VocabInlineFormConfigVisitor', () => {
         };
 
         const constructor = new ConstructFormConfigVisitor(logger as any);
-        const constructed = constructor.start({ data: input, formMode: 'edit' });
+        const constructed = await constructor.start({ data: input, formMode: 'edit' });
 
         const visitor = new VocabInlineFormConfigVisitor(logger);
         await visitor.resolveVocabs(constructed);
@@ -92,7 +92,7 @@ describe('VocabInlineFormConfigVisitor', () => {
         };
 
         const constructor = new ConstructFormConfigVisitor(logger as any);
-        const constructed = constructor.start({ data: input, formMode: 'edit' });
+        const constructed = await constructor.start({ data: input, formMode: 'edit' });
 
         const visitor = new VocabInlineFormConfigVisitor(logger);
         await visitor.resolveVocabs(constructed);
@@ -132,7 +132,7 @@ describe('VocabInlineFormConfigVisitor', () => {
         };
 
         const constructor = new ConstructFormConfigVisitor(logger as any);
-        const constructed = constructor.start({ data: input, formMode: 'edit' });
+        const constructed = await constructor.start({ data: input, formMode: 'edit' });
 
         const visitor = new VocabInlineFormConfigVisitor(logger);
         await visitor.resolveVocabs(constructed);
@@ -184,7 +184,7 @@ describe('VocabInlineFormConfigVisitor', () => {
         };
 
         const constructor = new ConstructFormConfigVisitor(logger as any);
-        const constructed = constructor.start({ data: input, formMode: 'edit', record: { access_type: 'legacy' } });
+        const constructed = await constructor.start({ data: input, formMode: 'edit', record: { access_type: 'legacy' } });
 
         const visitor = new VocabInlineFormConfigVisitor(logger);
         await visitor.resolveVocabs(constructed, 'default', { includeHistoricalValues: true });
@@ -228,7 +228,7 @@ describe('VocabInlineFormConfigVisitor', () => {
         };
 
         const constructor = new ConstructFormConfigVisitor(logger as any);
-        const constructed = constructor.start({ data: input, formMode: 'edit', record: { access_type: 'legacy' } });
+        const constructed = await constructor.start({ data: input, formMode: 'edit', record: { access_type: 'legacy' } });
 
         const visitor = new VocabInlineFormConfigVisitor(logger);
         await visitor.resolveVocabs(constructed, 'default', { includeHistoricalValues: true });
@@ -269,7 +269,7 @@ describe('VocabInlineFormConfigVisitor', () => {
         };
 
         const constructor = new ConstructFormConfigVisitor(logger as any);
-        const constructed = constructor.start({ data: input, formMode: 'edit', record: { access_type: 'open' } });
+        const constructed = await constructor.start({ data: input, formMode: 'edit', record: { access_type: 'open' } });
 
         const visitor = new VocabInlineFormConfigVisitor(logger);
         await visitor.resolveVocabs(constructed, 'default', { includeHistoricalValues: true });
@@ -311,7 +311,7 @@ describe('VocabInlineFormConfigVisitor', () => {
         };
 
         const constructor = new ConstructFormConfigVisitor(logger as any);
-        const constructed = constructor.start({ data: input, formMode: 'edit', record: { status: ['active', 'old-b'] } });
+        const constructed = await constructor.start({ data: input, formMode: 'edit', record: { status: ['active', 'old-b'] } });
 
         const visitor = new VocabInlineFormConfigVisitor(logger);
         await visitor.resolveVocabs(constructed, 'default', { includeHistoricalValues: true });
@@ -353,7 +353,7 @@ describe('VocabInlineFormConfigVisitor', () => {
         };
 
         const constructor = new ConstructFormConfigVisitor(logger as any);
-        const constructed = constructor.start({ data: input, formMode: 'edit' });
+        const constructed = await constructor.start({ data: input, formMode: 'edit' });
 
         const visitor = new VocabInlineFormConfigVisitor(logger);
         await visitor.resolveVocabs(constructed, 'default');
@@ -396,7 +396,7 @@ describe('VocabInlineFormConfigVisitor', () => {
         };
 
         const constructor = new ConstructFormConfigVisitor(logger as any);
-        const constructed = constructor.start({ data: input, formMode: 'edit' });
+        const constructed = await constructor.start({ data: input, formMode: 'edit' });
 
         const visitor = new VocabInlineFormConfigVisitor(logger);
         let thrown: unknown = null;
@@ -447,7 +447,7 @@ describe('VocabInlineFormConfigVisitor', () => {
         };
 
         const constructor = new ConstructFormConfigVisitor(logger as any);
-        const constructed = constructor.start({ data: input, formMode: 'edit' });
+        const constructed = await constructor.start({ data: input, formMode: 'edit' });
 
         const visitor = new VocabInlineFormConfigVisitor(logger);
         await visitor.resolveVocabs(constructed, 'default');
@@ -490,7 +490,7 @@ describe('VocabInlineFormConfigVisitor', () => {
         };
 
         const constructor = new ConstructFormConfigVisitor(logger as any);
-        const constructed = constructor.start({ data: input, formMode: 'edit' });
+        const constructed = await constructor.start({ data: input, formMode: 'edit' });
 
         const visitor = new VocabInlineFormConfigVisitor(logger);
         await visitor.resolveVocabs(constructed, 'default');
@@ -531,7 +531,7 @@ describe('VocabInlineFormConfigVisitor', () => {
         };
 
         const constructor = new ConstructFormConfigVisitor(logger as any);
-        const constructed = constructor.start({
+        const constructed = await constructor.start({
             data: input,
             formMode: 'edit',
             record: {

--- a/packages/sails-ng-common/src/jsonata-helpers.ts
+++ b/packages/sails-ng-common/src/jsonata-helpers.ts
@@ -8,7 +8,7 @@ export type JSONataEvaluate = (context: unknown) => Promise<unknown>;
 /**
  * A function that registers a custom JSONata function.
  */
-export type JSONataRegisterFunction = (name: string, implementation: (this: jsonata.Focus, ...args: any[]) => any, signature?: string) => void;
+export type JSONataRegisterFunction = (name: string, implementation: (this: jsonata.Focus, ...args: unknown[]) => unknown, signature?: string) => void;
 
 export const jsonataLibrary = {jsonata: jsonata};
 
@@ -24,8 +24,7 @@ export const jsonataLibrary = {jsonata: jsonata};
 export function jsonataCompile(expression: string, options?: jsonata.JsonataOptions): jsonata.Expression {
   const compiled = jsonata(expression, options);
 
-  // override the built-in JSONata 'eval' function
-  // TODO: check this actually overrides the 'eval' function
+  // Disable JSONata's dynamic eval function so browser/server validators only run the configured expression.
   compiled.registerFunction("eval", () => undefined);
 
   // TODO: register helper functions
@@ -48,11 +47,9 @@ export async function jsonataCompileAndEvaluate(expression: string, context: unk
   return await jsonataEvaluate(compiled, context, bindings);
 }
 
-export async function jsonataEvaluateFunc(expression: string, bindings?: Record<string, unknown>): Promise<JSONataEvaluate> {
+export function jsonataEvaluateFunc(expression: string, bindings?: Record<string, unknown>): JSONataEvaluate {
   const compiled = jsonataCompile(expression);
   return async function (value: unknown) {
     return await jsonataEvaluate(compiled, value, bindings);
   }
 }
-
-

--- a/packages/sails-ng-common/src/validation/validators-support.ts
+++ b/packages/sails-ng-common/src/validation/validators-support.ts
@@ -4,78 +4,80 @@ import {
   FormValidatorDefinition, FormValidatorErrors,
   FormValidatorFns
 } from "./form.model";
-import {isTypeFormValidatorDefinition} from "../config/form-types.model";
+import { isTypeFormValidatorDefinition } from "../config/form-types.model";
 
 
 export class ValidatorsSupport {
-    /**
-     * Create validator definition mapping from the validator definitions.
-     * @param definition The form validator definitions.
-     */
-    public createValidatorDefinitionMapping(
-        definition: FormValidatorDefinition[] | null | undefined
-    ): Map<string, FormValidatorDefinition> {
-        const defMap = new Map<string, FormValidatorDefinition>();
-        for (const definitionItem of (definition ?? [])) {
-            if (!isTypeFormValidatorDefinition(definitionItem)) {
-                throw new Error(`Validator definition does not have valid 'class', 'message', and 'create' properties: ${JSON.stringify(definitionItem)}`);
-            }
-            const validatorClass = definitionItem?.class;
-            const message = definitionItem?.message;
-            if (defMap.has(validatorClass)) {
-                const messages = [message, defMap.get(validatorClass)?.message];
-                throw new Error(`Duplicate validator class '${validatorClass}' - the validator classes must be unique. `
-                    + `To help you find the duplicates, these are the messages of the duplicates: '${messages.join(", ")}'.`);
-            }
-            defMap.set(validatorClass, definitionItem);
-        }
-        return defMap;
+  /**
+   * Create validator definition mapping from the validator definitions.
+   * @param definition The form validator definitions.
+   */
+  public createValidatorDefinitionMapping(
+    definition: FormValidatorDefinition[] | null | undefined
+  ): Map<string, FormValidatorDefinition> {
+    const defMap = new Map<string, FormValidatorDefinition>();
+    for (const definitionItem of (definition ?? [])) {
+      if (!isTypeFormValidatorDefinition(definitionItem)) {
+        throw new Error(`Validator definition does not have valid 'class', 'message', and 'create' properties: ${JSON.stringify(definitionItem)}`);
+      }
+      const validatorClass = definitionItem?.class;
+      const message = definitionItem?.message;
+      if (defMap.has(validatorClass)) {
+        const messages = [message, defMap.get(validatorClass)?.message];
+        throw new Error(`Duplicate validator class '${validatorClass}' - the validator classes must be unique. `
+          + `To help you find the duplicates, these are the messages of the duplicates: '${messages.join(", ")}'.`);
+      }
+      defMap.set(validatorClass, definitionItem);
     }
+    return defMap;
+  }
 
-    /**
-     * Create form validator instances from the validator definition mapping.
-     * @param defMap The validator definition mapping.
-     * @param config The form validator config blocks.
-     */
-    public createFormValidatorInstancesFromMapping(
-      defMap: Map<string, FormValidatorDefinition>,
-      config: FormValidatorConfig[] | null | undefined,
-    ): FormValidatorFns {
-        const result: FormValidatorFns = {syncDefs: [], asyncDefs: []};
-        for (const validatorConfigItem of (config ?? [])) {
-            const validatorClass = validatorConfigItem?.class;
-            const def = defMap.get(validatorClass);
-            if (!def) {
-                throw new Error(`No validator definition with class '${validatorClass}', `
-                    + `the available validators are: '${Array.from(defMap.keys()).sort().join(", ")}'.`);
-            }
-            const message = validatorConfigItem?.message ?? def.message;
-            const createConfig: FormValidatorCreateConfig = {
-              ...validatorConfigItem?.config ?? {},
-              class: validatorClass,
-              message: message,
-            };
+  /**
+   * Create form validator instances from the validator definition mapping.
+   * @param defMap The validator definition mapping.
+   * @param config The form validator config blocks.
+   */
+  public createFormValidatorInstancesFromMapping(
+    defMap: Map<string, FormValidatorDefinition>,
+    config: FormValidatorConfig[] | null | undefined,
+  ): FormValidatorFns {
+    const result: FormValidatorFns = { syncDefs: [], asyncDefs: [] };
+    for (const validatorConfigItem of (config ?? [])) {
+      const validatorClass = validatorConfigItem?.class;
+      const def = defMap.get(validatorClass);
+      if (!def) {
+        throw new Error(`No validator definition with class '${validatorClass}', `
+          + `the available validators are: '${Array.from(defMap.keys()).sort().join(", ")}'.`);
+      }
+      const message = validatorConfigItem?.message ?? def.message;
+      const createConfig: FormValidatorCreateConfig = {
+        ...validatorConfigItem?.config ?? {},
+        class: validatorClass,
+        message: message,
+      };
 
-            if ('create' in def) {
-              result.syncDefs.push(def.create(createConfig));
-            } else if ('createAsync' in def) {
-              result.asyncDefs.push(def.createAsync(createConfig));
-            }
-        }
-        return result;
+      if ('create' in def) {
+        result.syncDefs.push(def.create(createConfig));
+      } else if ('createAsync' in def) {
+        result.asyncDefs.push(def.createAsync(createConfig));
+      } else {
+        throw new Error(`Validator definition '${validatorClass}' does not provide a create or createAsync factory.`);
+      }
     }
+    return result;
+  }
 
-    /**
-     * Get the form validator errors for a component's control.
-     * @param errors The control's errors.
-     */
-    public getFormValidatorComponentErrors(errors: FormValidatorErrors | null): FormValidatorComponentErrors[] {
-        return Object.entries(errors ?? {}).map(([key, item]) => ({
-                class: key,
-                message: item.message ?? null,
-                params: {...item.params},
-            })) ?? [];
-    }
+  /**
+   * Get the form validator errors for a component's control.
+   * @param errors The control's errors.
+   */
+  public getFormValidatorComponentErrors(errors: FormValidatorErrors | null): FormValidatorComponentErrors[] {
+    return Object.entries(errors ?? {}).map(([key, item]) => ({
+      class: key,
+      message: item.message ?? null,
+      params: { ...item.params },
+    })) ?? [];
+  }
 
   public checkValidationGroups(availableGroups: FormValidationGroups, enabledGroupNames: string[]) {
     const availableGroupNames = Object.keys(availableGroups);

--- a/packages/sails-ng-common/src/validation/validators.ts
+++ b/packages/sails-ng-common/src/validation/validators.ts
@@ -1,4 +1,4 @@
-import {FormValidatorControl, FormValidatorDefinition} from "./form.model";
+import { FormValidatorControl, FormValidatorDefinition } from "./form.model";
 import {
   formValidatorGetDefinitionArray,
   formValidatorGetDefinitionBoolean,
@@ -8,8 +8,7 @@ import {
   formValidatorGetDefinitionString,
   formValidatorLengthOrSize
 } from "./helpers";
-import {toBoolean} from "../config/helpers";
-import {JSONataEvaluate} from "../jsonata-helpers";
+import { JSONataEvaluate } from "../jsonata-helpers";
 
 
 /**
@@ -50,9 +49,9 @@ export const formValidatorsSharedDefinitions: FormValidatorDefinition[] = [
 
         let value;
         try {
-            value = parseFloat(control.value?.toString() ?? null);
+          value = parseFloat(control.value?.toString() ?? null);
         } catch (err) {
-            value = undefined;
+          value = undefined;
         }
 
         // Controls with NaN values after parsing should be treated as not having a
@@ -89,14 +88,14 @@ export const formValidatorsSharedDefinitions: FormValidatorDefinition[] = [
 
         let value;
         try {
-            value = parseFloat(control.value?.toString() ?? null);
+          value = parseFloat(control.value?.toString() ?? null);
         } catch (err) {
-            value = undefined;
+          value = undefined;
         }
 
         // Controls with NaN values after parsing should be treated as not having a
         // maximum, per the HTML forms spec: https://www.w3.org/TR/html5/forms.html#attr-input-max
-          if (value === undefined || (!isNaN(value) && value > optionMaxValue)) {
+        if (value === undefined || (!isNaN(value) && value > optionMaxValue)) {
           return {
             [optionNameValue]: {
               [optionMessageKey]: optionMessageValue,
@@ -243,15 +242,15 @@ export const formValidatorsSharedDefinitions: FormValidatorDefinition[] = [
         const value = control.value?.toString() ?? "";
         const testOutcome = optionPatternValue.test(value);
         if (!testOutcome) {
-        return {
-          [optionNameValue]: {
-            [optionMessageKey]: optionMessageValue,
-            params: {
-              requiredPattern: optionPatternValue,
+          return {
+            [optionNameValue]: {
+              [optionMessageKey]: optionMessageValue,
+              params: {
+                requiredPattern: optionPatternValue,
 
-              description: optionDescriptionValue,actual: control.value,
+                description: optionDescriptionValue, actual: control.value,
+              },
             },
-          },
           };
         }
         return null;
@@ -274,7 +273,7 @@ export const formValidatorsSharedDefinitions: FormValidatorDefinition[] = [
       let regexStr = (pattern instanceof RegExp ? pattern?.source : pattern?.toString()) ?? "";
 
       // The pattern must start with '^' (start anchor)
-      if (regexStr.charAt(0) !== "^"){
+      if (regexStr.charAt(0) !== "^") {
         regexStr = ("^" + regexStr);
       }
 
@@ -360,9 +359,9 @@ export const formValidatorsSharedDefinitions: FormValidatorDefinition[] = [
         let success: boolean | null = null;
         try {
           if (typeof evaluator !== "function") {
-                  throw new Error("Missing evaluator");
-              }
-              success = await evaluator(value) === true;
+            throw new Error("Missing evaluator");
+          }
+          success = await evaluator(value) === true;
         } catch (err) {
           success = false;
           console.error(`Validator 'jsonata-expression' with description '${optionDescriptionValue}' could not run due to error: ${err}`);

--- a/packages/sails-ng-common/test/unit/jsonata-helpers.test.ts
+++ b/packages/sails-ng-common/test/unit/jsonata-helpers.test.ts
@@ -81,5 +81,3 @@ describe('JSONata helpers', async function () {
     });
   });
 });
-
-

--- a/packages/sails-ng-common/test/unit/jsonata-helpers.test.ts
+++ b/packages/sails-ng-common/test/unit/jsonata-helpers.test.ts
@@ -1,7 +1,7 @@
-import {jsonataCompile, jsonataCompileAndEvaluate, jsonataEvaluate, jsonataEvaluateFunc} from "../../src";
+import { jsonataCompile, jsonataCompileAndEvaluate, jsonataEvaluate, jsonataEvaluateFunc } from "../../src";
 
 
-describe('JSONata helpers', async function () {
+describe('JSONata helpers', function () {
   let expect: Chai.ExpectStatic;
 
   before(async function () {
@@ -13,7 +13,7 @@ describe('JSONata helpers', async function () {
     if ('message' in (error as Record<string, unknown>) && expected instanceof Error) {
       expect((error as Record<string, unknown>).message).to.eql(expected.message);
     } else {
-      expect.fail(`Threw unexpected error ${JSON.stringify({error, type: typeof error})}`);
+      expect.fail(`Threw unexpected error ${JSON.stringify({ error, type: typeof error })}`);
     }
   }
 
@@ -21,7 +21,7 @@ describe('JSONata helpers', async function () {
     {
       args: {
         expression: "$sum(example.value)",
-        input: {example: [{value: 4}, {value: 7}, {value: 13}]},
+        input: { example: [{ value: 4 }, { value: 7 }, { value: 13 }] },
         bindings: undefined,
       },
       expected: 24,
@@ -30,14 +30,14 @@ describe('JSONata helpers', async function () {
       args: {
         expression: "$a + $b()",
         input: {},
-        bindings: {a: 4, b: () => 78},
+        bindings: { a: 4, b: () => 78 },
       },
       expected: 82,
     },
     {
       args: {
         expression: '$.name',
-        input: {name: 'testing'},
+        input: { name: 'testing' },
         bindings: undefined,
       },
       expected: "testing",
@@ -45,13 +45,13 @@ describe('JSONata helpers', async function () {
     {
       args: {
         expression: '{{{{invalid',
-        input: {name: 'testing'},
+        input: { name: 'testing' },
         bindings: undefined,
       },
       expected: new Error('Expected ":" before end of expression'),
     },
   ];
-  cases.forEach(({args, expected}) => {
+  cases.forEach(({ args, expected }) => {
     it(`should have expected result using args "${JSON.stringify(args)}" expected "${JSON.stringify(expected)}"`, async function () {
       try {
         const compiled = jsonataCompile(args.expression);

--- a/test/integration/services/FormRecordConsistencyService.test.ts
+++ b/test/integration/services/FormRecordConsistencyService.test.ts
@@ -311,7 +311,7 @@ describe('The FormRecordConsistencyService', function () {
       },
     ];
     cases.forEach(({ args, expected }) => {
-      it(`should merge as expected ${JSON.stringify(expected)} for args ${JSON.stringify(args)}`, done => {
+      it(`should merge as expected ${JSON.stringify(expected)} for args ${JSON.stringify(args)}`, async () => {
         const clientFormConfig: FormConfigFrame = {
           name: 'client-form-config',
           type: 'rdmp',
@@ -324,14 +324,13 @@ describe('The FormRecordConsistencyService', function () {
           enabledValidationGroups: ['all'],
           componentDefinitions: args.componentDefinitions ?? [],
         };
-        const result = FormRecordConsistencyService.mergeRecordClientFormConfig(
+        const result = await FormRecordConsistencyService.mergeRecordClientFormConfig(
           args.original,
           args.changed,
           clientFormConfig,
           'edit'
         );
         expect(result).to.eql(expected);
-        done();
       });
     });
 
@@ -354,7 +353,7 @@ describe('The FormRecordConsistencyService', function () {
   });
 
   describe('buildDataModelDefault methods', function () {
-    it('creates the expected default data model by using the most specific defaultValue', function () {
+    it('creates the expected default data model by using the most specific defaultValue', async function () {
       const formConfig: FormConfigFrame = {
         name: 'remove-item-constraint-roles',
         type: 'rdmp',
@@ -531,7 +530,7 @@ describe('The FormRecordConsistencyService', function () {
         },
         repeatable_1: [{ text_group_repeatable_1: 'hello world from repeating groups' }],
       };
-      const result = FormRecordConsistencyService.buildDataModelDefaultForFormConfig(formConfig, 'edit');
+      const result = await FormRecordConsistencyService.buildDataModelDefaultForFormConfig(formConfig, 'edit');
       expect(result).to.eql(expected);
     });
   });
@@ -1023,7 +1022,7 @@ describe('The FormRecordConsistencyService', function () {
   });
 
   describe('buildSchemaForFormConfig methods', function () {
-    it('builds the expected schema', function () {
+    it('builds the expected schema', async function () {
       const formConfig: FormModel & FormConfigFrame = {
         ...formModelConfigStandard,
         componentDefinitions: [
@@ -1216,7 +1215,7 @@ describe('The FormRecordConsistencyService', function () {
         },
       };
 
-      const actual = FormRecordConsistencyService.buildSchemaForFormConfig(formConfig, 'edit');
+      const actual = await FormRecordConsistencyService.buildSchemaForFormConfig(formConfig, 'edit');
       expect(actual).to.eql(expected);
     });
   });


### PR DESCRIPTION
This pull request refactors several Angular component test files to standardize and improve the way dynamic assets are injected and configured in tests. The main change is the replacement of direct calls to `setUpDynamicAssets` with the use of a `DynamicAssetOptions` object, which is then passed to `createFormAndWaitForReady`. This approach makes dynamic asset injection more explicit, modular, and easier to maintain across tests. Additionally, there is a minor fix to ensure that an asynchronous method is properly awaited and a test assertion is updated to handle an asynchronous result.

Key changes include:

**Test Refactoring for Dynamic Asset Injection:**

* Replaced inline calls to `setUpDynamicAssets` with the construction and use of `DynamicAssetOptions` objects in the following test files: `checkbox-tree.component.spec.ts`, `content.component.spec.ts`, `delete-button.component.spec.ts`, and `question-tree.component.spec.ts`. These options are now passed as an argument to `createFormAndWaitForReady`, improving clarity and maintainability of dynamic asset setup in tests. [[1]](diffhunk://#diff-051a4d99dd673d230621cd38f8b59a93ef9a8e39c5e13ea73044291d2715fce8L4-R4) [[2]](diffhunk://#diff-051a4d99dd673d230621cd38f8b59a93ef9a8e39c5e13ea73044291d2715fce8L131-L141) [[3]](diffhunk://#diff-051a4d99dd673d230621cd38f8b59a93ef9a8e39c5e13ea73044291d2715fce8L168-R171) [[4]](diffhunk://#diff-051a4d99dd673d230621cd38f8b59a93ef9a8e39c5e13ea73044291d2715fce8L185-L195) [[5]](diffhunk://#diff-051a4d99dd673d230621cd38f8b59a93ef9a8e39c5e13ea73044291d2715fce8L222-R226) [[6]](diffhunk://#diff-07efd2d81b818a02c7eb9963da396e664ff70dec7f946a9b0299d7062bfb68e1L4-R4) [[7]](diffhunk://#diff-07efd2d81b818a02c7eb9963da396e664ff70dec7f946a9b0299d7062bfb68e1R15) [[8]](diffhunk://#diff-07efd2d81b818a02c7eb9963da396e664ff70dec7f946a9b0299d7062bfb68e1L35-R38) [[9]](diffhunk://#diff-07efd2d81b818a02c7eb9963da396e664ff70dec7f946a9b0299d7062bfb68e1L51-R59) [[10]](diffhunk://#diff-07efd2d81b818a02c7eb9963da396e664ff70dec7f946a9b0299d7062bfb68e1L84-R90) [[11]](diffhunk://#diff-07efd2d81b818a02c7eb9963da396e664ff70dec7f946a9b0299d7062bfb68e1L118-R125) [[12]](diffhunk://#diff-07efd2d81b818a02c7eb9963da396e664ff70dec7f946a9b0299d7062bfb68e1L150-R158) [[13]](diffhunk://#diff-07efd2d81b818a02c7eb9963da396e664ff70dec7f946a9b0299d7062bfb68e1L242-R251) [[14]](diffhunk://#diff-07efd2d81b818a02c7eb9963da396e664ff70dec7f946a9b0299d7062bfb68e1L272-R282) [[15]](diffhunk://#diff-f585de4ea197b7edffa97ca9c7dccfc0a0f015b982e8d67f37a29e18ba3072f7L3-R3) [[16]](diffhunk://#diff-f585de4ea197b7edffa97ca9c7dccfc0a0f015b982e8d67f37a29e18ba3072f7L56-R68) [[17]](diffhunk://#diff-4d9b1cfa173fb7a10a8c047d7b0788bfd80ec4323db574a0e86b5f05a6d3067aL1-R1) [[18]](diffhunk://#diff-4d9b1cfa173fb7a10a8c047d7b0788bfd80ec4323db574a0e86b5f05a6d3067aL587-R600) [[19]](diffhunk://#diff-4d9b1cfa173fb7a10a8c047d7b0788bfd80ec4323db574a0e86b5f05a6d3067aL723-L732) [[20]](diffhunk://#diff-4d9b1cfa173fb7a10a8c047d7b0788bfd80ec4323db574a0e86b5f05a6d3067aL751-R755) [[21]](diffhunk://#diff-4d9b1cfa173fb7a10a8c047d7b0788bfd80ec4323db574a0e86b5f05a6d3067aL830-R843) [[22]](diffhunk://#diff-4d9b1cfa173fb7a10a8c047d7b0788bfd80ec4323db574a0e86b5f05a6d3067aL860-R866)

**Test Assertion Improvements:**

* Updated assertions in `suggested-validation-summary.component.spec.ts` to await the asynchronous `allValidationErrorsDisplay()` method, ensuring correct test behavior. [[1]](diffhunk://#diff-1718b14421ab45ab05163b09248e9d82ca1abd181d7cedaf6248399dcedd8da4L160-R160) [[2]](diffhunk://#diff-1718b14421ab45ab05163b09248e9d82ca1abd181d7cedaf6248399dcedd8da4L176-R176)

**Bug Fixes / Minor Improvements:**

* Ensured the `gotoPage(1)` call in `deleted-records.component.ts` is properly awaited, addressing potential race conditions during initialization.

These changes collectively improve test reliability, maintainability, and clarity, especially around dynamic asset handling in form-related component tests.