### PR TITLE
Chore: Update codecov install to use new gpg key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,17 +205,19 @@ jobs:
           name: Install npm dependencies
           command: npm ci --ignore-scripts --strict-peer-deps
       - run: &installCodecov
+          # https://docs.codecov.com/docs/codecov-uploader#integrity-checking-the-codecov-cli
           name: Install codecov
           command: |
             mkdir -p /tmp/.codecov-cli
             cd /tmp/.codecov-cli
-            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+            curl https://keybase.io/codecovsecops/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
             curl -Os https://cli.codecov.io/latest/linux/codecov
             curl -Os https://cli.codecov.io/latest/linux/codecov.SHA256SUM
             curl -Os https://cli.codecov.io/latest/linux/codecov.SHA256SUM.sig
             gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
             shasum -a 256 -c codecov.SHA256SUM
             chmod +x codecov
+            /tmp/.codecov-cli/codecov --help
       - run:
           name: Setup test directories
           command: |


### PR DESCRIPTION
## Summary

Fix tests failures due to invalid codecov gpg key.

## Context / related work

* Issue is due to codecov changing the account that holds their signing key https://github.com/codecov/codecov-action/issues/1956

## Technical implementation details

* Update url to codecov gpg key


