### PR TITLE
Feature: Add validation-group handling to save button flow

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/save-button.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/save-button.component.ts
@@ -73,7 +73,7 @@ export class SaveButtonComponent extends FormFieldBaseComponent<undefined> {
           closeOnSave: this.componentDefinition?.config?.closeOnSave,
           redirectLocation: this.componentDefinition?.config?.redirectLocation,
           redirectDelaySeconds: this.componentDefinition?.config?.redirectDelaySeconds,
-          enabledValidationGroups: this.getFormComponent.enabledValidationGroups,
+          enabledValidationGroups: this.componentDefinition?.config?.enabledValidationGroups ?? this.getFormComponent.enabledValidationGroups,
           sourceId: this.name ?? undefined
         })
       );

--- a/angular/projects/researchdatabox/form/src/app/form-save-flow.integration.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-save-flow.integration.spec.ts
@@ -53,6 +53,7 @@ describe('Form Save Flow Integration', () => {
               label: 'Save',
               targetStep: 'next_step',
               forceSave: true,
+              enabledValidationGroups: ['all', 'review-submit'],
             },
           },
         },
@@ -100,7 +101,7 @@ describe('Form Save Flow Integration', () => {
       expect(requestedEvents[0].type).toBe('form.save.requested');
       expect(requestedEvents[0].force).toBe(true);
       expect(requestedEvents[0].targetStep).toBe('next_step');
-      expect(requestedEvents[0].enabledValidationGroups).toEqual(["none"]);
+      expect(requestedEvents[0].enabledValidationGroups).toEqual(['all', 'review-submit']);
 
       // Assert: 2) NgRx submitForm action observed (promotion by adapter effect)
       const sawSubmitForm = observedActions.some(a => a.type === FormActions.submitForm.type);
@@ -112,7 +113,7 @@ describe('Form Save Flow Integration', () => {
 
       // Assert: 4) FormComponent.saveForm invoked with expected args
       expect(formComponent.saveForm).toHaveBeenCalledWith({
-        force: true, targetStep: 'next_step', enabledValidationGroups:  ['none'],
+        force: true, targetStep: 'next_step', enabledValidationGroups: ['all', 'review-submit'],
         closeOnSave: undefined, redirectLocation: undefined, redirectDelaySeconds: undefined,
       });
     } finally {

--- a/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
@@ -337,6 +337,86 @@ describe('FormComponent', () => {
     });
   });
 
+  it('applies requested validation groups before saving', async () => {
+    const formConfig: FormConfigFrame = {
+      name: 'grouped-save-validation',
+      debugValue: false,
+      enabledValidationGroups: ['all', 'value-driven'],
+      validationGroups: {
+        all: {
+          description: 'Default validation group.',
+          initialMembership: 'all',
+        },
+        'value-driven': {
+          description: 'A group enabled by form values before review submit.',
+          initialMembership: 'none',
+        },
+        'submit-for-review': {
+          description: 'Review submission validation group.',
+          initialMembership: 'none',
+        },
+      },
+      componentDefinitions: [
+        {
+          name: 'dirty_field',
+          model: {
+            class: 'SimpleInputModel',
+            config: {
+              value: 'dirty value',
+            },
+          },
+          component: {
+            class: 'SimpleInputComponent',
+          },
+        },
+        {
+          name: 'review_required',
+          model: {
+            class: 'SimpleInputModel',
+            config: {
+              value: '',
+              validators: [
+                {
+                  class: 'required',
+                  groups: {
+                    include: ['submit-for-review'],
+                    exclude: ['all'],
+                  },
+                },
+              ],
+            },
+          },
+          component: {
+            class: 'SimpleInputComponent',
+          },
+        },
+      ],
+    };
+
+    const { fixture, formComponent } = await createFormAndWaitForReady(formConfig);
+    const updateSpy = spyOn(formComponent.recordService, 'update').and.resolveTo({ success: true } as any);
+    formComponent.form?.markAsDirty();
+
+    expect(formComponent.form?.valid).toBeTrue();
+
+    await formComponent.saveForm({
+      targetStep: 'queued',
+      enabledValidationGroups: ['all', 'value-driven', 'submit-for-review'],
+    });
+
+    expect(formComponent.enabledValidationGroups).toEqual(['all', 'value-driven', 'submit-for-review']);
+    expect(formComponent.form?.valid).toBeFalse();
+    expect(formComponent.form?.get('review_required')?.hasError('required')).toBeTrue();
+    expect(updateSpy).not.toHaveBeenCalled();
+
+    formComponent.form?.get('dirty_field')?.setValue('changed again');
+    await fixture.whenStable();
+
+    expect(formComponent.enabledValidationGroups).toEqual(['all', 'value-driven']);
+    expect(formComponent.form?.get('review_required')?.hasError('required')).toBeFalse();
+    expect(formComponent.form?.valid).toBeTrue();
+  });
+
   it('omits disabled controls from Form Values Debug data', async () => {
     const formConfig: FormConfigFrame = {
       name: 'debug-filter-disabled',

--- a/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
@@ -409,12 +409,31 @@ describe('FormComponent', () => {
     expect(formComponent.form?.get('review_required')?.hasError('required')).toBeTrue();
     expect(updateSpy).not.toHaveBeenCalled();
 
+    await formComponent.saveForm({
+      targetStep: 'queued',
+      enabledValidationGroups: ['all', 'value-driven', 'submit-for-review'],
+    });
+
+    expect(formComponent.enabledValidationGroups).toEqual(['all', 'value-driven', 'submit-for-review']);
+    expect(formComponent.form?.valid).toBeFalse();
+    expect(updateSpy).not.toHaveBeenCalled();
+
     formComponent.form?.get('dirty_field')?.setValue('changed again');
     await fixture.whenStable();
 
     expect(formComponent.enabledValidationGroups).toEqual(['all', 'value-driven']);
     expect(formComponent.form?.get('review_required')?.hasError('required')).toBeFalse();
     expect(formComponent.form?.valid).toBeTrue();
+  });
+
+  it('compares validation groups independent of order', () => {
+    const fixture = TestBed.createComponent(FormComponent);
+    const formComponent = fixture.componentInstance as unknown as {
+      validationGroupNamesEqual: (first: string[], second: string[]) => boolean;
+    };
+
+    expect(formComponent.validationGroupNamesEqual(['all', 'value-driven'], ['value-driven', 'all'])).toBeTrue();
+    expect(formComponent.validationGroupNamesEqual(['all', 'value-driven'], ['all', 'submit-for-review'])).toBeFalse();
   });
 
   it('omits disabled controls from Form Values Debug data', async () => {

--- a/angular/projects/researchdatabox/form/src/app/form.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.ts
@@ -207,6 +207,8 @@ export class FormComponent extends BaseComponent implements OnDestroy {
    */
   private eventBus = inject(FormComponentEventBus);
   private focusRequestCoordinator = inject(FormComponentFocusRequestCoordinator);
+  private preTemporarySaveValidationGroups: string[] = [];
+  private resetTemporaryValidationGroupsOnNextChange = false;
   public readonly eventScopeId = `form-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
   /**
    * Status of the form, derived from the facade as signal
@@ -657,6 +659,9 @@ export class FormComponent extends BaseComponent implements OnDestroy {
 
       this.subMaps['formValueChangesSub']?.unsubscribe();
       this.subMaps['formValueChangesSub'] = this.form.valueChanges.subscribe(() => {
+        if (this.resetTemporaryValidationGroupsOnNextChange) {
+          this.resetTemporaryValidationGroups();
+        }
         if (!this.shouldRefreshDebugSnapshots()) {
           return;
         }
@@ -1045,6 +1050,21 @@ export class FormComponent extends BaseComponent implements OnDestroy {
     const targetStep = options?.targetStep ?? '';
     const enabledValidationGroups = options?.enabledValidationGroups ?? ['all'];
 
+    if (this.form && options?.enabledValidationGroups) {
+      this.preTemporarySaveValidationGroups = [...this.enabledValidationGroups];
+      this.enabledValidationGroups = enabledValidationGroups;
+      this.resetTemporaryValidationGroupsOnNextChange = !this.validationGroupNamesEqual(
+        enabledValidationGroups,
+        this.preTemporarySaveValidationGroups
+      );
+      const validationGroups = this.validationGroups;
+      this.componentDefArr?.forEach(mapEntry =>
+        this.formService.updateValidators(mapEntry, enabledValidationGroups, validationGroups)
+      );
+      this.form.updateValueAndValidity({ emitEvent: false });
+      this.broadcastFormStatus();
+    }
+
     // Check if the form is ready, defined, modified OR forceSave is set
     // Status check will ensure saves requests will not overlap within the Angular Form app context
     const formIsSaving = _isNull(this.saveResponse());
@@ -1134,6 +1154,26 @@ export class FormComponent extends BaseComponent implements OnDestroy {
       this.loggerService.warn(`${this.logName}: ${message} Cannot submit.`);
       this.eventBus.publish(createFormSaveFailureEvent({ error: message }));
     }
+  }
+
+  private resetTemporaryValidationGroups(): void {
+    if (!this.form || this.validationGroupNamesEqual(this.enabledValidationGroups, this.preTemporarySaveValidationGroups)) {
+      this.resetTemporaryValidationGroupsOnNextChange = false;
+      return;
+    }
+    const enabledValidationGroups = [...this.preTemporarySaveValidationGroups];
+    this.enabledValidationGroups = enabledValidationGroups;
+    const validationGroups = this.validationGroups;
+    this.componentDefArr?.forEach(mapEntry =>
+      this.formService.updateValidators(mapEntry, enabledValidationGroups, validationGroups)
+    );
+    this.form.updateValueAndValidity({ emitEvent: false });
+    this.broadcastFormStatus();
+    this.resetTemporaryValidationGroupsOnNextChange = false;
+  }
+
+  private validationGroupNamesEqual(first: string[], second: string[]): boolean {
+    return first.length === second.length && first.every((value, index) => value === second[index]);
   }
 
   public async deleteRecord(options?: DeleteEventConfig) {

--- a/angular/projects/researchdatabox/form/src/app/form.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.ts
@@ -1051,7 +1051,9 @@ export class FormComponent extends BaseComponent implements OnDestroy {
     const enabledValidationGroups = options?.enabledValidationGroups ?? ['all'];
 
     if (this.form && options?.enabledValidationGroups) {
-      this.preTemporarySaveValidationGroups = [...this.enabledValidationGroups];
+      if (!this.resetTemporaryValidationGroupsOnNextChange) {
+        this.preTemporarySaveValidationGroups = [...this.enabledValidationGroups];
+      }
       this.enabledValidationGroups = enabledValidationGroups;
       this.resetTemporaryValidationGroupsOnNextChange = !this.validationGroupNamesEqual(
         enabledValidationGroups,
@@ -1173,7 +1175,12 @@ export class FormComponent extends BaseComponent implements OnDestroy {
   }
 
   private validationGroupNamesEqual(first: string[], second: string[]): boolean {
-    return first.length === second.length && first.every((value, index) => value === second[index]);
+    if (first.length !== second.length) {
+      return false;
+    }
+    const sortedFirst = [...first].sort();
+    const sortedSecond = [...second].sort();
+    return sortedFirst.every((value, index) => value === sortedSecond[index]);
   }
 
   public async deleteRecord(options?: DeleteEventConfig) {

--- a/packages/redbox-core/src/visitor/construct.visitor.ts
+++ b/packages/redbox-core/src/visitor/construct.visitor.ts
@@ -1138,6 +1138,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
     this.sharedProps.setPropOverride('targetStep', item.config, config);
     this.sharedProps.setPropOverride('forceSave', item.config, config);
     this.sharedProps.setPropOverride('labelSaving', item.config, config);
+    this.sharedProps.setPropOverride('enabledValidationGroups', item.config, config);
     this.sharedProps.setPropOverride('buttonCssClasses', item.config, config);
   }
 

--- a/packages/sails-ng-common/src/config/component/save-button.model.ts
+++ b/packages/sails-ng-common/src/config/component/save-button.model.ts
@@ -21,6 +21,7 @@ export class SaveButtonFieldComponentConfig extends FieldComponentConfig impleme
     forceSave?: boolean;
     labelSaving?: string;
     buttonCssClasses?: string;
+    enabledValidationGroups?: string[];
     closeOnSave?: boolean;
     redirectLocation?: string;
     redirectDelaySeconds?: number;

--- a/packages/sails-ng-common/src/config/component/save-button.outline.ts
+++ b/packages/sails-ng-common/src/config/component/save-button.outline.ts
@@ -36,6 +36,11 @@ export interface SaveButtonFieldComponentConfigFrame extends FieldComponentConfi
      */
     buttonCssClasses?: string;
   /**
+   * Validation groups to enable for this save request.
+   * Defaults to the form's current enabled validation groups.
+   */
+  enabledValidationGroups?: string[];
+  /**
    * Whether to 'close' the form by redirecting on a successful save. Default false.
    */
   closeOnSave?: boolean;


### PR DESCRIPTION
## Summary

Add support for validation-group handling to the save button and associated form flows. The save action now respects "actioned" validation groups so validations run only for the relevant groups when the save button is used.

---

## Context / Motivation

The form save workflow previously applied global validation which made it difficult to target validations to specific action flows. This change adds group-aware validation handling so save actions validate only the intended fields/groups, improving UX and preventing unrelated validation failures.

---

## Key Features

### UI behavior
- Save button now triggers validation scoped to configured validation groups (actioned groups).
- Form component wiring updated to surface validation-group decisions to the save flow.

### Form configuration and visitors
- Save-button component config and outline updated to include validation-group metadata.
- Visitor logic adjusted to support constructing validation-group-aware behavior across form renders.

### Testing
- Added/updated unit tests for form component behavior and save flows.
- Integration spec updated to cover the save-flow validation grouping.

---

## Testing

- Updated `form.component.spec.ts` with new unit tests covering validation-group handling.
- Updated `form-save-flow.integration.spec.ts` for integration-level verification.
- CI remains unchanged; tests should pass locally and in CI.

---

## Architectural / Operational Impact

### Runtime
- Small runtime changes to how validation checks are selected at save time; no change to persistence or API contracts.

### Backwards compatibility
- Default behavior is preserved when no validation groups are configured; change is non-breaking.

---

## Deployment Notes

- No special migration required. Ensure the updated component configuration is available to clients using custom form configs.

---

## Impact

Enables more targeted validation on save operations, reducing false-positive validation errors and improving the save UX for multi-group forms.
