### PR TITLE
fix finding a component by lineage path

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/form.service.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.service.spec.ts
@@ -487,4 +487,48 @@ describe('The FormService', () => {
     expect(createSpy).toHaveBeenCalled();
     expect(seedVocabSpy).toHaveBeenCalledWith({ vocabTrees: { access: { childrenByParentId: {}, selectedNotations: [] } } });
   });
+
+  it("should find nested component", async function () {
+    const entryTwo: FormFieldCompMapEntry = {
+      // @ts-ignore
+      compConfigJson: {name: "two"},
+      // @ts-ignore
+      lineagePaths: {dataModel: ["one", "two"]},
+      // @ts-ignore
+      component: {formFieldCompMapEntries: []},
+    };
+    const entryOne: FormFieldCompMapEntry = {
+      // @ts-ignore
+      compConfigJson: {name: "one"},
+      // @ts-ignore
+      lineagePaths: {dataModel: ["one"]},
+      // @ts-ignore
+      component: {formFieldCompMapEntries: [entryTwo]},
+    };
+    const entries: FormFieldCompMapEntry[] = [entryOne];
+    const actual = service.getFormFieldCompMapEntry({dataModel: ["one", "two"]}, entries);
+    expect(actual).toEqual(entryTwo);
+  });
+
+  it("should not find nested component with incorrect query", async function () {
+    const entryTwo: FormFieldCompMapEntry = {
+      // @ts-ignore
+      compConfigJson: {name: "two"},
+      // @ts-ignore
+      lineagePaths: {dataModel: ["one", "two"]},
+      // @ts-ignore
+      component: {formFieldCompMapEntries: []},
+    };
+    const entryOne: FormFieldCompMapEntry = {
+      // @ts-ignore
+      compConfigJson: {name: "one"},
+      // @ts-ignore
+      lineagePaths: {dataModel: ["one"]},
+      // @ts-ignore
+      component: {formFieldCompMapEntries: [entryTwo]},
+    };
+    const entries: FormFieldCompMapEntry[] = [entryOne];
+    const actual = service.getFormFieldCompMapEntry({dataModel: ["two"]}, entries);
+    expect(actual).toEqual(undefined);
+  });
 });

--- a/angular/projects/researchdatabox/form/src/app/form.service.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.service.ts
@@ -1178,12 +1178,12 @@ export class FormService extends HttpClientService {
 
   /**
    * Find the first matching form field component map entry by name or lineage path.
-   * @param name The form config name or lineage path to look for.
+   * @param target The form config name or lineage path to look for.
    * @param formFieldCompMapEntries The entries to search in, recursing into any children.
    * @return The first matching entry, or undefined if none match.
    */
   public getFormFieldCompMapEntry(
-    name: string | LineagePathsOptional,
+    target: string | LineagePathsOptional,
     formFieldCompMapEntries: FormFieldCompMapEntry[],
   ): FormFieldCompMapEntry | undefined {
     const collection: FormFieldCompMapEntry[] = [...formFieldCompMapEntries];
@@ -1195,28 +1195,33 @@ export class FormService extends HttpClientService {
         return undefined;
       }
 
-      if (typeof name === "string") {
+      if (typeof target === "string") {
         // Find component by name only.
-        if (mapEntry.compConfigJson?.name === name) {
+        if (mapEntry.compConfigJson?.name === target) {
           return mapEntry;
         }
 
         // If not found, add the component's children to search.
         collection.push(...mapEntry.component?.formFieldCompMapEntries ?? []);
 
-      } else if (!!name && mapEntry.lineagePaths) {
-        // Find component by checking if any mapEntry lineage path starts with the name.
-        const base = name;
-        const check = mapEntry.lineagePaths;
+      } else if (!!target && mapEntry.lineagePaths) {
+        // Find component by checking name against the mapEntry lineage path.
+        const entryLineagePaths = mapEntry.lineagePaths;
 
-        if (isMatchingLineagePaths(base, check)) {
+        if (isMatchingLineagePaths(target, entryLineagePaths)) {
+          // The linage paths match, found!
           return mapEntry;
         }
 
-        if (isPrefixLineagePaths(base, check)) {
-          // Add the mapEntry's children
+        if (isPrefixLineagePaths(entryLineagePaths, target)) {
+          // If the map entry's lineage paths are a prefix to the target, add the mapEntry's children.
           collection.push(...mapEntry.component?.formFieldCompMapEntries ?? []);
         }
+      } else {
+        this.loggerService.warn(`${this.logName}: Skipping due to empty name or map entry lineage paths ${JSON.stringify({
+          name: target,
+          entryLineagePaths: mapEntry.lineagePaths,
+        })}`);
       }
     }
     return undefined;

--- a/packages/sails-ng-common/test/unit/naming-helpers.test.ts
+++ b/packages/sails-ng-common/test/unit/naming-helpers.test.ts
@@ -1,8 +1,8 @@
 import {
   buildLineagePaths,
   getJSONPointerByArrayPaths,
-  getObjectWithJsonPointer,
-  LineagePaths
+  getObjectWithJsonPointer, isMatchingLineagePaths, isPrefixLineagePaths,
+  LineagePaths, LineagePathsOptional
 } from '../../src';
 
 let expect: Chai.ExpectStatic;
@@ -152,5 +152,113 @@ describe('Naming Helpers: getObjectWithJsonPointer', () => {
   it('returns undefined when the path-segment array traverses through a non-object intermediate', () => {
     const doc = { a: { b: 1 } };
     expect(getObjectWithJsonPointer(doc, ['a', 'b', 'c'])).to.equal(undefined);
+  });
+});
+
+describe('Naming Helpers: matching lineage paths', () => {
+  const isMatchingLineagePathsCases: {
+    title: string, args: { a: LineagePathsOptional, b: LineagePathsOptional }, expected: boolean
+  }[] = [
+    {
+      title: "exact match",
+      args: {
+        a: {dataModel: ["one", "two"], angularComponents: []},
+        b: {dataModel: ["one", "two"], angularComponents: []},
+      },
+      expected: true,
+    },
+    {
+      title: "no match",
+      args: {
+        a: {dataModel: ["two"]},
+        b: {dataModel: ["one"]},
+      },
+      expected: false,
+    },
+    {
+      title: "a has extra",
+      args: {
+        a: {dataModel: ["one", "two"], angularComponents: []},
+        b: {dataModel: ["one"], formConfig: ["componentDefinitions", 0]},
+      },
+      expected: false,
+    },
+    {
+      title: "matches with extra props",
+      args: {
+        a: {dataModel: ["one"], angularComponents: []},
+        b: {dataModel: ["one"], formConfig: ["componentDefinitions", 0]},
+      },
+      expected: true,
+    },
+    {
+      title: "b has extra",
+      args: {
+        a: {dataModel: ["one"]},
+        b: {dataModel: ["one", "two"]},
+      },
+      expected: false,
+    },
+  ];
+  isMatchingLineagePathsCases.forEach(({title, args, expected}) => {
+    it(`${title} returns ${expected} given args ${JSON.stringify(args)}`, () => {
+      expect(isMatchingLineagePaths(args.a, args.b)).to.eql(expected);
+    });
+  });
+});
+describe('Naming Helpers: prefix lineage paths', () => {
+  const isMatchingLineagePathsCases: {
+    title: string, args: {base: LineagePathsOptional, check: LineagePathsOptional}, expected:boolean
+  }[] = [
+    {
+      title: "exact match",
+      args: {base: {dataModel: ["one", "two"]}, check: {dataModel: ["one", "two"]}},
+      expected: true,
+    },
+    {
+      title: "no match",
+      args: {
+        base: {dataModel: ["two"]},
+        check: {dataModel: ["one"]},
+      },
+      expected: false,
+    },
+    {
+      title: "base has extra",
+      args: {
+        base: {dataModel: ["one", "two"]},
+        check: {dataModel: ["one"]},
+      },
+      expected: false,
+    },
+    {
+      title: "matches with extra props",
+      args: {
+        base: {dataModel: ["one", "two"], formConfig: ["componentDefinitions", 0]},
+        check: {dataModel: ["one", "two", "three"], angularComponents: []},
+      },
+      expected: true,
+    },
+    {
+      title: "check has extra",
+      args: {
+        base: {dataModel: ["one"]},
+        check: {dataModel: ["one", "two"]},
+      },
+      expected: true,
+    },
+    {
+      title: "extra prop",
+      args: {
+        base: {dataModel: ["one"], angularComponents: []},
+        check: {dataModel: ["one", "two"]},
+      },
+      expected: true,
+    },
+  ];
+  isMatchingLineagePathsCases.forEach(({title, args, expected}) => {
+    it(`${title} returns ${expected} given args ${JSON.stringify(args)}`, () => {
+      expect(isPrefixLineagePaths(args.base, args.check)).to.eql(expected);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Ensure a nested component can be found by lineage path.

## Testing

* Add more tests for the lineage path comparison functions.
* Add tests to ensure `FormService.getFormFieldCompMapEntry` can find a nested component.
