### PR TITLE
Bugfix: Sync checkbox tree display after model value updates

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/checkbox-tree.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/checkbox-tree.component.spec.ts
@@ -492,6 +492,70 @@ describe("CheckboxTreeComponent", () => {
     expect((compiled.textContent ?? "").includes("Loading...")).toBeFalse();
   });
 
+  it("queues overlapping display sync while lazy child nodes are loading", async () => {
+    const vocabTreeService = TestBed.inject(VocabTreeService);
+    const deferred = createDeferred<{ data: Array<Record<string, unknown>>; meta: Record<string, unknown> }>();
+    spyOn(vocabTreeService, "getChildren").and.callFake((_vocabRef: string, parentId?: string) => {
+      if (!parentId) {
+        return Promise.resolve({
+          data: [{ id: "root", label: "Root", value: "01", notation: "01", parent: null, hasChildren: true }],
+          meta: { vocabularyId: "v1", parentId: null, total: 1 }
+        } as any);
+      }
+      return deferred.promise as Promise<any>;
+    });
+
+    const formConfig: FormConfigFrame = {
+      name: "testing",
+      componentDefinitions: [
+        {
+          name: "anzsrc",
+          component: {
+            class: "CheckboxTreeComponent",
+            config: {
+              vocabRef: "anzsrc-2020-for",
+              inlineVocab: false,
+              leafOnly: true
+            }
+          },
+          model: {
+            class: "CheckboxTreeModel",
+            config: {
+              value: []
+            }
+          }
+        }
+      ]
+    };
+
+    const { fixture, formComponent } = await createFormAndWaitForReady(formConfig);
+    const component = fixture.debugElement.query(By.directive(CheckboxTreeComponent)).componentInstance as CheckboxTreeComponent;
+    const control = (formComponent as any).form.get("anzsrc");
+
+    control.setValue([{ notation: "0101", label: "Leaf 1", name: "0101 - Leaf 1", genealogy: ["01"] }], { emitEvent: false });
+    const firstSync = component.syncDisplayFromModel();
+    await Promise.resolve();
+    control.setValue([{ notation: "0102", label: "Leaf 2", name: "0102 - Leaf 2", genealogy: ["01"] }], { emitEvent: false });
+    const secondSync = component.syncDisplayFromModel();
+
+    deferred.resolve({
+      data: [
+        { id: "leaf-1", label: "Leaf 1", value: "0101", notation: "0101", parent: "root", hasChildren: false },
+        { id: "leaf-2", label: "Leaf 2", value: "0102", notation: "0102", parent: "root", hasChildren: false }
+      ],
+      meta: { vocabularyId: "v1", parentId: "root", total: 2 }
+    });
+    await firstSync;
+    await secondSync;
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const checkboxes = Array.from((fixture.nativeElement as HTMLElement).querySelectorAll('input[type="checkbox"]')) as HTMLInputElement[];
+    expect(checkboxes.length).toBe(2);
+    expect(checkboxes[0].checked).toBeFalse();
+    expect(checkboxes[1].checked).toBeTrue();
+  });
+
   it("handles empty vocabulary response without errors", async () => {
     const vocabTreeService = TestBed.inject(VocabTreeService);
     spyOn(vocabTreeService, "getChildren").and.resolveTo({

--- a/angular/projects/researchdatabox/form/src/app/component/checkbox-tree.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/checkbox-tree.component.ts
@@ -702,6 +702,13 @@ export class CheckboxTreeComponent extends FormFieldBaseComponent<CheckboxTreeMo
       .subscribe(() => this.syncSelectionFromModel());
   }
 
+  // Invoked by the framework after expression-driven model.value updates,
+  // which use emitEvent:false and therefore bypass the valueChanges subscription.
+  public async syncDisplayFromModel(): Promise<void> {
+    this.syncSelectionFromModel();
+    await this.expandToSelectedNodes();
+  }
+
   private describeLoadError(error: unknown): string {
     return (error as Error)?.message || "Unable to load vocabulary tree.";
   }

--- a/angular/projects/researchdatabox/form/src/app/component/checkbox-tree.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/checkbox-tree.component.ts
@@ -232,6 +232,8 @@ export class CheckboxTreeComponent extends FormFieldBaseComponent<CheckboxTreeMo
   private readonly loadingNodeIds = new Set<string>();
   private readonly loadedNodeIds = new Set<string>();
   private modelSubscriptionInitialised = false;
+  private displaySyncInFlight?: Promise<void>;
+  private displaySyncQueued = false;
 
   private leafOnly = true;
   private inlineVocab = false;
@@ -705,8 +707,24 @@ export class CheckboxTreeComponent extends FormFieldBaseComponent<CheckboxTreeMo
   // Invoked by the framework after expression-driven model.value updates,
   // which use emitEvent:false and therefore bypass the valueChanges subscription.
   public async syncDisplayFromModel(): Promise<void> {
-    this.syncSelectionFromModel();
-    await this.expandToSelectedNodes();
+    if (this.displaySyncInFlight) {
+      this.displaySyncQueued = true;
+      return this.displaySyncInFlight;
+    }
+    this.displaySyncInFlight = this.runDisplaySyncFromModel();
+    return this.displaySyncInFlight;
+  }
+
+  private async runDisplaySyncFromModel(): Promise<void> {
+    try {
+      do {
+        this.displaySyncQueued = false;
+        this.syncSelectionFromModel();
+        await this.expandToSelectedNodes();
+      } while (this.displaySyncQueued);
+    } finally {
+      this.displaySyncInFlight = undefined;
+    }
   }
 
   private describeLoadError(error: unknown): string {


### PR DESCRIPTION
## Summary

Adds checkbox tree display synchronisation for expression-driven model value updates.

---

## Context / Motivation

Checkbox tree selections were already synchronised through the model value change subscription. However, framework-driven expression updates can update `model.value` with `emitEvent:false`, bypassing that subscription and leaving the rendered tree out of sync with the underlying model.

---

## Key Features

### Checkbox tree model synchronisation

- Adds a `syncDisplayFromModel()` hook for the checkbox tree form component.
- Reuses the existing selection synchronisation path so externally updated model values are reflected in the rendered checked state.
- Expands the tree to selected nodes after synchronising so selected values remain visible after expression-driven updates.

---

## Testing

- No automated tests were added in this branch.
- Change is limited to the checkbox tree form component display synchronisation path.

---

## Architectural / Operational Impact

### Form component lifecycle

The checkbox tree now participates in the framework display refresh hook used after model updates that do not emit value change events. This keeps the component state aligned with the model without changing the persisted value format or vocabulary loading behaviour.

---

## Backwards Compatibility

The change is backwards compatible. It does not alter checkbox tree configuration, stored values, API contracts, or existing user-driven selection behaviour.

---

## Deployment Notes

No migration or deployment steps are required.

---

## Impact

Checkbox tree fields now correctly refresh their displayed selection state when model values are updated programmatically by form expressions.
