### PR TITLE
Bugfix: Preserve default sort on pagination before column sort selected

### DIFF
--- a/angular/projects/researchdatabox/dashboard/src/app/dashboard.component.spec.ts
+++ b/angular/projects/researchdatabox/dashboard/src/app/dashboard.component.spec.ts
@@ -227,6 +227,61 @@ describe('DashboardComponent standard', () => {
     );
   });
 
+  it('keeps the clicked sort when paginating after a column sort is selected', async () => {
+    const fixture = TestBed.createComponent(DashboardComponent);
+    const dashboardComponent = fixture.componentInstance;
+    const recordService = TestBed.inject(RecordService);
+    const getRecordsSpy = spyOn(recordService, 'getRecords').and.returnValue(Promise.resolve(recordDataStandard.records as any));
+    spyOn(dashboardComponent, 'evaluatePlanTableColumns').and.returnValue({
+      items: recordDataStandard.records.items,
+      totalItems: recordDataStandard.records.totalItems,
+      currentPage: recordDataStandard.records.currentPage,
+      noItems: recordDataStandard.records.noItems,
+    } as any);
+
+    dashboardComponent.dashboardTypeSelected = 'standard';
+    dashboardComponent.recordType = 'rdmp';
+    dashboardComponent.filterFieldPath = 'metadata.title';
+    dashboardComponent.sortFields = {
+      draft: ['metadata.contributor_data_manager.text_full_name', 'metadata.title', 'metaMetadata.lastSaveDate'],
+    };
+    dashboardComponent.tableConfig = {
+      draft: [
+        { variable: 'metadata.contributor_data_manager.text_full_name', noSort: '', secondarySort: '' },
+        { variable: 'metadata.title', noSort: '', secondarySort: '' },
+        { variable: 'metaMetadata.lastSaveDate', noSort: '', secondarySort: '' },
+      ],
+    };
+    dashboardComponent.sortMap = {
+      draft: {
+        'metadata.contributor_data_manager.text_full_name': { sort: 'desc', secondarySort: '', defaultSort: false },
+        'metadata.title': { sort: 'desc', secondarySort: '', defaultSort: false },
+        'metaMetadata.lastSaveDate': { sort: 'desc', secondarySort: '', defaultSort: true },
+      },
+    };
+
+    await dashboardComponent.sortChanged({
+      step: 'draft',
+      sort: 'asc',
+      secondarySort: '',
+      variable: 'metadata.title',
+    } as any);
+    await dashboardComponent.pageChanged({ page: 2 } as any, 'draft');
+
+    expect(getRecordsSpy).toHaveBeenCalledTimes(2);
+    expect(getRecordsSpy.calls.mostRecent().args).toEqual([
+      'rdmp',
+      'draft',
+      2,
+      '',
+      'metadata.title:1',
+      'metadata.title',
+      '',
+      '',
+      '',
+    ]);
+  });
+
   it('initializes a dashboard view and loads view templates', async () => {
     const fixture = TestBed.createComponent(DashboardComponent);
     const dashboardComponent = fixture.componentInstance;

--- a/angular/projects/researchdatabox/dashboard/src/app/dashboard.component.spec.ts
+++ b/angular/projects/researchdatabox/dashboard/src/app/dashboard.component.spec.ts
@@ -186,6 +186,47 @@ describe('DashboardComponent standard', () => {
     expect(dashboardComponent.records['draft'].items.length).toBeGreaterThan(0);
   });
 
+  it('keeps the default sort when paginating before any column sort is selected', async () => {
+    const fixture = TestBed.createComponent(DashboardComponent);
+    const dashboardComponent = fixture.componentInstance;
+    const recordService = TestBed.inject(RecordService);
+    const getRecordsSpy = spyOn(recordService, 'getRecords').and.returnValue(Promise.resolve(recordDataStandard.records as any));
+    spyOn(dashboardComponent, 'evaluatePlanTableColumns').and.returnValue({
+      items: recordDataStandard.records.items,
+      totalItems: recordDataStandard.records.totalItems,
+      currentPage: recordDataStandard.records.currentPage,
+      noItems: recordDataStandard.records.noItems,
+    } as any);
+
+    dashboardComponent.dashboardTypeSelected = 'standard';
+    dashboardComponent.recordType = 'rdmp';
+    dashboardComponent.filterFieldPath = 'metadata.title';
+    dashboardComponent.sortFields = {
+      draft: ['metadata.title', 'metadata.contributor_data_manager.text_full_name', 'metaMetadata.lastSaveDate'],
+    };
+    dashboardComponent.sortMap = {
+      draft: {
+        'metadata.title': { sort: 'desc', secondarySort: '', defaultSort: false },
+        'metadata.contributor_data_manager.text_full_name': { sort: 'desc', secondarySort: '', defaultSort: false },
+        'metaMetadata.lastSaveDate': { sort: 'desc', secondarySort: '', defaultSort: true },
+      },
+    };
+
+    await dashboardComponent.pageChanged({ page: 2 } as any, 'draft');
+
+    expect(getRecordsSpy).toHaveBeenCalledWith(
+      'rdmp',
+      'draft',
+      2,
+      '',
+      'metaMetadata.lastSaveDate:-1',
+      'metadata.title',
+      '',
+      '',
+      ''
+    );
+  });
+
   it('initializes a dashboard view and loads view templates', async () => {
     const fixture = TestBed.createComponent(DashboardComponent);
     const dashboardComponent = fixture.componentInstance;
@@ -444,7 +485,7 @@ describe('DashboardComponent standard', () => {
       dashboardComponent.sortFields = { draft: [''] };
       const sortMapAtStep = { '': { sort: 'desc', secondarySort: 'dateCreated' } };
       const secondarySort = dashboardComponent.getSecondarySortStringFromSortMap(sortMapAtStep, 'draft');
-      expect(secondarySort).toEqual('dateCreated:-1');
+      expect(secondarySort).toEqual('');
     });
 
     it('handles step that does not exist in sortFields', () => {
@@ -588,7 +629,7 @@ describe('DashboardComponent standard', () => {
       expect(sortString).toEqual('title:-1');
     });
 
-    it('uses last matching field with sort when multiple fields exist', () => {
+    it('uses first matching field with sort when multiple fields exist', () => {
       const fixture = TestBed.createComponent(DashboardComponent);
       const dashboardComponent = fixture.componentInstance as any;
       dashboardComponent.sortFields = { draft: ['title', 'date', 'name'] };
@@ -598,7 +639,7 @@ describe('DashboardComponent standard', () => {
         name: { sort: 'desc' },
       };
       const sortString = dashboardComponent.getSortStringFromSortMap(sortMapAtStep, 'draft');
-      expect(sortString).toEqual('name:-1');
+      expect(sortString).toEqual('date:1');
     });
 
     it('returns default sort when sortField is empty string', () => {

--- a/angular/projects/researchdatabox/dashboard/src/app/dashboard.component.ts
+++ b/angular/projects/researchdatabox/dashboard/src/app/dashboard.component.ts
@@ -860,12 +860,12 @@ export class DashboardComponent extends BaseComponent {
     let sortMapAtStep = this.sortMap[step];
 
     if (this.dashboardTypeSelected == 'standard') {
-      let stagedRecords = await this.recordService.getRecords(this.recordType, step, event.page, '', this.getSortStringFromSortMap(sortMapAtStep, step), this.filterFieldPath, this.getFilterSearchString(step), '', this.getSecondarySortStringFromSortMap(sortMapAtStep, step));
+      let stagedRecords = await this.recordService.getRecords(this.recordType, step, event.page, '', this.getSortStringFromSortMap(sortMapAtStep, step, true), this.filterFieldPath, this.getFilterSearchString(step), '', this.getSecondarySortStringFromSortMap(sortMapAtStep, step, true));
       let planTable: PlanTable = this.evaluatePlanTableColumns({}, {}, {}, step, stagedRecords, this.recordType);
       this.records[step] = planTable;
       this.isProcessingPageChange = false;
     } else if (this.dashboardTypeSelected == 'workspace') {
-      let stagedRecords = await this.recordService.getRecords('', '', event.page, this.packageType, this.getSortStringFromSortMap(sortMapAtStep, step), this.filterFieldPath, this.getFilterSearchString(step), '', this.getSecondarySortStringFromSortMap(sortMapAtStep, step));
+      let stagedRecords = await this.recordService.getRecords('', '', event.page, this.packageType, this.getSortStringFromSortMap(sortMapAtStep, step, true), this.filterFieldPath, this.getFilterSearchString(step), '', this.getSecondarySortStringFromSortMap(sortMapAtStep, step, true));
       let planTable: PlanTable = this.evaluatePlanTableColumns({}, {}, {}, step, stagedRecords, '');
       this.records[step] = planTable;
       this.isProcessingPageChange = false;
@@ -917,46 +917,14 @@ export class DashboardComponent extends BaseComponent {
   }
 
 
-  private getSortStringFromSortMap(sortMapAtStep: any, step: string, forceDefault: boolean = false) {
-    let fields = _get(this.sortFields, step);
-    let sortString = 'metaMetadata.lastSaveDate:-1';
-    if (!_isUndefined(fields) && !_isEmpty(fields)) {
-      for (let i = 0; i < fields.length; i++) {
-        let sortField = fields[i];
-        if (!_isEmpty(sortMapAtStep) && !_isEmpty(sortField) && _has(sortMapAtStep, sortField)) {
-          if (sortMapAtStep[sortField].sort != null && forceDefault && sortMapAtStep[sortField].defaultSort == true) {
-            sortString = `${sortField}:`;
-            if (sortMapAtStep[sortField].sort == 'desc') {
-              sortString = sortString + "-1";
-            } else {
-              sortString = sortString + "1";
-            }
-            return sortString;
-          } else {
-            if (sortMapAtStep[sortField].sort != null) {
-              sortString = `${sortField}:`;
-              if (sortMapAtStep[sortField].sort == 'desc') {
-                sortString = sortString + "-1";
-              } else {
-                sortString = sortString + "1";
-              }
-            }
-          }
-        }
-      }
-    }
-    return sortString;
-  }
-
-
-  private getSecondarySortStringFromSortMap(sortMapAtStep: any, step: string) {
-
+  private getActiveSortFieldFromSortMap(sortMapAtStep: any, step: string, forceDefault: boolean = false) {
     let fields = _get(this.sortFields, step);
 
     if (_isUndefined(fields) || _isEmpty(fields) || _isEmpty(sortMapAtStep)) {
       return '';
     }
 
+    let activeSortField = '';
     for (let i = 0; i < fields.length; i++) {
       let sortField = fields[i];
 
@@ -964,25 +932,61 @@ export class DashboardComponent extends BaseComponent {
         continue;
       }
 
-      if (sortMapAtStep[sortField].sort != null) {
+      let sort = _get(sortMapAtStep, [sortField, 'sort']);
+      if (sort !== 'asc' && sort !== 'desc') {
+        continue;
+      }
 
-        let secondarySort = sortMapAtStep[sortField].secondarySort;
+      if (forceDefault && _get(sortMapAtStep, [sortField, 'defaultSort']) == true) {
+        return sortField;
+      }
 
-        if (sortMapAtStep[sortField].sort == 'desc') {
-          if (secondarySort != null && secondarySort !== '') {
-            let sortString = `${secondarySort}:`;
-            sortString = sortString + "-1";
-            return sortString;
-          }
-        } else {
-          if (secondarySort != null && secondarySort !== '') {
-            let sortString = `${secondarySort}:`;
-            sortString = sortString + "1";
-            return sortString;
-          }
-        }
+      if (_isEmpty(activeSortField)) {
+        activeSortField = sortField;
       }
     }
+
+    return activeSortField;
+  }
+
+
+  private getSortStringFromSortMap(sortMapAtStep: any, step: string, forceDefault: boolean = false) {
+    let sortString = 'metaMetadata.lastSaveDate:-1';
+    let sortField = this.getActiveSortFieldFromSortMap(sortMapAtStep, step, forceDefault);
+
+    if (!_isEmpty(sortField)) {
+      sortString = `${sortField}:`;
+      if (_get(sortMapAtStep, [sortField, 'sort']) == 'desc') {
+        sortString = sortString + "-1";
+      } else {
+        sortString = sortString + "1";
+      }
+    }
+
+    return sortString;
+  }
+
+
+  private getSecondarySortStringFromSortMap(sortMapAtStep: any, step: string, forceDefault: boolean = false) {
+    let sortField = this.getActiveSortFieldFromSortMap(sortMapAtStep, step, forceDefault);
+
+    if (_isEmpty(sortField)) {
+      return '';
+    }
+
+    let secondarySort = _get(sortMapAtStep, [sortField, 'secondarySort']);
+    let sort = _get(sortMapAtStep, [sortField, 'sort']);
+
+    if (secondarySort != null && secondarySort !== '') {
+      let sortString = `${secondarySort}:`;
+      if (sort == 'desc') {
+        sortString = sortString + "-1";
+      } else {
+        sortString = sortString + "1";
+      }
+      return sortString;
+    }
+
     return '';
   }
 
@@ -1079,9 +1083,9 @@ export class DashboardComponent extends BaseComponent {
       this.records[step].currentPage = 1;
       let stagedRecords: any;
       if (this.dashboardTypeSelected == 'workspace') {
-        stagedRecords = await this.recordService.getRecords('', '', 1, this.packageType, this.getSortStringFromSortMap(sortMapAtStep, step), this.filterFieldPath, this.getFilterSearchString(step), '', this.getSecondarySortStringFromSortMap(sortMapAtStep, step));
+        stagedRecords = await this.recordService.getRecords('', '', 1, this.packageType, this.getSortStringFromSortMap(sortMapAtStep, step, true), this.filterFieldPath, this.getFilterSearchString(step), '', this.getSecondarySortStringFromSortMap(sortMapAtStep, step, true));
       } else {
-        stagedRecords = await this.recordService.getRecords(this.recordType, step, 1, '', this.getSortStringFromSortMap(sortMapAtStep, step), this.filterFieldPath, this.getFilterSearchString(step), '', this.getSecondarySortStringFromSortMap(sortMapAtStep, step));
+        stagedRecords = await this.recordService.getRecords(this.recordType, step, 1, '', this.getSortStringFromSortMap(sortMapAtStep, step, true), this.filterFieldPath, this.getFilterSearchString(step), '', this.getSecondarySortStringFromSortMap(sortMapAtStep, step, true));
       }
 
       let recordType = this.dashboardTypeSelected == 'workspace' ? '' : this.recordType;
@@ -1102,9 +1106,9 @@ export class DashboardComponent extends BaseComponent {
       this.records[step].currentPage = 1;
       let stagedRecords: any;
       if (this.dashboardTypeSelected == 'workspace') {
-        stagedRecords = await this.recordService.getRecords('', '', 1, this.packageType, this.getSortStringFromSortMap(sortMapAtStep, step), this.filterFieldPath, this.getFilterSearchString(step), '', this.getSecondarySortStringFromSortMap(sortMapAtStep, step));
+        stagedRecords = await this.recordService.getRecords('', '', 1, this.packageType, this.getSortStringFromSortMap(sortMapAtStep, step, true), this.filterFieldPath, this.getFilterSearchString(step), '', this.getSecondarySortStringFromSortMap(sortMapAtStep, step, true));
       } else {
-        stagedRecords = await this.recordService.getRecords(this.recordType, step, 1, '', this.getSortStringFromSortMap(sortMapAtStep, step), this.filterFieldPath, this.getFilterSearchString(step), '', this.getSecondarySortStringFromSortMap(sortMapAtStep, step));
+        stagedRecords = await this.recordService.getRecords(this.recordType, step, 1, '', this.getSortStringFromSortMap(sortMapAtStep, step, true), this.filterFieldPath, this.getFilterSearchString(step), '', this.getSecondarySortStringFromSortMap(sortMapAtStep, step, true));
       }
 
       let recordType = this.dashboardTypeSelected == 'workspace' ? '' : this.recordType;


### PR DESCRIPTION
## Summary

Fixes pagination in the dashboard to preserve the configured default sort field when the user pages through results before clicking any column header to sort.

---

## Context / Motivation

When a dashboard step defines a default sort field (e.g. `metaMetadata.lastSaveDate`) via `defaultSort: true` in the `sortMap`, paginating to page 2+ would incorrectly fall back to a hardcoded fallback sort string instead of honouring the configured default. This caused the sort order to change unexpectedly as users navigated between pages.

---

## Key Features

### Sort Field Unification

- Extracted `getActiveSortFieldFromSortMap` to centralise sort-field resolution for both primary and secondary sort strings, eliminating duplicated iteration logic

### Pagination Sort Consistency

- All pagination call sites (`pageChanged`, `filterByStatus`, `tableHeaderClicked`) now pass `forceDefault=true` so the default sort field is always used when no column sort has been explicitly selected

### Tiebreaker Behaviour Change

- Changed the multi-field tiebreaker from last-match-wins to first-match-wins, aligning with the expected priority order defined in `sortFields`

### Secondary Sort Simplification

- Refactored `getSecondarySortStringFromSortMap` to derive its field from `getActiveSortFieldFromSortMap` instead of independently iterating the sort map

---

## Testing

- Added new spec: verifies pagination to page 2 uses the default sort field when no column has been clicked
- Updated existing specs to match the first-match tiebreaker change
- Updated empty-secondary-sort expectation to return empty string rather than a fallback value

---

## Architectural / Operational Impact

### Sorting Logic Consolidation

The sort string generation logic is now unified behind a single entry point, reducing the surface area for bugs when the sort-map iteration logic needs to evolve.

---

## Backwards Compatibility

Fully backward compatible. The only observable change is that dashboards with multiple sort fields and no explicit column sort now use the first matching field (by `sortFields` order) instead of the last matching field. This matches the intended configuration semantics.

---

## Deployment Notes

No migration or deployment steps required.

---

## Impact

Pagination in dashboard views now consistently applies the configured default sort, preventing unexpected reordering when navigating between pages.
