### PR TITLE
Chore: Generalize inline repeatable form classes

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/repeatable.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/repeatable.component.spec.ts
@@ -369,6 +369,88 @@ describe('RepeatableComponent', () => {
     expect(fixture.nativeElement.querySelector('.rb-form-repeatable-item')).toBeTruthy();
   });
 
+  it('should mark inline field repeatable items with a generic modifier class', async () => {
+    const formConfig: FormConfigFrame = {
+      name: 'testing_repeatable_inline_fields_css',
+      componentDefinitions: [
+        {
+          name: 'repeatable_inline_fields_css',
+          model: {
+            class: 'RepeatableModel',
+            config: {
+              value: ['one']
+            }
+          },
+          component: {
+            class: 'RepeatableComponent',
+            config: {
+              elementTemplate: {
+                name: "",
+                model: {
+                  class: 'SimpleInputModel',
+                  config: {
+                    value: 'one',
+                  }
+                },
+                component: {
+                  class: 'SimpleInputComponent',
+                  config: {
+                    hostCssClasses: 'rb-form-inline-fields rb-form-grid-cols-3',
+                  }
+                }
+              },
+            },
+          }
+        },
+      ]
+    };
+    const {fixture} = await createFormAndWaitForReady(formConfig);
+
+    expect(fixture.nativeElement.querySelector('.rb-form-repeatable-item--inline-fields')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('.rb-form-grid-cols-3')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('.rb-form-repeatable-item--contributor')).toBeFalsy();
+  });
+
+  it('should treat legacy contributor inline classes as inline field repeatable items', async () => {
+    const formConfig: FormConfigFrame = {
+      name: 'testing_repeatable_legacy_contributor_inline_css',
+      componentDefinitions: [
+        {
+          name: 'repeatable_legacy_contributor_inline_css',
+          model: {
+            class: 'RepeatableModel',
+            config: {
+              value: ['one']
+            }
+          },
+          component: {
+            class: 'RepeatableComponent',
+            config: {
+              elementTemplate: {
+                name: "",
+                model: {
+                  class: 'SimpleInputModel',
+                  config: {
+                    value: 'one',
+                  }
+                },
+                component: {
+                  class: 'SimpleInputComponent',
+                  config: {
+                    hostCssClasses: 'rb-form-contributor-inline',
+                  }
+                }
+              },
+            },
+          }
+        },
+      ]
+    };
+    const {fixture} = await createFormAndWaitForReady(formConfig);
+
+    expect(fixture.nativeElement.querySelector('.rb-form-repeatable-item--inline-fields')).toBeTruthy();
+  });
+
   it('should support zero-row repeatables with hidden add button', async () => {
     const formConfig: FormConfigFrame = {
       name: 'testing_repeatable_zero_rows',

--- a/angular/projects/researchdatabox/form/src/app/component/repeatable.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/repeatable.component.ts
@@ -21,15 +21,14 @@ import { FormBaseWrapperComponent } from "./base-wrapper.component";
 import { DefaultLayoutComponent } from "./default-layout.component";
 import { createFormDefinitionChangeRequestEvent, createFormStatusDirtyRequestEvent, FormComponentEventBus } from '../form-state';
 import { CustomSetValueControl } from '../form-state/custom-set-value.control';
-import {FormComponent} from "../form.component";
+import { FormComponent } from "../form.component";
 import { FieldValueChangedEvent, FormComponentEventType } from '../form-state';
 
 type RepeatableSetValueOptions = ModifyOptions;
 
 class RepeatableFormArray
   extends FormArray<AbstractControl<unknown>>
-  implements CustomSetValueControl<Array<unknown>>
-{
+  implements CustomSetValueControl<Array<unknown>> {
   public customValueSetter?: (value: Array<unknown>, options?: RepeatableSetValueOptions) => Promise<void> | void;
 
   public async setCustomValue(
@@ -779,7 +778,7 @@ export interface RepeatableElementEntry {
 @Component({
   selector: 'redbox-form-repeatable-component-layout',
   template: `
-  <div class="rb-form-repeatable-item" [class.rb-form-repeatable-item--contributor]="isContributorInline">
+  <div class="rb-form-repeatable-item" [class.rb-form-repeatable-item--inline-fields]="isInlineLayout">
     <div class="rb-form-repeatable-item__content">
       <ng-container #componentContainer></ng-container>
     </div>
@@ -808,12 +807,13 @@ export class RepeatableElementLayoutComponent<ValueType> extends DefaultLayoutCo
   public removeFn?: () => void;
   public canRemove = false;
 
-  protected get isContributorInline(): boolean {
+  protected get isInlineLayout(): boolean {
     const hostCssClasses = this.formFieldCompMapEntry?.compConfigJson?.component?.config?.hostCssClasses;
     if (typeof hostCssClasses !== 'string') {
       return false;
     }
-    return hostCssClasses.split(/\s+/).includes('rb-form-contributor-inline');
+    const hostCssClassList = hostCssClasses.split(/\s+/);
+    return hostCssClassList.includes('rb-form-contributor-inline') || hostCssClassList.includes('rb-form-inline-fields');
   }
 
   protected clickedRemove() {

--- a/angular/projects/researchdatabox/form/src/app/form.component.scss
+++ b/angular/projects/researchdatabox/form/src/app/form.component.scss
@@ -564,6 +564,7 @@
   .rb-form-inline-fields--split-end,
   .rb-form-grid-split-end
 ) > .rb-form-group {
+  display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   column-gap: var(--rb-form-gap-2);
 }

--- a/angular/projects/researchdatabox/form/src/app/form.component.scss
+++ b/angular/projects/researchdatabox/form/src/app/form.component.scss
@@ -335,10 +335,11 @@
   margin-top: 2.25rem;
 }
 
-.rb-form-edit .rb-form-repeatable-item:has(.rb-form-inline-label):not(:has(.rb-form-contributor-inline)) .rb-form-repeatable-item__remove {
+.rb-form-edit .rb-form-repeatable-item:has(.rb-form-inline-label):not(:has(.rb-form-inline-fields, .rb-form-contributor-inline)) .rb-form-repeatable-item__remove {
   margin-top: 0;
 }
 
+.rb-form-edit .rb-form-repeatable-item.rb-form-repeatable-item--inline-fields .rb-form-repeatable-item__remove,
 .rb-form-edit .rb-form-repeatable-item.rb-form-repeatable-item--contributor .rb-form-repeatable-item__remove {
   margin-top: 2.25rem;
 }
@@ -347,6 +348,7 @@
   display: block;
 }
 
+.rb-form-edit .rb-form-repeatable-item__content .rb-form-inline-fields .rb-form-inline-label,
 .rb-form-edit .rb-form-repeatable-item__content .rb-form-contributor-inline .rb-form-inline-label {
   display: none;
 }
@@ -495,6 +497,7 @@
   margin-top: 0.28rem;
 }
 
+.rb-form-edit .rb-form-inline-fields .rb-form-group,
 .rb-form-edit .rb-form-contributor-inline .rb-form-group {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
@@ -502,23 +505,81 @@
 }
 
 @media (min-width: 992px) {
-  .rb-form-edit .rb-form-contributor-inline .rb-form-group {
-    grid-template-columns: minmax(0, 0.65fr) minmax(0, 1.15fr) repeat(2, minmax(0, 1fr));
+  .rb-form-edit .rb-form-grid-cols-2 .rb-form-group {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+
+  .rb-form-edit .rb-form-grid-cols-3 .rb-form-group {
+    grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
+  }
+
+  .rb-form-edit .rb-form-grid-cols-4 .rb-form-group,
+  .rb-form-edit .rb-form-contributor-inline--with-title .rb-form-group {
+    grid-template-columns: repeat(4, minmax(0, 1fr)) !important;
   }
 }
 
+.rb-form-edit .rb-form-inline-fields .rb-form-group > redbox-form-base-wrapper.rb-form-grid-span-1 {
+  grid-column: span 1 !important;
+}
+
+.rb-form-edit .rb-form-inline-fields .rb-form-group > redbox-form-base-wrapper.rb-form-grid-span-2 {
+  grid-column: span 2 !important;
+}
+
+.rb-form-edit .rb-form-inline-fields .rb-form-group > redbox-form-base-wrapper.rb-form-grid-span-3 {
+  grid-column: span 3 !important;
+}
+
+.rb-form-edit .rb-form-inline-fields .rb-form-group > redbox-form-base-wrapper.rb-form-grid-span-full {
+  grid-column: 1 / -1 !important;
+}
+
+.rb-form-edit .rb-form-inline-fields .rb-form-contributor-inline__field,
+.rb-form-edit .rb-form-inline-fields .rb-form-inline-fields__field,
+.rb-form-edit .rb-form-contributor-inline .rb-form-inline-fields__field,
 .rb-form-edit .rb-form-contributor-inline .rb-form-contributor-inline__field {
   width: 100%;
 }
 
+.rb-form-edit .rb-form-inline-fields .rb-form-field-layout,
+.rb-form-edit .rb-form-inline-fields .rb-form-inline-layout,
 .rb-form-edit .rb-form-contributor-inline .rb-form-field-layout,
 .rb-form-edit .rb-form-contributor-inline .rb-form-inline-layout {
   margin-bottom: 0;
 }
 
+.rb-form-edit .rb-form-inline-fields .rb-form-inline-layout,
+.rb-form-edit .rb-form-inline-fields .rb-form-inline-layout__control,
 .rb-form-edit .rb-form-contributor-inline .rb-form-inline-layout,
 .rb-form-edit .rb-form-contributor-inline .rb-form-inline-layout__control {
   width: 100%;
+}
+
+.rb-form-edit .rb-form-funding-inline > .rb-form-group,
+.rb-form-edit .rb-form-inline-fields--split-end > .rb-form-group,
+.rb-form-edit .rb-form-grid-split-end > .rb-form-group {
+  grid-template-columns: minmax(0, 1fr) auto;
+  column-gap: var(--rb-form-gap-2);
+}
+
+.rb-form-edit .rb-form-funding-inline > .rb-form-group > redbox-form-base-wrapper.rb-form-inline-fields__field,
+.rb-form-edit .rb-form-funding-inline > .rb-form-group > redbox-form-base-wrapper.rb-form-contributor-inline__field,
+.rb-form-edit .rb-form-inline-fields--split-end > .rb-form-group > redbox-form-base-wrapper.rb-form-inline-fields__field,
+.rb-form-edit .rb-form-inline-fields--split-end > .rb-form-group > redbox-form-base-wrapper.rb-form-contributor-inline__field,
+.rb-form-edit .rb-form-grid-split-end > .rb-form-group > redbox-form-base-wrapper.rb-form-inline-fields__field,
+.rb-form-edit .rb-form-grid-split-end > .rb-form-group > redbox-form-base-wrapper.rb-form-contributor-inline__field {
+  min-width: 0;
+  width: 100%;
+}
+
+.rb-form-edit .rb-form-funding-inline > .rb-form-group > redbox-form-base-wrapper.rb-form-inline-fields__field--fixed,
+.rb-form-edit .rb-form-funding-inline > .rb-form-group > redbox-form-base-wrapper.rb-form-contributor-inline__field--role,
+.rb-form-edit .rb-form-inline-fields--split-end > .rb-form-group > redbox-form-base-wrapper.rb-form-inline-fields__field--fixed,
+.rb-form-edit .rb-form-inline-fields--split-end > .rb-form-group > redbox-form-base-wrapper.rb-form-contributor-inline__field--role,
+.rb-form-edit .rb-form-grid-split-end > .rb-form-group > redbox-form-base-wrapper.rb-form-inline-fields__field--fixed,
+.rb-form-edit .rb-form-grid-split-end > .rb-form-group > redbox-form-base-wrapper.rb-form-contributor-inline__field--role {
+  width: 35rem;
 }
 
 .rb-form-edit .rb-form-related-link-inline .rb-form-group {
@@ -715,6 +776,7 @@
   // Inline contributor/related-link groups → render as a tighter grid
   // so values like Title/Name/Email/ORCID sit side-by-side when possible.
   .rb-form-contributor-inline .rb-form-group,
+  .rb-form-inline-fields .rb-form-group,
   .rb-form-related-link-inline .rb-form-group {
     display: grid !important;
     grid-template-columns: repeat(2, minmax(0, 1fr)) !important;

--- a/angular/projects/researchdatabox/form/src/app/form.component.scss
+++ b/angular/projects/researchdatabox/form/src/app/form.component.scss
@@ -505,7 +505,7 @@
 
 @media (min-width: 992px) {
   .rb-form-edit .rb-form-contributor-inline .rb-form-group {
-    --rb-form-inline-grid-columns: repeat(4, minmax(0, 1fr));
+    --rb-form-inline-grid-columns: minmax(0, 0.65fr) minmax(0, 1.15fr) repeat(2, minmax(0, 1fr));
   }
 
   .rb-form-edit .rb-form-grid-cols-2 .rb-form-group {
@@ -522,19 +522,19 @@
   }
 }
 
-.rb-form-edit .rb-form-inline-fields .rb-form-group > redbox-form-base-wrapper.rb-form-grid-span-1 {
+.rb-form-edit :is(.rb-form-inline-fields, .rb-form-contributor-inline) .rb-form-group > redbox-form-base-wrapper.rb-form-grid-span-1 {
   grid-column: span 1 !important;
 }
 
-.rb-form-edit .rb-form-inline-fields .rb-form-group > redbox-form-base-wrapper.rb-form-grid-span-2 {
+.rb-form-edit :is(.rb-form-inline-fields, .rb-form-contributor-inline) .rb-form-group > redbox-form-base-wrapper.rb-form-grid-span-2 {
   grid-column: span 2 !important;
 }
 
-.rb-form-edit .rb-form-inline-fields .rb-form-group > redbox-form-base-wrapper.rb-form-grid-span-3 {
+.rb-form-edit :is(.rb-form-inline-fields, .rb-form-contributor-inline) .rb-form-group > redbox-form-base-wrapper.rb-form-grid-span-3 {
   grid-column: span 3 !important;
 }
 
-.rb-form-edit .rb-form-inline-fields .rb-form-group > redbox-form-base-wrapper.rb-form-grid-span-full {
+.rb-form-edit :is(.rb-form-inline-fields, .rb-form-contributor-inline) .rb-form-group > redbox-form-base-wrapper.rb-form-grid-span-full {
   grid-column: 1 / -1 !important;
 }
 

--- a/angular/projects/researchdatabox/form/src/app/form.component.scss
+++ b/angular/projects/researchdatabox/form/src/app/form.component.scss
@@ -499,26 +499,26 @@
 .rb-form-edit .rb-form-inline-fields .rb-form-group,
 .rb-form-edit .rb-form-contributor-inline .rb-form-group {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  grid-template-columns: var(--rb-form-inline-grid-columns, repeat(auto-fit, minmax(130px, 1fr)));
   gap: var(--rb-form-gap-1);
 }
 
 @media (min-width: 992px) {
   .rb-form-edit .rb-form-contributor-inline .rb-form-group {
-    grid-template-columns: repeat(4, minmax(0, 1fr)) !important;
+    --rb-form-inline-grid-columns: repeat(4, minmax(0, 1fr));
   }
 
   .rb-form-edit .rb-form-grid-cols-2 .rb-form-group {
-    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+    --rb-form-inline-grid-columns: repeat(2, minmax(0, 1fr));
   }
 
   .rb-form-edit .rb-form-grid-cols-3 .rb-form-group {
-    grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
+    --rb-form-inline-grid-columns: repeat(3, minmax(0, 1fr));
   }
 
   .rb-form-edit .rb-form-grid-cols-4 .rb-form-group,
   .rb-form-edit .rb-form-contributor-inline--with-title .rb-form-group {
-    grid-template-columns: repeat(4, minmax(0, 1fr)) !important;
+    --rb-form-inline-grid-columns: repeat(4, minmax(0, 1fr));
   }
 }
 
@@ -559,29 +559,35 @@
   width: 100%;
 }
 
-.rb-form-edit .rb-form-funding-inline > .rb-form-group,
-.rb-form-edit .rb-form-inline-fields--split-end > .rb-form-group,
-.rb-form-edit .rb-form-grid-split-end > .rb-form-group {
+.rb-form-edit :is(
+  .rb-form-funding-inline,
+  .rb-form-inline-fields--split-end,
+  .rb-form-grid-split-end
+) > .rb-form-group {
   grid-template-columns: minmax(0, 1fr) auto;
   column-gap: var(--rb-form-gap-2);
 }
 
-.rb-form-edit .rb-form-funding-inline > .rb-form-group > redbox-form-base-wrapper.rb-form-inline-fields__field,
-.rb-form-edit .rb-form-funding-inline > .rb-form-group > redbox-form-base-wrapper.rb-form-contributor-inline__field,
-.rb-form-edit .rb-form-inline-fields--split-end > .rb-form-group > redbox-form-base-wrapper.rb-form-inline-fields__field,
-.rb-form-edit .rb-form-inline-fields--split-end > .rb-form-group > redbox-form-base-wrapper.rb-form-contributor-inline__field,
-.rb-form-edit .rb-form-grid-split-end > .rb-form-group > redbox-form-base-wrapper.rb-form-inline-fields__field,
-.rb-form-edit .rb-form-grid-split-end > .rb-form-group > redbox-form-base-wrapper.rb-form-contributor-inline__field {
+.rb-form-edit :is(
+  .rb-form-funding-inline,
+  .rb-form-inline-fields--split-end,
+  .rb-form-grid-split-end
+) > .rb-form-group > redbox-form-base-wrapper:is(
+  .rb-form-inline-fields__field,
+  .rb-form-contributor-inline__field
+) {
   min-width: 0;
   width: 100%;
 }
 
-.rb-form-edit .rb-form-funding-inline > .rb-form-group > redbox-form-base-wrapper.rb-form-inline-fields__field--fixed,
-.rb-form-edit .rb-form-funding-inline > .rb-form-group > redbox-form-base-wrapper.rb-form-contributor-inline__field--role,
-.rb-form-edit .rb-form-inline-fields--split-end > .rb-form-group > redbox-form-base-wrapper.rb-form-inline-fields__field--fixed,
-.rb-form-edit .rb-form-inline-fields--split-end > .rb-form-group > redbox-form-base-wrapper.rb-form-contributor-inline__field--role,
-.rb-form-edit .rb-form-grid-split-end > .rb-form-group > redbox-form-base-wrapper.rb-form-inline-fields__field--fixed,
-.rb-form-edit .rb-form-grid-split-end > .rb-form-group > redbox-form-base-wrapper.rb-form-contributor-inline__field--role {
+.rb-form-edit :is(
+  .rb-form-funding-inline,
+  .rb-form-inline-fields--split-end,
+  .rb-form-grid-split-end
+) > .rb-form-group > redbox-form-base-wrapper:is(
+  .rb-form-inline-fields__field--fixed,
+  .rb-form-contributor-inline__field--role
+) {
   width: 35rem;
 }
 

--- a/angular/projects/researchdatabox/form/src/app/form.component.scss
+++ b/angular/projects/researchdatabox/form/src/app/form.component.scss
@@ -339,8 +339,7 @@
   margin-top: 0;
 }
 
-.rb-form-edit .rb-form-repeatable-item.rb-form-repeatable-item--inline-fields .rb-form-repeatable-item__remove,
-.rb-form-edit .rb-form-repeatable-item.rb-form-repeatable-item--contributor .rb-form-repeatable-item__remove {
+.rb-form-edit .rb-form-repeatable-item.rb-form-repeatable-item--inline-fields .rb-form-repeatable-item__remove {
   margin-top: 2.25rem;
 }
 
@@ -505,6 +504,10 @@
 }
 
 @media (min-width: 992px) {
+  .rb-form-edit .rb-form-contributor-inline .rb-form-group {
+    grid-template-columns: repeat(4, minmax(0, 1fr)) !important;
+  }
+
   .rb-form-edit .rb-form-grid-cols-2 .rb-form-group {
     grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
   }

--- a/packages/redbox-core/src/config/reusableContributorFormDefinitions.config.ts
+++ b/packages/redbox-core/src/config/reusableContributorFormDefinitions.config.ts
@@ -12,7 +12,7 @@ export const reusableContributorFormDefinitions: ReusableFormDefinitions = {
         config: {
           type: "text",
           hostCssClasses: "d-block",
-          wrapperCssClasses: "rb-form-contributor-inline__field rb-form-contributor-inline__field--title",
+          wrapperCssClasses: "rb-form-inline-fields__field rb-form-contributor-inline__field rb-form-contributor-inline__field--title",
           onItemSelect: {rawPath: 'metadata.title'},
         }
       },
@@ -33,7 +33,7 @@ export const reusableContributorFormDefinitions: ReusableFormDefinitions = {
         class: "TypeaheadInputComponent",
         config: {
           hostCssClasses: "flex-grow-1 d-block",
-          wrapperCssClasses: "rb-form-contributor-inline__field",
+          wrapperCssClasses: "rb-form-inline-fields__field rb-form-contributor-inline__field",
           vocabRef: 'party',
           sourceType: 'namedQuery',
           queryId: 'party',
@@ -64,7 +64,7 @@ export const reusableContributorFormDefinitions: ReusableFormDefinitions = {
         config: {
           type: "text",
           hostCssClasses: "flex-grow-1 d-block",
-          wrapperCssClasses: "rb-form-contributor-inline__field",
+          wrapperCssClasses: "rb-form-inline-fields__field rb-form-contributor-inline__field",
           onItemSelect: {rawPath: 'metadata.email'},
         }
       },
@@ -86,7 +86,7 @@ export const reusableContributorFormDefinitions: ReusableFormDefinitions = {
         config: {
           type: "text",
           hostCssClasses: "flex-grow-1 d-block",
-          wrapperCssClasses: "rb-form-contributor-inline__field",
+          wrapperCssClasses: "rb-form-inline-fields__field rb-form-contributor-inline__field",
           onItemSelect: {rawPath: 'metadata.orcid'},
         }
       },
@@ -194,7 +194,7 @@ export const reusableContributorFormDefinitions: ReusableFormDefinitions = {
       component: {
         class: "GroupComponent",
         config: {
-          hostCssClasses: "rb-form-contributor-inline",
+          hostCssClasses: "rb-form-inline-fields rb-form-contributor-inline rb-form-grid-cols-3",
           componentDefinitions: [
             {
               overrides: {reusableFormName: "standard-contributor-fields"},
@@ -217,7 +217,7 @@ export const reusableContributorFormDefinitions: ReusableFormDefinitions = {
       component: {
         class: "GroupComponent",
         config: {
-          hostCssClasses: "rb-form-contributor-inline",
+          hostCssClasses: "rb-form-inline-fields rb-form-contributor-inline rb-form-grid-cols-3",
           componentDefinitions: [
             {
               overrides: {reusableFormName: "standard-contributor-fields-lookup-only"},
@@ -240,7 +240,7 @@ export const reusableContributorFormDefinitions: ReusableFormDefinitions = {
       component: {
         class: "GroupComponent",
         config: {
-          hostCssClasses: "rb-form-contributor-inline rb-form-contributor-inline--with-title",
+          hostCssClasses: "rb-form-inline-fields rb-form-contributor-inline rb-form-grid-cols-4 rb-form-contributor-inline--with-title",
           componentDefinitions: [
             {
               overrides: {reusableFormName: "standard-contributor-fields-with-title"},
@@ -263,7 +263,7 @@ export const reusableContributorFormDefinitions: ReusableFormDefinitions = {
       component: {
         class: "GroupComponent",
         config: {
-          hostCssClasses: "rb-form-contributor-inline rb-form-contributor-inline--with-title",
+          hostCssClasses: "rb-form-inline-fields rb-form-contributor-inline rb-form-grid-cols-4 rb-form-contributor-inline--with-title",
           componentDefinitions: [
             {
               overrides: {reusableFormName: "standard-contributor-fields-with-title-lookup-only"},
@@ -314,6 +314,7 @@ export const reusableContributorFormDefinitions: ReusableFormDefinitions = {
                     component: {
                       class: "GroupComponent",
                       config: {
+                        hostCssClasses: "rb-form-inline-fields rb-form-contributor-inline rb-form-grid-cols-4",
                         componentDefinitions: [
                           {
                             overrides: {reusableFormName: "standard-contributor-fields-lookup-only"},
@@ -325,7 +326,7 @@ export const reusableContributorFormDefinitions: ReusableFormDefinitions = {
                             component: {
                               class: "DropdownInputComponent",
                               config: {
-                                hostCssClasses: "rb-form-contributor-inline__field rb-form-contributor-inline__field--role",
+                                hostCssClasses: "rb-form-inline-fields__field rb-form-inline-fields__field--fixed rb-form-contributor-inline__field rb-form-contributor-inline__field--role",
                                 options: [
                                   {
                                     label: "View",


### PR DESCRIPTION
## Summary

Adds a generic inline-fields styling model for repeatable form rows, then migrates reusable contributor definitions to use those generic classes while preserving legacy contributor-inline behavior.

---

## Context / Motivation

Inline contributor layouts were previously coupled to contributor-specific CSS hooks, which limited reuse for other repeatable inline field groups and made layout variants harder to express consistently. This update introduces shared inline class semantics so repeatable row rendering and styling can be reused across contributor and non-contributor inline patterns.

---

## Key Features

### Generic inline repeatable row handling

- Updated repeatable row layout class binding to use a generic inline-fields modifier instead of a contributor-only modifier.
- Extended inline layout detection so repeatable rows are marked inline when either legacy contributor-inline or new inline-fields host classes are present.
- Preserved compatibility with existing contributor-inline configurations while enabling new generic inline configurations.

### Inline grid and split-end styling primitives

- Added reusable grid column utility classes for inline groups including 2, 3, and 4-column variants.
- Added generic inline field span utilities for fixed-width and full-span behaviors in repeatable group layouts.
- Generalized split-end/funding inline layout rules to support shared inline class patterns beyond contributor-only selectors.

### Reusable contributor definition migration

- Updated reusable contributor form definitions to include generic inline-fields host and wrapper classes in addition to existing contributor classes.
- Added grid column class usage in contributor reusable definitions for predictable inline layout structure.
- Updated role/fixed-width field classing to align with the new generic inline field utility classes.

### Test coverage updates

- Added repeatable component specs verifying generic inline repeatable modifier application for new inline-fields classes.
- Added compatibility coverage confirming legacy contributor-inline classes still produce inline repeatable behavior.

---

## Testing

- Added/updated unit tests: repeatable component spec coverage for generic inline-fields and legacy contributor-inline detection paths.
- Added/updated integration tests: none in this branch.
- CI/CD workflow updates: none.

---

## Architectural / Operational Impact

### Form styling model

Introduces a more composable inline layout class contract for dynamic form rendering. This reduces coupling to contributor-specific selectors and makes future reusable inline group definitions easier to implement without CSS duplication.

### Frontend behavior

Repeatable row rendering now derives inline-row treatment from either old or new class markers, reducing regression risk during phased migration of form definitions.

---

## Backwards Compatibility

Backwards compatible. Legacy contributor-inline class usage remains supported, and new generic inline class additions are additive to current form definitions.

---

## Deployment Notes

No migration scripts required. Deploy as standard frontend/backend package rollout; updated reusable form class names are bundled with application code and applied at runtime.

---

## Impact

Enables reusable, generic inline repeatable layouts while retaining contributor inline compatibility, improving maintainability of form styling and reducing future layout-specific duplication.
