### PR TITLE
Bugfix: Make body-parser skip paths configurable and route-specific

### DIFF
--- a/packages/redbox-core/src/config/custom.config.ts
+++ b/packages/redbox-core/src/config/custom.config.ts
@@ -12,7 +12,7 @@ export interface CustomCacheControlConfig {
 
 export interface CustomBodyParserConfig {
     /** Route patterns that should bypass the body parser */
-    skipPaths: Record<string, string>;
+    skipPaths: string[] | Record<string, string>;
 }
 
 export interface CustomConfig {

--- a/packages/redbox-core/src/config/custom.config.ts
+++ b/packages/redbox-core/src/config/custom.config.ts
@@ -10,9 +10,17 @@ export interface CustomCacheControlConfig {
     noCache: string[];
 }
 
+export interface CustomBodyParserConfig {
+    /** Route patterns that should bypass the body parser */
+    skipPaths: Record<string, string>;
+}
+
 export interface CustomConfig {
     /** Cache control settings */
     cacheControl: CustomCacheControlConfig;
+
+    /** Body parser settings */
+    bodyParser: CustomBodyParserConfig;
 }
 
 export const custom: CustomConfig = {
@@ -25,5 +33,14 @@ export const custom: CustomConfig = {
             'login_oidc',
             'logout'
         ]
+    },
+    bodyParser: {
+        skipPaths: {
+            attachmentUpload: '/:branding/:portal/record/:oid/attach',
+            attachmentUploadById: '/:branding/:portal/record/:oid/attach/:attachId',
+            companionAttachmentUpload: '/:branding/:portal/companion/record/:oid/attach',
+            companionAttachmentUploadById: '/:branding/:portal/companion/record/:oid/attach/:attachId',
+            openIdConnectLogin: '/user/login_oidc'
+        }
     }
 };

--- a/packages/redbox-core/src/config/http.config.ts
+++ b/packages/redbox-core/src/config/http.config.ts
@@ -17,6 +17,7 @@ const skipper = require('skipper');
 import { redboxSession as redboxSessionMiddleware } from '../middleware/redboxSession';
 import { redboxSession as redboxSessionConfigValue } from './redboxSession.config';
 import type { CompanionConfig } from './companion.config';
+import type { CustomConfig } from './custom.config';
 import * as BrandingServiceModule from '../services/BrandingService';
 import * as PathRulesServiceModule from '../services/PathRulesService';
 
@@ -32,11 +33,7 @@ declare const sails: {
                 maxAge?: number;
             };
         };
-        custom: {
-            cacheControl: {
-                noCache: string[];
-            };
-        };
+        custom: CustomConfig;
     };
     hooks?: {
         http?: {
@@ -116,6 +113,52 @@ let _lazyCompanionSocketWired = false;
 function isStaticAssetPath(reqPath: string): boolean {
     return /^\/(?:[^/]+\/[^/]+\/)?(?:js|styles|images|fonts|angular|icons)\//.test(reqPath) ||
         /^\/(?:apple-touch-icon|favicon-|site\.webmanifest)/.test(reqPath);
+}
+
+function normalizeBodyParserPath(value: string): string {
+    const withoutQuery = String(value ?? '').trim().split('?')[0]?.toLowerCase() ?? '';
+    if (!withoutQuery) {
+        return '/';
+    }
+    const normalizedPath = withoutQuery.startsWith('/') ? withoutQuery : `/${withoutQuery}`;
+    return normalizedPath.length > 1 ? normalizedPath.replace(/\/+$/, '') || '/' : normalizedPath;
+}
+
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function buildBodyParserRouteMatcher(routePattern: string): RegExp | null {
+    const normalizedRoutePattern = normalizeBodyParserPath(routePattern);
+    if (normalizedRoutePattern === '/') {
+        return null;
+    }
+
+    const matcherParts = normalizedRoutePattern
+        .split('/')
+        .filter(Boolean)
+        .map((segment) => segment.startsWith(':') ? '[^/]+' : escapeRegExp(segment));
+
+    return new RegExp(`^/${matcherParts.join('/')}$`, 'i');
+}
+
+function resolveBodyParserSkipPaths(customConfig?: Partial<CustomConfig>): string[] {
+    const configuredSkipPaths = customConfig?.bodyParser?.skipPaths;
+    if (Array.isArray(configuredSkipPaths)) {
+        return configuredSkipPaths.filter((skipPath): skipPath is string => typeof skipPath === 'string');
+    }
+    if (configuredSkipPaths && typeof configuredSkipPaths === 'object') {
+        return Object.values(configuredSkipPaths).filter((skipPath): skipPath is string => typeof skipPath === 'string');
+    }
+    return [];
+}
+
+export function shouldSkipBodyParser(requestPath: string, configuredSkipPaths: string[]): boolean {
+    const normalizedRequestPath = normalizeBodyParserPath(requestPath);
+    return configuredSkipPaths.some((configuredSkipPath) => {
+        const routeMatcher = buildBodyParserRouteMatcher(configuredSkipPath);
+        return routeMatcher?.test(normalizedRequestPath) ?? false;
+    });
 }
 
 export function isImmutableAssetPath(reqPath: string): boolean {
@@ -579,8 +622,9 @@ export const http: HttpConfig = {
         ],
 
         myBodyParser: function (req: Request, res: Response, next: NextFunction) {
-            // ignore if there is '/attach/' on the url
-            if (req.url.toLowerCase().includes('/attach')) {
+            const requestPath = req.originalUrl ?? req.url;
+            const skipPaths = resolveBodyParserSkipPaths(sails.config.custom);
+            if (shouldSkipBodyParser(requestPath, skipPaths)) {
                 return next();
             }
             const skipperMiddleware = skipper({

--- a/packages/redbox-core/src/config/http.config.ts
+++ b/packages/redbox-core/src/config/http.config.ts
@@ -130,6 +130,8 @@ function escapeRegExp(value: string): string {
 
 function buildBodyParserRouteMatcher(routePattern: string): RegExp | null {
     const normalizedRoutePattern = normalizeBodyParserPath(routePattern);
+
+    // Exclude root path '/' from matching to prevent skipping body parser globally
     if (normalizedRoutePattern === '/') {
         return null;
     }

--- a/packages/redbox-core/src/config/http.config.ts
+++ b/packages/redbox-core/src/config/http.config.ts
@@ -121,7 +121,16 @@ function normalizeBodyParserPath(value: string): string {
         return '/';
     }
     const normalizedPath = withoutQuery.startsWith('/') ? withoutQuery : `/${withoutQuery}`;
-    return normalizedPath.length > 1 ? normalizedPath.replace(/\/+$/, '') || '/' : normalizedPath;
+    if (normalizedPath.length <= 1) {
+        return normalizedPath;
+    }
+
+    let endIndex = normalizedPath.length;
+    while (endIndex > 1 && normalizedPath.charCodeAt(endIndex - 1) === 47) {
+        endIndex -= 1;
+    }
+
+    return normalizedPath.slice(0, endIndex) || '/';
 }
 
 function escapeRegExp(value: string): string {

--- a/packages/redbox-core/src/config/http.config.ts
+++ b/packages/redbox-core/src/config/http.config.ts
@@ -109,6 +109,8 @@ let _lazyRedboxSessionMiddleware: RequestHandler | null = null;
 let _lazyCompanionMiddleware: RequestHandler | null = null;
 let _lazyCompanionMountPath = '/companion';
 let _lazyCompanionSocketWired = false;
+let _cachedBodyParserSkipPathConfig: CustomConfig['bodyParser']['skipPaths'] | undefined;
+let _cachedBodyParserSkipPathMatchers: RegExp[] = [];
 
 function isStaticAssetPath(reqPath: string): boolean {
     return /^\/(?:[^/]+\/[^/]+\/)?(?:js|styles|images|fonts|angular|icons)\//.test(reqPath) ||
@@ -162,6 +164,18 @@ function resolveBodyParserSkipPaths(customConfig?: Partial<CustomConfig>): strin
         return Object.values(configuredSkipPaths).filter((skipPath): skipPath is string => typeof skipPath === 'string');
     }
     return [];
+}
+
+function resolveBodyParserSkipMatchers(customConfig?: Partial<CustomConfig>): RegExp[] {
+    const configuredSkipPaths = customConfig?.bodyParser?.skipPaths;
+    if (_cachedBodyParserSkipPathConfig !== configuredSkipPaths) {
+        _cachedBodyParserSkipPathConfig = configuredSkipPaths;
+        _cachedBodyParserSkipPathMatchers = resolveBodyParserSkipPaths(customConfig)
+            .map((skipPath) => buildBodyParserRouteMatcher(skipPath))
+            .filter((matcher): matcher is RegExp => matcher !== null);
+    }
+
+    return _cachedBodyParserSkipPathMatchers;
 }
 
 export function shouldSkipBodyParser(requestPath: string, configuredSkipPaths: string[]): boolean {
@@ -634,8 +648,9 @@ export const http: HttpConfig = {
 
         myBodyParser: function (req: Request, res: Response, next: NextFunction) {
             const requestPath = req.originalUrl ?? req.url;
-            const skipPaths = resolveBodyParserSkipPaths(sails.config.custom);
-            if (shouldSkipBodyParser(requestPath, skipPaths)) {
+            const normalizedRequestPath = normalizeBodyParserPath(requestPath);
+            const skipMatchers = resolveBodyParserSkipMatchers(sails.config.custom);
+            if (skipMatchers.some((skipMatcher) => skipMatcher.test(normalizedRequestPath))) {
                 return next();
             }
             const skipperMiddleware = skipper({

--- a/packages/redbox-core/test/config/httpConfigSecurity.test.ts
+++ b/packages/redbox-core/test/config/httpConfigSecurity.test.ts
@@ -7,6 +7,7 @@ import {
   http,
   isImmutableAssetPath,
   resolvePublicAssetPath,
+  shouldSkipBodyParser,
   sanitizeStaticResourcePath,
   sanitizeStaticSegment
 } from '../../src/config/http.config';
@@ -140,6 +141,59 @@ describe('HTTP config security helpers', function () {
       expect(headers['Cache-Control']).to.equal('max-age=600, private');
       expect(headers['Pragma']).to.equal('no-cache');
       expect(headers['Cross-Origin-Opener-Policy']).to.equal('same-origin-allow-popups');
+    });
+  });
+
+  describe('body parser skip path helpers', function () {
+    it('should only match branded routes when the configured pattern includes branding and portal placeholders', function () {
+      expect(shouldSkipBodyParser('/default/rdmp/record/oid-1/attach', ['/:branding/:portal/record/:oid/attach'])).to.equal(true);
+      expect(shouldSkipBodyParser('/default/rdmp/record/oid-1/attach/file-1', ['/:branding/:portal/record/:oid/attach/:attachId'])).to.equal(true);
+      expect(shouldSkipBodyParser('/user/login_oidc', ['/user/login_oidc'])).to.equal(true);
+      expect(shouldSkipBodyParser('/default/rdmp/user/login_oidc', ['/user/login_oidc'])).to.equal(false);
+      expect(shouldSkipBodyParser('/default/rdmp/user/login_oidc', ['/:branding/:portal/user/login_oidc'])).to.equal(true);
+      expect(shouldSkipBodyParser('/default/rdmp/user/login', ['/user/login_oidc'])).to.equal(false);
+    });
+
+    it('should support hook-provided skip paths alongside the defaults', function () {
+      const configuredSkipPaths = Object.values({
+        attachmentUpload: '/:branding/:portal/record/:oid/attach',
+        openIdConnectLogin: '/user/login_oidc',
+        hookCallback: '/:branding/:portal/hook/callback'
+      });
+
+      expect(shouldSkipBodyParser('/default/rdmp/hook/callback', configuredSkipPaths)).to.equal(true);
+      expect(shouldSkipBodyParser('/default/rdmp/record/oid-1/attach', configuredSkipPaths)).to.equal(true);
+      expect(shouldSkipBodyParser('/hook/callback', configuredSkipPaths)).to.equal(false);
+      expect(shouldSkipBodyParser('/default/rdmp/hook/other', configuredSkipPaths)).to.equal(false);
+    });
+
+    it('should let middleware read configured skip paths from sails.config.custom', function () {
+      const originalCustomConfig = (global as any).sails.config.custom;
+      (global as any).sails.config.custom = {
+        cacheControl: { noCache: [] },
+        bodyParser: {
+          skipPaths: {
+            attachmentUpload: '/:branding/:portal/record/:oid/attach',
+            openIdConnectLogin: '/user/login_oidc',
+            hookCallback: '/:branding/:portal/hook/callback'
+          }
+        }
+      };
+
+      let nextCalls = 0;
+      try {
+        http.middleware.myBodyParser?.(
+          { originalUrl: '/default/rdmp/hook/callback', url: '/default/rdmp/hook/callback' } as any,
+          {} as any,
+          () => {
+            nextCalls += 1;
+          }
+        );
+      } finally {
+        (global as any).sails.config.custom = originalCustomConfig;
+      }
+
+      expect(nextCalls).to.equal(1);
     });
   });
 });

--- a/packages/redbox-core/test/config/httpConfigSecurity.test.ts
+++ b/packages/redbox-core/test/config/httpConfigSecurity.test.ts
@@ -151,6 +151,7 @@ describe('HTTP config security helpers', function () {
       expect(shouldSkipBodyParser('/DEFAULT/RDMP/record/oid-1/attach', ['/:branding/:portal/record/:oid/attach'])).to.equal(true);
       expect(shouldSkipBodyParser('/default/rdmp/record/oid-1/attach?foo=bar', ['/:branding/:portal/record/:oid/attach'])).to.equal(true);
       expect(shouldSkipBodyParser('/default/rdmp/record/oid-1/attach/', ['/:branding/:portal/record/:oid/attach'])).to.equal(true);
+      expect(shouldSkipBodyParser('/default/rdmp/record/oid-1/attach////', ['/:branding/:portal/record/:oid/attach'])).to.equal(true);
       expect(shouldSkipBodyParser('/user/login_oidc', ['/user/login_oidc'])).to.equal(true);
       expect(shouldSkipBodyParser('/default/rdmp/user/login_oidc', ['/user/login_oidc'])).to.equal(false);
       expect(shouldSkipBodyParser('/default/rdmp/user/login_oidc', ['/:branding/:portal/user/login_oidc'])).to.equal(true);

--- a/packages/redbox-core/test/config/httpConfigSecurity.test.ts
+++ b/packages/redbox-core/test/config/httpConfigSecurity.test.ts
@@ -148,6 +148,9 @@ describe('HTTP config security helpers', function () {
     it('should only match branded routes when the configured pattern includes branding and portal placeholders', function () {
       expect(shouldSkipBodyParser('/default/rdmp/record/oid-1/attach', ['/:branding/:portal/record/:oid/attach'])).to.equal(true);
       expect(shouldSkipBodyParser('/default/rdmp/record/oid-1/attach/file-1', ['/:branding/:portal/record/:oid/attach/:attachId'])).to.equal(true);
+      expect(shouldSkipBodyParser('/DEFAULT/RDMP/record/oid-1/attach', ['/:branding/:portal/record/:oid/attach'])).to.equal(true);
+      expect(shouldSkipBodyParser('/default/rdmp/record/oid-1/attach?foo=bar', ['/:branding/:portal/record/:oid/attach'])).to.equal(true);
+      expect(shouldSkipBodyParser('/default/rdmp/record/oid-1/attach/', ['/:branding/:portal/record/:oid/attach'])).to.equal(true);
       expect(shouldSkipBodyParser('/user/login_oidc', ['/user/login_oidc'])).to.equal(true);
       expect(shouldSkipBodyParser('/default/rdmp/user/login_oidc', ['/user/login_oidc'])).to.equal(false);
       expect(shouldSkipBodyParser('/default/rdmp/user/login_oidc', ['/:branding/:portal/user/login_oidc'])).to.equal(true);
@@ -194,6 +197,63 @@ describe('HTTP config security helpers', function () {
       }
 
       expect(nextCalls).to.equal(1);
+    });
+
+    it('should delegate non-matching requests to skipper instead of calling next directly', function () {
+      const originalCustomConfig = (global as any).sails.config.custom;
+      const httpConfigModulePath = require.resolve('../../src/config/http.config');
+      const skipperModulePath = require.resolve('skipper');
+      const originalHttpModule = require.cache[httpConfigModulePath];
+      const originalSkipperModule = require.cache[skipperModulePath];
+      const originalSkipperExports = originalSkipperModule?.exports;
+
+      let nextCalls = 0;
+      let skipperCalls = 0;
+
+      try {
+        (global as any).sails.config.custom = {
+          cacheControl: { noCache: [] },
+          bodyParser: {
+            skipPaths: {
+              attachmentUpload: '/:branding/:portal/record/:oid/attach',
+              openIdConnectLogin: '/user/login_oidc',
+              hookCallback: '/:branding/:portal/hook/callback'
+            }
+          }
+        };
+
+        if (originalSkipperModule) {
+          originalSkipperModule.exports = function () {
+            return function () {
+              skipperCalls += 1;
+            };
+          };
+        }
+
+        delete require.cache[httpConfigModulePath];
+        const reloadedHttp = require('../../src/config/http.config').http;
+
+        reloadedHttp.middleware.myBodyParser?.(
+          { originalUrl: '/default/rdmp/hook/other', url: '/default/rdmp/hook/other' } as any,
+          {} as any,
+          () => {
+            nextCalls += 1;
+          }
+        );
+      } finally {
+        (global as any).sails.config.custom = originalCustomConfig;
+        if (originalSkipperModule) {
+          originalSkipperModule.exports = originalSkipperExports;
+        }
+        if (originalHttpModule) {
+          require.cache[httpConfigModulePath] = originalHttpModule;
+        } else {
+          delete require.cache[httpConfigModulePath];
+        }
+      }
+
+      expect(skipperCalls).to.equal(1);
+      expect(nextCalls).to.equal(0);
     });
   });
 });


### PR DESCRIPTION
## Summary

This PR makes body-parser skip behaviour configuration-driven and route-pattern aware, so only the intended attachment and login routes bypass request parsing.

---

## Context / Motivation

The previous body-parser bypass logic relied on a broad URL substring check, which was too permissive and risked skipping parsing for unrelated routes. This change narrows the behavior to explicitly configured route patterns and adds coverage to prevent regressions.

---

## Key Features

### Configurable body-parser skip paths

- Introduces dedicated `custom.bodyParser.skipPaths` configuration for skip candidates.
- Supports route patterns with dynamic placeholders so attachment and companion upload routes can be matched precisely.
- Prevents root-path patterns from accidentally disabling body parsing globally.

### Safer matching and normalization

- Normalizes request paths before matching to make the behavior resilient to query strings, trailing slashes, and case differences.
- Matches only the intended routes rather than any path containing a broad substring.

### Regression coverage

- Adds helper-level tests for configured route matching and negative cases.
- Verifies middleware reads skip paths from `sails.config.custom`.
- Verifies non-matching requests continue through skipper rather than bypassing parsing entirely.

---

## Testing

- Added/updated unit tests for body-parser skip path matching.
- Added middleware regression coverage for configured skip paths.
- Added a non-match test to confirm skipper is still invoked for ordinary requests.

---

## Architectural / Operational Impact

### Request parsing safety

This reduces the chance of accidentally disabling body parsing for unrelated endpoints, which is important for authentication and upload workflows that depend on correct request handling.

### Configuration ownership

Skip behavior now lives in `custom.config`, making the routes that bypass parsing explicit and easier to audit or extend in hooks.

---

## Backwards Compatibility

The change preserves the intended attachment and OIDC login bypass behavior, but it is stricter than the previous substring match. Any additional routes that relied on the old broad `/attach` check will need to be added explicitly to `custom.bodyParser.skipPaths`.

---

## Deployment Notes

No schema or data migration is required. Deployment only needs the updated configuration and code path, with any additional skip routes added through configuration if required by downstream hooks.

---

## Impact

Body-parser skipping is now explicit, test-backed, and much less likely to interfere with unrelated requests.
