### PR TITLE
Fix TranslationService caching and dashboard config merge

### DIFF
--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/translation.service.spec.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/translation.service.spec.ts
@@ -82,6 +82,65 @@ describe('TranslationService testing', () => {
     expect(translationService.t('key1')).toEqual("value1");
   });
 
+  it('should cache translations separately for different interpolation option objects', async function () {
+    const mockConfigData = {
+      csrfToken: 'test',
+      rootContext: 'base',
+      branding: 'default',
+      portal: 'rdmp',
+      baseUrl: '',
+      i18NextOpts: {
+        lng: 'en',
+        fallbackLng: 'en',
+        supportedLngs: ['en'],
+        ns: ['translation'],
+        resources: {
+          en: {
+            translation: {
+              'dashboard-heading': 'My {{stage}} {{recordTypeName}}'
+            }
+          }
+        }
+      }
+    };
+    configService.getConfig = function () { return mockConfigData };
+    await translationService.waitForInit();
+
+    expect(translationService.t('dashboard-heading', { stage: 'Draft', recordTypeName: 'Records' })).toEqual('My Draft Records');
+    expect(translationService.t('dashboard-heading', { stage: 'Queued For Review', recordTypeName: 'Records' })).toEqual('My Queued For Review Records');
+  });
+
+  it('should create the same cache entry for equivalent option objects with different property order', async function () {
+    const mockConfigData = {
+      csrfToken: 'test',
+      rootContext: 'base',
+      branding: 'default',
+      portal: 'rdmp',
+      baseUrl: '',
+      i18NextOpts: {
+        lng: 'en',
+        fallbackLng: 'en',
+        supportedLngs: ['en'],
+        ns: ['translation'],
+        resources: {
+          en: {
+            translation: {
+              'dashboard-heading': 'My {{stage}} {{recordTypeName}}'
+            }
+          }
+        }
+      }
+    };
+    configService.getConfig = function () { return mockConfigData };
+    await translationService.waitForInit();
+
+    const firstOptions = { stage: 'Draft', recordTypeName: 'Records' };
+    const secondOptions = { recordTypeName: 'Records', stage: 'Draft' };
+
+    expect(translationService.t('dashboard-heading', firstOptions)).toEqual('My Draft Records');
+    expect(translationService.t('dashboard-heading', secondOptions)).toEqual('My Draft Records');
+  });
+
   it('should resolve translation keys containing colon characters', async function () {
     const mockConfigData = {
       csrfToken: 'test',

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/translation.service.spec.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/translation.service.spec.ts
@@ -141,6 +141,13 @@ describe('TranslationService testing', () => {
     expect(translationService.t('dashboard-heading', secondOptions)).toEqual('My Draft Records');
   });
 
+  it('should serialize circular arrays in translation cache keys', function () {
+    const circularArray: unknown[] = [];
+    circularArray.push(circularArray);
+
+    expect((translationService as any).serializeTranslationCacheKeyPart(circularArray)).toEqual('array:[array:[circular]]');
+  });
+
   it('should resolve translation keys containing colon characters', async function () {
     const mockConfigData = {
       csrfToken: 'test',

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/translation.service.spec.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/translation.service.spec.ts
@@ -148,6 +148,11 @@ describe('TranslationService testing', () => {
     expect((translationService as any).serializeTranslationCacheKeyPart(circularArray)).toEqual('array:[array:[circular]]');
   });
 
+  it('should create distinct cache keys when string values contain pipe characters', function () {
+    expect((translationService as any).buildTranslationCacheKey('a|string:b', undefined, undefined))
+      .not.toEqual((translationService as any).buildTranslationCacheKey('a', 'b|undefined', undefined));
+  });
+
   it('should resolve translation keys containing colon characters', async function () {
     const mockConfigData = {
       csrfToken: 'test',

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/translation.service.spec.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/translation.service.spec.ts
@@ -141,6 +141,43 @@ describe('TranslationService testing', () => {
     expect(translationService.t('dashboard-heading', secondOptions)).toEqual('My Draft Records');
   });
 
+  it('should clear cached translations when the language changes', async function () {
+    const mockConfigData = {
+      csrfToken: 'test',
+      rootContext: 'base',
+      branding: 'default',
+      portal: 'rdmp',
+      baseUrl: '',
+      i18NextOpts: {
+        lng: 'en',
+        fallbackLng: 'en',
+        supportedLngs: ['en', 'fr'],
+        ns: ['translation'],
+        resources: {
+          en: {
+            translation: {
+              'dashboard-heading': 'My {{stage}} {{recordTypeName}}'
+            }
+          },
+          fr: {
+            translation: {
+              'dashboard-heading': 'Mes {{stage}} {{recordTypeName}}'
+            }
+          }
+        }
+      }
+    };
+    configService.getConfig = function () { return mockConfigData };
+    await translationService.waitForInit();
+
+    const options = { stage: 'Draft', recordTypeName: 'Records' };
+    expect(translationService.t('dashboard-heading', options)).toEqual('My Draft Records');
+
+    await translationService.changeLanguage('fr');
+
+    expect(translationService.t('dashboard-heading', options)).toEqual('Mes Draft Records');
+  });
+
   it('should serialize circular arrays in translation cache keys', function () {
     const circularArray: unknown[] = [];
     circularArray.push(circularArray);

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/translation.service.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/translation.service.ts
@@ -86,6 +86,41 @@ export class TranslationService extends HttpClientService implements Service {
 
   private readonly translationKeyValueCache: Map<string, TranslationResult> = new Map();
 
+  private buildTranslationCacheKey(...parts: unknown[]): string {
+    return parts.map((part) => this.serializeTranslationCacheKeyPart(part)).join('|');
+  }
+
+  private serializeTranslationCacheKeyPart(value: unknown, seen: WeakSet<object> = new WeakSet<object>()): string {
+    if (value === null) {
+      return 'null';
+    }
+
+    if (value === undefined) {
+      return 'undefined';
+    }
+
+    if (Array.isArray(value)) {
+      return `array:[${value.map((item) => this.serializeTranslationCacheKeyPart(item, seen)).join(',')}]`;
+    }
+
+    if (typeof value === 'object') {
+      const objectValue = value as Record<string, unknown>;
+      if (seen.has(objectValue)) {
+        return 'object:[circular]';
+      }
+
+      seen.add(objectValue);
+      const entries = Object.keys(objectValue)
+        .sort()
+        .map((key) => `${key}:${this.serializeTranslationCacheKeyPart(objectValue[key], seen)}`);
+      seen.delete(objectValue);
+
+      return `object:{${entries.join(',')}}`;
+    }
+
+    return `${typeof value}:${String(value)}`;
+  }
+
   constructor(
     @Inject(HttpClient) protected override http: HttpClient,
     @Inject(APP_BASE_HREF) public override rootContext: string,
@@ -186,7 +221,7 @@ export class TranslationService extends HttpClientService implements Service {
       return '';
     }
 
-    const cacheKey = Array.isArray(key) ? key.join('][') : String(key);
+    const cacheKey = this.buildTranslationCacheKey(key, defaultValueOrOptions, options);
 
     if (this.translationKeyValueCache.has(cacheKey)) {
       return this.translationKeyValueCache.get(cacheKey);

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/translation.service.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/translation.service.ts
@@ -87,7 +87,7 @@ export class TranslationService extends HttpClientService implements Service {
   private readonly translationKeyValueCache: Map<string, TranslationResult> = new Map();
 
   private buildTranslationCacheKey(...parts: unknown[]): string {
-    return parts.map((part) => this.serializeTranslationCacheKeyPart(part)).join('|');
+    return JSON.stringify(parts.map((part) => this.serializeTranslationCacheKeyPart(part)));
   }
 
   private serializeTranslationCacheKeyPart(value: unknown, seen: WeakSet<object> = new WeakSet<object>()): string {

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/translation.service.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/translation.service.ts
@@ -100,7 +100,15 @@ export class TranslationService extends HttpClientService implements Service {
     }
 
     if (Array.isArray(value)) {
-      return `array:[${value.map((item) => this.serializeTranslationCacheKeyPart(item, seen)).join(',')}]`;
+      if (seen.has(value)) {
+        return 'array:[circular]';
+      }
+
+      seen.add(value);
+      const items = value.map((item) => this.serializeTranslationCacheKeyPart(item, seen));
+      seen.delete(value);
+
+      return `array:[${items.join(',')}]`;
     }
 
     if (typeof value === 'object') {

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/translation.service.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/translation.service.ts
@@ -146,7 +146,10 @@ export class TranslationService extends HttpClientService implements Service {
     this.loadPath = `${this.rootContext}/default/rdmp/locales/{{lng}}/{{ns}}.json`;
     this.i18NextService.on('initialized', () => this.translationChanges.next());
     this.i18NextService.on('loaded', () => this.translationChanges.next());
-    this.i18NextService.on('languageChanged', () => this.translationChanges.next());
+    this.i18NextService.on('languageChanged', () => {
+      this.translationKeyValueCache.clear();
+      this.translationChanges.next();
+    });
   }
 
   async initTranslator(): Promise<this> {

--- a/packages/redbox-core/src/services/DashboardConfigService.ts
+++ b/packages/redbox-core/src/services/DashboardConfigService.ts
@@ -132,6 +132,7 @@ export namespace Services {
       }
       return _.mergeWith({}, ...validConfigs, (_objValue: unknown, srcValue: unknown) => {
         if (_.isArray(srcValue)) {
+          // Dashboard table config arrays are override-only; do not rely on lodash's default index-wise array merge.
           return _.cloneDeep(srcValue);
         }
         return undefined;

--- a/packages/redbox-core/src/services/DashboardConfigService.ts
+++ b/packages/redbox-core/src/services/DashboardConfigService.ts
@@ -130,7 +130,12 @@ export namespace Services {
       if (validConfigs.length === 0) {
         return this.getDefaultDashboardTableConfig();
       }
-      return _.merge({}, ...validConfigs) as DashboardTableConfig;
+      return _.mergeWith({}, ...validConfigs, (_objValue: unknown, srcValue: unknown) => {
+        if (_.isArray(srcValue)) {
+          return _.cloneDeep(srcValue);
+        }
+        return undefined;
+      }) as DashboardTableConfig;
     }
 
     private async getDashboardTypeDefinitionForBrand(brand: BrandingModel, dashboardType: string): Promise<DashboardTypeDefinition | null> {

--- a/packages/redbox-core/test/services/DashboardConfigService.test.ts
+++ b/packages/redbox-core/test/services/DashboardConfigService.test.ts
@@ -147,6 +147,40 @@ describe('DashboardConfigService', function () {
     expect(result!.mergedConfig.rowConfig?.[0].title).to.equal('Override');
   });
 
+  it('replaces rowConfig arrays instead of merging inherited columns by index', async function () {
+    (global as any).DashboardTypesService.getDashboardTypeDefinition = sinon.stub().resolves({
+      name: 'standard',
+      formatRules: { filterBy: {} },
+      tableConfig: {
+        rowConfig: [
+          { title: 'Type Title', variable: 'metadata.title', template: '{{metadata.title}}', initialSort: 'desc' },
+          { title: 'Type Modified', variable: 'metaMetadata.lastSaveDate', template: '{{dateModified}}', defaultSort: true }
+        ]
+      }
+    });
+    (global as any).WorkflowStepsService.get = sinon.stub().returns(of({
+      name: 'finalised',
+      config: {
+        dashboard: {
+          table: {
+            rowConfig: [
+              { title: 'Workflow Title', variable: 'metadata.title', template: '{{metadata.title}}' },
+              { title: 'Workflow State', variable: 'workflow.stageLabel', template: '{{get workflow "stageLabel"}}' }
+            ]
+          }
+        }
+      }
+    }));
+
+    const result = await service.getMergedDashboardTableConfig({ id: 'brand1' } as any, 'rdmp', 'finalised');
+
+    expect(result).to.not.be.null;
+    expect(result!.mergedConfig.rowConfig).to.deep.equal([
+      { title: 'Workflow Title', variable: 'metadata.title', template: '{{metadata.title}}' },
+      { title: 'Workflow State', variable: 'workflow.stageLabel', template: '{{get workflow "stageLabel"}}' }
+    ]);
+  });
+
   it('merges dashboard view type and override config', async function () {
     (global as any).AppConfigService.getAppConfigByBrandAndKey = sinon.stub().resolves({
       recordTypes: {},


### PR DESCRIPTION
## Summary

Fixes two cache and merge behaviours that affected dashboard rendering: translation lookups now cache by the full translation invocation, including interpolation options, and dashboard table config inheritance now replaces array-based row configuration instead of merging rows by index.

---

## Context / Motivation

Dashboard labels can be translated with the same key but different interpolation values. The previous translation cache keyed mostly by the translation key itself, so one lookup could incorrectly satisfy later lookups that used different options. Dashboard table configuration inheritance also used a deep merge that treated arrays as merge targets, which could leave inherited column properties attached to overridden rows.

---

## Key Features

### Translation Cache Keys

- Adds a structured translation cache key builder that includes the key, default value or options argument, and options argument.
- Serializes objects with sorted keys so equivalent option objects produce the same cache entry regardless of property order.
- Handles arrays, null, undefined, primitives, and circular object or array references during cache key serialization.

### Dashboard Config Merging

- Updates dashboard table config merging to replace arrays from later config layers instead of merging inherited array entries by index.
- Preserves existing deep merge behaviour for non-array configuration values.
- Prevents workflow-level `rowConfig` overrides from carrying over unrelated properties from dashboard type defaults.

---

## Testing

- Added Angular unit coverage for translation interpolation cache separation, stable option-object cache keys, and circular array serialization.
- Added DashboardConfigService test coverage confirming `rowConfig` arrays are replaced rather than index-merged.

---

## Architectural / Operational Impact

### Cache Correctness

Translation caching remains local to `TranslationService`, but cache entries now reflect the arguments that affect translated output. This avoids stale or incorrect UI text when the same translation key is reused with different interpolation values.

### Config Inheritance Semantics

Dashboard table configuration now treats array values as complete overrides during merge. This better matches `rowConfig` usage, where array order and element identity define the displayed table columns.

---

## Backwards Compatibility

The changes are backwards compatible for existing translation calls and dashboard config objects. Dashboard configs that relied on array entries being merged by index may need to define complete replacement rows, which is the safer behaviour for ordered table column definitions.

---

## Deployment Notes

No migration or deployment steps are required. The changes are application code and test updates only.

---

## Impact

Improves dashboard text correctness and makes dashboard table configuration overrides deterministic across inherited configuration layers.
