### PR TITLE
Feature: Support multiple validators of the same class on one control

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/form.service.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.service.spec.ts
@@ -279,6 +279,31 @@ describe('The FormService', () => {
       expect(control.valid).toBeTrue();
       expect(control.errors).toBeNull();
     });
+
+    it('should keep both errors when the same validator class is used twice on one control', async () => {
+      const control = new FormControl("hello world 2!");
+      const validators: FormValidatorConfig[] = [
+        { class: 'pattern', message: "@must-start-with-prefix", config: { pattern: "^prefix.*$", description: "must start with prefix" } },
+        { class: 'pattern', message: "@must-end-with-suffix", config: { pattern: ".*suffix$", description: "must end with suffix" } },
+      ];
+      const mapEntry = {
+        lineagePaths: {
+          formConfig: ["componentDefinitions", "0"],
+        },
+      } as unknown as FormFieldCompMapEntry;
+
+      service.setValidators(control, validators, ["all"], {}, { doUpdate: true }, mapEntry);
+      await waitForAsyncValidation();
+
+      expect(control.invalid).toBeTrue();
+      // Both validators kept their own entry in the merged errors object (no collision).
+      expect(Object.keys(control.errors ?? {}).sort()).toEqual(["pattern#0", "pattern#1"]);
+
+      // The real class is recovered for display, so both appear as 'pattern'.
+      const componentErrors = service.getFormValidatorComponentErrors(control);
+      expect(componentErrors.map(e => e.class)).toEqual(["pattern", "pattern"]);
+      expect(componentErrors.map(e => e.message).sort()).toEqual(["@must-end-with-suffix", "@must-start-with-prefix"]);
+    });
   });
 
   describe('getDynamicImportFormCompiledItems', () => {

--- a/packages/redbox-core/test/unit/validator.visitor.test.ts
+++ b/packages/redbox-core/test/unit/validator.visitor.test.ts
@@ -787,4 +787,88 @@ describe("Validator Visitor", async () => {
       });
       expect(actual).to.eql(expected);
     });
+
+    it("should include results from multiple validators of the same class on one control", async function () {
+      const formConfig: FormConfigFrame = {
+        name: "default-1.0-draft",
+        componentDefinitions: [
+          {
+            name: 'text_7',
+            layout: {
+              class: 'DefaultLayout',
+              config: {
+                label: 'TextField with default wrapper defined',
+                helpText: 'This is a help text',
+              }
+            },
+            model: {
+              class: 'SimpleInputModel',
+              config: {
+                defaultValue: 'hello world 2!',
+                validators: [
+                  {
+                    class: 'pattern',
+                    message: "@must-start-with-prefix",
+                    config: { pattern: "^prefix.*$", description: "must start with prefix" },
+                  },
+                  {
+                    class: 'pattern',
+                    message: "@must-end-with-suffix",
+                    config: { pattern: ".*suffix$", description: "must end with suffix" },
+                  },
+                ]
+              }
+            },
+            component: {
+              class: 'SimpleInputComponent'
+            }
+          },
+        ]
+      };
+      const expected: FormValidatorSummaryErrors[] = [
+        {
+          errors: [
+            {
+              message: "@must-start-with-prefix",
+              class: "pattern",
+              params: {
+                actual: "hello world 2!",
+                description: "must start with prefix",
+                requiredPattern: "^prefix.*$",
+              },
+            },
+            {
+              message: "@must-end-with-suffix",
+              class: "pattern",
+              params: {
+                actual: "hello world 2!",
+                description: "must end with suffix",
+                requiredPattern: "^.*suffix$",
+              },
+            },
+          ],
+          id: "text_7",
+          message: "TextField with default wrapper defined",
+          lineagePaths: {
+            formConfig: ["componentDefinitions", "0"],
+            dataModel: ["text_7"],
+            angularComponents: ["text_7"],
+            angularComponentsJsonPointer: "/text_7",
+            layout: ["text_7-layout"],
+            layoutJsonPointer: "/text_7-layout",
+          },
+        }
+      ];
+
+      const constructor = new ConstructFormConfigVisitor(logger);
+      const constructed = await constructor.start({ data: formConfig, formMode: "edit" });
+
+      const visitor = new ValidatorFormConfigVisitor(logger);
+      const actual = await visitor.start({
+        form: constructed,
+        enabledValidationGroups: ["all"],
+        validatorDefinitions: formValidatorsSharedDefinitions
+      });
+      expect(actual).to.eql(expected);
+    });
 });

--- a/packages/sails-ng-common/src/validation/form.model.ts
+++ b/packages/sails-ng-common/src/validation/form.model.ts
@@ -29,6 +29,15 @@ export type FormValidatorErrors = {
   [key: string]: {
     message: string;
     params: FormValidatorErrorParams;
+    /**
+     * The validator class.
+     *
+     * Only set when the error key differs from the class, which happens when the same
+     * validator class is used more than once on a control. In that case the key is made
+     * unique so Angular's error merging keeps every instance, while this property carries
+     * the real class for display.
+     */
+    class?: string;
   } & FormValidatorTargetField;
 };
 
@@ -39,6 +48,13 @@ export type FormValidatorErrors = {
 export type FormValidatorCreateConfig = {
   class?: string;
   message?: string;
+  /**
+   * The key to use for this validator's entry in the merged errors object.
+   *
+   * Defaults to the class. Set to a unique value when the same class is used more than
+   * once on a control, so Angular's error merging does not overwrite earlier instances.
+   */
+  errorKey?: string;
   [key: string]: unknown;
 } & FormValidatorTargetField;
 

--- a/packages/sails-ng-common/src/validation/form.model.ts
+++ b/packages/sails-ng-common/src/validation/form.model.ts
@@ -53,6 +53,11 @@ export type FormValidatorCreateConfig = {
    *
    * Defaults to the class. Set to a unique value when the same class is used more than
    * once on a control, so Angular's error merging does not overwrite earlier instances.
+   *
+   * @internal - This field is managed automatically by the framework. Do not set it
+   * manually in form configuration; doing so will produce an error key that does not
+   * match the validator class, breaking the display recovery in
+   * `getFormValidatorComponentErrors`.
    */
   errorKey?: string;
   [key: string]: unknown;

--- a/packages/sails-ng-common/src/validation/helpers.ts
+++ b/packages/sails-ng-common/src/validation/helpers.ts
@@ -111,14 +111,23 @@ export function formValidatorBuildError(
   const optionMessageValue = formValidatorGetDefinitionString(config, optionMessageKey);
   const optionTargetFieldKey = "targetField";
   const optionTargetFieldValue = formValidatorGetDefinitionObject(config, optionTargetFieldKey, {});
+  // The error key is the validator class, unless a unique error key was assigned because the
+  // same class is used more than once on a control. Keying by a unique value lets Angular's
+  // error merging keep every instance instead of overwriting earlier ones.
+  const optionErrorKeyKey = "errorKey";
+  const optionErrorKeyValue = formValidatorGetDefinitionString(config, optionErrorKeyKey, optionNameValue);
   const result: FormValidatorErrors = {
-    [optionNameValue]: {
+    [optionErrorKeyValue]: {
       [optionMessageKey]: optionMessageValue,
       params: {...params},
     }
   };
+  // Preserve the real class when the key differs, so the class can be recovered for display.
+  if (optionErrorKeyValue !== optionNameValue) {
+    result[optionErrorKeyValue][optionNameKey] = optionNameValue;
+  }
   if (Object.keys(optionTargetFieldValue).length > 0) {
-    result[optionNameValue][optionTargetFieldKey] = optionTargetFieldValue
+    result[optionErrorKeyValue][optionTargetFieldKey] = optionTargetFieldValue
   }
   return result;
 }

--- a/packages/sails-ng-common/src/validation/validators-support.ts
+++ b/packages/sails-ng-common/src/validation/validators-support.ts
@@ -42,6 +42,17 @@ export class ValidatorsSupport {
     config: (FormValidatorConfig | FormValidatorTargetFieldConfig)[] | null | undefined,
   ): FormValidatorFns {
     const result: FormValidatorFns = { syncDefs: [], asyncDefs: [] };
+
+    // Count how many times each class is used so we know which ones are duplicated.
+    // Duplicated classes need a unique error key so Angular's error merging keeps every
+    // instance instead of overwriting earlier ones (the merge key would otherwise collide).
+    const classCounts = new Map<string, number>();
+    for (const validatorConfigItem of (config ?? [])) {
+      const validatorClass = validatorConfigItem?.class;
+      classCounts.set(validatorClass, (classCounts.get(validatorClass) ?? 0) + 1);
+    }
+    const classOccurrences = new Map<string, number>();
+
     for (const validatorConfigItem of (config ?? [])) {
       const validatorClass = validatorConfigItem?.class;
       const def = defMap.get(validatorClass);
@@ -55,6 +66,14 @@ export class ValidatorsSupport {
         class: validatorClass,
         message: message,
       };
+
+      // Only assign a unique error key when the class is used more than once on this control.
+      // Single-use classes keep the class as the error key, so the error shape is unchanged.
+      const occurrence = (classOccurrences.get(validatorClass) ?? 0);
+      classOccurrences.set(validatorClass, occurrence + 1);
+      if ((classCounts.get(validatorClass) ?? 0) > 1) {
+        createConfig.errorKey = `${validatorClass}#${occurrence}`;
+      }
 
       if ('targetField' in validatorConfigItem && validatorConfigItem.targetField !== undefined) {
         createConfig.targetField = validatorConfigItem.targetField;
@@ -79,7 +98,9 @@ export class ValidatorsSupport {
     const result: FormValidatorComponentErrors[] = [];
     for (const [key, value] of Object.entries(errors ?? {})) {
       const item: FormValidatorComponentErrors = {
-        class: key,
+        // The error key matches the class unless the class was duplicated on a control, in
+        // which case the real class is carried on the value so it can be recovered here.
+        class: value.class ?? key,
         message: value.message ?? null,
         params: {...value.params},
       };

--- a/packages/sails-ng-common/test/unit/validators.test.ts
+++ b/packages/sails-ng-common/test/unit/validators.test.ts
@@ -712,4 +712,69 @@ describe("Validator", async () => {
       new ValidatorsSupport().checkValidationGroups({ "a-group": { description: "", initialMembership: "all" } }, ["a-group"]);
     });
   });
+
+  describe("duplicate validator classes on one control", async () => {
+    // Mimic how Angular's Validators.compose merges validator results: a shallow spread
+    // keyed by the returned object's keys. Distinct keys must survive the merge.
+    function mergeAngularStyle(results: (FormValidatorErrors | null)[]): FormValidatorErrors {
+      return results.reduce<FormValidatorErrors>((acc, res) => ({ ...acc, ...(res ?? {}) }), {});
+    }
+
+    it(`keeps a single validator's error key equal to its class (unchanged shape)`, async function () {
+      const fns = vs.createFormValidatorInstancesFromMapping(
+        vs.createValidatorDefinitionMapping(formValidatorsSharedDefinitions),
+        [{ class: "pattern", config: { pattern: "^prefix.*$", description: "must start with prefix" } }],
+      );
+      const result = fns.syncDefs[0](new SimpleServerFormValidatorControl("nope"));
+      // Keyed by class, with no extra 'class' field on the value.
+      expect(result).to.eql({
+        pattern: {
+          message: "@validator-error-pattern",
+          params: { actual: "nope", description: "must start with prefix", requiredPattern: "^prefix.*$" },
+        },
+      });
+    });
+
+    it(`gives two sync validators of the same class distinct error keys that both survive merging`, async function () {
+      const fns = vs.createFormValidatorInstancesFromMapping(
+        vs.createValidatorDefinitionMapping(formValidatorsSharedDefinitions),
+        [
+          { class: "pattern", message: "@must-start-with-prefix", config: { pattern: "^prefix.*$", description: "must start with prefix" } },
+          { class: "pattern", message: "@must-end-with-suffix", config: { pattern: ".*suffix$", description: "must end with suffix" } },
+        ],
+      );
+      const control = new SimpleServerFormValidatorControl("nope");
+      const merged = mergeAngularStyle(fns.syncDefs.map(fn => fn(control)));
+
+      // Both validators kept their own entry (no collision).
+      expect(Object.keys(merged).sort()).to.eql(["pattern#0", "pattern#1"]);
+
+      // The real class is recovered for both when flattened for display.
+      const componentErrors = vs.getFormValidatorComponentErrors(merged);
+      expect(componentErrors.map(e => e.class)).to.eql(["pattern", "pattern"]);
+      expect(componentErrors.map(e => e.message).sort()).to.eql(["@must-end-with-suffix", "@must-start-with-prefix"]);
+    });
+
+    it(`gives two async validators of the same class distinct error keys that both survive merging`, async function () {
+      const expression = "$ = 45";
+      async function evaluator(value: unknown) {
+        return await jsonataEvaluate(jsonataCompile(expression), value);
+      }
+      const fns = vs.createFormValidatorInstancesFromMapping(
+        vs.createValidatorDefinitionMapping(formValidatorsSharedDefinitions),
+        [
+          { class: "jsonata-expression", message: "@first", config: { description: "first", expression, evaluator } },
+          { class: "jsonata-expression", message: "@second", config: { description: "second", expression, evaluator } },
+        ],
+      );
+      const control = new SimpleServerFormValidatorControl(46); // fails both
+      const merged = mergeAngularStyle(await Promise.all(fns.asyncDefs.map(fn => fn(control))));
+
+      expect(Object.keys(merged).sort()).to.eql(["jsonata-expression#0", "jsonata-expression#1"]);
+
+      const componentErrors = vs.getFormValidatorComponentErrors(merged);
+      expect(componentErrors.map(e => e.class)).to.eql(["jsonata-expression", "jsonata-expression"]);
+      expect(componentErrors.map(e => e.message).sort()).to.eql(["@first", "@second"]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Allows multiple validators of the same class (e.g. two `pattern` validators with different patterns) on a single form control by preventing Angular's error merge key collision.

---

## Context / Motivation

When the same validator class was used more than once on a single control, Angular's `Validators.compose` would overwrite earlier error entries because the merge key was simply the class name. The second instance would silently replace the first, making it impossible to apply multiple `pattern` or `jsonata-expression` validators to the same field. This resolves issue #4120.

---

## Key Features

### Duplicate-safe Error Keying

- `validators-support.ts`: Pre-counts validator class occurrences per control and assigns a unique `class#N` error key to each duplicate instance. Single-use classes are unaffected — the error shape remains identical.
- `form.model.ts`: Adds optional `class` and `errorKey` properties to type definitions so the real class can be recovered for display when the error key differs.
- `helpers.ts`: Builds errors keyed by `errorKey` when present, and stores the original class on the value so downstream display logic (via `getFormValidatorComponentErrors`) can recover it.

### Backward-compatible Display Recovery

- `validators-support.ts`: `getFormValidatorComponentErrors` falls back to using the error key as the class name when no explicit `class` property exists on the error value, preserving existing behaviour for all single-use validators.

---

## Testing

- Unit tests covering duplicate sync validators (`pattern`) and async validators (`jsonata-expression`) asserting distinct merged error keys
- Unit test verifying Angular-style merge preserves both entries
- Unit test confirming single-use validators keep the unchanged `class`-keyed shape
- Integration-level test in `form.service.spec.ts` asserting the component error recovery produces the correct class and message values

---

## Architectural / Operational Impact

### Type Definitions

Two optional properties (`class`, `errorKey`) were added to `FormValidatorCreateConfig` and `FormValidatorErrors` respectively. Neither is required for existing consumers — they are only populated when duplicates are detected.

### Merged Error Object Shape

Validators that are the sole instance of their class produce identical error objects as before. Duplicate instances introduce `class#N` keys with an extra `class` field on the value. No existing consumer inspects these intermediate keys directly; all display goes through `getFormValidatorComponentErrors`, which transparently recovers the canonical class name.

---

## Backwards Compatibility

Fully backward compatible. Single-use validators produce identical error objects. The only behavioural change is that duplicate validators now both appear in validation results instead of the last one silently winning.

---

## Deployment Notes

No migration or configuration changes required. Pure code deployment.

---

## Impact

Enables form configuration authors to apply multiple validators of the same type (e.g. two different `pattern` checks) on a single field, a pattern that previously would silently discard all but the last instance.
