### PR TITLE
Feature: Add repeatable component sorting, date formatting helpers, and contributor form refactoring

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/date-input.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/date-input.component.spec.ts
@@ -58,8 +58,8 @@ describe('parseFreeTextDate', () => {
 describe('DateInputComponent', () => {
   beforeEach(async () => {
     await createTestbedModule({
-      declarations: [DateInputComponent]
-      , imports: [BsDatepickerModule.forRoot()]
+      declarations: [DateInputComponent],
+      imports: [BsDatepickerModule.forRoot()],
     });
   });
 
@@ -83,13 +83,12 @@ describe('DateInputComponent', () => {
           model: {
             class: 'DateInputModel',
             config: {
-              value: new Date('2025-08-10T10:00:00Z')
+              value: new Date('2025-08-10T10:00:00Z'),
             },
           },
           component: {
             class: 'DateInputComponent',
-            config: {
-            },
+            config: {},
           },
         },
       ],
@@ -115,13 +114,12 @@ describe('DateInputComponent', () => {
           model: {
             class: 'DateInputModel',
             config: {
-              value: new Date('2025-08-10T10:00:00Z')
+              value: new Date('2025-08-10T10:00:00Z'),
             },
           },
           component: {
             class: 'DateInputComponent',
-            config: {
-            },
+            config: {},
           },
         },
       ],
@@ -147,13 +145,12 @@ describe('DateInputComponent', () => {
           model: {
             class: 'DateInputModel',
             config: {
-              value: '2025-08-10T10:00:00.000Z' as unknown as Date
+              value: '2025-08-10T10:00:00.000Z' as unknown as Date,
             },
           },
           component: {
             class: 'DateInputComponent',
-            config: {
-            },
+            config: {},
           },
         },
       ],
@@ -250,7 +247,7 @@ describe('DateInputComponent', () => {
           model: {
             class: 'DateInputModel',
             config: {
-              value: new Date('2025-08-10T10:00:00Z')
+              value: new Date('2025-08-10T10:00:00Z'),
             },
           },
           component: {
@@ -298,7 +295,7 @@ describe('DateInputComponent', () => {
           component: {
             class: 'DateInputComponent',
             config: {
-              robustParsing: false
+              robustParsing: false,
             },
           },
         },
@@ -335,7 +332,7 @@ describe('DateInputComponent', () => {
           model: {
             class: 'DateInputModel',
             config: {
-              value: new Date('2025-08-10T10:00:00Z')
+              value: new Date('2025-08-10T10:00:00Z'),
             },
           },
           component: {
@@ -446,5 +443,44 @@ describe('DateInputComponent', () => {
 
     expect(dateInputComp.model?.formControl?.value).toEqual(new Date('2025-08-10T10:00:00Z'));
     expect(inputElement.value).toEqual('2025/08/10');
+  });
+
+  it('should emit a value change when typed text is normalized to a Date', async () => {
+    const formConfig: FormConfigFrame = {
+      name: 'testing_emit_normalized_text',
+      debugValue: true,
+      defaultComponentConfig: {
+        defaultComponentCssClasses: 'row',
+      },
+      editCssClasses: 'redbox-form form',
+      componentDefinitions: [
+        {
+          name: 'date_test',
+          model: {
+            class: 'DateInputModel',
+            config: {},
+          },
+          component: {
+            class: 'DateInputComponent',
+            config: {},
+          },
+        },
+      ],
+    };
+
+    const { fixture } = await createFormAndWaitForReady(formConfig);
+    const inputElement = fixture.nativeElement.querySelector('input[type="text"]') as HTMLInputElement;
+    const dateInputDebug = fixture.debugElement.query(By.directive(DateInputComponent));
+    const dateInputComp = dateInputDebug.componentInstance as DateInputComponent;
+    const emittedValues: unknown[] = [];
+    dateInputComp.model?.formControl?.valueChanges.subscribe(value => emittedValues.push(value));
+
+    inputElement.value = '2026/06/10';
+    inputElement.dispatchEvent(new Event('input', { bubbles: true }));
+    inputElement.dispatchEvent(new FocusEvent('blur', { bubbles: true }));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(emittedValues.some(value => value instanceof Date && value.getUTCFullYear() === 2026)).toBeTrue();
   });
 });

--- a/angular/projects/researchdatabox/form/src/app/component/date-input.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/date-input.component.ts
@@ -1,5 +1,10 @@
 import { Component, ElementRef, Input, ViewChild } from '@angular/core';
-import { FormFieldBaseComponent, FormFieldCompMapEntry, FormFieldModel, ModifyOptions } from "@researchdatabox/portal-ng-common";
+import {
+  FormFieldBaseComponent,
+  FormFieldCompMapEntry,
+  FormFieldModel,
+  ModifyOptions,
+} from '@researchdatabox/portal-ng-common';
 import { DateInputFieldComponentConfig } from '@researchdatabox/sails-ng-common/dist/src/config/component/date-input.model';
 import {
   DateInputComponentName,
@@ -238,31 +243,29 @@ export class DateInputModel extends FormFieldModel<DateInputModelValueType> {
           (blur)="onInputBlur($event)"
         />
         <div class="input-group-append">
-          <span class="input-group-text date-input-addon" (click)="toggleDatepicker()" >
+          <span class="input-group-text date-input-addon" (click)="toggleDatepicker()">
             <i class="fa fa-calendar"></i>
           </span>
         </div>
         @if (enableTimePicker) {
-          <input
-            type="time"
-            class="form-control"
-            [readonly]="isReadonly"
-            (change)="onTimeChange($event)"
-          />
+          <input type="time" class="form-control" [readonly]="isReadonly" (change)="onTimeChange($event)" />
         }
       </div>
       <ng-container *ngTemplateOutlet="getTemplateRef('after')" />
     }
   `,
-  styles: [`
-    .date-input-width {
-      flex: none !important;
-      width: 50% !important;
-    }
-    .date-input-addon {
-      height: 34px;
-    }`],
-  standalone: false
+  styles: [
+    `
+      .date-input-width {
+        flex: none !important;
+        width: 50% !important;
+      }
+      .date-input-addon {
+        height: 34px;
+      }
+    `,
+  ],
+  standalone: false,
 })
 export class DateInputComponent extends FormFieldBaseComponent<DateInputModelValueType> {
   protected override logName = DateInputComponentName;
@@ -293,7 +296,7 @@ export class DateInputComponent extends FormFieldBaseComponent<DateInputModelVal
     this.tooltip = this.getStringProperty('tooltip');
     let dateConfig = this.componentDefinition?.config as DateInputFieldComponentConfigFrame;
     let defaultConfig = new DateInputFieldComponentConfig();
-    let cfg = (_isUndefined(dateConfig) || _isEmpty(dateConfig)) ? defaultConfig : dateConfig;
+    let cfg = _isUndefined(dateConfig) || _isEmpty(dateConfig) ? defaultConfig : dateConfig;
     this.placeholder = cfg.placeholder ?? defaultConfig.placeholder ?? this.placeholder;
     this.showWeekNumbers = cfg.showWeekNumbers ?? defaultConfig.showWeekNumbers ?? this.showWeekNumbers;
     this.robustParsing = cfg.robustParsing ?? defaultConfig.robustParsing ?? this.robustParsing;
@@ -301,7 +304,8 @@ export class DateInputComponent extends FormFieldBaseComponent<DateInputModelVal
     this.bsFullConfig = cfg.bsFullConfig ?? {};
     if (!_isUndefined(this.model)) {
       this.model.dateFormat = cfg.dateFormat ?? defaultConfig.dateFormat ?? this.dateFormatDefault;
-      this.model.enableTimePicker = cfg.enableTimePicker ?? defaultConfig.enableTimePicker ?? this.enableTimePickerDefault;
+      this.model.enableTimePicker =
+        cfg.enableTimePicker ?? defaultConfig.enableTimePicker ?? this.enableTimePickerDefault;
     }
   }
 
@@ -329,7 +333,7 @@ export class DateInputComponent extends FormFieldBaseComponent<DateInputModelVal
     }
 
     if (normalizedValue !== undefined && !areDateInputValuesEqual(this.formControl?.value, normalizedValue)) {
-      this.formControl?.setValue(normalizedValue, { emitEvent: false });
+      this.formControl?.setValue(normalizedValue, { emitEvent: typeof dateValue === 'string' });
     }
 
     this.onDateChange((normalizedValue ?? dateValue ?? null) as DateInputModelValueType);
@@ -404,7 +408,7 @@ export class DateInputComponent extends FormFieldBaseComponent<DateInputModelVal
       return {
         dateInputFormat: this.dateFormat,
         showWeekNumbers: this.showWeekNumbers,
-        containerClass: this.containerClass
+        containerClass: this.containerClass,
       } as BsDatepickerConfig;
     } else {
       return this.bsFullConfig as BsDatepickerConfig;

--- a/angular/projects/researchdatabox/form/src/app/component/repeatable.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/repeatable.component.spec.ts
@@ -881,6 +881,58 @@ describe('RepeatableComponent', () => {
     expect(fixture.nativeElement.querySelectorAll('.rb-form-repeatable-item').length).toBe(0);
   }));
 
+  it('should emit exactly one value change event when moving an element', fakeAsync(() => {
+    const formConfig: FormConfigFrame = {
+      name: 'testing_repeatable_move_emit',
+      componentDefinitions: [
+        {
+          name: 'repeatable_move',
+          model: {
+            class: 'RepeatableModel',
+            config: { value: ['one', 'two', 'three'] }
+          },
+          component: {
+            class: 'RepeatableComponent',
+            config: {
+              canSort: true,
+              elementTemplate: {
+                name: '',
+                model: {
+                  class: 'SimpleInputModel',
+                  config: {}
+                },
+                component: {
+                  class: 'SimpleInputComponent'
+                }
+              }
+            }
+          }
+        }
+      ]
+    };
+
+    let fixture: any;
+    createFormAndWaitForReady(formConfig).then(result => {
+      fixture = result.fixture;
+    });
+    flushMicrotasks();
+    tick();
+
+    const repeatable = fixture.componentInstance.componentDefArr[0].component as RepeatableComponent;
+    const formArray = repeatable.model?.getFormControl() as any;
+    let emitCount = 0;
+    const sub = formArray.valueChanges.subscribe(() => emitCount++);
+
+    repeatable.moveElementFn((repeatable as any).compDefMapEntries[0], 1)();
+    tick();
+    flushMicrotasks();
+
+    expect(emitCount).toBe(1);
+    expect(formArray.value).toEqual(['two', 'one', 'three']);
+
+    sub.unsubscribe();
+  }));
+
   it('should disable add and remove buttons and model when the repeatable is disabled', async () => {
     const formConfig: FormConfigFrame = {
       name: 'testing_repeatable_disabled_buttons_also_disabled',

--- a/angular/projects/researchdatabox/form/src/app/component/repeatable.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/repeatable.component.ts
@@ -1,7 +1,12 @@
 import { Component, ComponentRef, DestroyRef, inject, ViewChild, ViewContainerRef, TemplateRef } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormArray, AbstractControl } from '@angular/forms';
-import { FormFieldBaseComponent, FormFieldModel, FormFieldCompMapEntry, ModifyOptions } from '@researchdatabox/portal-ng-common';
+import {
+  FormFieldBaseComponent,
+  FormFieldModel,
+  FormFieldCompMapEntry,
+  ModifyOptions,
+} from '@researchdatabox/portal-ng-common';
 import {
   ContentComponentName,
   FormConfigFrame,
@@ -15,26 +20,30 @@ import {
   ReusableComponentName,
   SyncSourceEntry,
 } from '@researchdatabox/sails-ng-common';
-import { isEmpty as _isEmpty, cloneDeep as _cloneDeep, isEqual as _isEqual, isUndefined as _isUndefined } from 'lodash-es';
+import {
+  isEmpty as _isEmpty,
+  cloneDeep as _cloneDeep,
+  isEqual as _isEqual,
+  isUndefined as _isUndefined,
+} from 'lodash-es';
 import { FormService } from '../form.service';
-import { FormBaseWrapperComponent } from "./base-wrapper.component";
-import { DefaultLayoutComponent } from "./default-layout.component";
-import { createFormDefinitionChangeRequestEvent, createFormStatusDirtyRequestEvent, FormComponentEventBus } from '../form-state';
+import { FormBaseWrapperComponent } from './base-wrapper.component';
+import { DefaultLayoutComponent } from './default-layout.component';
+import {
+  createFormDefinitionChangeRequestEvent,
+  createFormStatusDirtyRequestEvent,
+  FormComponentEventBus,
+} from '../form-state';
 import { CustomSetValueControl } from '../form-state/custom-set-value.control';
-import { FormComponent } from "../form.component";
+import { FormComponent } from '../form.component';
 import { FieldValueChangedEvent, FormComponentEventType } from '../form-state';
 
 type RepeatableSetValueOptions = ModifyOptions;
 
-class RepeatableFormArray
-  extends FormArray<AbstractControl<unknown>>
-  implements CustomSetValueControl<Array<unknown>> {
+class RepeatableFormArray extends FormArray<AbstractControl<unknown>> implements CustomSetValueControl<Array<unknown>> {
   public customValueSetter?: (value: Array<unknown>, options?: RepeatableSetValueOptions) => Promise<void> | void;
 
-  public async setCustomValue(
-    value: Array<unknown>,
-    options?: RepeatableSetValueOptions
-  ): Promise<void> {
+  public async setCustomValue(value: Array<unknown>, options?: RepeatableSetValueOptions): Promise<void> {
     if (this.customValueSetter) {
       await this.customValueSetter(value, options);
       return;
@@ -59,19 +68,23 @@ class RepeatableFormArray
  */
 @Component({
   selector: 'redbox-form-repeatable',
-  template:
-    `
+  template: `
     <ng-container *ngTemplateOutlet="getTemplateRef('before')" />
     <div class="rb-form-repeatable">
-      <div class="rb-form-repeatable__items" [class.d-none]="isStatusReady() && hideWhenZeroRows && compDefMapEntries.length === 0">
+      <div
+        class="rb-form-repeatable__items"
+        [class.d-none]="isStatusReady() && hideWhenZeroRows && compDefMapEntries.length === 0"
+      >
         <ng-container #repeatableContainer></ng-container>
       </div>
       @if (isStatusReady() && isVisible && addButtonShow && (!hideWhenZeroRows || compDefMapEntries.length > 0)) {
-        <button type="button"
-                class="rb-form-repeatable__add btn btn-success"
-                (click)="appendNewElement()"
-                [attr.aria-label]="'add-button-label' | i18next"
-                [disabled]="isDisabled">
+        <button
+          type="button"
+          class="rb-form-repeatable__add btn btn-success"
+          (click)="appendNewElement()"
+          [attr.aria-label]="'add-button-label' | i18next"
+          [disabled]="isDisabled"
+        >
           <span class="fa fa-plus-circle" aria-hidden="true"></span>
           <span>{{ 'add-button-label' | i18next }}</span>
         </button>
@@ -79,7 +92,7 @@ class RepeatableFormArray
     </div>
     <ng-container *ngTemplateOutlet="getTemplateRef('after')" />
   `,
-  standalone: false
+  standalone: false,
 })
 export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> {
   protected override logName = RepeatableComponentName;
@@ -87,6 +100,7 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
   protected addButtonShow = true;
   protected allowZeroRows = false;
   protected hideWhenZeroRows = false;
+  protected canSort = false;
 
   protected formService = inject(FormService);
   protected elemInitFieldEntry?: FormFieldCompMapEntry;
@@ -97,14 +111,11 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
   @ViewChild('repeatableContainer', { read: ViewContainerRef, static: true }) repeatableContainer!: ViewContainerRef;
   @ViewChild('removeButtonTemplate', { read: TemplateRef<any>, static: false }) removeButtonTemplate!: TemplateRef<any>;
 
-
   private readonly eventBus = inject(FormComponentEventBus);
   private readonly destroyRef = inject(DestroyRef);
 
   public override get formFieldBaseComponents(): FormFieldBaseComponent<unknown>[] {
-    return this.formFieldCompMapEntries
-      .map(c => c.component)
-      .filter(c => c !== undefined && c !== null);
+    return this.formFieldCompMapEntries.map(c => c.component).filter(c => c !== undefined && c !== null);
   }
 
   public override get formFieldCompMapEntries(): FormFieldCompMapEntry[] {
@@ -117,27 +128,34 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
 
   protected override async initData() {
     // Prepare the element template
-    const formComponentName = this.formFieldCompMapEntry?.compConfigJson?.name ?? "";
+    const formComponentName = this.formFieldCompMapEntry?.compConfigJson?.name ?? '';
 
     const componentFormConfig = this.componentDefinition;
-    if (!isTypeFieldDefinitionName<RepeatableFieldComponentDefinitionFrame>(componentFormConfig, RepeatableComponentName)) {
+    if (
+      !isTypeFieldDefinitionName<RepeatableFieldComponentDefinitionFrame>(componentFormConfig, RepeatableComponentName)
+    ) {
       throw new Error(`Expected a repeatable component, but got ${JSON.stringify(componentFormConfig)}`);
     }
 
     const componentConfigFormConfig = componentFormConfig.config;
-    this.addButtonShow = _isUndefined(componentConfigFormConfig?.addButtonShow) ? true : componentConfigFormConfig?.addButtonShow;
+    this.addButtonShow = _isUndefined(componentConfigFormConfig?.addButtonShow)
+      ? true
+      : componentConfigFormConfig?.addButtonShow;
     this.allowZeroRows = componentConfigFormConfig?.allowZeroRows ?? false;
     this.hideWhenZeroRows = componentConfigFormConfig?.hideWhenZeroRows ?? false;
+    this.canSort = componentConfigFormConfig?.canSort ?? false;
     const elementTemplate = componentConfigFormConfig?.elementTemplate;
     if (!elementTemplate) {
-      throw new Error(`${this.logName}: elementTemplate is not defined in the component definition for '${formComponentName}'.`);
+      throw new Error(
+        `${this.logName}: elementTemplate is not defined in the component definition for '${formComponentName}'.`
+      );
     }
 
     // Resolve the classes using the FormService
     const newElementFormConfig: FormConfigFrame = {
       name: `form-config-generated-repeatable-${formComponentName}`,
       // Add an empty name to satisfy the FormConfig, the name will be replaced with a generated name.
-      componentDefinitions: [{ ...elementTemplate, name: "" }],
+      componentDefinitions: [{ ...elementTemplate, name: '' }],
       // TODO: Get the default config?
       // defaultComponentConfig: this.getFormComponent.formDefMap?.formConfig?.defaultComponentConfig,
       // Use the current enabledValidationGroups for creating the component.
@@ -145,40 +163,42 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
       enabledValidationGroups: this.getFormComponent.enabledValidationGroups,
       validationGroups: this.getFormComponent.validationGroups,
     };
-    const parentLineagePaths = this.formService.buildLineagePaths(
-      this.formFieldCompMapEntry?.lineagePaths,
-      {
-        angularComponents: [],
-        layout: [],
-        dataModel: [],
-        formConfig: ['component', 'config', 'elementTemplate'],
-      }
-    );
+    const parentLineagePaths = this.formService.buildLineagePaths(this.formFieldCompMapEntry?.lineagePaths, {
+      angularComponents: [],
+      layout: [],
+      dataModel: [],
+      formConfig: ['component', 'config', 'elementTemplate'],
+    });
     const formComponentsMap = await this.formService.createFormComponentsMap(newElementFormConfig, parentLineagePaths);
 
     if (_isEmpty(formComponentsMap)) {
       throw new Error(`${this.logName}: No components found in the formComponentsMap for '${formComponentName}'.`);
     }
     if (!this.model) {
-      throw new Error(`${this.logName}: model is not defined. Cannot initialize the component for '${formComponentName}'.`);
+      throw new Error(
+        `${this.logName}: model is not defined. Cannot initialize the component for '${formComponentName}'.`
+      );
     }
     const formControl = this.model.formControl;
     if (formControl instanceof RepeatableFormArray) {
-      formControl.customValueSetter = (value, options) => this.replaceAllElements(Array.isArray(value) ? value : [], options);
+      formControl.customValueSetter = (value, options) =>
+        this.replaceAllElements(Array.isArray(value) ? value : [], options);
     }
 
     this.elemInitFieldEntry = formComponentsMap.components[0];
     let layoutClass = this.elemInitFieldEntry?.layoutClass;
     if (!layoutClass) {
       // If the layout class is not defined, use the default layout class.
-      layoutClass = RepeatableElementLayoutComponent
+      layoutClass = RepeatableElementLayoutComponent;
     }
     this.elemInitFieldEntry.layoutClass = layoutClass;
 
     // Loop through the elements of the model and insert into the container
     const elemVals = this.model.initValue;
     if (!Array.isArray(elemVals)) {
-      throw new Error(`${this.logName}: model value is not an array. Cannot initialize the component for '${formComponentName}'.`);
+      throw new Error(
+        `${this.logName}: model value is not an array. Cannot initialize the component for '${formComponentName}'.`
+      );
     }
 
     // By default a repeatable creates one row. Legacy configs can opt into zero-row behavior.
@@ -189,7 +209,9 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
       // Undefined is not set to control.value, anything else is set, which is what we want.
       const elementTemplateValue = this.getElementTemplateDefaultValue();
       elemVals.push(elementTemplateValue);
-      this.loggerService.warn(`${this.logName}: Created one element for repeatable '${formComponentName}' with no value: ${JSON.stringify(elemVals)}`);
+      this.loggerService.warn(
+        `${this.logName}: Created one element for repeatable '${formComponentName}' with no value: ${JSON.stringify(elemVals)}`
+      );
     }
 
     for (const elementValue of elemVals) {
@@ -207,7 +229,8 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
 
     void this.syncFromCurrentSources(false);
 
-    this.eventBus.select$(FormComponentEventType.FIELD_VALUE_CHANGED)
+    this.eventBus
+      .select$(FormComponentEventType.FIELD_VALUE_CHANGED)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((event: FieldValueChangedEvent) => {
         if (this.isSyncSourceTriggerEvent(event, syncSources)) {
@@ -227,9 +250,10 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
 
   private isSyncSourceTriggerEvent(event: FieldValueChangedEvent, syncSources: SyncSourceEntry[]): boolean {
     const fieldId = event.fieldId || '';
-    return syncSources.some(source =>
-      fieldId.endsWith(`/${source.fieldName}`)
-      || (!!source.visibilityConditionField && fieldId.endsWith(`/${source.visibilityConditionField}`))
+    return syncSources.some(
+      source =>
+        fieldId.endsWith(`/${source.fieldName}`) ||
+        (!!source.visibilityConditionField && fieldId.endsWith(`/${source.visibilityConditionField}`))
     );
   }
 
@@ -278,14 +302,17 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
     if (rawFormValue && fieldName in rawFormValue) {
       return rawFormValue[fieldName];
     }
-    const pointerSource = this.getFormComponent.getQuerySource()?.jsonPointerSource as Record<string, unknown> | undefined;
+    const pointerSource = this.getFormComponent.getQuerySource()?.jsonPointerSource as
+      | Record<string, unknown>
+      | undefined;
     return pointerSource?.[fieldName];
   }
 
   private upsertSyncedSource(existing: unknown[], sourceValue: unknown, syncSource: SyncSourceEntry): unknown[] {
-    const source = (typeof sourceValue === 'object' && sourceValue !== null)
-      ? _cloneDeep(sourceValue as Record<string, unknown>)
-      : null;
+    const source =
+      typeof sourceValue === 'object' && sourceValue !== null
+        ? _cloneDeep(sourceValue as Record<string, unknown>)
+        : null;
     if (!source) {
       return existing;
     }
@@ -318,7 +345,7 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
   private isBlankPlaceholder(
     item: Record<string, unknown> | undefined,
     syncSource?: SyncSourceEntry,
-    source?: Record<string, unknown> | null,
+    source?: Record<string, unknown> | null
   ): boolean {
     if (!item) {
       return false;
@@ -338,14 +365,15 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
   private getBlankCheckFields(
     syncSource: SyncSourceEntry | undefined,
     item: Record<string, unknown>,
-    source?: Record<string, unknown> | null,
+    source?: Record<string, unknown> | null
   ): string[] {
     const configuredFields = this.normalizeBlankCheckFields(syncSource?.blankCheckFields);
     if (configuredFields.length > 0) {
       return configuredFields;
     }
 
-    const elementTemplate = (this.componentDefinition?.config as RepeatableFieldComponentConfig | undefined)?.elementTemplate;
+    const elementTemplate = (this.componentDefinition?.config as RepeatableFieldComponentConfig | undefined)
+      ?.elementTemplate;
     return this.inferBlankCheckFields(elementTemplate, item, source);
   }
 
@@ -373,7 +401,7 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
   private inferBlankCheckFields(
     elementTemplate: RepeatableFieldComponentConfig['elementTemplate'] | undefined,
     item: Record<string, unknown>,
-    source?: Record<string, unknown> | null,
+    source?: Record<string, unknown> | null
   ): string[] {
     if (!elementTemplate || typeof elementTemplate !== 'object') {
       return [];
@@ -394,18 +422,16 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
 
       const templateNode = node as Record<string, unknown>;
       const component = templateNode['component'];
-      const componentRecord = (component && typeof component === 'object')
-        ? component as Record<string, unknown>
-        : undefined;
-      const componentClass = typeof componentRecord?.['class'] === 'string'
-        ? componentRecord['class']
-        : undefined;
+      const componentRecord =
+        component && typeof component === 'object' ? (component as Record<string, unknown>) : undefined;
+      const componentClass = typeof componentRecord?.['class'] === 'string' ? componentRecord['class'] : undefined;
       const componentConfig = componentRecord?.['config'];
-      const componentConfigRecord = (componentConfig && typeof componentConfig === 'object')
-        ? componentConfig as Record<string, unknown>
-        : undefined;
+      const componentConfigRecord =
+        componentConfig && typeof componentConfig === 'object'
+          ? (componentConfig as Record<string, unknown>)
+          : undefined;
       const childDefinitions = Array.isArray(componentConfigRecord?.['componentDefinitions'])
-        ? componentConfigRecord['componentDefinitions'] as unknown[]
+        ? (componentConfigRecord['componentDefinitions'] as unknown[])
         : [];
 
       const name = typeof templateNode['name'] === 'string' ? templateNode['name'].trim() : '';
@@ -414,13 +440,13 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
       }
 
       const model = templateNode['model'];
-      const modelRecord = (model && typeof model === 'object') ? model as Record<string, unknown> : undefined;
+      const modelRecord = model && typeof model === 'object' ? (model as Record<string, unknown>) : undefined;
       const modelConfig = modelRecord?.['config'];
-      const modelConfigRecord = (modelConfig && typeof modelConfig === 'object')
-        ? modelConfig as Record<string, unknown>
-        : undefined;
-      const templateValue = [modelConfigRecord?.['newEntryValue'], modelConfigRecord?.['value']]
-        .find(value => !!value && typeof value === 'object' && !Array.isArray(value));
+      const modelConfigRecord =
+        modelConfig && typeof modelConfig === 'object' ? (modelConfig as Record<string, unknown>) : undefined;
+      const templateValue = [modelConfigRecord?.['newEntryValue'], modelConfigRecord?.['value']].find(
+        value => !!value && typeof value === 'object' && !Array.isArray(value)
+      );
       if (templateValue && typeof templateValue === 'object') {
         for (const key of Object.keys(templateValue as Record<string, unknown>)) {
           if (key) {
@@ -446,10 +472,7 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
       return [];
     }
 
-    const relevantKeys = new Set<string>([
-      ...Object.keys(item),
-      ...(source ? Object.keys(source) : []),
-    ]);
+    const relevantKeys = new Set<string>([...Object.keys(item), ...(source ? Object.keys(source) : [])]);
     const matchedFields = candidateFields.filter(fieldName => relevantKeys.has(fieldName));
     return matchedFields.length > 0 ? matchedFields : candidateFields;
   }
@@ -463,8 +486,8 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
   }
 
   private getElementTemplateDefaultValue(): unknown {
-    const elementTemplateModelConfig =
-      (this.componentDefinition?.config as RepeatableFieldComponentConfig | undefined)?.elementTemplate?.model?.config;
+    const elementTemplateModelConfig = (this.componentDefinition?.config as RepeatableFieldComponentConfig | undefined)
+      ?.elementTemplate?.model?.config;
     return elementTemplateModelConfig?.newEntryValue ?? elementTemplateModelConfig?.value;
   }
 
@@ -503,14 +526,12 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
   protected rebuildLineagePaths(options?: RepeatableSetValueOptions) {
     for (let index = 0; index < this.compDefMapEntries.length; index++) {
       const indexStr = index.toString();
-      const lineagePath = this.formService.buildLineagePaths(
-        this.formFieldCompMapEntry?.lineagePaths,
-        {
-          angularComponents: [indexStr],
-          layout: [indexStr],
-          dataModel: [indexStr],
-          formConfig: ['component', 'config', 'elementTemplate'],
-        });
+      const lineagePath = this.formService.buildLineagePaths(this.formFieldCompMapEntry?.lineagePaths, {
+        angularComponents: [indexStr],
+        layout: [indexStr],
+        dataModel: [indexStr],
+        formConfig: ['component', 'config', 'elementTemplate'],
+      });
       this.compDefMapEntries[index].defEntry.lineagePaths = lineagePath;
     }
     if (!this.shouldEmitComponentEvents(options)) {
@@ -519,12 +540,16 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
     // Every time the lineage paths are rebuilt, the form definition has essentially changed. Sending an event to notify listeners.
     this.eventBus.publish(
       createFormDefinitionChangeRequestEvent({
-        sourceId: this.formFieldConfigName() || undefined
+        sourceId: this.formFieldConfigName() || undefined,
       })
     );
   }
 
-  protected createFieldNewMapEntry(templateEntry: FormFieldCompMapEntry, value: any, options?: RepeatableSetValueOptions): RepeatableElementEntry {
+  protected createFieldNewMapEntry(
+    templateEntry: FormFieldCompMapEntry,
+    value: any,
+    options?: RepeatableSetValueOptions
+  ): RepeatableElementEntry {
     const localUniqueId = RepeatableFieldComponentConfig.getLocalUID();
 
     const elemEntry: FormFieldCompMapEntry = {
@@ -586,7 +611,10 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
 
     // Create new form field.
     const model = this.formService.createFormFieldModelInstance(
-      elemEntry, this.getFormComponent.enabledValidationGroups, this.getFormComponent.validationGroups);
+      elemEntry,
+      this.getFormComponent.enabledValidationGroups,
+      this.getFormComponent.validationGroups
+    );
     if (model !== null) {
       if (!_isUndefined(value)) {
         model.initValue = value;
@@ -604,7 +632,7 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
       defEntry: elemEntry,
       wrapperRef: null,
       localUniqueId: localUniqueId,
-      value: value
+      value: value,
     };
   }
 
@@ -626,14 +654,19 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
       return wrapperRef;
     }
     layoutInstance.removeFn = this.removeElementFn(elemEntry);
+    layoutInstance.moveUpFn = this.moveElementFn(elemEntry, -1);
+    layoutInstance.moveDownFn = this.moveElementFn(elemEntry, 1);
     layoutInstance.canRemove = this.shouldKeepAtLeastOneRow()
       ? this.compDefMapEntries.length > 1
       : this.compDefMapEntries.length > 0;
     elemEntry.layoutInstance = layoutInstance;
+    this.updateCanSortFlags();
     if (this.model?.formControl && compInstance?.model) {
       this.model.addElement(compInstance.model, options);
     } else {
-      this.loggerService.warn(`${this.logName}: model or formControl is not defined, not adding the element's form control to the 'this.formControl'. If any data is missing, this is why.`);
+      this.loggerService.warn(
+        `${this.logName}: model or formControl is not defined, not adding the element's form control to the 'this.formControl'. If any data is missing, this is why.`
+      );
     }
     elemEntry.wrapperRef = wrapperRef;
     return wrapperRef;
@@ -643,12 +676,16 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
     const that = this;
     return function () {
       that.loggerService.debug(`${that.logName}: removeElement called: `, elemEntry.localUniqueId);
-      that.loggerService.debug(`${that.logName}: removeElement called, matching elemEntry:`,
+      that.loggerService.debug(
+        `${that.logName}: removeElement called, matching elemEntry:`,
         that.compDefMapEntries.find(i => i === elemEntry)
       );
-      const defIdx = that.compDefMapEntries.findIndex((entry) => entry.localUniqueId === elemEntry.localUniqueId);
+      const defIdx = that.compDefMapEntries.findIndex(entry => entry.localUniqueId === elemEntry.localUniqueId);
       if (defIdx === -1) {
-        that.loggerService.warn(`${that.logName}: removeElement called, but no tracked element found with localUniqueId. Falling back to model removal.`, elemEntry.localUniqueId);
+        that.loggerService.warn(
+          `${that.logName}: removeElement called, but no tracked element found with localUniqueId. Falling back to model removal.`,
+          elemEntry.localUniqueId
+        );
         try {
           elemEntry.wrapperRef?.destroy();
           that.model?.removeElement(elemEntry.defEntry?.model, options);
@@ -656,6 +693,7 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
             that.requestFormDirty('repeatable.element.removed');
           }
           that.updateCanRemoveFlags();
+          that.updateCanSortFlags();
           that.rebuildLineagePaths(options);
         } catch (error) {
           that.loggerService.warn(`${that.logName}: fallback removeElement failed`, error);
@@ -669,8 +707,35 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
         that.requestFormDirty('repeatable.element.removed');
       }
       that.updateCanRemoveFlags();
+      that.updateCanSortFlags();
       that.rebuildLineagePaths(options);
-    }
+    };
+  }
+
+  public moveElementFn(elemEntry: RepeatableElementEntry, delta: -1 | 1, options?: RepeatableSetValueOptions) {
+    const that = this;
+    return function () {
+      if (!that.canSort || that.isDisabled) {
+        return;
+      }
+      const fromIndex = that.compDefMapEntries.findIndex(entry => entry.localUniqueId === elemEntry.localUniqueId);
+      const toIndex = fromIndex + delta;
+      if (fromIndex === -1 || toIndex < 0 || toIndex >= that.compDefMapEntries.length) {
+        return;
+      }
+
+      that.compDefMapEntries.splice(fromIndex, 1);
+      that.compDefMapEntries.splice(toIndex, 0, elemEntry);
+      if (elemEntry.wrapperRef) {
+        that.repeatableContainer.move(elemEntry.wrapperRef.hostView, toIndex);
+      }
+      that.model?.moveElement(fromIndex, toIndex, options);
+      if (that.shouldEmitComponentEvents(options)) {
+        that.requestFormDirty('repeatable.element.moved');
+      }
+      that.updateCanSortFlags();
+      that.rebuildLineagePaths(options);
+    };
   }
 
   protected shouldEmitComponentEvents(options?: RepeatableSetValueOptions): boolean {
@@ -698,6 +763,16 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
     }
   }
 
+  protected updateCanSortFlags() {
+    for (const [index, entry] of this.compDefMapEntries.entries()) {
+      if (entry.layoutInstance) {
+        entry.layoutInstance.canSort = this.canSort;
+        entry.layoutInstance.canMoveUp = this.canSort && index > 0;
+        entry.layoutInstance.canMoveDown = this.canSort && index < this.compDefMapEntries.length - 1;
+      }
+    }
+  }
+
   public override setDisabled(disabled: boolean, opts?: ModifyOptions): void {
     super.setDisabled(disabled, opts);
     // Also update the child repeatable's elements - both layout and component.
@@ -710,11 +785,9 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
         entry.defEntry.component.setDisabled(disabled, opts);
       }
     }
+    this.updateCanSortFlags();
   }
 }
-
-
-
 
 export class RepeatableComponentModel extends FormFieldModel<Array<unknown>> {
   protected override logName = RepeatableModelName;
@@ -746,7 +819,9 @@ export class RepeatableComponentModel extends FormFieldModel<Array<unknown>> {
 
   public removeElement(targetModel?: FormFieldModel<unknown>, options?: RepeatableSetValueOptions): void {
     if (this.formControl && this.formControl instanceof FormArray) {
-      const modelIdx = this.formControl?.controls.findIndex((control: unknown) => control === targetModel?.getFormControl());
+      const modelIdx = this.formControl?.controls.findIndex(
+        (control: unknown) => control === targetModel?.getFormControl()
+      );
       if (modelIdx === -1 || modelIdx === undefined) {
         throw new Error(`${this.logName}: model not found in formControl.`);
       }
@@ -755,9 +830,20 @@ export class RepeatableComponentModel extends FormFieldModel<Array<unknown>> {
       throw new Error(`${this.logName}: formControl is not a FormArray. Cannot remove element.`);
     }
   }
+
+  public moveElement(fromIndex: number, toIndex: number, options?: RepeatableSetValueOptions): void {
+    if (this.formControl && this.formControl instanceof FormArray) {
+      const control = this.formControl.at(fromIndex);
+      if (!control) {
+        throw new Error(`${this.logName}: model not found in formControl.`);
+      }
+      this.formControl.removeAt(fromIndex, { ...options, emitEvent: false });
+      this.formControl.insert(toIndex, control, options);
+    } else {
+      throw new Error(`${this.logName}: formControl is not a FormArray. Cannot move element.`);
+    }
+  }
 }
-
-
 
 /**
  * Used to store the information about a repeatable element in the form, including its model, component, and layout, and other information needed to add or remove it from the form dynamically.
@@ -778,34 +864,72 @@ export interface RepeatableElementEntry {
 @Component({
   selector: 'redbox-form-repeatable-component-layout',
   template: `
-  <div class="rb-form-repeatable-item" [class.rb-form-repeatable-item--inline-fields]="isInlineLayout">
-    <div class="rb-form-repeatable-item__content">
-      <ng-container #componentContainer></ng-container>
+    <div class="rb-form-repeatable-item" [class.rb-form-repeatable-item--inline-fields]="isInlineLayout">
+      <div class="rb-form-repeatable-item__content">
+        <ng-container #componentContainer></ng-container>
+      </div>
+      @if (isVisible && (canRemove || (canSort && (canMoveUp || canMoveDown)))) {
+        <div class="rb-form-repeatable-item__actions">
+          @if (canSort && (canMoveUp || canMoveDown)) {
+            <div class="rb-form-repeatable-item__sort btn-group-vertical">
+              <button
+                type="button"
+                class="rb-form-repeatable-item__move-up btn btn-outline-secondary"
+                (click)="clickedMoveUp()"
+                [attr.aria-label]="'move-up-button-label' | i18next"
+                [attr.title]="'move-up-button-label' | i18next"
+                [disabled]="isDisabled || !canMoveUp"
+              >
+                <span class="fa fa-arrow-up" aria-hidden="true"></span>
+              </button>
+              <button
+                type="button"
+                class="rb-form-repeatable-item__move-down btn btn-outline-secondary"
+                (click)="clickedMoveDown()"
+                [attr.aria-label]="'move-down-button-label' | i18next"
+                [attr.title]="'move-down-button-label' | i18next"
+                [disabled]="isDisabled || !canMoveDown"
+              >
+                <span class="fa fa-arrow-down" aria-hidden="true"></span>
+              </button>
+            </div>
+          }
+          @if (canRemove) {
+            <button
+              type="button"
+              class="rb-form-repeatable-item__remove btn btn-danger"
+              (click)="clickedRemove()"
+              [attr.aria-label]="'remove-button-label' | i18next"
+              [attr.title]="'remove-button-label' | i18next"
+              [disabled]="isDisabled"
+            >
+              <span class="fa fa-minus-circle" aria-hidden="true"></span>
+            </button>
+          }
+        </div>
+      }
     </div>
-    @if (isVisible && canRemove) {
-      <button
-        type="button"
-        class="rb-form-repeatable-item__remove btn btn-danger"
-        (click)="clickedRemove()"
-        [attr.aria-label]="'remove-button-label' | i18next"
-        [disabled]="isDisabled">
-        <span class="fa fa-minus-circle" aria-hidden="true"></span>
-      </button>
-    }
-  </div>
-  <ng-template #afterComponentTemplate>
-    @if (isVisible) {
-      @let componentValidationList = getFormValidatorComponentErrors;
-      <redbox-field-error-summary [errors]="componentValidationList" [fieldName]="componentName"></redbox-field-error-summary>
-    }
-  </ng-template>
+    <ng-template #afterComponentTemplate>
+      @if (isVisible) {
+        @let componentValidationList = getFormValidatorComponentErrors;
+        <redbox-field-error-summary
+          [errors]="componentValidationList"
+          [fieldName]="componentName"
+        ></redbox-field-error-summary>
+      }
+    </ng-template>
   `,
   standalone: false,
 })
 export class RepeatableElementLayoutComponent<ValueType> extends DefaultLayoutComponent<ValueType> {
   protected override logName = RepeatableElementLayoutName;
   public removeFn?: () => void;
+  public moveUpFn?: () => void;
+  public moveDownFn?: () => void;
   public canRemove = false;
+  public canSort = false;
+  public canMoveUp = false;
+  public canMoveDown = false;
 
   protected get isInlineLayout(): boolean {
     const hostCssClasses = this.formFieldCompMapEntry?.compConfigJson?.component?.config?.hostCssClasses;
@@ -813,10 +937,20 @@ export class RepeatableElementLayoutComponent<ValueType> extends DefaultLayoutCo
       return false;
     }
     const hostCssClassList = hostCssClasses.split(/\s+/);
-    return hostCssClassList.includes('rb-form-contributor-inline') || hostCssClassList.includes('rb-form-inline-fields');
+    return (
+      hostCssClassList.includes('rb-form-contributor-inline') || hostCssClassList.includes('rb-form-inline-fields')
+    );
   }
 
   protected clickedRemove() {
     this.removeFn?.call(this);
+  }
+
+  protected clickedMoveUp() {
+    this.moveUpFn?.call(this);
+  }
+
+  protected clickedMoveDown() {
+    this.moveDownFn?.call(this);
   }
 }

--- a/angular/projects/researchdatabox/form/src/app/component/repeatable.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/repeatable.component.ts
@@ -838,7 +838,8 @@ export class RepeatableComponentModel extends FormFieldModel<Array<unknown>> {
         throw new Error(`${this.logName}: model not found in formControl.`);
       }
       this.formControl.removeAt(fromIndex, { ...options, emitEvent: false });
-      this.formControl.insert(toIndex, control, options);
+      this.formControl.insert(toIndex, control, { ...options, emitEvent: false });
+      this.formControl.updateValueAndValidity(options);
     } else {
       throw new Error(`${this.logName}: formControl is not a FormArray. Cannot move element.`);
     }

--- a/angular/projects/researchdatabox/form/src/app/form-state/behaviours/behaviour-compiled-template-evaluator.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/behaviours/behaviour-compiled-template-evaluator.ts
@@ -1,5 +1,6 @@
 import { LoggerService } from '@researchdatabox/portal-ng-common';
 import {DynamicScriptResponse, jsonataLibrary} from "@researchdatabox/sails-ng-common";
+import jsonata from 'jsonata';
 
 /**
  * Minimal shape needed from the dynamically imported compiled-items module.
@@ -38,7 +39,7 @@ export class BehaviourCompiledTemplateEvaluator {
   ): Promise<unknown> {
     const key = ['behaviours', behaviourIndex, ...propertyPath];
     try {
-      return await this.compiledItems.evaluate(key, this.cloneContext(context), {libraries: jsonataLibrary});
+      return await this.compiledItems.evaluate(key, this.cloneContext(context), {jsonata, libraries: jsonataLibrary});
     } catch (error) {
       this.logger.error('BehaviourCompiledTemplateEvaluator: Failed to evaluate compiled behaviour template.', {
         error,

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
@@ -12,7 +12,6 @@ import {
 } from './form-component-base-event-producer-consumer';
 import {
   FormExpressionsConfigFrame,
-  getObjectWithJsonPointer,
   ExpressionsConditionKind,
   ExpressionsConditionKindType,
   FormExpressionsTargetModelValue,
@@ -177,7 +176,7 @@ export abstract class FormComponentEventBaseConsumer extends FormComponentEventB
       // expose to JSONata so a mutating expression cannot leak writes back
       // into Angular form state or event objects.
       const rawFormValue = this.formComp?.form?.getRawValue?.() ?? this.formComp?.form?.value ?? {};
-      const valueOriginal = normalizedFieldId ? getObjectWithJsonPointer(rawFormValue, normalizedFieldId)?.val : undefined;
+      const valueOriginal = normalizedFieldId ? this.getValueForEventField(rawFormValue, normalizedFieldId) : undefined;
       const value = this.cloneExpressionContextValue(valueOriginal, 'value');
       const eventClone = this.cloneExpressionContextValue(event, 'event');
       const formData = this.cloneExpressionContextValue(rawFormValue, 'formData');
@@ -228,6 +227,54 @@ export abstract class FormComponentEventBaseConsumer extends FormComponentEventB
       return value;
     }
   }
+
+  /**
+   * Read an event field value without using the logging JSON pointer helper.
+   * Some form events carry config-tree paths while the Angular form value is
+   * flat, so a missing path is an expected condition rather than an error.
+   */
+  protected getValueForEventField(rawFormValue: unknown, normalizedFieldId: string): unknown {
+    const directValue = this.getValueByJsonPointer(rawFormValue, normalizedFieldId);
+    if (directValue !== undefined) {
+      return directValue;
+    }
+
+    const lastSegment = normalizedFieldId.split('/').filter(Boolean).pop();
+    if (
+      lastSegment &&
+      rawFormValue &&
+      typeof rawFormValue === 'object' &&
+      Object.prototype.hasOwnProperty.call(rawFormValue, lastSegment)
+    ) {
+      return (rawFormValue as Record<string, unknown>)[lastSegment];
+    }
+
+    return undefined;
+  }
+
+  protected getValueByJsonPointer(source: unknown, pointer: string): unknown {
+    if (pointer === '') {
+      return source;
+    }
+    if (!pointer.startsWith('/')) {
+      return undefined;
+    }
+
+    let current = source;
+    for (const rawSegment of pointer.split('/').slice(1)) {
+      const segment = rawSegment.replace(/~1/g, '/').replace(/~0/g, '~');
+      if (
+        current === null ||
+        current === undefined ||
+        (typeof current !== 'object' && !Array.isArray(current)) ||
+        !Object.prototype.hasOwnProperty.call(current, segment)
+      ) {
+        return undefined;
+      }
+      current = (current as Record<string, unknown>)[segment];
+    }
+    return current;
+  }
   /**
    *
    * Checks if the event matches the JSON Pointer condition.
@@ -236,7 +283,6 @@ export abstract class FormComponentEventBaseConsumer extends FormComponentEventB
    * @returns
    */
   protected hasMatchedJSONPointerCondition(opts: FormComponentEventJSONPointerMatchOptions): boolean {
-    const querySource = opts.querySource;
     if (
       opts.event.sourceId == FormComponentEventType.FORM_DEFINITION_READY &&
       opts.expression.config.runOnFormReady === false
@@ -244,10 +290,6 @@ export abstract class FormComponentEventBaseConsumer extends FormComponentEventB
       return false;
     }
     const pointerCondition = this.getEventJSONPointerCondition(opts.condition);
-    // Check if the pointer has a match in the query source, broadcasts will fail this check
-    const ref = querySource
-      ? getObjectWithJsonPointer(querySource.jsonPointerSource, pointerCondition.jsonPointer)
-      : undefined;
     const targetEvent = pointerCondition.event;
     const hasMatchedTargetEvent = targetEvent === '*' || targetEvent === opts.event.type;
     // Scenarios where it will match if the `targetEvent` matches, that is '*' or the specific event type AND the `sourceId` matches:

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
@@ -30,6 +30,7 @@ import { AbstractControl } from '@angular/forms';
 import { isTypeFormValidationGroupsChangeRequestInfo, setControlValue } from '../custom-set-value.control';
 import { syncComponentDisplayFromModel } from '../custom-display-sync.control';
 import { FormFieldModel } from '@researchdatabox/portal-ng-common';
+import jsonata from 'jsonata';
 /**
  * Options main bag for matching events against conditions
  */
@@ -201,7 +202,7 @@ export abstract class FormComponentEventBaseConsumer extends FormComponentEventB
         runtimeContext,
       };
 
-      return await compiledItems.evaluate(templateKey, context, { libraries: jsonataLibrary });
+      return await compiledItems.evaluate(templateKey, context, { jsonata, libraries: jsonataLibrary });
     } catch (error) {
       this.loggerService.error(`${this.constructor.name}: Error evaluating expression template.`, error);
       return (event as { value?: unknown }).value;

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
@@ -171,12 +171,13 @@ export abstract class FormComponentEventBaseConsumer extends FormComponentEventB
 
     try {
       const dataFieldId = event.fieldId || '';
+      const normalizedFieldId = dataFieldId && !dataFieldId.startsWith('/') ? '/' + dataFieldId : dataFieldId;
 
       // Expressions are allowed to reshape their inputs. Clone everything we
       // expose to JSONata so a mutating expression cannot leak writes back
       // into Angular form state or event objects.
       const rawFormValue = this.formComp?.form?.getRawValue?.() ?? this.formComp?.form?.value ?? {};
-      const valueOriginal = dataFieldId ? getObjectWithJsonPointer(rawFormValue, dataFieldId)?.val : undefined;
+      const valueOriginal = normalizedFieldId ? getObjectWithJsonPointer(rawFormValue, normalizedFieldId)?.val : undefined;
       const value = this.cloneExpressionContextValue(valueOriginal, 'value');
       const eventClone = this.cloneExpressionContextValue(event, 'event');
       const formData = this.cloneExpressionContextValue(rawFormValue, 'formData');

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-base-event-consumer.ts
@@ -1,13 +1,18 @@
 import { FormComponentEventBus } from './form-component-event-bus.service';
 import {
   createFormValidationGroupsChangeRequestEvent,
-  FormComponentEvent, FormComponentEventType, FormComponentEventTypeValue
+  FormComponentEvent,
+  FormComponentEventType,
+  FormComponentEventTypeValue,
 } from './form-component-event.types';
-import { FormComponentEventBaseProducerConsumer, FormComponentEventBindingOptions, FormComponentEventQuerySource } from './form-component-base-event-producer-consumer';
+import {
+  FormComponentEventBaseProducerConsumer,
+  FormComponentEventBindingOptions,
+  FormComponentEventQuerySource,
+} from './form-component-base-event-producer-consumer';
 import {
   FormExpressionsConfigFrame,
   getObjectWithJsonPointer,
-  getLastSegmentFromJSONPointer,
   ExpressionsConditionKind,
   ExpressionsConditionKindType,
   FormExpressionsTargetModelValue,
@@ -23,31 +28,31 @@ import {
 } from '@researchdatabox/sails-ng-common';
 import { isEmpty as _isEmpty, set as _set } from 'lodash-es';
 import { AbstractControl } from '@angular/forms';
-import {isTypeFormValidationGroupsChangeRequestInfo, setControlValue} from "../custom-set-value.control";
-import { syncComponentDisplayFromModel } from "../custom-display-sync.control";
-import { FormFieldModel } from "@researchdatabox/portal-ng-common";
+import { isTypeFormValidationGroupsChangeRequestInfo, setControlValue } from '../custom-set-value.control';
+import { syncComponentDisplayFromModel } from '../custom-display-sync.control';
+import { FormFieldModel } from '@researchdatabox/portal-ng-common';
 /**
  * Options main bag for matching events against conditions
  */
 export interface FormComponentEventMatchOptions {
-	condition: string;
-	conditionKind: ExpressionsConditionKindType;
-	event: FormComponentEvent;
-	expression: FormExpressionsConfigFrame;
+  condition: string;
+  conditionKind: ExpressionsConditionKindType;
+  event: FormComponentEvent;
+  expression: FormExpressionsConfigFrame;
 }
 
 export interface FormComponentEventJSONPointerMatchOptions extends FormComponentEventMatchOptions {
-	conditionKind: typeof ExpressionsConditionKind.JSONPointer;
-	querySource: FormComponentEventQuerySource;
+  conditionKind: typeof ExpressionsConditionKind.JSONPointer;
+  querySource: FormComponentEventQuerySource;
 }
 
 export interface FormComponentEventJSONataMatchOptions extends FormComponentEventMatchOptions {
-	conditionKind: typeof ExpressionsConditionKind.JSONata;
+  conditionKind: typeof ExpressionsConditionKind.JSONata;
 }
 
 export interface FormComponentEventJSONataQueryMatchOptions extends FormComponentEventMatchOptions {
-	conditionKind: typeof ExpressionsConditionKind.JSONataQuery;
-	querySource: FormComponentEventQuerySource;
+  conditionKind: typeof ExpressionsConditionKind.JSONataQuery;
+  querySource: FormComponentEventQuerySource;
 }
 
 /**
@@ -58,119 +63,123 @@ export interface FormComponentEventJSONataQueryMatchOptions extends FormComponen
  * evaluation context, and target mutation.
  */
 export abstract class FormComponentEventBaseConsumer extends FormComponentEventBaseProducerConsumer {
+  /** Cache for the compiled items module */
+  protected compiledItemsCache?: DynamicScriptResponse;
 
-	/** Cache for the compiled items module */
-	protected compiledItemsCache?: DynamicScriptResponse;
+  /** The event type this consumer listens to - must be set by subclasses */
+  protected abstract readonly consumedEventType: FormComponentEventTypeValue;
 
-	/** The event type this consumer listens to - must be set by subclasses */
-	protected abstract readonly consumedEventType: FormComponentEventTypeValue;
+  constructor(eventBus: FormComponentEventBus) {
+    super(eventBus);
+  }
 
-	constructor(eventBus: FormComponentEventBus) {
-		super(eventBus);
-	}
+  /**
+   * Connect the consumer to a component instance. Replaces any existing subscription.
+   */
+  bind(options: FormComponentEventBindingOptions): void {
+    this.destroy();
+    try {
+      this.setupEventConsumption(options, this.consumedEventType);
+    } catch (error) {
+      this.loggerService.error(
+        `${this.constructor.name}: Error during setupEventConsumption for event type '${this.consumedEventType}'.`,
+        { error, consumedEventType: this.consumedEventType, options }
+      );
+      return;
+    }
+  }
 
-	/**
-	 * Connect the consumer to a component instance. Replaces any existing subscription.
-	 */
-	bind(options: FormComponentEventBindingOptions): void {
-		this.destroy();
-		try {
-			this.setupEventConsumption(options, this.consumedEventType);
-		} catch (error) {
-			this.loggerService.error(
-				`${this.constructor.name}: Error during setupEventConsumption for event type '${this.consumedEventType}'.`,
-				{ error, consumedEventType: this.consumedEventType, options }
-			);
-			return;
-		}
-	}
+  /**
+   * Tear down active subscriptions.
+   */
+  override destroy(): void {
+    super.destroy();
+    this.model = undefined;
+    this.compiledItemsCache = undefined;
+  }
 
-	/**
-	 * Tear down active subscriptions.
-	 */
-	override destroy(): void {
-		super.destroy();
-		this.model = undefined;
-		this.compiledItemsCache = undefined;
-	}
+  /**
+   * Get the compiled items module, caching the result for subsequent calls.
+   */
+  protected async getCompiledItems(): Promise<DynamicScriptResponse | undefined> {
+    if (this.compiledItemsCache) {
+      return this.compiledItemsCache;
+    }
+    if (!this.formComp) {
+      this.loggerService.warn(`${this.constructor.name}: No form component available to get compiled items.`);
+      return undefined;
+    }
+    try {
+      this.compiledItemsCache = await this.formComp.getFormCompiledItems();
+      return this.compiledItemsCache;
+    } catch (error) {
+      this.loggerService.error(`${this.constructor.name}: Error getting compiled items.`, error);
+      return undefined;
+    }
+  }
 
-	/**
-	 * Get the compiled items module, caching the result for subsequent calls.
-	 */
-	protected async getCompiledItems(): Promise<DynamicScriptResponse | undefined> {
-		if (this.compiledItemsCache) {
-			return this.compiledItemsCache;
-		}
-		if (!this.formComp) {
-			this.loggerService.warn(`${this.constructor.name}: No form component available to get compiled items.`);
-			return undefined;
-		}
-		try {
-			this.compiledItemsCache = await this.formComp.getFormCompiledItems();
-			return this.compiledItemsCache;
-		} catch (error) {
-			this.loggerService.error(`${this.constructor.name}: Error getting compiled items.`, error);
-			return undefined;
-		}
-	}
+  /**
+   * Build the key for the compiled JSONata expression property.
+   * The key format matches what TemplateFormConfigVisitor produces:
+   * [...lineagePaths.formConfig, 'expressions', expressionIndex, 'config', <property name>]
+   */
+  protected buildExpressionPropertyKey(
+    expression: FormExpressionsConfigFrame,
+    propertyName: string
+  ): (string | number)[] | undefined {
+    if (!this.options?.definition?.lineagePaths?.formConfig) {
+      this.loggerService.warn(
+        `${this.constructor.name}: No lineage paths available for building expression's ${propertyName} key.`
+      );
+      return undefined;
+    }
+    const expressionIndex = this.expressions?.indexOf(expression);
+    if (expressionIndex === undefined || expressionIndex < 0) {
+      this.loggerService.warn(`${this.constructor.name}: Expression not found in expressions array.`, expression);
+      return undefined;
+    }
+    return [...this.options.definition.lineagePaths.formConfig, 'expressions', expressionIndex, 'config', propertyName];
+  }
 
-	/**
-	 * Build the key for the compiled JSONata expression property.
-	 * The key format matches what TemplateFormConfigVisitor produces:
-	 * [...lineagePaths.formConfig, 'expressions', expressionIndex, 'config', <property name>]
-	 */
-	protected buildExpressionPropertyKey(expression: FormExpressionsConfigFrame, propertyName: string): (string | number)[] | undefined {
-		if (!this.options?.definition?.lineagePaths?.formConfig) {
-			this.loggerService.warn(`${this.constructor.name}: No lineage paths available for building expression's ${propertyName} key.`);
-			return undefined;
-		}
-		const expressionIndex = this.expressions?.indexOf(expression);
-		if (expressionIndex === undefined || expressionIndex < 0) {
-			this.loggerService.warn(`${this.constructor.name}: Expression not found in expressions array.`, expression);
-			return undefined;
-		}
-		return [
-			...(this.options.definition.lineagePaths.formConfig),
-			'expressions',
-			expressionIndex,
-			'config',
-			propertyName
-		];
-	}
-
-	/**
-	 * Evaluate the JSONata expression template with the provided context.
-	*
-	* Design note: when compiled templates are unavailable, fall back to the raw
-	* event value. That preserves historical behaviour for partially constructed
-	* forms instead of failing closed and clearing dependent fields.
+  /**
+   * Evaluate the JSONata expression template with the provided context.
+   *
+   * Design note: when compiled templates are unavailable, fall back to the raw
+   * event value. That preserves historical behaviour for partially constructed
+   * forms instead of failing closed and clearing dependent fields.
    *
    * @param expression - The expression config frame containing the template.
    * @param event - The event that triggered the evaluation.
    * @param propertyName - The property name in the expression config to evaluate (e.g., 'template', 'condition').
    * @returns The result of the evaluated expression.
-	 */
-	protected async evaluateExpressionJSONata(expression: FormExpressionsConfigFrame, event: FormComponentEvent, propertyName: string, additionalData: object = {}): Promise<unknown> {
-			const compiledItems = await this.getCompiledItems();
-			if (!compiledItems) {
-				return (event as { value?: unknown }).value;
-		}
+   */
+  protected async evaluateExpressionJSONata(
+    expression: FormExpressionsConfigFrame,
+    event: FormComponentEvent,
+    propertyName: string,
+    additionalData: object = {}
+  ): Promise<unknown> {
+    const compiledItems = await this.getCompiledItems();
+    if (!compiledItems) {
+      return (event as { value?: unknown }).value;
+    }
 
-		const templateKey = this.buildExpressionPropertyKey(expression, propertyName);
-		if (!templateKey) {
-			return (event as { value?: unknown }).value;
-		}
+    const templateKey = this.buildExpressionPropertyKey(expression, propertyName);
+    if (!templateKey) {
+      return (event as { value?: unknown }).value;
+    }
 
-		try {
-      const dataFieldId = getLastSegmentFromJSONPointer(event.fieldId || '');
+    try {
+      const dataFieldId = event.fieldId || '';
 
-	      // Expressions are allowed to reshape their inputs. Clone everything we
-	      // expose to JSONata so a mutating expression cannot leak writes back
-	      // into Angular form state or event objects.
-	      const valueOriginal = dataFieldId ? this.formComp?.form?.value[dataFieldId] : undefined;
-	      const value = this.cloneExpressionContextValue(valueOriginal, 'value');
-	      const eventClone = this.cloneExpressionContextValue(event, 'event');
-	      const formData = this.cloneExpressionContextValue(this.formComp?.form?.value ?? {}, 'formData');
+      // Expressions are allowed to reshape their inputs. Clone everything we
+      // expose to JSONata so a mutating expression cannot leak writes back
+      // into Angular form state or event objects.
+      const rawFormValue = this.formComp?.form?.getRawValue?.() ?? this.formComp?.form?.value ?? {};
+      const valueOriginal = dataFieldId ? getObjectWithJsonPointer(rawFormValue, dataFieldId)?.val : undefined;
+      const value = this.cloneExpressionContextValue(valueOriginal, 'value');
+      const eventClone = this.cloneExpressionContextValue(event, 'event');
+      const formData = this.cloneExpressionContextValue(rawFormValue, 'formData');
       const requestParams = this.cloneExpressionContextValue(
         (additionalData as { requestParams?: unknown }).requestParams ?? this.formComp?.requestParams?.() ?? {},
         'requestParams'
@@ -182,117 +191,127 @@ export abstract class FormComponentEventBaseConsumer extends FormComponentEventB
 
       // Build the context for JSONata evaluation
       // Include the event value and any additional data that may be useful
-			const context = {
-				...additionalData,
+      const context = {
+        ...additionalData,
         value: value,
-				event: eventClone,
-				// Include the current form data if available
-				formData: formData,
+        event: eventClone,
+        // Include the current form data if available
+        formData: formData,
         requestParams,
-				runtimeContext
-			};
+        runtimeContext,
+      };
 
-			return await compiledItems.evaluate(templateKey, context, {libraries :jsonataLibrary});
-		} catch (error) {
-				this.loggerService.error(`${this.constructor.name}: Error evaluating expression template.`, error);
-				return (event as { value?: unknown }).value;
-			}
-		}
+      return await compiledItems.evaluate(templateKey, context, { libraries: jsonataLibrary });
+    } catch (error) {
+      this.loggerService.error(`${this.constructor.name}: Error evaluating expression template.`, error);
+      return (event as { value?: unknown }).value;
+    }
+  }
 
-		/**
-		 * Best-effort clone used to isolate JSONata evaluation from live Angular
-		 * state. If cloning fails, continue with the original reference because the
-		 * form should still behave, even if the expression loses mutation safety.
-		 */
-		protected cloneExpressionContextValue<T>(value: T, label: string): T {
-			if (value === undefined) {
-				return value;
-			}
-			try {
-				return structuredClone(value);
-			} catch (error) {
-				this.loggerService.warn(`${this.constructor.name}: Failed to clone ${label} for JSONata context. Falling back to the original value.`, error);
-				return value;
-			}
-		}
-		/**
-		 *
-		 * Checks if the event matches the JSON Pointer condition.
-	 *
-	 * @param opts
-	 * @returns
-	 */
-	protected hasMatchedJSONPointerCondition(opts: FormComponentEventJSONPointerMatchOptions): boolean {
-		const querySource = opts.querySource;
-		if (opts.event.sourceId == FormComponentEventType.FORM_DEFINITION_READY && opts.expression.config.runOnFormReady === false) {
-			return false;
-		}
-		const pointerCondition = this.getEventJSONPointerCondition(opts.condition);
-		// Check if the pointer has a match in the query source, broadcasts will fail this check
-		const ref = querySource
-			? getObjectWithJsonPointer(querySource.jsonPointerSource, pointerCondition.jsonPointer)
-			: undefined;
-		const targetEvent = pointerCondition.event;
-		const hasMatchedTargetEvent = targetEvent === '*' || targetEvent === opts.event.type;
-		// Scenarios where it will match if the `targetEvent` matches, that is '*' or the specific event type AND the `sourceId` matches:
-		// 1. Scoped - the `pointerCondition.jsonPointer` will match the event.sourceId.
-		// Do not require the target component's local query source to also contain that
-		// pointer: cross-tree sync expressions intentionally listen to fields outside the
-		// target component's subtree (e.g. People tab -> Permissions tab).
-		const hasScopedMatch = pointerCondition.jsonPointer == opts.event.sourceId;
-		// 2. Broadcast - the opts.event.sourceId is '*' indicating broadcast, and the condition's jsonPointer matches path of the `fieldId` of the event OR this is a form ready event and the expression is set to run on form ready
-		const eventFieldId = opts.event.fieldId || "";
-		const isRunOnFormReady = (opts.event.sourceId == FormComponentEventType.FORM_DEFINITION_READY && opts.expression.config.runOnFormReady !== false);
-		// Precise JSON Pointer match: exact match OR path prefix followed by segment delimiter
-		const jsonPointer = pointerCondition.jsonPointer;
-		const hasPointerMatch = jsonPointer === ""
-			|| eventFieldId === jsonPointer
-			|| eventFieldId.startsWith(jsonPointer + "/");
-		let hasBroadcastMatch = ((opts.event.sourceId === '*' || isRunOnFormReady) && hasPointerMatch);
+  /**
+   * Best-effort clone used to isolate JSONata evaluation from live Angular
+   * state. If cloning fails, continue with the original reference because the
+   * form should still behave, even if the expression loses mutation safety.
+   */
+  protected cloneExpressionContextValue<T>(value: T, label: string): T {
+    if (value === undefined) {
+      return value;
+    }
+    try {
+      return structuredClone(value);
+    } catch (error) {
+      this.loggerService.warn(
+        `${this.constructor.name}: Failed to clone ${label} for JSONata context. Falling back to the original value.`,
+        error
+      );
+      return value;
+    }
+  }
+  /**
+   *
+   * Checks if the event matches the JSON Pointer condition.
+   *
+   * @param opts
+   * @returns
+   */
+  protected hasMatchedJSONPointerCondition(opts: FormComponentEventJSONPointerMatchOptions): boolean {
+    const querySource = opts.querySource;
+    if (
+      opts.event.sourceId == FormComponentEventType.FORM_DEFINITION_READY &&
+      opts.expression.config.runOnFormReady === false
+    ) {
+      return false;
+    }
+    const pointerCondition = this.getEventJSONPointerCondition(opts.condition);
+    // Check if the pointer has a match in the query source, broadcasts will fail this check
+    const ref = querySource
+      ? getObjectWithJsonPointer(querySource.jsonPointerSource, pointerCondition.jsonPointer)
+      : undefined;
+    const targetEvent = pointerCondition.event;
+    const hasMatchedTargetEvent = targetEvent === '*' || targetEvent === opts.event.type;
+    // Scenarios where it will match if the `targetEvent` matches, that is '*' or the specific event type AND the `sourceId` matches:
+    // 1. Scoped - the `pointerCondition.jsonPointer` will match the event.sourceId.
+    // Do not require the target component's local query source to also contain that
+    // pointer: cross-tree sync expressions intentionally listen to fields outside the
+    // target component's subtree (e.g. People tab -> Permissions tab).
+    const hasScopedMatch = pointerCondition.jsonPointer == opts.event.sourceId;
+    // 2. Broadcast - the opts.event.sourceId is '*' indicating broadcast, and the condition's jsonPointer matches path of the `fieldId` of the event OR this is a form ready event and the expression is set to run on form ready
+    const eventFieldId = opts.event.fieldId || '';
+    const isRunOnFormReady =
+      opts.event.sourceId == FormComponentEventType.FORM_DEFINITION_READY &&
+      opts.expression.config.runOnFormReady !== false;
+    // Precise JSON Pointer match: exact match OR path prefix followed by segment delimiter
+    const jsonPointer = pointerCondition.jsonPointer;
+    const hasPointerMatch =
+      jsonPointer === '' || eventFieldId === jsonPointer || eventFieldId.startsWith(jsonPointer + '/');
+    let hasBroadcastMatch = (opts.event.sourceId === '*' || isRunOnFormReady) && hasPointerMatch;
 
-		return (hasMatchedTargetEvent && (hasScopedMatch || hasBroadcastMatch));
-	}
+    return hasMatchedTargetEvent && (hasScopedMatch || hasBroadcastMatch);
+  }
   /**
    * Sets up event consumption for the specified event type.
-	 *
-	 * Matching and consumption stay serial on purpose. Several expressions can
-	 * target the same control, and preserving declaration order avoids hidden
-	 * race conditions between async template evaluations.
+   *
+   * Matching and consumption stay serial on purpose. Several expressions can
+   * target the same control, and preserving declaration order avoids hidden
+   * race conditions between async template evaluations.
    *
    * @param options
    * @param eventType
    */
-	protected setupEventConsumption(options: FormComponentEventBindingOptions, eventType: FormComponentEventTypeValue) {
-		this.options = options;
+  protected setupEventConsumption(options: FormComponentEventBindingOptions, eventType: FormComponentEventTypeValue) {
+    this.options = options;
 
-		const expressions: FormExpressionsConfigFrame[] | undefined  = options.definition?.expressions;
-		if (expressions === undefined || _isEmpty(expressions)) {
-			const msg = `${this.constructor.name}: No expressions defined for component '${options.component?.formFieldConfigName()}'. Change events will not be consumed.`;
-			this.logDebug(msg, options.definition);
-			return;
-		}
-		this.expressions = expressions;
+    const expressions: FormExpressionsConfigFrame[] | undefined = options.definition?.expressions;
+    if (expressions === undefined || _isEmpty(expressions)) {
+      const msg = `${this.constructor.name}: No expressions defined for component '${options.component?.formFieldConfigName()}'. Change events will not be consumed.`;
+      this.logDebug(msg, options.definition);
+      return;
+    }
+    this.expressions = expressions;
 
-		// Model is optional for some components
-		const model:  FormFieldModel<unknown> | undefined = options.definition?.model ?? options.component?.model;
-		if (!model || !model?.formControl) {
-			this.logDebug(`${this.constructor.name}: No model or no form control found for component '${options.component?.formFieldConfigName()}'. Change events may or may not be properly consumed.`, options.definition);
-		} else {
-			this.model = model;
-		}
+    // Model is optional for some components
+    const model: FormFieldModel<unknown> | undefined = options.definition?.model ?? options.component?.model;
+    if (!model || !model?.formControl) {
+      this.logDebug(
+        `${this.constructor.name}: No model or no form control found for component '${options.component?.formFieldConfigName()}'. Change events may or may not be properly consumed.`,
+        options.definition
+      );
+    } else {
+      this.model = model;
+    }
 
-		this.setupQuerySourceUpdateListener();
+    this.setupQuerySourceUpdateListener();
 
-		const sub = this.eventBus.select$(eventType).subscribe(async (event: FormComponentEvent) => {
-			const hasConditionMatches = await this.getMatchedExpressions(event, this.expressions!);
-			if (hasConditionMatches) {
-				for (const expr of hasConditionMatches) {
-					await this.consumeEvent(event, expr);
-				}
-			}
-		});
-		this.subscriptions.set(eventType, sub);
-	}
+    const sub = this.eventBus.select$(eventType).subscribe(async (event: FormComponentEvent) => {
+      const hasConditionMatches = await this.getMatchedExpressions(event, this.expressions!);
+      if (hasConditionMatches) {
+        for (const expr of hasConditionMatches) {
+          await this.consumeEvent(event, expr);
+        }
+      }
+    });
+    this.subscriptions.set(eventType, sub);
+  }
   /**
    * Returns all expressions that match the event based on their conditions.
    *
@@ -300,86 +319,97 @@ export abstract class FormComponentEventBaseConsumer extends FormComponentEventB
    * @param expressions
    * @returns
    */
-	protected async getMatchedExpressions(event: FormComponentEvent, expressions: FormExpressionsConfigFrame[]): Promise<FormExpressionsConfigFrame[] | null> {
-		const matchedExpressions: FormExpressionsConfigFrame[] = [];
-		for (const expr of expressions) {
-			// Will match if condition is undefined
-			if (expr.config.condition === undefined || expr.config.condition === null) {
-				matchedExpressions.push(expr);
-				continue;
-			}
-			// Will skip if the event is FORM_DEFINITION_READY and the expression is not set to run on form ready
-			if (event.sourceId == FormComponentEventType.FORM_DEFINITION_READY && expr.config.runOnFormReady === false) {
-				continue;
-			}
-			if (event.sourceId == FormComponentEventType.FORM_DEFINITION_READY && !this.componentDefQuerySource) {
-				// Ensure the query source is available since this is the first event after form ready
-				this.componentDefQuerySource = this.formComp?.getQuerySource();
-			}
-
-			const conditionKind = expr.config.conditionKind || ExpressionsConditionKind.JSONPointer;
-			let hasMatchedCondition = false;
-
-			if (conditionKind === ExpressionsConditionKind.JSONPointer) {
-				const matchOpts: FormComponentEventJSONPointerMatchOptions = {
-					condition: expr.config.condition || '',
-					conditionKind: ExpressionsConditionKind.JSONPointer,
-					querySource: this.getEventQuerySource(event)!,
-					event: event,
-					expression: expr
-				};
-				hasMatchedCondition = this.hasMatchedJSONPointerCondition(matchOpts);
-			} else if (conditionKind === ExpressionsConditionKind.JSONata) {
-				const matchOpts: FormComponentEventJSONataMatchOptions = {
-					condition: expr.config.condition || '',
-					conditionKind: ExpressionsConditionKind.JSONata,
-					event: event,
-					expression: expr
-				};
-				hasMatchedCondition = await this.hasMatchedJSONataCondition(matchOpts, expr);
-			} else if (conditionKind === ExpressionsConditionKind.JSONataQuery) {
-				const matchOpts: FormComponentEventJSONataQueryMatchOptions = {
-					condition: expr.config.condition || '',
-					conditionKind: ExpressionsConditionKind.JSONataQuery,
-					querySource: this.getEventQuerySource(event)!,
-					event: event,
-					expression: expr
-				};
-				// The querySource must be updated each time before evaluating the condition. The querySource is updated via subscription to the event bus, set up in `setupQuerySourceUpdateListener()` emitted via FormComponentEventType.FORM_DEFINITION_CHANGED.
-				// The challenge is that this may or may not have happened at this point. There's another event that fires that root form listens and recalculates the query source, so at this point should mitigate this risk.
-
-				hasMatchedCondition = await this.hasMatchedJSONataQueryCondition(matchOpts, expr);
+  protected async getMatchedExpressions(
+    event: FormComponentEvent,
+    expressions: FormExpressionsConfigFrame[]
+  ): Promise<FormExpressionsConfigFrame[] | null> {
+    const matchedExpressions: FormExpressionsConfigFrame[] = [];
+    for (const expr of expressions) {
+      // Will match if condition is undefined
+      if (expr.config.condition === undefined || expr.config.condition === null) {
+        matchedExpressions.push(expr);
+        continue;
+      }
+      // Will skip if the event is FORM_DEFINITION_READY and the expression is not set to run on form ready
+      if (event.sourceId == FormComponentEventType.FORM_DEFINITION_READY && expr.config.runOnFormReady === false) {
+        continue;
+      }
+      if (event.sourceId == FormComponentEventType.FORM_DEFINITION_READY && !this.componentDefQuerySource) {
+        // Ensure the query source is available since this is the first event after form ready
+        this.componentDefQuerySource = this.formComp?.getQuerySource();
       }
 
-			if (hasMatchedCondition) {
-				matchedExpressions.push(expr);
-			}
-		}
-		return !_isEmpty(matchedExpressions) ? matchedExpressions : null;
-	}
+      const conditionKind = expr.config.conditionKind || ExpressionsConditionKind.JSONPointer;
+      let hasMatchedCondition = false;
 
-	protected async hasMatchedJSONataCondition(opts: FormComponentEventJSONataMatchOptions, expression: FormExpressionsConfigFrame): Promise<boolean> {
+      if (conditionKind === ExpressionsConditionKind.JSONPointer) {
+        const matchOpts: FormComponentEventJSONPointerMatchOptions = {
+          condition: expr.config.condition || '',
+          conditionKind: ExpressionsConditionKind.JSONPointer,
+          querySource: this.getEventQuerySource(event)!,
+          event: event,
+          expression: expr,
+        };
+        hasMatchedCondition = this.hasMatchedJSONPointerCondition(matchOpts);
+      } else if (conditionKind === ExpressionsConditionKind.JSONata) {
+        const matchOpts: FormComponentEventJSONataMatchOptions = {
+          condition: expr.config.condition || '',
+          conditionKind: ExpressionsConditionKind.JSONata,
+          event: event,
+          expression: expr,
+        };
+        hasMatchedCondition = await this.hasMatchedJSONataCondition(matchOpts, expr);
+      } else if (conditionKind === ExpressionsConditionKind.JSONataQuery) {
+        const matchOpts: FormComponentEventJSONataQueryMatchOptions = {
+          condition: expr.config.condition || '',
+          conditionKind: ExpressionsConditionKind.JSONataQuery,
+          querySource: this.getEventQuerySource(event)!,
+          event: event,
+          expression: expr,
+        };
+        // The querySource must be updated each time before evaluating the condition. The querySource is updated via subscription to the event bus, set up in `setupQuerySourceUpdateListener()` emitted via FormComponentEventType.FORM_DEFINITION_CHANGED.
+        // The challenge is that this may or may not have happened at this point. There's another event that fires that root form listens and recalculates the query source, so at this point should mitigate this risk.
+
+        hasMatchedCondition = await this.hasMatchedJSONataQueryCondition(matchOpts, expr);
+      }
+
+      if (hasMatchedCondition) {
+        matchedExpressions.push(expr);
+      }
+    }
+    return !_isEmpty(matchedExpressions) ? matchedExpressions : null;
+  }
+
+  protected async hasMatchedJSONataCondition(
+    opts: FormComponentEventJSONataMatchOptions,
+    expression: FormExpressionsConfigFrame
+  ): Promise<boolean> {
     // JSONata will only match on broadcast events, not on scoped, or the form ready event is not set to run on form ready
-		const isRunOnFormReady = (opts.event.sourceId == FormComponentEventType.FORM_DEFINITION_READY && expression.config.runOnFormReady !== false);
+    const isRunOnFormReady =
+      opts.event.sourceId == FormComponentEventType.FORM_DEFINITION_READY && expression.config.runOnFormReady !== false;
     if (opts.event.sourceId !== '*' && !isRunOnFormReady) {
       return false;
     }
-		const result = await this.evaluateExpressionJSONata(expression, opts.event, 'condition');
-		return !!result;
-	}
+    const result = await this.evaluateExpressionJSONata(expression, opts.event, 'condition');
+    return !!result;
+  }
 
-	protected async hasMatchedJSONataQueryCondition(opts: FormComponentEventJSONataQueryMatchOptions, expression: FormExpressionsConfigFrame): Promise<boolean> {
+  protected async hasMatchedJSONataQueryCondition(
+    opts: FormComponentEventJSONataQueryMatchOptions,
+    expression: FormExpressionsConfigFrame
+  ): Promise<boolean> {
     // JSONataQuery will only match on broadcast events, not on scoped
-		const isRunOnFormReady = (opts.event.sourceId == FormComponentEventType.FORM_DEFINITION_READY && expression.config.runOnFormReady !== false);
+    const isRunOnFormReady =
+      opts.event.sourceId == FormComponentEventType.FORM_DEFINITION_READY && expression.config.runOnFormReady !== false;
     if (opts.event.sourceId !== '*' && !isRunOnFormReady) {
       return false;
     }
-		const result = await this.evaluateExpressionJSONata(expression, opts.event, 'condition', {
+    const result = await this.evaluateExpressionJSONata(expression, opts.event, 'condition', {
       querySource: opts.querySource?.querySource,
-      runtimeContext: opts.querySource?.runtimeContext
+      runtimeContext: opts.querySource?.runtimeContext,
     });
-		return !!result;
-	}
+    return !!result;
+  }
 
   /**
    * Sets the expression target property to the value.
@@ -405,11 +435,16 @@ export abstract class FormComponentEventBaseConsumer extends FormComponentEventB
    * @param expression The expression associated with this change.
    * @protected
    */
-  protected async setTarget(targetValue: unknown, exprTarget: string, event: FormComponentEvent, expression: FormExpressionsConfigFrame) {
+  protected async setTarget(
+    targetValue: unknown,
+    exprTarget: string,
+    event: FormComponentEvent,
+    expression: FormExpressionsConfigFrame
+  ) {
     if (exprTarget === FormExpressionsTargetModelValue) {
       // The model.value property must be handled specially.
       if (this.model?.formControl && this.model?.formControl.value !== targetValue) {
-        await setControlValue(this.model.formControl, targetValue, {emitEvent: false});
+        await setControlValue(this.model.formControl, targetValue, { emitEvent: false });
         await syncComponentDisplayFromModel(this.options?.component);
         // setControlValue with emitEvent:false suppresses Angular's
         // StatusChangeEvent/PristineChangeEvent. Without an explicit re-broadcast,
@@ -419,52 +454,47 @@ export abstract class FormComponentEventBaseConsumer extends FormComponentEventB
         // current form status so signal-effect consumers can re-evaluate.
         this.formComp?.broadcastFormStatus();
       }
-
     } else if (exprTarget === FormExpressionsTargetModelDisabled) {
       // The model.disabled property must be handled specially.
       const disabled = toBoolean(targetValue);
-      this.model?.setDisabled?.(disabled, {emitEvent: false, onlySelf: true});
-
+      this.model?.setDisabled?.(disabled, { emitEvent: false, onlySelf: true });
     } else if (exprTarget.startsWith(FormExpressionsTargetLayoutPrefix)) {
       const name = exprTarget.substring(FormExpressionsTargetLayoutPrefix.length);
       this.options?.definition?.layout?.setProperty?.(name, targetValue);
-
     } else if (exprTarget.startsWith(FormExpressionsTargetComponentPrefix)) {
       const name = exprTarget.substring(FormExpressionsTargetComponentPrefix.length);
       this.options?.definition?.component?.setProperty?.(name, targetValue);
-
     } else if (exprTarget === FormExpressionsTargetFieldVisible) {
       const name = 'visible';
       const visible = toBoolean(targetValue);
       this.options?.definition?.component?.setProperty?.(name, visible);
       this.options?.definition?.layout?.setProperty?.(name, visible);
-
     } else if (exprTarget === FormExpressionsTargetFieldDisabled) {
       const name = 'disabled';
       const disabled = toBoolean(targetValue);
       this.options?.definition?.component?.setProperty?.(name, disabled);
       this.options?.definition?.layout?.setProperty?.(name, disabled);
-      this.model?.setDisabled?.(disabled, {emitEvent: false, onlySelf: true});
-
+      this.model?.setDisabled?.(disabled, { emitEvent: false, onlySelf: true });
     } else if (exprTarget === FormExpressionsTargetValidationGroups) {
       if (isTypeFormValidationGroupsChangeRequestInfo(targetValue)) {
         // Only publish an event in response to scoped change events, don't need to respond to the broadcast events.
         // Only want to respond to events targeted to a specific component.
-        if (event.sourceId !== "*") {
-          this.eventBus.publish(createFormValidationGroupsChangeRequestEvent({
-            // Create a broadcast event, as this event is intended as a general broadcast.
-            sourceId: '*',
-            fieldId: event.fieldId,
-            ...targetValue,
-          }));
+        if (event.sourceId !== '*') {
+          this.eventBus.publish(
+            createFormValidationGroupsChangeRequestEvent({
+              // Create a broadcast event, as this event is intended as a general broadcast.
+              sourceId: '*',
+              fieldId: event.fieldId,
+              ...targetValue,
+            })
+          );
         }
       } else {
         this.loggerService.error(
           `FormComponentBaseEventConsumer: Invalid value '${targetValue}' for expression target ${FormExpressionsTargetValidationGroups}, expected {initial?: '[value]', groups: {include?: string[], exclude?: string[]}}.`,
-          {event, expression}
+          { event, expression }
         );
       }
-
     } else {
       this.loggerService.warn(
         `FormComponentBaseEventConsumer: Unknown target '${exprTarget}' in expression config.`,
@@ -478,5 +508,5 @@ export abstract class FormComponentEventBaseConsumer extends FormComponentEventB
    * @param event
    * @param expression
    */
-	protected abstract consumeEvent(event: FormComponentEvent, expression: FormExpressionsConfigFrame): Promise<void>;
+  protected abstract consumeEvent(event: FormComponentEvent, expression: FormExpressionsConfigFrame): Promise<void>;
 }

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-change-event-consumer.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-change-event-consumer.spec.ts
@@ -3,14 +3,11 @@ import { FormControl, Validators } from '@angular/forms';
 import { FormFieldBaseComponent, FormFieldCompMapEntry, LoggerService } from '@researchdatabox/portal-ng-common';
 import { FormComponentEventBus } from './form-component-event-bus.service';
 import { FormComponentValueChangeEventConsumer } from './form-component-change-event-consumer';
-import {
-  FormComponentEventType,
-  FieldValueChangedEvent
-} from './form-component-event.types';
+import { FormComponentEventType, FieldValueChangedEvent } from './form-component-event.types';
 import { ExpressionsConditionKind, FormExpressionsConfigFrame } from '@researchdatabox/sails-ng-common';
 import { Subject } from 'rxjs';
 import { CustomSetValueControl } from '../custom-set-value.control';
-import {createSetup} from "./spec-helper";
+import { createSetup } from './spec-helper';
 
 describe('FormComponentValueChangeEventConsumer', () => {
   let eventBus: jasmine.SpyObj<FormComponentEventBus>;
@@ -22,9 +19,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
     loggerService = jasmine.createSpyObj<LoggerService>('LoggerService', ['debug', 'warn', 'error']);
 
     TestBed.configureTestingModule({
-      providers: [
-        { provide: LoggerService, useValue: loggerService }
-      ]
+      providers: [{ provide: LoggerService, useValue: loggerService }],
     });
 
     eventStream$ = new Subject();
@@ -38,8 +33,6 @@ describe('FormComponentValueChangeEventConsumer', () => {
     consumer.destroy();
   });
 
-
-
   it('should subscribe to FIELD_VALUE_CHANGED events when bound', () => {
     const expr: FormExpressionsConfigFrame = {
       name: 'model-update',
@@ -47,8 +40,8 @@ describe('FormComponentValueChangeEventConsumer', () => {
         target: 'model.value',
         condition: 'otherField',
         conditionKind: ExpressionsConditionKind.JSONPointer,
-        template: ''
-      }
+        template: '',
+      },
     };
     const { definition, component } = createSetup([expr]);
 
@@ -64,8 +57,8 @@ describe('FormComponentValueChangeEventConsumer', () => {
         target: 'model.value',
         condition: 'otherField',
         conditionKind: ExpressionsConditionKind.JSONPointer,
-        template: ''
-      }
+        template: '',
+      },
     };
     const { control, definition, component } = createSetup([expr]);
 
@@ -78,7 +71,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
       fieldId: 'otherField',
       sourceId: 'otherField',
       value: 'newValue',
-      timestamp: Date.now()
+      timestamp: Date.now(),
     };
 
     eventStream$.next(event);
@@ -94,15 +87,15 @@ describe('FormComponentValueChangeEventConsumer', () => {
         target: 'model.value',
         condition: 'otherField',
         conditionKind: ExpressionsConditionKind.JSONPointer,
-        template: ''
-      }
+        template: '',
+      },
     };
     const { control, definition, component } = createSetup([expr]);
     control.addValidators(Validators.required);
     control.updateValueAndValidity();
     const formComponent = {
       getQuerySource: () => undefined,
-      broadcastFormStatus: jasmine.createSpy('broadcastFormStatus')
+      broadcastFormStatus: jasmine.createSpy('broadcastFormStatus'),
     };
 
     spyOn<any>(consumer, 'getMatchedExpressions').and.returnValue(Promise.resolve([expr]));
@@ -115,7 +108,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
       fieldId: 'otherField',
       sourceId: 'otherField',
       value: 'newValue',
-      timestamp: Date.now()
+      timestamp: Date.now(),
     };
 
     eventStream$.next(event);
@@ -133,14 +126,14 @@ describe('FormComponentValueChangeEventConsumer', () => {
         target: 'model.value',
         condition: 'otherField',
         conditionKind: ExpressionsConditionKind.JSONPointer,
-        template: ''
-      }
+        template: '',
+      },
     };
     const { control, definition, component } = createSetup([expr]);
     control.setValue('sameValue');
     const formComponent = {
       getQuerySource: () => undefined,
-      broadcastFormStatus: jasmine.createSpy('broadcastFormStatus')
+      broadcastFormStatus: jasmine.createSpy('broadcastFormStatus'),
     };
 
     spyOn<any>(consumer, 'getMatchedExpressions').and.returnValue(Promise.resolve([expr]));
@@ -154,7 +147,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
       fieldId: 'otherField',
       sourceId: 'otherField',
       value: 'sameValue',
-      timestamp: Date.now()
+      timestamp: Date.now(),
     };
 
     eventStream$.next(event);
@@ -171,15 +164,15 @@ describe('FormComponentValueChangeEventConsumer', () => {
         target: 'model.value',
         condition: 'otherField',
         conditionKind: ExpressionsConditionKind.JSONPointer,
-        template: ''
-      }
+        template: '',
+      },
     };
     const { control, definition } = createSetup([expr]);
     const syncDisplayFromModel = jasmine.createSpy('syncDisplayFromModel').and.resolveTo();
     const component = {
       formFieldConfigName: () => 'test-field',
       model: { formControl: control },
-      syncDisplayFromModel
+      syncDisplayFromModel,
     } as unknown as FormFieldBaseComponent<unknown>;
 
     spyOn<any>(consumer, 'getMatchedExpressions').and.returnValue(Promise.resolve([expr]));
@@ -191,7 +184,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
       fieldId: 'otherField',
       sourceId: 'otherField',
       value: 'newValue',
-      timestamp: Date.now()
+      timestamp: Date.now(),
     };
 
     eventStream$.next(event);
@@ -208,8 +201,8 @@ describe('FormComponentValueChangeEventConsumer', () => {
         target: 'model.value',
         condition: 'otherField',
         conditionKind: ExpressionsConditionKind.JSONPointer,
-        template: ''
-      }
+        template: '',
+      },
     };
     const control = new FormControl({ name: '' });
     const definition = {
@@ -217,7 +210,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
       expressions: [expr],
       lineagePaths: { formConfig: ['root'] },
       layout: { componentDefinition: { config: {} } },
-      component: { componentDefinition: { config: {} } }
+      component: { componentDefinition: { config: {} } },
     } as unknown as FormFieldCompMapEntry;
     const syncDisplayFromModel = jasmine.createSpy('syncDisplayFromModel').and.resolveTo();
     const component = {
@@ -225,9 +218,9 @@ describe('FormComponentValueChangeEventConsumer', () => {
       model: { formControl: control },
       formFieldBaseComponents: [
         {
-          syncDisplayFromModel
-        }
-      ]
+          syncDisplayFromModel,
+        },
+      ],
     } as unknown as FormFieldBaseComponent<unknown>;
 
     spyOn<any>(consumer, 'getMatchedExpressions').and.returnValue(Promise.resolve([expr]));
@@ -239,7 +232,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
       fieldId: 'otherField',
       sourceId: 'otherField',
       value: { name: 'Alice Scott' },
-      timestamp: Date.now()
+      timestamp: Date.now(),
     };
 
     eventStream$.next(event);
@@ -250,207 +243,206 @@ describe('FormComponentValueChangeEventConsumer', () => {
   }));
 
   describe('target updates', async () => {
+    it('should update layout config when target starts with "layout."', fakeAsync(() => {
+      const expr: FormExpressionsConfigFrame = {
+        name: 'layout-update',
+        config: {
+          target: 'layout.disabled',
+          condition: 'otherField',
+          template: '',
+        },
+      };
+      const { definition, component } = createSetup([expr]);
 
-  it('should update layout config when target starts with "layout."', fakeAsync(() => {
-    const expr: FormExpressionsConfigFrame = {
-      name: 'layout-update',
-      config: {
-        target: 'layout.disabled',
-        condition: 'otherField',
-        template: ''
-      }
-    };
-    const { definition, component } = createSetup([expr]);
+      spyOn<any>(consumer, 'getMatchedExpressions').and.returnValue(Promise.resolve([expr]));
+      const layoutSetPropertySpy = spyOn<any>(definition?.layout, 'setProperty');
+      const componentSetPropertySpy = spyOn<any>(definition?.component, 'setProperty');
+      const modelSetDisabledSpy = spyOn<any>(component?.model, 'setDisabled');
 
-    spyOn<any>(consumer, 'getMatchedExpressions').and.returnValue(Promise.resolve([expr]));
-    const layoutSetPropertySpy = spyOn<any>(definition?.layout, 'setProperty');
-    const componentSetPropertySpy = spyOn<any>(definition?.component, 'setProperty');
-    const modelSetDisabledSpy = spyOn<any>(component?.model, 'setDisabled');
+      consumer.bind({ component, definition });
 
-    consumer.bind({ component, definition });
+      const event: FieldValueChangedEvent = {
+        type: 'field.value.changed',
+        fieldId: 'otherField',
+        sourceId: 'otherField',
+        value: 'enabled',
+        timestamp: Date.now(),
+      };
 
-    const event: FieldValueChangedEvent = {
-      type: 'field.value.changed',
-      fieldId: 'otherField',
-      sourceId: 'otherField',
-      value: 'enabled',
-      timestamp: Date.now()
-    };
+      eventStream$.next(event);
+      tick();
 
-    eventStream$.next(event);
-    tick();
-
-    expect(layoutSetPropertySpy).toHaveBeenCalledOnceWith('disabled', 'enabled');
-    expect(componentSetPropertySpy).toHaveBeenCalledTimes(0);
-    expect(modelSetDisabledSpy).toHaveBeenCalledTimes(0);
-  }));
-
-  it('should update component config when target starts with "component."', fakeAsync(() => {
-    const expr: FormExpressionsConfigFrame = {
-      name: 'component-update',
-      config: {
-        target: 'component.someSetting',
-        condition: 'otherField',
-        template: ''
-      }
-    };
-    const { definition, component } = createSetup([expr]);
-
-    spyOn<any>(consumer, 'getMatchedExpressions').and.returnValue(Promise.resolve([expr]));
-    const layoutSetPropertySpy = spyOn<any>(definition?.layout, 'setProperty');
-    const componentSetPropertySpy = spyOn<any>(definition?.component, 'setProperty');
-    const modelSetDisabledSpy = spyOn<any>(component?.model, 'setDisabled');
-
-    consumer.bind({ component, definition });
-
-    const event: FieldValueChangedEvent = {
-      type: 'field.value.changed',
-      fieldId: 'otherField',
-      sourceId: 'otherField',
-      value: 'enabled',
-      timestamp: Date.now()
-    };
-
-    eventStream$.next(event);
-    tick();
-
-    expect(layoutSetPropertySpy).toHaveBeenCalledTimes(0);
-    expect(componentSetPropertySpy).toHaveBeenCalledOnceWith('someSetting', 'enabled');
-    expect(modelSetDisabledSpy).toHaveBeenCalledTimes(0);
-  }));
-
-  it('should update component config and formControl.disabled when target is "component.disabled"', fakeAsync(() => {
-    const expr: FormExpressionsConfigFrame = {
-      name: 'component-update',
-      config: {
-        target: 'component.disabled',
-        condition: 'otherField',
-        template: ''
-      }
-    };
-    const { control, definition, component } = createSetup([expr]);
-
-    spyOn<any>(consumer, 'getMatchedExpressions').and.returnValue(Promise.resolve([expr]));
-    const layoutSetPropertySpy = spyOn<any>(definition?.layout, 'setProperty');
-    const componentSetPropertySpy = spyOn<any>(definition?.component, 'setProperty');
-    const modelSetDisabledSpy = spyOn<any>(component?.model, 'setDisabled');
-
-    consumer.bind({ component, definition });
-
-    const event: FieldValueChangedEvent = {
-      type: 'field.value.changed',
-      fieldId: 'otherField',
-      sourceId: 'otherField',
-      value: 'enabled',
-      timestamp: Date.now()
-    };
-
-    eventStream$.next(event);
-    tick();
-
-    expect(layoutSetPropertySpy).toHaveBeenCalledTimes(0);
-    // The component.setProperty method has a special case for 'disabled' that also calls model.setDisabled.
-    expect(componentSetPropertySpy).toHaveBeenCalledOnceWith('disabled', 'enabled');
-    expect(modelSetDisabledSpy).toHaveBeenCalledTimes(0);
-  }));
-  it('should update model disabled when target is model.disabled', fakeAsync(() => {
-    const expr: FormExpressionsConfigFrame = {
-      name: 'model-disabled-update',
-      config: {
-        target: 'model.disabled',
-        condition: 'otherField',
-        template: ''
-      }
-    };
-    const { definition, component } = createSetup([expr]);
-
-    spyOn<any>(consumer, 'getMatchedExpressions').and.returnValue(Promise.resolve([expr]));
-    const layoutSetPropertySpy = spyOn<any>(definition?.layout, 'setProperty');
-    const componentSetPropertySpy = spyOn<any>(definition?.component, 'setProperty');
-    const modelSetDisabledSpy = spyOn<any>(component?.model, 'setDisabled');
-
-    consumer.bind({ component, definition });
-
-    const event: FieldValueChangedEvent = {
-      type: 'field.value.changed',
-      fieldId: 'otherField',
-      sourceId: 'otherField',
-      value: 'enabled',
-      timestamp: Date.now()
-    };
-
-    eventStream$.next(event);
-    tick();
-
-    expect(layoutSetPropertySpy).toHaveBeenCalledTimes(0);
-    expect(componentSetPropertySpy).toHaveBeenCalledTimes(0);
-    expect(modelSetDisabledSpy).toHaveBeenCalledOnceWith(true, {emitEvent: false, onlySelf: true});
+      expect(layoutSetPropertySpy).toHaveBeenCalledOnceWith('disabled', 'enabled');
+      expect(componentSetPropertySpy).toHaveBeenCalledTimes(0);
+      expect(modelSetDisabledSpy).toHaveBeenCalledTimes(0);
     }));
-  it('should update component, layout, model disabled when target is field.disabled', fakeAsync(() => {
-    const expr: FormExpressionsConfigFrame = {
-      name: 'field-disabled-update',
-      config: {
-        target: 'field.disabled',
-        condition: 'otherField',
-        template: ''
-      }
-    };
-    const { definition, component } = createSetup([expr]);
 
-    spyOn<any>(consumer, 'getMatchedExpressions').and.returnValue(Promise.resolve([expr]));
-    const layoutSetPropertySpy = spyOn<any>(definition?.layout, 'setProperty');
-    const componentSetPropertySpy = spyOn<any>(definition?.component, 'setProperty');
-    const modelSetDisabledSpy = spyOn<any>(component?.model, 'setDisabled');
+    it('should update component config when target starts with "component."', fakeAsync(() => {
+      const expr: FormExpressionsConfigFrame = {
+        name: 'component-update',
+        config: {
+          target: 'component.someSetting',
+          condition: 'otherField',
+          template: '',
+        },
+      };
+      const { definition, component } = createSetup([expr]);
 
-    consumer.bind({ component, definition });
+      spyOn<any>(consumer, 'getMatchedExpressions').and.returnValue(Promise.resolve([expr]));
+      const layoutSetPropertySpy = spyOn<any>(definition?.layout, 'setProperty');
+      const componentSetPropertySpy = spyOn<any>(definition?.component, 'setProperty');
+      const modelSetDisabledSpy = spyOn<any>(component?.model, 'setDisabled');
 
-    const event: FieldValueChangedEvent = {
-      type: 'field.value.changed',
-      fieldId: 'otherField',
-      sourceId: 'otherField',
-      value: 'enabled',
-      timestamp: Date.now()
-    };
+      consumer.bind({ component, definition });
 
-    eventStream$.next(event);
-    tick();
+      const event: FieldValueChangedEvent = {
+        type: 'field.value.changed',
+        fieldId: 'otherField',
+        sourceId: 'otherField',
+        value: 'enabled',
+        timestamp: Date.now(),
+      };
 
-    expect(layoutSetPropertySpy).toHaveBeenCalledOnceWith('disabled', true);
-    expect(componentSetPropertySpy).toHaveBeenCalledOnceWith('disabled', true);
-    expect(modelSetDisabledSpy).toHaveBeenCalledOnceWith(true, {emitEvent: false, onlySelf: true});
+      eventStream$.next(event);
+      tick();
+
+      expect(layoutSetPropertySpy).toHaveBeenCalledTimes(0);
+      expect(componentSetPropertySpy).toHaveBeenCalledOnceWith('someSetting', 'enabled');
+      expect(modelSetDisabledSpy).toHaveBeenCalledTimes(0);
     }));
-  it('should update component and layout visible when target is field.visible', fakeAsync(() => {
-    const expr: FormExpressionsConfigFrame = {
-      name: 'field-disabled-update',
-      config: {
-        target: 'field.visible',
-        condition: 'otherField',
-        template: ''
-      }
-    };
-    const { definition, component } = createSetup([expr]);
 
-    spyOn<any>(consumer, 'getMatchedExpressions').and.returnValue(Promise.resolve([expr]));
-    const layoutSetPropertySpy = spyOn<any>(definition?.layout, 'setProperty');
-    const componentSetPropertySpy = spyOn<any>(definition?.component, 'setProperty');
-    const modelSetDisabledSpy = spyOn<any>(component?.model, 'setDisabled');
+    it('should update component config and formControl.disabled when target is "component.disabled"', fakeAsync(() => {
+      const expr: FormExpressionsConfigFrame = {
+        name: 'component-update',
+        config: {
+          target: 'component.disabled',
+          condition: 'otherField',
+          template: '',
+        },
+      };
+      const { control, definition, component } = createSetup([expr]);
 
-    consumer.bind({ component, definition });
+      spyOn<any>(consumer, 'getMatchedExpressions').and.returnValue(Promise.resolve([expr]));
+      const layoutSetPropertySpy = spyOn<any>(definition?.layout, 'setProperty');
+      const componentSetPropertySpy = spyOn<any>(definition?.component, 'setProperty');
+      const modelSetDisabledSpy = spyOn<any>(component?.model, 'setDisabled');
 
-    const event: FieldValueChangedEvent = {
-      type: 'field.value.changed',
-      fieldId: 'otherField',
-      sourceId: 'otherField',
-      value: false,
-      timestamp: Date.now()
-    };
+      consumer.bind({ component, definition });
 
-    eventStream$.next(event);
-    tick();
+      const event: FieldValueChangedEvent = {
+        type: 'field.value.changed',
+        fieldId: 'otherField',
+        sourceId: 'otherField',
+        value: 'enabled',
+        timestamp: Date.now(),
+      };
 
-    expect(layoutSetPropertySpy).toHaveBeenCalledOnceWith('visible', false);
-    expect(componentSetPropertySpy).toHaveBeenCalledOnceWith('visible', false);
-    expect(modelSetDisabledSpy).toHaveBeenCalledTimes(0);
+      eventStream$.next(event);
+      tick();
+
+      expect(layoutSetPropertySpy).toHaveBeenCalledTimes(0);
+      // The component.setProperty method has a special case for 'disabled' that also calls model.setDisabled.
+      expect(componentSetPropertySpy).toHaveBeenCalledOnceWith('disabled', 'enabled');
+      expect(modelSetDisabledSpy).toHaveBeenCalledTimes(0);
+    }));
+    it('should update model disabled when target is model.disabled', fakeAsync(() => {
+      const expr: FormExpressionsConfigFrame = {
+        name: 'model-disabled-update',
+        config: {
+          target: 'model.disabled',
+          condition: 'otherField',
+          template: '',
+        },
+      };
+      const { definition, component } = createSetup([expr]);
+
+      spyOn<any>(consumer, 'getMatchedExpressions').and.returnValue(Promise.resolve([expr]));
+      const layoutSetPropertySpy = spyOn<any>(definition?.layout, 'setProperty');
+      const componentSetPropertySpy = spyOn<any>(definition?.component, 'setProperty');
+      const modelSetDisabledSpy = spyOn<any>(component?.model, 'setDisabled');
+
+      consumer.bind({ component, definition });
+
+      const event: FieldValueChangedEvent = {
+        type: 'field.value.changed',
+        fieldId: 'otherField',
+        sourceId: 'otherField',
+        value: 'enabled',
+        timestamp: Date.now(),
+      };
+
+      eventStream$.next(event);
+      tick();
+
+      expect(layoutSetPropertySpy).toHaveBeenCalledTimes(0);
+      expect(componentSetPropertySpy).toHaveBeenCalledTimes(0);
+      expect(modelSetDisabledSpy).toHaveBeenCalledOnceWith(true, { emitEvent: false, onlySelf: true });
+    }));
+    it('should update component, layout, model disabled when target is field.disabled', fakeAsync(() => {
+      const expr: FormExpressionsConfigFrame = {
+        name: 'field-disabled-update',
+        config: {
+          target: 'field.disabled',
+          condition: 'otherField',
+          template: '',
+        },
+      };
+      const { definition, component } = createSetup([expr]);
+
+      spyOn<any>(consumer, 'getMatchedExpressions').and.returnValue(Promise.resolve([expr]));
+      const layoutSetPropertySpy = spyOn<any>(definition?.layout, 'setProperty');
+      const componentSetPropertySpy = spyOn<any>(definition?.component, 'setProperty');
+      const modelSetDisabledSpy = spyOn<any>(component?.model, 'setDisabled');
+
+      consumer.bind({ component, definition });
+
+      const event: FieldValueChangedEvent = {
+        type: 'field.value.changed',
+        fieldId: 'otherField',
+        sourceId: 'otherField',
+        value: 'enabled',
+        timestamp: Date.now(),
+      };
+
+      eventStream$.next(event);
+      tick();
+
+      expect(layoutSetPropertySpy).toHaveBeenCalledOnceWith('disabled', true);
+      expect(componentSetPropertySpy).toHaveBeenCalledOnceWith('disabled', true);
+      expect(modelSetDisabledSpy).toHaveBeenCalledOnceWith(true, { emitEvent: false, onlySelf: true });
+    }));
+    it('should update component and layout visible when target is field.visible', fakeAsync(() => {
+      const expr: FormExpressionsConfigFrame = {
+        name: 'field-disabled-update',
+        config: {
+          target: 'field.visible',
+          condition: 'otherField',
+          template: '',
+        },
+      };
+      const { definition, component } = createSetup([expr]);
+
+      spyOn<any>(consumer, 'getMatchedExpressions').and.returnValue(Promise.resolve([expr]));
+      const layoutSetPropertySpy = spyOn<any>(definition?.layout, 'setProperty');
+      const componentSetPropertySpy = spyOn<any>(definition?.component, 'setProperty');
+      const modelSetDisabledSpy = spyOn<any>(component?.model, 'setDisabled');
+
+      consumer.bind({ component, definition });
+
+      const event: FieldValueChangedEvent = {
+        type: 'field.value.changed',
+        fieldId: 'otherField',
+        sourceId: 'otherField',
+        value: false,
+        timestamp: Date.now(),
+      };
+
+      eventStream$.next(event);
+      tick();
+
+      expect(layoutSetPropertySpy).toHaveBeenCalledOnceWith('visible', false);
+      expect(componentSetPropertySpy).toHaveBeenCalledOnceWith('visible', false);
+      expect(modelSetDisabledSpy).toHaveBeenCalledTimes(0);
     }));
   });
 
@@ -461,8 +453,8 @@ describe('FormComponentValueChangeEventConsumer', () => {
         target: 'model.value',
         hasTemplate: true,
         condition: 'otherField',
-        template: ''
-      }
+        template: '',
+      },
     };
     const { control, definition, component } = createSetup([expr]);
 
@@ -476,7 +468,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
       fieldId: 'source',
       sourceId: 'source',
       value: 'orig',
-      timestamp: Date.now()
+      timestamp: Date.now(),
     };
 
     eventStream$.next(event);
@@ -493,8 +485,8 @@ describe('FormComponentValueChangeEventConsumer', () => {
         target: 'model.value',
         hasTemplate: true,
         condition: 'source',
-        template: ''
-      }
+        template: '',
+      },
     };
     const { definition, component } = createSetup([expr]);
     const evaluateSpy = jasmine.createSpy('evaluate').and.resolveTo('templatedValue');
@@ -505,10 +497,10 @@ describe('FormComponentValueChangeEventConsumer', () => {
       form: {
         value: {
           source: {
-            bad: () => 'not cloneable 1'
-          }
-        }
-      }
+            bad: () => 'not cloneable 1',
+          },
+        },
+      },
     };
     spyOn<any>(consumer, 'getCompiledItems').and.resolveTo({ evaluate: evaluateSpy });
 
@@ -517,9 +509,9 @@ describe('FormComponentValueChangeEventConsumer', () => {
       fieldId: 'source',
       sourceId: 'source',
       value: {
-        bad: () => 'not cloneable 2'
+        bad: () => 'not cloneable 2',
       },
-      timestamp: Date.now()
+      timestamp: Date.now(),
     };
 
     const result = await (consumer as any).evaluateExpressionJSONata(expr, event, 'template');
@@ -539,7 +531,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
       [
         'FormComponentValueChangeEventConsumer: Failed to clone formData for JSONata context. Falling back to the original value.',
         "DataCloneError: Failed to execute 'structuredClone' on 'Window': () => 'not cloneable 1' could not be cloned.",
-      ]
+      ],
     ]);
     expect(loggerService.error).not.toHaveBeenCalled();
 
@@ -550,6 +542,50 @@ describe('FormComponentValueChangeEventConsumer', () => {
     expect(context.value).toBe((consumer as any).formComp.form.value.source);
   });
 
+  it('should evaluate JSONata with raw form values so disabled fields are available', async () => {
+    const expr: FormExpressionsConfigFrame = {
+      name: 'template-raw-form-value',
+      config: {
+        target: 'model.value',
+        hasTemplate: true,
+        condition: 'source',
+        template: '',
+      },
+    };
+    const { definition, component } = createSetup([expr]);
+    const evaluateSpy = jasmine.createSpy('evaluate').and.resolveTo('templatedValue');
+    const rawValue = {
+      source: 'raw source',
+      citation_publication_date: '2026-06-10T00:00:00.000Z',
+    };
+
+    (consumer as any).options = { component, definition };
+    (consumer as any).expressions = [expr];
+    (consumer as any).formComp = {
+      form: {
+        value: {
+          source: 'enabled source',
+        },
+        getRawValue: () => rawValue,
+      },
+    };
+    spyOn<any>(consumer, 'getCompiledItems').and.resolveTo({ evaluate: evaluateSpy });
+
+    const event: FieldValueChangedEvent = {
+      type: 'field.value.changed',
+      fieldId: 'source',
+      sourceId: 'source',
+      value: 'event source',
+      timestamp: Date.now(),
+    };
+
+    await (consumer as any).evaluateExpressionJSONata(expr, event, 'template');
+
+    const [, context] = evaluateSpy.calls.mostRecent().args;
+    expect(context.formData).toEqual(rawValue);
+    expect(context.value).toBe('raw source');
+  });
+
   it('should include requestParams in JSONata evaluation context', async () => {
     const expr: FormExpressionsConfigFrame = {
       name: 'template-request-params',
@@ -557,8 +593,8 @@ describe('FormComponentValueChangeEventConsumer', () => {
         target: 'model.value',
         hasTemplate: true,
         condition: 'source',
-        template: ''
-      }
+        template: '',
+      },
     };
     const { definition, component } = createSetup([expr]);
     const evaluateSpy = jasmine.createSpy('evaluate').and.resolveTo('templatedValue');
@@ -568,12 +604,12 @@ describe('FormComponentValueChangeEventConsumer', () => {
     (consumer as any).formComp = {
       form: {
         value: {
-          source: 'current'
-        }
+          source: 'current',
+        },
       },
       requestParams: () => ({
-        focusTabId: 'tab2'
-      })
+        focusTabId: 'tab2',
+      }),
     };
     spyOn<any>(consumer, 'getCompiledItems').and.resolveTo({ evaluate: evaluateSpy });
 
@@ -582,7 +618,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
       fieldId: 'source',
       sourceId: '*',
       value: 'orig',
-      timestamp: Date.now()
+      timestamp: Date.now(),
     };
 
     await (consumer as any).evaluateExpressionJSONata(expr, event, 'template');
@@ -599,8 +635,8 @@ describe('FormComponentValueChangeEventConsumer', () => {
         target: 'model.value',
         condition: '$exists(runtimeContext.requestParams.focusTabId) and querySource[0].name = "parent"',
         conditionKind: ExpressionsConditionKind.JSONataQuery,
-        template: ''
-      }
+        template: '',
+      },
     };
     const evaluateExpressionSpy = spyOn<any>(consumer, 'evaluateExpressionJSONata').and.resolveTo(true);
     const event: FieldValueChangedEvent = {
@@ -608,35 +644,38 @@ describe('FormComponentValueChangeEventConsumer', () => {
       fieldId: 'source',
       sourceId: '*',
       value: 'orig',
-      timestamp: Date.now()
+      timestamp: Date.now(),
     };
 
-    const matched = await (consumer as any).hasMatchedJSONataQueryCondition({
-      condition: expr.config.condition || '',
-      conditionKind: ExpressionsConditionKind.JSONataQuery,
-      expression: expr,
-      event,
-      querySource: {
-        queryOrigSource: [],
-        querySource: [{ name: 'parent' }],
-        jsonPointerSource: {},
-        runtimeContext: {
-          requestParams: {
-            focusTabId: 'tab2'
-          }
+    const matched = await (consumer as any).hasMatchedJSONataQueryCondition(
+      {
+        condition: expr.config.condition || '',
+        conditionKind: ExpressionsConditionKind.JSONataQuery,
+        expression: expr,
+        event,
+        querySource: {
+          queryOrigSource: [],
+          querySource: [{ name: 'parent' }],
+          jsonPointerSource: {},
+          runtimeContext: {
+            requestParams: {
+              focusTabId: 'tab2',
+            },
+          },
+          event,
         },
-        event
-      }
-    }, expr);
+      },
+      expr
+    );
 
     expect(matched).toBeTrue();
     expect(evaluateExpressionSpy).toHaveBeenCalledWith(expr, event, 'condition', {
       querySource: [{ name: 'parent' }],
       runtimeContext: {
         requestParams: {
-          focusTabId: 'tab2'
-        }
-      }
+          focusTabId: 'tab2',
+        },
+      },
     });
   });
 
@@ -646,8 +685,8 @@ describe('FormComponentValueChangeEventConsumer', () => {
       config: {
         target: 'unknown.target',
         condition: 'otherField',
-        template: ''
-      }
+        template: '',
+      },
     } as unknown as FormExpressionsConfigFrame;
     const { definition, component } = createSetup([expr]);
 
@@ -660,7 +699,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
       fieldId: 'otherField',
       sourceId: 'otherField',
       value: 'val',
-      timestamp: Date.now()
+      timestamp: Date.now(),
     };
 
     eventStream$.next(event);
@@ -684,23 +723,23 @@ describe('FormComponentValueChangeEventConsumer', () => {
       config: {
         target: 'model.value',
         condition: undefined,
-        template: ''
-      }
+        template: '',
+      },
     };
     const exprNull: FormExpressionsConfigFrame = {
       name: 'null-condition',
       config: {
         target: 'model.value',
         condition: null as any,
-        template: ''
-      }
+        template: '',
+      },
     };
     const event: FieldValueChangedEvent = {
       type: 'field.value.changed',
       fieldId: 'otherField',
       sourceId: 'otherField',
       value: 'val',
-      timestamp: Date.now()
+      timestamp: Date.now(),
     };
 
     const matched = await (consumer as any).getMatchedExpressions(event, [exprUndefined, exprNull]);
@@ -717,8 +756,8 @@ describe('FormComponentValueChangeEventConsumer', () => {
       config: {
         target: 'model.value',
         condition: 'otherField',
-        template: ''
-      }
+        template: '',
+      },
     };
     const { definition, component } = createSetup([expr]);
 
@@ -733,7 +772,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
       fieldId: 'otherField',
       sourceId: 'otherField',
       value: 'val',
-      timestamp: Date.now()
+      timestamp: Date.now(),
     };
 
     eventStream$.next(event);
@@ -747,8 +786,8 @@ describe('FormComponentValueChangeEventConsumer', () => {
       config: {
         target: 'model.value',
         condition: 'otherField',
-        template: ''
-      }
+        template: '',
+      },
     };
     const control = new FormControl('existing') as FormControl & CustomSetValueControl<unknown>;
     const customSetter = jasmine.createSpy('customSetter').and.resolveTo(undefined);
@@ -759,12 +798,12 @@ describe('FormComponentValueChangeEventConsumer', () => {
       expressions: [expr],
       lineagePaths: { formConfig: ['root'] },
       layout: { componentDefinition: { config: {} } },
-      component: { componentDefinition: { config: {} } }
+      component: { componentDefinition: { config: {} } },
     } as unknown as FormFieldCompMapEntry;
 
     const component = {
       formFieldConfigName: () => 'test-field',
-      model: { formControl: control }
+      model: { formControl: control },
     } as unknown as FormFieldBaseComponent<unknown>;
 
     spyOn<any>(consumer, 'getMatchedExpressions').and.returnValue(Promise.resolve([expr]));
@@ -776,7 +815,7 @@ describe('FormComponentValueChangeEventConsumer', () => {
       fieldId: 'otherField',
       sourceId: 'otherField',
       value: [{ name: 'new row' }],
-      timestamp: Date.now()
+      timestamp: Date.now(),
     };
 
     eventStream$.next(event);

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-change-event-consumer.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-change-event-consumer.spec.ts
@@ -586,6 +586,46 @@ describe('FormComponentValueChangeEventConsumer', () => {
     expect(context.value).toBe('raw source');
   });
 
+  it('should normalize a plain field name to a JSON Pointer for context.value lookup', async () => {
+    const expr: FormExpressionsConfigFrame = {
+      name: 'template-plain-field-name',
+      config: {
+        target: 'model.value',
+        hasTemplate: true,
+        condition: 'source',
+        template: '',
+      },
+    };
+    const { definition, component } = createSetup([expr]);
+    const evaluateSpy = jasmine.createSpy('evaluate').and.resolveTo('templatedValue');
+    const rawValue = {
+      source: 'plain-name value',
+    };
+
+    (consumer as any).options = { component, definition };
+    (consumer as any).expressions = [expr];
+    (consumer as any).formComp = {
+      form: {
+        value: rawValue,
+        getRawValue: () => rawValue,
+      },
+    };
+    spyOn<any>(consumer, 'getCompiledItems').and.resolveTo({ evaluate: evaluateSpy });
+
+    const event: FieldValueChangedEvent = {
+      type: 'field.value.changed',
+      fieldId: 'source',
+      sourceId: 'source',
+      value: 'event source',
+      timestamp: Date.now(),
+    };
+
+    await (consumer as any).evaluateExpressionJSONata(expr, event, 'template');
+
+    const [, context] = evaluateSpy.calls.mostRecent().args;
+    expect(context.value).toBe('plain-name value');
+  });
+
   it('should include requestParams in JSONata evaluation context', async () => {
     const expr: FormExpressionsConfigFrame = {
       name: 'template-request-params',

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-change-event-consumer.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-change-event-consumer.spec.ts
@@ -626,6 +626,48 @@ describe('FormComponentValueChangeEventConsumer', () => {
     expect(context.value).toBe('plain-name value');
   });
 
+  it('should quietly fall back to the flat field value when the event fieldId is a config path', async () => {
+    const expr: FormExpressionsConfigFrame = {
+      name: 'template-config-path-field-name',
+      config: {
+        target: 'model.value',
+        hasTemplate: true,
+        condition: '/mainTab/about/dataRecord',
+        template: '',
+      },
+    };
+    const { definition, component } = createSetup([expr]);
+    const evaluateSpy = jasmine.createSpy('evaluate').and.resolveTo('templatedValue');
+    const dataRecord = { oid: 'record-1', title: 'Selected record' };
+    const rawValue = {
+      dataRecord,
+    };
+
+    (consumer as any).options = { component, definition };
+    (consumer as any).expressions = [expr];
+    (consumer as any).formComp = {
+      form: {
+        value: rawValue,
+        getRawValue: () => rawValue,
+      },
+    };
+    spyOn<any>(consumer, 'getCompiledItems').and.resolveTo({ evaluate: evaluateSpy });
+
+    const event: FieldValueChangedEvent = {
+      type: 'field.value.changed',
+      fieldId: '/mainTab/about/dataRecord',
+      sourceId: '/mainTab/about/dataRecord',
+      value: dataRecord,
+      timestamp: Date.now(),
+    };
+
+    await (consumer as any).evaluateExpressionJSONata(expr, event, 'template');
+
+    const [, context] = evaluateSpy.calls.mostRecent().args;
+    expect(context.value).toEqual(dataRecord);
+    expect(loggerService.error).not.toHaveBeenCalled();
+  });
+
   it('should include requestParams in JSONata evaluation context', async () => {
     const expr: FormExpressionsConfigFrame = {
       name: 'template-request-params',

--- a/angular/projects/researchdatabox/form/src/app/form.component.scss
+++ b/angular/projects/researchdatabox/form/src/app/form.component.scss
@@ -314,9 +314,17 @@
   min-width: 0;
 }
 
-.rb-form-edit .rb-form-repeatable-item__remove {
+/* The per-row controls (sort + remove) are grouped into one compact toolbar so
+   they read as a single unit aligned to the right of each repeatable row. */
+.rb-form-edit .rb-form-repeatable-item__actions {
   flex: 0 0 auto;
   align-self: start;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--rb-form-gap-2);
+}
+
+.rb-form-edit .rb-form-repeatable-item__remove {
   min-width: 34px;
   min-height: 34px;
   height: 34px;
@@ -327,19 +335,34 @@
   justify-content: center;
 }
 
+.rb-form-edit .rb-form-repeatable-item__sort {
+  flex: 0 0 auto;
+}
+
+.rb-form-edit .rb-form-repeatable-item__sort .btn {
+  min-width: 34px;
+  min-height: 26px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .rb-form-edit select.form-select {
   height: auto;
 }
 
-.rb-form-edit .rb-form-repeatable-item:has(.rb-form-field-label) .rb-form-repeatable-item__remove {
+.rb-form-edit .rb-form-repeatable-item:has(.rb-form-field-label) .rb-form-repeatable-item__actions {
   margin-top: 2.25rem;
 }
 
-.rb-form-edit .rb-form-repeatable-item:has(.rb-form-inline-label):not(:has(.rb-form-inline-fields, .rb-form-contributor-inline)) .rb-form-repeatable-item__remove {
+.rb-form-edit
+  .rb-form-repeatable-item:has(.rb-form-inline-label):not(:has(.rb-form-inline-fields, .rb-form-contributor-inline))
+  .rb-form-repeatable-item__actions {
   margin-top: 0;
 }
 
-.rb-form-edit .rb-form-repeatable-item.rb-form-repeatable-item--inline-fields .rb-form-repeatable-item__remove {
+.rb-form-edit .rb-form-repeatable-item.rb-form-repeatable-item--inline-fields .rb-form-repeatable-item__actions {
   margin-top: 2.25rem;
 }
 
@@ -424,8 +447,7 @@
   border-radius: 0.65rem;
   border: 1px solid var(--rb-form-validation-outline);
   background:
-    linear-gradient(120deg, rgba(255, 255, 255, 0.9), rgba(255, 244, 241, 0.95)),
-    var(--rb-form-validation-surface);
+    linear-gradient(120deg, rgba(255, 255, 255, 0.9), rgba(255, 244, 241, 0.95)), var(--rb-form-validation-surface);
   box-shadow: 0 6px 16px -14px var(--rb-form-validation-shadow);
 }
 
@@ -449,7 +471,10 @@
   font-weight: 700;
   letter-spacing: 0.02em;
   line-height: 1.45;
-  transition: transform 140ms ease, box-shadow 140ms ease, background-color 140ms ease;
+  transition:
+    transform 140ms ease,
+    box-shadow 140ms ease,
+    background-color 140ms ease;
 }
 
 .rb-form-edit .rb-form-field-error-toggle:hover,
@@ -527,24 +552,40 @@
     --rb-form-inline-grid-columns: repeat(4, minmax(0, 1fr));
   }
 
+  .rb-form-edit .rb-form-grid-cols-5 .rb-form-group {
+    --rb-form-inline-grid-columns: minmax(0, 0.65fr) repeat(4, minmax(0, 1fr));
+  }
+
   .rb-form-edit .rb-form-contributor-inline.rb-form-grid-cols-3 .rb-form-group {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
 
-.rb-form-edit :is(.rb-form-inline-fields, .rb-form-contributor-inline) .rb-form-group > redbox-form-base-wrapper.rb-form-grid-span-1 {
+.rb-form-edit
+  :is(.rb-form-inline-fields, .rb-form-contributor-inline)
+  .rb-form-group
+  > redbox-form-base-wrapper.rb-form-grid-span-1 {
   grid-column: span 1 !important;
 }
 
-.rb-form-edit :is(.rb-form-inline-fields, .rb-form-contributor-inline) .rb-form-group > redbox-form-base-wrapper.rb-form-grid-span-2 {
+.rb-form-edit
+  :is(.rb-form-inline-fields, .rb-form-contributor-inline)
+  .rb-form-group
+  > redbox-form-base-wrapper.rb-form-grid-span-2 {
   grid-column: span 2 !important;
 }
 
-.rb-form-edit :is(.rb-form-inline-fields, .rb-form-contributor-inline) .rb-form-group > redbox-form-base-wrapper.rb-form-grid-span-3 {
+.rb-form-edit
+  :is(.rb-form-inline-fields, .rb-form-contributor-inline)
+  .rb-form-group
+  > redbox-form-base-wrapper.rb-form-grid-span-3 {
   grid-column: span 3 !important;
 }
 
-.rb-form-edit :is(.rb-form-inline-fields, .rb-form-contributor-inline) .rb-form-group > redbox-form-base-wrapper.rb-form-grid-span-full {
+.rb-form-edit
+  :is(.rb-form-inline-fields, .rb-form-contributor-inline)
+  .rb-form-group
+  > redbox-form-base-wrapper.rb-form-grid-span-full {
   grid-column: 1 / -1 !important;
 }
 
@@ -569,36 +610,26 @@
   width: 100%;
 }
 
-.rb-form-edit :is(
-  .rb-form-funding-inline,
-  .rb-form-inline-fields--split-end,
-  .rb-form-grid-split-end
-) > .rb-form-group {
+.rb-form-edit
+  :is(.rb-form-funding-inline, .rb-form-inline-fields--split-end, .rb-form-grid-split-end)
+  > .rb-form-group {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   column-gap: var(--rb-form-gap-2);
 }
 
-.rb-form-edit :is(
-  .rb-form-funding-inline,
-  .rb-form-inline-fields--split-end,
-  .rb-form-grid-split-end
-) > .rb-form-group > redbox-form-base-wrapper:is(
-  .rb-form-inline-fields__field,
-  .rb-form-contributor-inline__field
-) {
+.rb-form-edit
+  :is(.rb-form-funding-inline, .rb-form-inline-fields--split-end, .rb-form-grid-split-end)
+  > .rb-form-group
+  > redbox-form-base-wrapper:is(.rb-form-inline-fields__field, .rb-form-contributor-inline__field) {
   min-width: 0;
   width: 100%;
 }
 
-.rb-form-edit :is(
-  .rb-form-funding-inline,
-  .rb-form-inline-fields--split-end,
-  .rb-form-grid-split-end
-) > .rb-form-group > redbox-form-base-wrapper:is(
-  .rb-form-inline-fields__field--fixed,
-  .rb-form-contributor-inline__field--role
-) {
+.rb-form-edit
+  :is(.rb-form-funding-inline, .rb-form-inline-fields--split-end, .rb-form-grid-split-end)
+  > .rb-form-group
+  > redbox-form-base-wrapper:is(.rb-form-inline-fields__field--fixed, .rb-form-contributor-inline__field--role) {
   width: 35rem;
 }
 
@@ -627,7 +658,7 @@
   resize: vertical;
 }
 
-.rb-form-edit .rb-form-repeatable-item:has(.rb-form-related-link-inline) .rb-form-repeatable-item__remove {
+.rb-form-edit .rb-form-repeatable-item:has(.rb-form-related-link-inline) .rb-form-repeatable-item__actions {
   position: relative;
   top: 2rem;
   margin-top: 2.25rem;
@@ -716,7 +747,7 @@
   }
 
   .rb-form-repeatable__add,
-  .rb-form-repeatable-item__remove {
+  .rb-form-repeatable-item__actions {
     display: none !important;
   }
 

--- a/angular/projects/researchdatabox/form/src/app/form.service.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.service.ts
@@ -84,6 +84,7 @@ import { APP_BASE_HREF } from "@angular/common";
 import { firstValueFrom } from "rxjs";
 import { FormValidationGroupsChangeInitial } from "./form-state";
 import { VocabTreeService } from './service/vocab-tree.service';
+import jsonata from 'jsonata';
 
 // Lazy validator-definition contract provided by index.bundle.js / client-script.ts.
 // `formValidatorDefinitions` is the historical synchronous accessor and is preserved
@@ -1249,7 +1250,7 @@ export class FormService extends HttpClientService {
           try {
             const compiledItems = await this.formCompiledItems;
             for (const key of keys) {
-              const result = await compiledItems.evaluate(key, value, { libraries: jsonataLibrary });
+              const result = await compiledItems.evaluate(key, value, { jsonata, libraries: jsonataLibrary });
               if (result !== undefined) {
                 return result;
               }

--- a/language-defaults/en/translation.json
+++ b/language-defaults/en/translation.json
@@ -841,6 +841,8 @@
   "form.validationErrorsAriaLabel": "{{fieldName}} validation errors",
   "add-button-label": "Add Item",
   "remove-button-label": "Remove Item",
+  "move-up-button-label": "Move up",
+  "move-down-button-label": "Move down",
   "select-all-items": "Select All Items",
   "select-item": "Select",
   "move-up-button": "Move entry up",

--- a/packages/redbox-core/src/config/reusableContributorFormDefinitions.config.ts
+++ b/packages/redbox-core/src/config/reusableContributorFormDefinitions.config.ts
@@ -1,39 +1,40 @@
-import {ReusableFormDefinitions} from "@researchdatabox/sails-ng-common";
+import { ReusableFormDefinitions } from '@researchdatabox/sails-ng-common';
 
 export const reusableContributorFormDefinitions: ReusableFormDefinitions = {
   /**
    * Standard contributor field for title.
    */
-  "standard-contributor-field-title": [
+  'standard-contributor-field-title': [
     {
-      name: "title",
+      name: 'title',
       component: {
-        class: "SimpleInputComponent",
+        class: 'SimpleInputComponent',
         config: {
-          type: "text",
-          hostCssClasses: "d-block",
-          wrapperCssClasses: "rb-form-inline-fields__field rb-form-contributor-inline__field rb-form-contributor-inline__field--title",
-          onItemSelect: {rawPath: 'metadata.title'},
-        }
+          type: 'text',
+          hostCssClasses: 'd-block',
+          wrapperCssClasses:
+            'rb-form-inline-fields__field rb-form-contributor-inline__field rb-form-contributor-inline__field--title',
+          onItemSelect: { rawPath: 'metadata.title' },
+        },
       },
-      model: {class: "SimpleInputModel", config: {}},
+      model: { class: 'SimpleInputModel', config: {} },
       layout: {
-        class: "InlineLayout",
-        config: {label: "Title", hostCssClasses: "d-flex align-items-center gap-2"}
+        class: 'InlineLayout',
+        config: { label: 'Title', hostCssClasses: 'd-flex align-items-center gap-2' },
       },
-    }
+    },
   ],
   /**
    * Standard contributor field for name, that has typeahead and allows entering freeform text.
    */
-  "standard-contributor-field-name": [
+  'standard-contributor-field-name': [
     {
-      name: "name",
+      name: 'name',
       component: {
-        class: "TypeaheadInputComponent",
+        class: 'TypeaheadInputComponent',
         config: {
-          hostCssClasses: "flex-grow-1 d-block",
-          wrapperCssClasses: "rb-form-inline-fields__field rb-form-contributor-inline__field",
+          hostCssClasses: 'flex-grow-1 d-block',
+          wrapperCssClasses: 'rb-form-inline-fields__field rb-form-contributor-inline__field',
           vocabRef: 'party',
           sourceType: 'namedQuery',
           queryId: 'party',
@@ -44,193 +45,201 @@ export const reusableContributorFormDefinitions: ReusableFormDefinitions = {
           debounceMs: 250,
           maxResults: 25,
           valueMode: 'value',
-        }
+        },
       },
-      model: {class: "TypeaheadInputModel", config: {}},
+      model: { class: 'TypeaheadInputModel', config: {} },
       layout: {
-        class: "InlineLayout",
-        config: {label: "Name", hostCssClasses: "d-flex align-items-center gap-2"}
+        class: 'InlineLayout',
+        config: { label: 'Name', hostCssClasses: 'd-flex align-items-center gap-2' },
       },
-    }
+    },
   ],
   /**
    * Standard contributor field for email.
    */
-  "standard-contributor-field-email": [
+  'standard-contributor-field-email': [
     {
-      name: "email",
+      name: 'email',
       component: {
-        class: "SimpleInputComponent",
+        class: 'SimpleInputComponent',
         config: {
-          type: "text",
-          hostCssClasses: "flex-grow-1 d-block",
-          wrapperCssClasses: "rb-form-inline-fields__field rb-form-contributor-inline__field",
-          onItemSelect: {rawPath: 'metadata.email'},
-        }
+          type: 'text',
+          hostCssClasses: 'flex-grow-1 d-block',
+          wrapperCssClasses: 'rb-form-inline-fields__field rb-form-contributor-inline__field',
+          onItemSelect: { rawPath: 'metadata.email' },
+        },
       },
-      model: {class: "SimpleInputModel", config: {validators: [{class: "email"}]}},
+      model: { class: 'SimpleInputModel', config: { validators: [{ class: 'email' }] } },
       layout: {
-        class: "InlineLayout",
-        config: {label: "Email", hostCssClasses: "d-flex align-items-center gap-2"}
+        class: 'InlineLayout',
+        config: { label: 'Email', hostCssClasses: 'd-flex align-items-center gap-2' },
       },
     },
   ],
   /**
    * Standard contributor field for ORCID.
    */
-  "standard-contributor-field-orcid": [
+  'standard-contributor-field-orcid': [
     {
-      name: "orcid",
+      name: 'orcid',
       component: {
-        class: "SimpleInputComponent",
+        class: 'SimpleInputComponent',
         config: {
-          type: "text",
-          hostCssClasses: "flex-grow-1 d-block",
-          wrapperCssClasses: "rb-form-inline-fields__field rb-form-contributor-inline__field",
-          onItemSelect: {rawPath: 'metadata.orcid'},
-        }
+          type: 'text',
+          hostCssClasses: 'flex-grow-1 d-block',
+          wrapperCssClasses: 'rb-form-inline-fields__field rb-form-contributor-inline__field',
+          onItemSelect: { rawPath: 'metadata.orcid' },
+        },
       },
-      model: {class: "SimpleInputModel", config: {validators: [{class: "orcid"}]}},
+      model: { class: 'SimpleInputModel', config: { validators: [{ class: 'orcid' }] } },
       layout: {
-        class: "InlineLayout",
-        config: {label: "ORCID", hostCssClasses: "d-flex align-items-center gap-2"}
+        class: 'InlineLayout',
+        config: { label: 'ORCID', hostCssClasses: 'd-flex align-items-center gap-2' },
       },
     },
   ],
   /**
    * Standard contributor form fields.
    */
-  "standard-contributor-fields": [
+  'standard-contributor-fields': [
     {
-      overrides: {reusableFormName: "standard-contributor-field-name"},
-      name: "standard_contributor_field_name",
-      component: {class: "ReusableComponent", config: {componentDefinitions: []}},
+      overrides: { reusableFormName: 'standard-contributor-field-name' },
+      name: 'standard_contributor_field_name',
+      component: { class: 'ReusableComponent', config: { componentDefinitions: [] } },
     },
     {
-      overrides: {reusableFormName: "standard-contributor-field-email"},
-      name: "standard_contributor_field_email",
-      component: {class: "ReusableComponent", config: {componentDefinitions: []}},
+      overrides: { reusableFormName: 'standard-contributor-field-email' },
+      name: 'standard_contributor_field_email',
+      component: { class: 'ReusableComponent', config: { componentDefinitions: [] } },
     },
     {
-      overrides: {reusableFormName: "standard-contributor-field-orcid"},
-      name: "standard_contributor_field_orcid",
-      component: {class: "ReusableComponent", config: {componentDefinitions: []}},
+      overrides: { reusableFormName: 'standard-contributor-field-orcid' },
+      name: 'standard_contributor_field_orcid',
+      component: { class: 'ReusableComponent', config: { componentDefinitions: [] } },
     },
   ],
   /**
    * Standard contributor form fields in lookup-only mode.
    */
-  "standard-contributor-fields-lookup-only": [
+  'standard-contributor-fields-lookup-only': [
     {
-      overrides: {reusableFormName: "standard-contributor-field-name"},
-      name: "standard_contributor_field_name",
+      overrides: { reusableFormName: 'standard-contributor-field-name' },
+      name: 'standard_contributor_field_name',
       component: {
-        class: "ReusableComponent", config: {
+        class: 'ReusableComponent',
+        config: {
           componentDefinitions: [
             {
-              name: "name", component: {class: "TypeaheadInputComponent", config: {requireSelection: true}}
-            }
-          ]
-        }
+              name: 'name',
+              component: { class: 'TypeaheadInputComponent', config: { requireSelection: true } },
+            },
+          ],
+        },
       },
     },
     {
-      overrides: {reusableFormName: "standard-contributor-field-email"},
-      name: "standard_contributor_field_email",
+      overrides: { reusableFormName: 'standard-contributor-field-email' },
+      name: 'standard_contributor_field_email',
       component: {
-        class: "ReusableComponent", config: {
+        class: 'ReusableComponent',
+        config: {
           componentDefinitions: [
             {
-              name: "email", component: {class: "SimpleInputComponent", config: {readonly: true}}
-            }
-          ]
-        }
+              name: 'email',
+              component: { class: 'SimpleInputComponent', config: { readonly: true } },
+            },
+          ],
+        },
       },
     },
     {
-      overrides: {reusableFormName: "standard-contributor-field-orcid"},
-      name: "standard_contributor_field_orcid",
-      component: {class: "ReusableComponent", config: {componentDefinitions: []}},
+      overrides: { reusableFormName: 'standard-contributor-field-orcid' },
+      name: 'standard_contributor_field_orcid',
+      component: { class: 'ReusableComponent', config: { componentDefinitions: [] } },
     },
   ],
   /**
    * Standard contributor form fields in lookup-only mode without ORCID.
    */
-  "standard-contributor-fields-lookup-only-name-email": [
+  'standard-contributor-fields-lookup-only-name-email': [
     {
-      overrides: {reusableFormName: "standard-contributor-field-name"},
-      name: "standard_contributor_field_name",
+      overrides: { reusableFormName: 'standard-contributor-field-name' },
+      name: 'standard_contributor_field_name',
       component: {
-        class: "ReusableComponent", config: {
+        class: 'ReusableComponent',
+        config: {
           componentDefinitions: [
             {
-              name: "name", component: {class: "TypeaheadInputComponent", config: {requireSelection: true}}
-            }
-          ]
-        }
+              name: 'name',
+              component: { class: 'TypeaheadInputComponent', config: { requireSelection: true } },
+            },
+          ],
+        },
       },
     },
     {
-      overrides: {reusableFormName: "standard-contributor-field-email"},
-      name: "standard_contributor_field_email",
+      overrides: { reusableFormName: 'standard-contributor-field-email' },
+      name: 'standard_contributor_field_email',
       component: {
-        class: "ReusableComponent", config: {
+        class: 'ReusableComponent',
+        config: {
           componentDefinitions: [
             {
-              name: "email", component: {class: "SimpleInputComponent", config: {readonly: true}}
-            }
-          ]
-        }
+              name: 'email',
+              component: { class: 'SimpleInputComponent', config: { readonly: true } },
+            },
+          ],
+        },
       },
     },
   ],
   /**
    * Standard contributor form fields with title for people sections.
    */
-  "standard-contributor-fields-with-title": [
+  'standard-contributor-fields-with-title': [
     {
-      overrides: {reusableFormName: "standard-contributor-field-title"},
-      name: "standard_contributor_field_title",
-      component: {class: "ReusableComponent", config: {componentDefinitions: []}},
+      overrides: { reusableFormName: 'standard-contributor-field-title' },
+      name: 'standard_contributor_field_title',
+      component: { class: 'ReusableComponent', config: { componentDefinitions: [] } },
     },
     {
-      overrides: {reusableFormName: "standard-contributor-fields"},
-      name: "standard_contributor_fields_reusable_with_title",
-      component: {class: "ReusableComponent", config: {componentDefinitions: []}},
+      overrides: { reusableFormName: 'standard-contributor-fields' },
+      name: 'standard_contributor_fields_reusable_with_title',
+      component: { class: 'ReusableComponent', config: { componentDefinitions: [] } },
     },
   ],
   /**
    * Standard contributor form fields with title for people sections in lookup-only mode.
    */
-  "standard-contributor-fields-with-title-lookup-only": [
+  'standard-contributor-fields-with-title-lookup-only': [
     {
-      overrides: {reusableFormName: "standard-contributor-field-title"},
-      name: "standard_contributor_field_title",
-      component: {class: "ReusableComponent", config: {componentDefinitions: []}},
+      overrides: { reusableFormName: 'standard-contributor-field-title' },
+      name: 'standard_contributor_field_title',
+      component: { class: 'ReusableComponent', config: { componentDefinitions: [] } },
     },
     {
-      overrides: {reusableFormName: "standard-contributor-fields-lookup-only"},
-      name: "standard_contributor_fields_lookup_only_reusable_with_title",
-      component: {class: "ReusableComponent", config: {componentDefinitions: []}},
+      overrides: { reusableFormName: 'standard-contributor-fields-lookup-only' },
+      name: 'standard_contributor_fields_lookup_only_reusable_with_title',
+      component: { class: 'ReusableComponent', config: { componentDefinitions: [] } },
     },
   ],
   /**
    * Standard contributor form fields group.
    */
-  "standard-contributor-fields-group": [
+  'standard-contributor-fields-group': [
     {
-      name: "standard_contributor_fields_group",
-      layout: {class: "DefaultLayout", config: {label: "Standard Contributor"}},
-      model: {class: "GroupModel", config: {}},
+      name: 'standard_contributor_fields_group',
+      layout: { class: 'DefaultLayout', config: { label: 'Standard Contributor' } },
+      model: { class: 'GroupModel', config: {} },
       component: {
-        class: "GroupComponent",
+        class: 'GroupComponent',
         config: {
-          hostCssClasses: "rb-form-inline-fields rb-form-contributor-inline rb-form-grid-cols-3",
+          hostCssClasses: 'rb-form-inline-fields rb-form-contributor-inline rb-form-grid-cols-3',
           componentDefinitions: [
             {
-              overrides: {reusableFormName: "standard-contributor-fields"},
-              name: "standard_contributor_fields_reusable",
-              component: {class: "ReusableComponent", config: {componentDefinitions: []}},
+              overrides: { reusableFormName: 'standard-contributor-fields' },
+              name: 'standard_contributor_fields_reusable',
+              component: { class: 'ReusableComponent', config: { componentDefinitions: [] } },
             },
           ],
         },
@@ -240,20 +249,20 @@ export const reusableContributorFormDefinitions: ReusableFormDefinitions = {
   /**
    * Standard contributor form fields group in lookup-only mode.
    */
-  "standard-contributor-fields-lookup-only-group": [
+  'standard-contributor-fields-lookup-only-group': [
     {
-      name: "standard_contributor_fields_lookup_only_group",
-      layout: {class: "DefaultLayout", config: {label: "Standard Contributor"}},
-      model: {class: "GroupModel", config: {}},
+      name: 'standard_contributor_fields_lookup_only_group',
+      layout: { class: 'DefaultLayout', config: { label: 'Standard Contributor' } },
+      model: { class: 'GroupModel', config: {} },
       component: {
-        class: "GroupComponent",
+        class: 'GroupComponent',
         config: {
-          hostCssClasses: "rb-form-inline-fields rb-form-contributor-inline rb-form-grid-cols-3",
+          hostCssClasses: 'rb-form-inline-fields rb-form-contributor-inline rb-form-grid-cols-3',
           componentDefinitions: [
             {
-              overrides: {reusableFormName: "standard-contributor-fields-lookup-only"},
-              name: "standard_contributor_fields_lookup_only_reusable",
-              component: {class: "ReusableComponent", config: {componentDefinitions: []}},
+              overrides: { reusableFormName: 'standard-contributor-fields-lookup-only' },
+              name: 'standard_contributor_fields_lookup_only_reusable',
+              component: { class: 'ReusableComponent', config: { componentDefinitions: [] } },
             },
           ],
         },
@@ -263,20 +272,20 @@ export const reusableContributorFormDefinitions: ReusableFormDefinitions = {
   /**
    * Standard contributor form fields group in lookup-only mode without ORCID.
    */
-  "standard-contributor-fields-lookup-only-name-email-group": [
+  'standard-contributor-fields-lookup-only-name-email-group': [
     {
-      name: "standard_contributor_fields_lookup_only_name_email_group",
-      layout: {class: "DefaultLayout", config: {label: "Standard Contributor"}},
-      model: {class: "GroupModel", config: {}},
+      name: 'standard_contributor_fields_lookup_only_name_email_group',
+      layout: { class: 'DefaultLayout', config: { label: 'Standard Contributor' } },
+      model: { class: 'GroupModel', config: {} },
       component: {
-        class: "GroupComponent",
+        class: 'GroupComponent',
         config: {
-          hostCssClasses: "rb-form-inline-fields rb-form-contributor-inline rb-form-grid-cols-2",
+          hostCssClasses: 'rb-form-inline-fields rb-form-contributor-inline rb-form-grid-cols-2',
           componentDefinitions: [
             {
-              overrides: {reusableFormName: "standard-contributor-fields-lookup-only-name-email"},
-              name: "standard_contributor_fields_lookup_only_name_email_reusable",
-              component: {class: "ReusableComponent", config: {componentDefinitions: []}},
+              overrides: { reusableFormName: 'standard-contributor-fields-lookup-only-name-email' },
+              name: 'standard_contributor_fields_lookup_only_name_email_reusable',
+              component: { class: 'ReusableComponent', config: { componentDefinitions: [] } },
             },
           ],
         },
@@ -286,20 +295,21 @@ export const reusableContributorFormDefinitions: ReusableFormDefinitions = {
   /**
    * Standard contributor form fields group with title for people sections.
    */
-  "standard-contributor-fields-with-title-group": [
+  'standard-contributor-fields-with-title-group': [
     {
-      name: "standard_contributor_fields_with_title_group",
-      layout: {class: "DefaultLayout", config: {label: "Standard Contributor"}},
-      model: {class: "GroupModel", config: {}},
+      name: 'standard_contributor_fields_with_title_group',
+      layout: { class: 'DefaultLayout', config: { label: 'Standard Contributor' } },
+      model: { class: 'GroupModel', config: {} },
       component: {
-        class: "GroupComponent",
+        class: 'GroupComponent',
         config: {
-          hostCssClasses: "rb-form-inline-fields rb-form-contributor-inline rb-form-grid-cols-4 rb-form-contributor-inline--with-title",
+          hostCssClasses:
+            'rb-form-inline-fields rb-form-contributor-inline rb-form-grid-cols-4 rb-form-contributor-inline--with-title',
           componentDefinitions: [
             {
-              overrides: {reusableFormName: "standard-contributor-fields-with-title"},
-              name: "standard_contributor_fields_with_title_reusable",
-              component: {class: "ReusableComponent", config: {componentDefinitions: []}},
+              overrides: { reusableFormName: 'standard-contributor-fields-with-title' },
+              name: 'standard_contributor_fields_with_title_reusable',
+              component: { class: 'ReusableComponent', config: { componentDefinitions: [] } },
             },
           ],
         },
@@ -309,20 +319,113 @@ export const reusableContributorFormDefinitions: ReusableFormDefinitions = {
   /**
    * Standard contributor form fields group with title for people sections in lookup-only mode.
    */
-  "standard-contributor-fields-with-title-lookup-only-group": [
+  'standard-contributor-fields-with-title-lookup-only-group': [
     {
-      name: "standard_contributor_fields_with_title_lookup_only_group",
-      layout: {class: "DefaultLayout", config: {label: "Standard Contributor"}},
-      model: {class: "GroupModel", config: {}},
+      name: 'standard_contributor_fields_with_title_lookup_only_group',
+      layout: { class: 'DefaultLayout', config: { label: 'Standard Contributor' } },
+      model: { class: 'GroupModel', config: {} },
       component: {
-        class: "GroupComponent",
+        class: 'GroupComponent',
         config: {
-          hostCssClasses: "rb-form-inline-fields rb-form-contributor-inline rb-form-grid-cols-4 rb-form-contributor-inline--with-title",
+          hostCssClasses:
+            'rb-form-inline-fields rb-form-contributor-inline rb-form-grid-cols-4 rb-form-contributor-inline--with-title',
           componentDefinitions: [
             {
-              overrides: {reusableFormName: "standard-contributor-fields-with-title-lookup-only"},
-              name: "standard_contributor_fields_with_title_lookup_only_reusable",
-              component: {class: "ReusableComponent", config: {componentDefinitions: []}},
+              overrides: { reusableFormName: 'standard-contributor-fields-with-title-lookup-only' },
+              name: 'standard_contributor_fields_with_title_lookup_only_reusable',
+              component: { class: 'ReusableComponent', config: { componentDefinitions: [] } },
+            },
+          ],
+        },
+      },
+    },
+  ],
+  /**
+   * Citation contributor fields with separate family and given names.
+   */
+  'citation-contributor-fields-with-title-family-given-group': [
+    {
+      name: 'citation_contributor_fields_with_title_family_given_group',
+      layout: { class: 'DefaultLayout', config: { label: 'Citation Contributor' } },
+      model: { class: 'GroupModel', config: {} },
+      component: {
+        class: 'GroupComponent',
+        config: {
+          hostCssClasses:
+            'rb-form-inline-fields rb-form-contributor-inline rb-form-grid-cols-5 rb-form-contributor-inline--with-title',
+          componentDefinitions: [
+            {
+              overrides: { reusableFormName: 'standard-contributor-field-title' },
+              name: 'citation_contributor_field_title',
+              component: {
+                class: 'ReusableComponent',
+                config: {
+                  componentDefinitions: [
+                    {
+                      name: 'title',
+                      overrides: { replaceName: 'honorific' },
+                      component: {
+                        class: 'SimpleInputComponent',
+                        config: { onItemSelect: { rawPath: 'metadata.title' } },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+            {
+              overrides: { reusableFormName: 'standard-contributor-field-name' },
+              name: 'citation_contributor_field_family_name',
+              component: {
+                class: 'ReusableComponent',
+                config: {
+                  componentDefinitions: [
+                    {
+                      name: 'name',
+                      overrides: { replaceName: 'family_name' },
+                      component: {
+                        class: 'TypeaheadInputComponent',
+                        config: {
+                          labelField: 'metadata.familyName',
+                          valueField: 'metadata.familyName',
+                          onItemSelect: { rawPath: 'metadata.familyName' },
+                        },
+                      },
+                      layout: {
+                        class: 'InlineLayout',
+                        config: { label: '@dmpt-people-family-hdr', hostCssClasses: 'd-flex align-items-center gap-2' },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+            {
+              name: 'given_name',
+              component: {
+                class: 'SimpleInputComponent',
+                config: {
+                  type: 'text',
+                  hostCssClasses: 'flex-grow-1 d-block',
+                  wrapperCssClasses: 'rb-form-inline-fields__field rb-form-contributor-inline__field',
+                  onItemSelect: { rawPath: 'metadata.givenName' },
+                },
+              },
+              model: { class: 'SimpleInputModel', config: {} },
+              layout: {
+                class: 'InlineLayout',
+                config: { label: '@dmpt-people-given-hdr', hostCssClasses: 'd-flex align-items-center gap-2' },
+              },
+            },
+            {
+              overrides: { reusableFormName: 'standard-contributor-field-email' },
+              name: 'citation_contributor_field_email',
+              component: { class: 'ReusableComponent', config: { componentDefinitions: [] } },
+            },
+            {
+              overrides: { reusableFormName: 'standard-contributor-field-orcid' },
+              name: 'citation_contributor_field_orcid',
+              component: { class: 'ReusableComponent', config: { componentDefinitions: [] } },
             },
           ],
         },
@@ -333,80 +436,81 @@ export const reusableContributorFormDefinitions: ReusableFormDefinitions = {
    * Contributor permissions repeatable.
    * Consuming configs should override labels, syncSources, and expressions as needed.
    */
-  "contributor-permissions": [
+  'contributor-permissions': [
     {
-      name: "contributor_permissions_repeatable",
+      name: 'contributor_permissions_repeatable',
       component: {
-        class: "RepeatableComponent",
+        class: 'RepeatableComponent',
         config: {
           addButtonShow: true,
           allowZeroRows: true,
           hideWhenZeroRows: false,
           syncSources: [
             {
-              fieldName: "",
-              blankCheckFields: ["name", "email", "username"],
-              defaultTemplate: {username: null, role: "View&Edit"}
+              fieldName: '',
+              blankCheckFields: ['name', 'email', 'username'],
+              defaultTemplate: { username: null, role: 'View&Edit' },
             },
             {
-              fieldName: "",
-              blankCheckFields: ["name", "email", "username"],
-              defaultTemplate: {username: null, role: "View&Edit"}
-            }
+              fieldName: '',
+              blankCheckFields: ['name', 'email', 'username'],
+              defaultTemplate: { username: null, role: 'View&Edit' },
+            },
           ],
           elementTemplate: {
-            name: "",
-            overrides: {reusableFormName: "standard-contributor-fields-lookup-only-name-email-group"},
+            name: '',
+            overrides: { reusableFormName: 'standard-contributor-fields-lookup-only-name-email-group' },
             component: {
-              class: "ReusableComponent",
+              class: 'ReusableComponent',
               config: {
-                label: "@dmpt-user-permissions-tab-dmp-permissions",
+                label: '@dmpt-user-permissions-tab-dmp-permissions',
                 componentDefinitions: [
                   {
-                    name: "standard_contributor_fields_lookup_only_name_email_group",
-                    overrides: {replaceName: ""},
+                    name: 'standard_contributor_fields_lookup_only_name_email_group',
+                    overrides: { replaceName: '' },
                     component: {
-                      class: "GroupComponent",
+                      class: 'GroupComponent',
                       config: {
-                        hostCssClasses: "rb-form-inline-fields rb-form-contributor-inline rb-form-grid-cols-3",
+                        hostCssClasses: 'rb-form-inline-fields rb-form-contributor-inline rb-form-grid-cols-3',
                         componentDefinitions: [
                           {
-                            overrides: {reusableFormName: "standard-contributor-fields-lookup-only-name-email"},
-                            name: "standard_contributor_fields_lookup_only_name_email_reusable",
-                            component: {class: "ReusableComponent", config: {componentDefinitions: []}},
+                            overrides: { reusableFormName: 'standard-contributor-fields-lookup-only-name-email' },
+                            name: 'standard_contributor_fields_lookup_only_name_email_reusable',
+                            component: { class: 'ReusableComponent', config: { componentDefinitions: [] } },
                           },
                           {
-                            name: "role",
+                            name: 'role',
                             component: {
-                              class: "DropdownInputComponent",
+                              class: 'DropdownInputComponent',
                               config: {
-                                hostCssClasses: "rb-form-inline-fields__field rb-form-inline-fields__field--fixed rb-form-contributor-inline__field rb-form-contributor-inline__field--role",
+                                hostCssClasses:
+                                  'rb-form-inline-fields__field rb-form-inline-fields__field--fixed rb-form-contributor-inline__field rb-form-contributor-inline__field--role',
                                 options: [
                                   {
-                                    label: "View",
-                                    value: "View"
+                                    label: 'View',
+                                    value: 'View',
                                   },
                                   {
-                                    label: "Edit",
-                                    value: "View&Edit"
-                                  }
-                                ]
-                              }
+                                    label: 'Edit',
+                                    value: 'View&Edit',
+                                  },
+                                ],
+                              },
                             },
                             model: {
-                              class: "DropdownInputModel",
+                              class: 'DropdownInputModel',
                               config: {
-                                validators: [{class: "required"}]
-                              }
+                                validators: [{ class: 'required' }],
+                              },
                             },
                             layout: {
-                              class: "InlineLayout",
+                              class: 'InlineLayout',
                               config: {
-                                label: "@dmpt-user-permissions-tab-role-hdr",
-                                hostCssClasses: "d-flex align-items-center gap-2"
-                              }
-                            }
-                          }
+                                label: '@dmpt-user-permissions-tab-role-hdr',
+                                hostCssClasses: 'd-flex align-items-center gap-2',
+                              },
+                            },
+                          },
                         ],
                       },
                     },
@@ -415,51 +519,51 @@ export const reusableContributorFormDefinitions: ReusableFormDefinitions = {
               },
             },
             model: {
-              class: "GroupModel",
+              class: 'GroupModel',
               config: {
                 value: {
-                  role: "View"
+                  role: 'View',
                 },
                 newEntryValue: {
-                  role: "View"
+                  role: 'View',
                 },
               },
             },
             layout: {
-              class: "DefaultLayout",
+              class: 'DefaultLayout',
               config: {
-                label: "@dmpt-user-permissions-tab-dmp-permissions",
-                helpText: "@dmpt-user-permissions-tab-dmp-permission-help",
+                label: '@dmpt-user-permissions-tab-dmp-permissions',
+                helpText: '@dmpt-user-permissions-tab-dmp-permission-help',
               },
             },
           } as never,
         },
       },
       model: {
-        class: "RepeatableModel",
+        class: 'RepeatableModel',
         config: {
           defaultValue: [
             {
-              role: "View"
-            }
+              role: 'View',
+            },
           ],
           validators: [
             {
-              class: "required",
+              class: 'required',
               config: {
-                anyOfFields: ["name", "email", "username", "orcid"],
+                anyOfFields: ['name', 'email', 'username', 'orcid'],
               },
-            }
+            },
           ],
         },
       },
       layout: {
-        class: "DefaultLayout",
+        class: 'DefaultLayout',
         config: {
-          label: "@dmpt-user-permissions-tab-dmp-permissions",
-          helpText: "@dmpt-user-permissions-tab-dmp-permission-help",
+          label: '@dmpt-user-permissions-tab-dmp-permissions',
+          helpText: '@dmpt-user-permissions-tab-dmp-permission-help',
         },
       },
     },
   ],
-}
+};

--- a/packages/redbox-core/src/services/TemplateService.ts
+++ b/packages/redbox-core/src/services/TemplateService.ts
@@ -74,7 +74,7 @@ export namespace Services {
             if (jsonataExpr) {
               result.push({
                 key: input.key,
-                value: `jsonata(${JSON.stringify(jsonataExpr)}).evaluate(context, extra?.libraries)`,
+                value: `(() => { const expression = jsonata(${JSON.stringify(jsonataExpr)}); expression.registerFunction("eval", () => undefined); return expression.evaluate(context, extra?.libraries); })()`,
               });
             }
             break;

--- a/packages/redbox-core/src/services/TemplateService.ts
+++ b/packages/redbox-core/src/services/TemplateService.ts
@@ -17,9 +17,9 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-import {PopulateExportedMethods} from '../decorator/PopulateExportedMethods.decorator';
-import {Services as services} from '../CoreService';
-import Handlebars, {TemplateDelegate as HandlebarsTemplateDelegate} from "handlebars";
+import { PopulateExportedMethods } from '../decorator/PopulateExportedMethods.decorator';
+import { Services as services } from '../CoreService';
+import Handlebars, { TemplateDelegate as HandlebarsTemplateDelegate } from 'handlebars';
 import {
   buildKeyString,
   jsonataCompile,
@@ -28,141 +28,138 @@ import {
   TemplateCompileInput,
   TemplateCompileItem,
   TemplateCompileKey,
-  templateCompileKind
-} from "@researchdatabox/sails-ng-common";
-
+  templateCompileKind,
+} from '@researchdatabox/sails-ng-common';
 
 export namespace Services {
+  @PopulateExportedMethods
+  export class Template extends services.Core.Service {
+    private helpersRegistered: boolean = false;
 
-    @PopulateExportedMethods
-    export class Template extends services.Core.Service {
-
-        private helpersRegistered: boolean = false;
-
-        /**
-         * Ensure shared Handlebars helpers are registered on the server.
-         */
-        private ensureHelpersRegistered() {
-            if (!this.helpersRegistered) {
-                registerSharedHandlebarsHelpers(Handlebars);
-                this.helpersRegistered = true;
-                sails.log.verbose('TemplateService: Registered shared Handlebars helpers');
-            }
-        }
-
-        /**
-         * Compile one or more inputs into an output mapping.
-         *
-         * The mapping provides a function 'evaluate(key, context)'.
-         * Provide the key for the template, and the context to apply to the template.
-         * @param inputs
-         */
-        public buildClientMapping(inputs: TemplateCompileInput[]): TemplateCompileItem[] {
-            const keys = inputs.map(i => buildKeyString(i.key));
-            const keysUnique = new Set(keys);
-            if (keysUnique.size != keys.length) {
-                const duplicates = keys.filter((item, index) => keys.indexOf(item) != index);
-                const duplicatesUnique = Array.from(new Set(duplicates)).sort();
-                throw new Error(`Keys must be unique: '${duplicatesUnique.join(', ')}'`);
-            }
-
-            const result: TemplateCompileItem[] = [];
-            for (const input of inputs) {
-                // The key is stored as a string array (composite key).
-                // The duplicate check above uses the flattened, normalized string form (buildKeyString)
-                // to ensure uniqueness across the composite keys.
-                switch (input.kind) {
-                    case "jsonata":
-                        const jsonataExpr = this.buildClientJsonata(input.value);
-                        if (jsonataExpr) {
-                            result.push({
-                                key: input.key,
-                                value: `jsonata(${JSON.stringify(jsonataExpr)}).evaluate(context)`,
-                            });
-                        }
-                        break;
-                    case "handlebars":
-                        result.push({
-                            key: input.key,
-                            value: `Handlebars.template(${this.buildClientHandlebars(input.value)?.toString()})(context)`,
-                        });
-                        break;
-                    default:
-                        throw new Error(`Unknown input kind '${input.kind}' expected one of: '${templateCompileKind.join(', ')}'`);
-                }
-            }
-            return result;
-        }
-
-        /**
-         * Compile a JSONata expression to a form that is ready to be executed on the client.
-         *
-         * The expression will be normalised and have some transformations applied.
-         *
-         * @param expression The JSONata expression to compile.
-         */
-        public buildClientJsonata(expression: string): string | null {
-            try {
-                expression = normaliseVisual(expression);
-                // Validate the expression by compiling it
-                const compiled = jsonataCompile(expression);
-                sails.log.verbose(`Validated client JSONata expression '${expression}'`, compiled);
-                // Return the expression string for client-side compilation
-                // The client will call jsonata(expression).evaluate(context)
-                return expression;
-            } catch (error) {
-                sails.log.error(`Could not compile client JSONata expression '${expression}'`, error);
-                return null;
-            }
-        }
-
-        /**
-         * Compile a Handlebars template to a form that is ready to be executed on the client.
-         *
-         * The template will be normalised and have some transformations applied.
-         *
-         * @param template
-         */
-        public buildClientHandlebars(template: string): string | null {
-            try {
-                this.ensureHelpersRegistered();
-                template = normaliseVisual(template);
-                // handlebars pre-compiled output is already a string
-                const result = Handlebars.precompile(template)?.toString();
-                sails.log.verbose(`Built client Handlebars template '${template}'`);
-                return result;
-            } catch (error) {
-                sails.log.error(`Could not build client Handlebars template '${template}'`, error);
-                return null;
-            }
-        }
-
-        /**
-         * Compile a Handlebars template to a form that is ready to be executed on the server.
-         *
-         * The template will be normalised and have some transformations applied.
-         *
-         * @param template
-         */
-        public buildServerHandlebars(template: string): HandlebarsTemplateDelegate | null {
-            try {
-                this.ensureHelpersRegistered();
-                template = normaliseVisual(template);
-                const result = Handlebars.compile(template);
-                sails.log.verbose(`Built server Handlebars template '${template}'`);
-                return result;
-            } catch (error) {
-                sails.log.error(`Could not build server Handlebars template '${template}'`, error);
-                return null;
-            }
-        }
-
-        public buildKeyString(key: TemplateCompileKey): string {
-            return buildKeyString(key);
-        }
+    /**
+     * Ensure shared Handlebars helpers are registered on the server.
+     */
+    private ensureHelpersRegistered() {
+      if (!this.helpersRegistered) {
+        registerSharedHandlebarsHelpers(Handlebars);
+        this.helpersRegistered = true;
+        sails.log.verbose('TemplateService: Registered shared Handlebars helpers');
+      }
     }
+
+    /**
+     * Compile one or more inputs into an output mapping.
+     *
+     * The mapping provides a function 'evaluate(key, context)'.
+     * Provide the key for the template, and the context to apply to the template.
+     * @param inputs
+     */
+    public buildClientMapping(inputs: TemplateCompileInput[]): TemplateCompileItem[] {
+      const keys = inputs.map(i => buildKeyString(i.key));
+      const keysUnique = new Set(keys);
+      if (keysUnique.size != keys.length) {
+        const duplicates = keys.filter((item, index) => keys.indexOf(item) != index);
+        const duplicatesUnique = Array.from(new Set(duplicates)).sort();
+        throw new Error(`Keys must be unique: '${duplicatesUnique.join(', ')}'`);
+      }
+
+      const result: TemplateCompileItem[] = [];
+      for (const input of inputs) {
+        // The key is stored as a string array (composite key).
+        // The duplicate check above uses the flattened, normalized string form (buildKeyString)
+        // to ensure uniqueness across the composite keys.
+        switch (input.kind) {
+          case 'jsonata':
+            const jsonataExpr = this.buildClientJsonata(input.value);
+            if (jsonataExpr) {
+              result.push({
+                key: input.key,
+                value: `jsonata(${JSON.stringify(jsonataExpr)}).evaluate(context, extra?.libraries)`,
+              });
+            }
+            break;
+          case 'handlebars':
+            result.push({
+              key: input.key,
+              value: `Handlebars.template(${this.buildClientHandlebars(input.value)?.toString()})(context)`,
+            });
+            break;
+          default:
+            throw new Error(`Unknown input kind '${input.kind}' expected one of: '${templateCompileKind.join(', ')}'`);
+        }
+      }
+      return result;
+    }
+
+    /**
+     * Compile a JSONata expression to a form that is ready to be executed on the client.
+     *
+     * The expression will be normalised and have some transformations applied.
+     *
+     * @param expression The JSONata expression to compile.
+     */
+    public buildClientJsonata(expression: string): string | null {
+      try {
+        expression = normaliseVisual(expression);
+        // Validate the expression by compiling it
+        const compiled = jsonataCompile(expression);
+        sails.log.verbose(`Validated client JSONata expression '${expression}'`, compiled);
+        // Return the expression string for client-side compilation
+        // The client will call jsonata(expression).evaluate(context)
+        return expression;
+      } catch (error) {
+        sails.log.error(`Could not compile client JSONata expression '${expression}'`, error);
+        return null;
+      }
+    }
+
+    /**
+     * Compile a Handlebars template to a form that is ready to be executed on the client.
+     *
+     * The template will be normalised and have some transformations applied.
+     *
+     * @param template
+     */
+    public buildClientHandlebars(template: string): string | null {
+      try {
+        this.ensureHelpersRegistered();
+        template = normaliseVisual(template);
+        // handlebars pre-compiled output is already a string
+        const result = Handlebars.precompile(template)?.toString();
+        sails.log.verbose(`Built client Handlebars template '${template}'`);
+        return result;
+      } catch (error) {
+        sails.log.error(`Could not build client Handlebars template '${template}'`, error);
+        return null;
+      }
+    }
+
+    /**
+     * Compile a Handlebars template to a form that is ready to be executed on the server.
+     *
+     * The template will be normalised and have some transformations applied.
+     *
+     * @param template
+     */
+    public buildServerHandlebars(template: string): HandlebarsTemplateDelegate | null {
+      try {
+        this.ensureHelpersRegistered();
+        template = normaliseVisual(template);
+        const result = Handlebars.compile(template);
+        sails.log.verbose(`Built server Handlebars template '${template}'`);
+        return result;
+      } catch (error) {
+        sails.log.error(`Could not build server Handlebars template '${template}'`, error);
+        return null;
+      }
+    }
+
+    public buildKeyString(key: TemplateCompileKey): string {
+      return buildKeyString(key);
+    }
+  }
 }
 
 declare global {
-    let TemplateService: Services.Template;
+  let TemplateService: Services.Template;
 }

--- a/packages/redbox-core/src/visitor/construct.visitor.ts
+++ b/packages/redbox-core/src/visitor/construct.visitor.ts
@@ -59,10 +59,7 @@ import {
 } from '@researchdatabox/sails-ng-common';
 import { InlineFieldLayoutConfig } from '@researchdatabox/sails-ng-common';
 import { FormExpressionsConfig } from '@researchdatabox/sails-ng-common';
-import {
-  FormComponentDefinitionFrame,
-  FormComponentDefinitionOutline,
-} from '@researchdatabox/sails-ng-common';
+import { FormComponentDefinitionFrame, FormComponentDefinitionOutline } from '@researchdatabox/sails-ng-common';
 import {
   ContentComponentName,
   ContentFieldComponentDefinitionFrame,
@@ -601,6 +598,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
     this.sharedProps.setPropOverride('addButtonShow', item.config, frame);
     this.sharedProps.setPropOverride('allowZeroRows', item.config, frame);
     this.sharedProps.setPropOverride('hideWhenZeroRows', item.config, frame);
+    this.sharedProps.setPropOverride('canSort', item.config, frame);
 
     const currentFormConfigPath = this.formPathHelper.formPath.formConfig;
 
@@ -627,7 +625,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
     if (!nameIsFalsy && !nameWillBeTransformedToFalsy) {
       this.logger.error(
         `Repeatable element template must have a 'falsy' name: elementTemplateName '${JSON.stringify(elementTemplateName)}' ` +
-        `elementTemplateClass ${JSON.stringify(elementTemplateClass)} elementTemplateReplaceName ${JSON.stringify(elementTemplateReplaceName)}`
+          `elementTemplateClass ${JSON.stringify(elementTemplateClass)} elementTemplateReplaceName ${JSON.stringify(elementTemplateReplaceName)}`
       );
       throw new Error(
         `Repeatable element template must have a 'falsy' name, got ${JSON.stringify(frame.elementTemplate?.name)} at ${JSON.stringify(currentFormConfigPath)}.`
@@ -680,7 +678,9 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
     this.setModelValue(item, currentData?.config);
   }
 
-  async visitRepeatableElementFieldLayoutDefinition(item: RepeatableElementFieldLayoutDefinitionOutline): Promise<void> {
+  async visitRepeatableElementFieldLayoutDefinition(
+    item: RepeatableElementFieldLayoutDefinitionOutline
+  ): Promise<void> {
     // Get the current raw data for constructing the class instance.
     const currentData = this.getData();
     if (
@@ -703,7 +703,9 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
 
   /* Validation Summary */
 
-  async visitValidationSummaryFieldComponentDefinition(item: ValidationSummaryFieldComponentDefinitionOutline): Promise<void> {
+  async visitValidationSummaryFieldComponentDefinition(
+    item: ValidationSummaryFieldComponentDefinitionOutline
+  ): Promise<void> {
     // Get the current raw data for constructing the class instance.
     const currentData = this.getData();
     if (
@@ -726,11 +728,15 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
     this.sharedProps.setPropOverride('showWhenValid', item.config, config);
   }
 
-  async visitValidationSummaryFormComponentDefinition(item: ValidationSummaryFormComponentDefinitionOutline): Promise<void> {
+  async visitValidationSummaryFormComponentDefinition(
+    item: ValidationSummaryFormComponentDefinitionOutline
+  ): Promise<void> {
     await this.populateFormComponent(item);
   }
 
-  async visitSuggestedValidationSummaryFieldComponentDefinition(item: SuggestedValidationSummaryFieldComponentDefinitionOutline): Promise<void> {
+  async visitSuggestedValidationSummaryFieldComponentDefinition(
+    item: SuggestedValidationSummaryFieldComponentDefinitionOutline
+  ): Promise<void> {
     const currentData = this.getData();
     if (
       !isTypeFieldDefinitionName<SuggestedValidationSummaryFieldComponentDefinitionFrame>(
@@ -753,7 +759,9 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
     this.sharedProps.setPropOverride('header', item.config, config);
   }
 
-  async visitSuggestedValidationSummaryFormComponentDefinition(item: SuggestedValidationSummaryFormComponentDefinitionOutline): Promise<void> {
+  async visitSuggestedValidationSummaryFormComponentDefinition(
+    item: SuggestedValidationSummaryFormComponentDefinitionOutline
+  ): Promise<void> {
     await this.populateFormComponent(item);
   }
 
@@ -997,7 +1005,9 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
     await this.populateFormComponent(item);
   }
 
-  async visitAccordionPanelFieldComponentDefinition(item: AccordionPanelFieldComponentDefinitionOutline): Promise<void> {
+  async visitAccordionPanelFieldComponentDefinition(
+    item: AccordionPanelFieldComponentDefinitionOutline
+  ): Promise<void> {
     const currentData = this.getData();
     if (
       !isTypeFieldDefinitionName<AccordionPanelFieldComponentDefinitionFrame>(currentData, AccordionPanelComponentName)
@@ -1278,7 +1288,9 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
 
   /* Rich Text Editor */
 
-  async visitRichTextEditorFieldComponentDefinition(item: RichTextEditorFieldComponentDefinitionOutline): Promise<void> {
+  async visitRichTextEditorFieldComponentDefinition(
+    item: RichTextEditorFieldComponentDefinitionOutline
+  ): Promise<void> {
     const currentData = this.getData();
     if (
       !isTypeFieldDefinitionName<RichTextEditorFieldComponentDefinitionFrame>(currentData, RichTextEditorComponentName)
@@ -1793,7 +1805,9 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
 
   /* Record Selector */
 
-  async visitRecordSelectorFieldComponentDefinition(item: RecordSelectorFieldComponentDefinitionOutline): Promise<void> {
+  async visitRecordSelectorFieldComponentDefinition(
+    item: RecordSelectorFieldComponentDefinitionOutline
+  ): Promise<void> {
     const currentData = this.getData();
     if (
       !isTypeFieldDefinitionName<RecordSelectorFieldComponentDefinitionFrame>(currentData, RecordSelectorComponentName)
@@ -1881,7 +1895,9 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
 
   /* Typeahead Input */
 
-  async visitTypeaheadInputFieldComponentDefinition(item: TypeaheadInputFieldComponentDefinitionOutline): Promise<void> {
+  async visitTypeaheadInputFieldComponentDefinition(
+    item: TypeaheadInputFieldComponentDefinitionOutline
+  ): Promise<void> {
     const currentData = this.getData();
     if (
       !isTypeFieldDefinitionName<TypeaheadInputFieldComponentDefinitionFrame>(currentData, TypeaheadInputComponentName)
@@ -2079,7 +2095,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
       this.formPathHelper.formPath,
       item,
       // Provide the model value so the component visible state can be set correctly.
-      this.currentModelValue(),
+      this.currentModelValue()
     );
 
     // Apply the reusable component overrides.
@@ -2223,7 +2239,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
     if (item?.config?.value !== undefined || config?.value !== undefined) {
       throw new Error(
         `${this.logName}: Use 'model.config.defaultValue' in form config ` +
-        `instead of 'model.config.value' - item: ${JSON.stringify(item)} config: ${JSON.stringify(config)}`
+          `instead of 'model.config.value' - item: ${JSON.stringify(item)} config: ${JSON.stringify(config)}`
       );
     }
 
@@ -2238,8 +2254,8 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
     if (!isElementTemplate && (item.config.newEntryValue !== undefined || config?.newEntryValue !== undefined)) {
       throw new Error(
         `${this.logName}: Only repeatable elementTemplates can define 'model.config.newEntryValue', ` +
-        `use 'model.config.defaultValue' in other places ` +
-        `- item: ${JSON.stringify(item)} config: ${JSON.stringify(config)}`
+          `use 'model.config.defaultValue' in other places ` +
+          `- item: ${JSON.stringify(item)} config: ${JSON.stringify(config)}`
       );
     }
 
@@ -2247,9 +2263,9 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
     if (isElementTemplate && (item.config.defaultValue !== undefined || config?.defaultValue !== undefined)) {
       throw new Error(
         `${this.logName}: Set the repeatable elementTemplate new item default ` +
-        `using 'elementTemplate.model.config.newEntryValue', not 'elementTemplate.model.config.defaultValue', ` +
-        `set the repeatable default in 'repeatable.model.config.defaultValue' ` +
-        `- item: ${JSON.stringify(item)} config: ${JSON.stringify(config)}`
+          `using 'elementTemplate.model.config.newEntryValue', not 'elementTemplate.model.config.defaultValue', ` +
+          `set the repeatable default in 'repeatable.model.config.defaultValue' ` +
+          `- item: ${JSON.stringify(item)} config: ${JSON.stringify(config)}`
       );
     }
 
@@ -2257,10 +2273,10 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
     if (isElementTemplateDescendant && (item.config.defaultValue !== undefined || config?.defaultValue !== undefined)) {
       throw new Error(
         `${this.logName}: Set the repeatable elementTemplate descendant component new item default ` +
-        `using 'elementTemplate.model.config.newEntryValue', ` +
-        `set the repeatable default in 'repeatable.model.config.defaultValue', ` +
-        `not the descendant components ` +
-        `- item: ${JSON.stringify(item)} config: ${JSON.stringify(config)}`
+          `using 'elementTemplate.model.config.newEntryValue', ` +
+          `set the repeatable default in 'repeatable.model.config.defaultValue', ` +
+          `not the descendant components ` +
+          `- item: ${JSON.stringify(item)} config: ${JSON.stringify(config)}`
       );
     }
 
@@ -2379,7 +2395,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
     if (isElementTemplate || isElementTemplateDescendant) {
       throw new Error(
         `${this.logName}: Cannot merge default values for a repeatable elementTemplate or descendants ` +
-        `- itemName: ${JSON.stringify(itemName)} itemDefaultValue: ${JSON.stringify(itemDefaultValue)}`
+          `- itemName: ${JSON.stringify(itemName)} itemDefaultValue: ${JSON.stringify(itemDefaultValue)}`
       );
     }
 

--- a/packages/redbox-core/src/visitor/migrate-config-v4-v5.visitor.ts
+++ b/packages/redbox-core/src/visitor/migrate-config-v4-v5.visitor.ts
@@ -3,14 +3,17 @@ import {
   FormConfig,
   guessType,
   QuestionTreeFieldComponentConfig,
-  QuestionTreeFieldComponentConfigFrame, QuestionTreeFieldComponentDefinitionOutline,
+  QuestionTreeFieldComponentConfigFrame,
+  QuestionTreeFieldComponentDefinitionOutline,
   QuestionTreeFieldModelConfig,
   QuestionTreeFieldModelDefinitionOutline,
   QuestionTreeFormComponentDefinitionOutline,
   QuestionTreeMeta,
   QuestionTreeOutcome,
   QuestionTreeQuestion,
-  QuestionTreeQuestionAnswer, QuestionTreeQuestionRuleIn, QuestionTreeQuestionRules
+  QuestionTreeQuestionAnswer,
+  QuestionTreeQuestionRuleIn,
+  QuestionTreeQuestionRules,
 } from '@researchdatabox/sails-ng-common';
 import { FormConfigOutline } from '@researchdatabox/sails-ng-common';
 import {
@@ -708,7 +711,7 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     // Convert fields to components
     const fields: Record<string, unknown>[] = currentData.fields ?? [];
     // this.logger.info(`Processing '${item.name}': with ${fields.length} fields at ${JSON.stringify(this.v4FormPath)}.`);
-    for (let index = 0; index < fields.length; index++){
+    for (let index = 0; index < fields.length; index++) {
       const field = fields[index];
       const v4FormPathMore = ['fields', index.toString()];
       if (this.shouldOmitLegacyField(field, v4FormPathMore)) {
@@ -735,7 +738,10 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
         const hiddenComponentIndex = item.componentDefinitions.length;
         await this.acceptV4FormConfigPath(
           hiddenBinding.component,
-          this.formPathHelper.lineagePathsForFormConfigComponentDefinition(hiddenBinding.component, hiddenComponentIndex),
+          this.formPathHelper.lineagePathsForFormConfigComponentDefinition(
+            hiddenBinding.component,
+            hiddenComponentIndex
+          ),
           hiddenBinding.v4FormPathMore
         );
         await this.enforceLegacyHiddenBindingConfig(hiddenBinding.component, hiddenBinding.allowRoles);
@@ -827,7 +833,8 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     if (this.isLegacyAnchorControl(field)) {
       const definition = (field?.definition ?? {}) as Record<string, unknown>;
       const href = typeof definition.value === 'string' ? definition.value : '';
-      let cssClasses = this.normalizeLegacyButtonCssClasses(definition.cssClasses ?? definition.cssClass) ?? 'btn btn-primary';
+      let cssClasses =
+        this.normalizeLegacyButtonCssClasses(definition.cssClasses ?? definition.cssClass) ?? 'btn btn-primary';
       cssClasses = this.removeLegacyCssToken(cssClasses, 'margin-15');
       const label = typeof definition.label === 'string' ? definition.label : '';
       const showPencil = definition.showPencil === true;
@@ -981,6 +988,7 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     this.sharedProps.setPropOverride('addButtonShow', item.config, definition);
     this.sharedProps.setPropOverride('allowZeroRows', item.config, definition);
     this.sharedProps.setPropOverride('hideWhenZeroRows', item.config, definition);
+    this.sharedProps.setPropOverride('canSort', item.config, definition);
     const currentFormConfigPath = this.formPathHelper.formPath.formConfig;
 
     const fields = field?.definition?.fields ?? [];
@@ -1056,7 +1064,9 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     this.sharedPopulateFieldModelConfig(item.config, field);
   }
 
-  async visitRepeatableElementFieldLayoutDefinition(item: RepeatableElementFieldLayoutDefinitionOutline): Promise<void> {
+  async visitRepeatableElementFieldLayoutDefinition(
+    item: RepeatableElementFieldLayoutDefinitionOutline
+  ): Promise<void> {
     const field = this.getV4Data();
     item.config = new RepeatableElementFieldLayoutConfig();
     this.sharedPopulateFieldLayoutConfig(item.config, field);
@@ -1072,7 +1082,9 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
       const hasExplicitLabel = typeof definition.label === 'string';
       const contributorLabel = hasExplicitLabel
         ? (definition.label as string)
-        : (typeof definition.name === 'string' ? definition.name : undefined);
+        : typeof definition.name === 'string'
+          ? definition.name
+          : undefined;
       if (contributorLabel && item.layout?.config && !item.layout.config.label) {
         item.layout.config.label = contributorLabel;
       }
@@ -1081,17 +1093,23 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
 
   /* Validation Summary */
 
-  async visitValidationSummaryFieldComponentDefinition(item: ValidationSummaryFieldComponentDefinitionOutline): Promise<void> {
+  async visitValidationSummaryFieldComponentDefinition(
+    item: ValidationSummaryFieldComponentDefinitionOutline
+  ): Promise<void> {
     const field = this.getV4Data();
     item.config = new ValidationSummaryFieldComponentConfig();
     this.sharedPopulateFieldComponentConfig(item.config, field);
   }
 
-  async visitValidationSummaryFormComponentDefinition(item: ValidationSummaryFormComponentDefinitionOutline): Promise<void> {
+  async visitValidationSummaryFormComponentDefinition(
+    item: ValidationSummaryFormComponentDefinitionOutline
+  ): Promise<void> {
     await this.populateFormComponent(item);
   }
 
-  async visitSuggestedValidationSummaryFieldComponentDefinition(item: SuggestedValidationSummaryFieldComponentDefinitionOutline): Promise<void> {
+  async visitSuggestedValidationSummaryFieldComponentDefinition(
+    item: SuggestedValidationSummaryFieldComponentDefinitionOutline
+  ): Promise<void> {
     const field = this.getV4Data();
     item.config = new SuggestedValidationSummaryFieldComponentConfig();
     this.sharedPopulateFieldComponentConfig(item.config, field);
@@ -1101,13 +1119,17 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     this.sharedProps.setPropOverride('header', item.config, field?.definition);
   }
 
-  async visitSuggestedValidationSummaryFormComponentDefinition(item: SuggestedValidationSummaryFormComponentDefinitionOutline): Promise<void> {
+  async visitSuggestedValidationSummaryFormComponentDefinition(
+    item: SuggestedValidationSummaryFormComponentDefinitionOutline
+  ): Promise<void> {
     await this.populateFormComponent(item);
   }
 
   /* Record Metadata Retriever */
 
-  async visitRecordMetadataRetrieverFieldComponentDefinition(item: RecordMetadataRetrieverFieldComponentDefinitionOutline): Promise<void> {
+  async visitRecordMetadataRetrieverFieldComponentDefinition(
+    item: RecordMetadataRetrieverFieldComponentDefinitionOutline
+  ): Promise<void> {
     const field = this.getV4Data();
     item.config = new RecordMetadataRetrieverFieldComponentConfig();
     this.sharedPopulateFieldComponentConfig(item.config, field);
@@ -1115,7 +1137,9 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     item.config.visible = false;
   }
 
-  async visitRecordMetadataRetrieverFormComponentDefinition(item: RecordMetadataRetrieverFormComponentDefinitionOutline): Promise<void> {
+  async visitRecordMetadataRetrieverFormComponentDefinition(
+    item: RecordMetadataRetrieverFormComponentDefinitionOutline
+  ): Promise<void> {
     await this.populateFormComponent(item);
     if (item.layout?.config) {
       item.layout.config.label = undefined;
@@ -1159,7 +1183,8 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     item.config = config;
     this.sharedPopulateFieldComponentConfig(item.config, field);
 
-    const isButtonBarContainer = field?.class === 'ButtonBarContainer' || field?.compClass === 'ButtonBarContainerComponent';
+    const isButtonBarContainer =
+      field?.class === 'ButtonBarContainer' || field?.compClass === 'ButtonBarContainerComponent';
     const isLegacyInlineContainer = this.isLegacyInlineContainer(field);
     if (isButtonBarContainer) {
       this.isInsideButtonBarContainer = true;
@@ -1175,7 +1200,7 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
 
       const fields: Record<string, unknown>[] = field?.definition?.fields ?? [];
       // this.logger.info(`Processing '${item.class}': with ${fields.length} fields at ${JSON.stringify(this.v4FormPath)}.`);
-      for (let index = 0; index < fields.length; index++){
+      for (let index = 0; index < fields.length; index++) {
         const childField = fields[index];
         if (childField?.class === 'Spacer' || childField?.compClass === 'SpacerComponent') {
           continue;
@@ -1206,11 +1231,18 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
         const hiddenBinding = await this.constructLegacyNameBindingCompanion(childField, v4FormPathMore);
         if (hiddenBinding) {
           await this.retargetLegacyTextBlockBinding(formComponent, hiddenBinding.sourceName, hiddenBinding.sourceName);
-          await this.ensureLegacyTextBlockComponentNameIsUnique(formComponent, hiddenBinding.sourceName, v4FormPathMore);
+          await this.ensureLegacyTextBlockComponentNameIsUnique(
+            formComponent,
+            hiddenBinding.sourceName,
+            v4FormPathMore
+          );
           const hiddenComponentIndex = config.componentDefinitions.length;
           await this.acceptV4FormConfigPath(
             hiddenBinding.component,
-            this.formPathHelper.lineagePathsForGroupFieldComponentDefinition(hiddenBinding.component, hiddenComponentIndex),
+            this.formPathHelper.lineagePathsForGroupFieldComponentDefinition(
+              hiddenBinding.component,
+              hiddenComponentIndex
+            ),
             hiddenBinding.v4FormPathMore
           );
           await this.enforceLegacyHiddenBindingConfig(hiddenBinding.component, hiddenBinding.allowRoles);
@@ -1308,7 +1340,7 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
 
     const fields: Record<string, unknown>[] = field?.definition?.fields ?? [];
     // this.logger.info(`Processing '${item.class}': with ${fields.length} fields at ${JSON.stringify(this.v4FormPath)}.`);
-    for (let index = 0; index < fields.length; index++){
+    for (let index = 0; index < fields.length; index++) {
       const field1 = fields[index];
       const v4FormPathMore = ['definition', 'fields', index.toString()];
       if (this.shouldOmitLegacyField(field1, v4FormPathMore)) {
@@ -1335,7 +1367,10 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
         const hiddenComponentIndex = config.componentDefinitions.length;
         await this.acceptV4FormConfigPath(
           hiddenBinding.component,
-          this.formPathHelper.lineagePathsForTabContentFieldComponentDefinition(hiddenBinding.component, hiddenComponentIndex),
+          this.formPathHelper.lineagePathsForTabContentFieldComponentDefinition(
+            hiddenBinding.component,
+            hiddenComponentIndex
+          ),
           hiddenBinding.v4FormPathMore
         );
         await this.enforceLegacyHiddenBindingConfig(hiddenBinding.component, hiddenBinding.allowRoles);
@@ -1492,7 +1527,9 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
 
   /* Rich Text Editor */
 
-  async visitRichTextEditorFieldComponentDefinition(item: RichTextEditorFieldComponentDefinitionOutline): Promise<void> {
+  async visitRichTextEditorFieldComponentDefinition(
+    item: RichTextEditorFieldComponentDefinitionOutline
+  ): Promise<void> {
     const field = this.getV4Data();
     item.config = new RichTextEditorFieldComponentConfig();
     this.sharedPopulateFieldComponentConfig(item.config, field);
@@ -1576,12 +1613,12 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     if (typeof notesEnabled === 'boolean') {
       const metadataFields = notesEnabled
         ? [
-          {
-            id: 'notes',
-            name: 'Notes',
-            placeholder: 'Notes about this file.',
-          },
-        ]
+            {
+              id: 'notes',
+              name: 'Notes',
+              placeholder: 'Notes about this file.',
+            },
+          ]
         : [];
       this.sharedProps.setPropOverride('restrictions', item.config, {
         restrictions: {
@@ -1625,9 +1662,10 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
 
     for (const prop of mappedProps) {
       if (field?.definition?.[prop] !== undefined) {
-        const value = prop === 'fileNameTemplate'
-          ? this.convertLegacyPdfListFileNameTemplate(field.definition[prop])
-          : field.definition[prop];
+        const value =
+          prop === 'fileNameTemplate'
+            ? this.convertLegacyPdfListFileNameTemplate(field.definition[prop])
+            : field.definition[prop];
         this.sharedProps.setPropOverride(prop, item.config, { [prop]: value });
       }
     }
@@ -1679,7 +1717,7 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
       'editNotesTitle',
       'cancelEditNotesButtonText',
       'applyEditNotesButtonText',
-      'editNotesCssClasses'
+      'editNotesCssClasses',
     ] as const;
 
     for (const prop of mappedProps) {
@@ -1699,7 +1737,9 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     await this.populateFormComponent(item);
   }
 
-  async visitPublishDataLocationSelectorFieldComponentDefinition(item: PublishDataLocationSelectorFieldComponentDefinitionOutline): Promise<void> {
+  async visitPublishDataLocationSelectorFieldComponentDefinition(
+    item: PublishDataLocationSelectorFieldComponentDefinitionOutline
+  ): Promise<void> {
     const field = this.getV4Data();
     item.config = new PublishDataLocationSelectorFieldComponentConfig();
     this.sharedPopulateFieldComponentConfig(item.config, field);
@@ -1730,13 +1770,17 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     }
   }
 
-  async visitPublishDataLocationSelectorFieldModelDefinition(item: PublishDataLocationSelectorFieldModelDefinitionOutline): Promise<void> {
+  async visitPublishDataLocationSelectorFieldModelDefinition(
+    item: PublishDataLocationSelectorFieldModelDefinitionOutline
+  ): Promise<void> {
     const field = this.getV4Data();
     item.config = new PublishDataLocationSelectorFieldModelConfig();
     this.sharedPopulateFieldModelConfig(item.config, field);
   }
 
-  async visitPublishDataLocationSelectorFormComponentDefinition(item: PublishDataLocationSelectorFormComponentDefinitionOutline): Promise<void> {
+  async visitPublishDataLocationSelectorFormComponentDefinition(
+    item: PublishDataLocationSelectorFormComponentDefinitionOutline
+  ): Promise<void> {
     await this.populateFormComponent(item);
     const field = this.getV4Data();
     const definition = (field?.definition ?? {}) as Record<string, unknown>;
@@ -1887,7 +1931,9 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
 
   /* Record Selector */
 
-  async visitRecordSelectorFieldComponentDefinition(item: RecordSelectorFieldComponentDefinitionOutline): Promise<void> {
+  async visitRecordSelectorFieldComponentDefinition(
+    item: RecordSelectorFieldComponentDefinitionOutline
+  ): Promise<void> {
     const field = this.getV4Data();
     item.config = new RecordSelectorFieldComponentConfig();
     this.sharedPopulateFieldComponentConfig(item.config, field);
@@ -1925,7 +1971,7 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     });
     this.sharedProps.setPropOverride('filterFields', item.config, {
       filterFields: Array.isArray(definition.filterFields)
-        ? definition.filterFields.map((fieldName) => String(fieldName))
+        ? definition.filterFields.map(fieldName => String(fieldName))
         : [],
     });
   }
@@ -1939,15 +1985,17 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
       if (!value || typeof value !== 'object') {
         return null;
       }
-      const oid = typeof (value as Record<string, unknown>).oid === 'string'
-        ? String((value as Record<string, unknown>).oid).trim()
-        : '';
+      const oid =
+        typeof (value as Record<string, unknown>).oid === 'string'
+          ? String((value as Record<string, unknown>).oid).trim()
+          : '';
       if (!oid) {
         return null;
       }
-      const title = typeof (value as Record<string, unknown>).title === 'string'
-        ? String((value as Record<string, unknown>).title)
-        : undefined;
+      const title =
+        typeof (value as Record<string, unknown>).title === 'string'
+          ? String((value as Record<string, unknown>).title)
+          : undefined;
       return title ? { oid, title } : { oid };
     };
 
@@ -1986,7 +2034,9 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
 
   /* Typeahead Input */
 
-  async visitTypeaheadInputFieldComponentDefinition(item: TypeaheadInputFieldComponentDefinitionOutline): Promise<void> {
+  async visitTypeaheadInputFieldComponentDefinition(
+    item: TypeaheadInputFieldComponentDefinitionOutline
+  ): Promise<void> {
     const field = this.getV4Data();
     item.config = new TypeaheadInputFieldComponentConfig();
     this.sharedPopulateFieldComponentConfig(item.config, field);
@@ -2163,7 +2213,10 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
       const reusableComponentItem = this.sharedProps.sharedConstructFormComponent(reusableComponentItemData);
 
       if (reusableComponentItem.component?.config) {
-        this.sharedPopulateFieldComponentConfig(reusableComponentItem.component.config as FieldComponentConfigFrame, field);
+        this.sharedPopulateFieldComponentConfig(
+          reusableComponentItem.component.config as FieldComponentConfigFrame,
+          field
+        );
       }
       if (reusableComponentItem.layout?.config) {
         this.sharedPopulateFieldLayoutConfig(reusableComponentItem.layout.config as FieldLayoutConfigFrame, field);
@@ -2218,9 +2271,7 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
 
   /* Data classification to Question Tree config migration */
 
-
   public migrateDataClassificationToQuestionTree(data: any): QuestionTreeFieldComponentConfigFrame {
-
     const v4Definition = data.createDataClassificationStructure();
     const v4OrderedOutcomes: string[] = data.orderedOutcomes ?? [];
 
@@ -2228,11 +2279,11 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     //       The outcome meta is additional data that can be included in any outcomes, but is not the 'main' outcome.
     //       A question tree may have multiple outcomes, and multiple meta properties, each with the same or multiple values.
     const availableOutcomes: QuestionTreeOutcome[] = v4OrderedOutcomes.map(o => {
-      return { value: o, label: o }
+      return { value: o, label: o };
     });
     const availableMeta: QuestionTreeMeta = {};
     const questions: QuestionTreeQuestion[] = [];
-    const defaultOutcomePropName = "classification";
+    const defaultOutcomePropName = 'classification';
     for (const [questionId, questionInfo] of Object.entries(v4Definition)) {
       const qInfo = questionInfo as Record<string, unknown>;
 
@@ -2252,7 +2303,7 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
         const answerLabel = rawAnswer?.label;
         const answerOutcome = rawAnswer?.outcome;
         const answerOutcomeGuessedType = guessType(answerOutcome);
-        if (answerOutcomeGuessedType === "string") {
+        if (answerOutcomeGuessedType === 'string') {
           questionAnswers.push({
             value: answerValue,
             label: answerLabel,
@@ -2261,9 +2312,11 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
         } else if (answerOutcomeGuessedType === 'object') {
           // Use the v4 'classification' property as the v5 outcome,
           // any other property is outcome meta / additional data.
-          const meta = Object.fromEntries(Object.entries(answerOutcome)
-            .filter(([k, v]) => k !== defaultOutcomePropName && !!v)
-            .map(([k, v]) => [k, v?.toString() ?? ""]));
+          const meta = Object.fromEntries(
+            Object.entries(answerOutcome)
+              .filter(([k, v]) => k !== defaultOutcomePropName && !!v)
+              .map(([k, v]) => [k, v?.toString() ?? ''])
+          );
           questionAnswers.push({
             value: answerValue,
             label: answerLabel,
@@ -2278,7 +2331,7 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
               availableMeta[k][v] = v;
             }
           });
-        } else if (["undefined", "null"].includes(answerOutcomeGuessedType)) {
+        } else if (['undefined', 'null'].includes(answerOutcomeGuessedType)) {
           questionAnswers.push({
             value: answerValue,
             label: answerLabel,
@@ -2289,18 +2342,19 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
       }
 
       const rules: QuestionTreeQuestionRules = {
-        op: "or", args: [
+        op: 'or',
+        args: [
           ...Object.entries(rawConditions).map(([ruleQuestionId, ruleAnswerValue]) => {
-            return { op: "in", q: ruleQuestionId, a: ruleAnswerValue } as QuestionTreeQuestionRuleIn;
-          })
-        ]
+            return { op: 'in', q: ruleQuestionId, a: ruleAnswerValue } as QuestionTreeQuestionRuleIn;
+          }),
+        ],
       };
 
       questions.push({
         id: questionId,
-        label: typeof rawLabel === "string" ? rawLabel : undefined,
-        answersMin: parseInt(rawMinAnswers?.toString() ?? "1"),
-        answersMax: parseInt(rawMaxAnswers?.toString() ?? "1"),
+        label: typeof rawLabel === 'string' ? rawLabel : undefined,
+        answersMin: parseInt(rawMinAnswers?.toString() ?? '1'),
+        answersMax: parseInt(rawMaxAnswers?.toString() ?? '1'),
         answers: questionAnswers,
         rules: rules,
       });
@@ -2315,7 +2369,11 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
 
   /* Shared */
 
-  protected async acceptV4FormConfigPath(item: CanVisit, more?: LineagePathsPartial, v4FormPath?: string[]): Promise<void> {
+  protected async acceptV4FormConfigPath(
+    item: CanVisit,
+    more?: LineagePathsPartial,
+    v4FormPath?: string[]
+  ): Promise<void> {
     // Copy the original lineage paths so they can be restored.
     const original = [...(this.v4FormPath ?? [])];
     try {
@@ -2354,13 +2412,18 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     return true;
   }
 
-  protected constructFormComponent(field: Record<string, unknown>, more?: LineagePath): AllFormComponentDefinitionOutlines {
+  protected constructFormComponent(
+    field: Record<string, unknown>,
+    more?: LineagePath
+  ): AllFormComponentDefinitionOutlines {
     const { componentClassName, modelClassName, layoutClassName: mappedLayoutClassName } = this.mapV4ToV5(field);
     let layoutClassName = mappedLayoutClassName;
     const definition = (field?.definition ?? {}) as Record<string, unknown>;
     const isLegacyInlineContainer = this.isLegacyInlineContainer(field);
 
-    const name = String(definition.name ?? definition.id ?? [componentClassName, ...this.v4FormPath, ...(more ?? [])].join('-'));
+    const name = String(
+      definition.name ?? definition.id ?? [componentClassName, ...this.v4FormPath, ...(more ?? [])].join('-')
+    );
 
     // Build the form component definition frame
     const currentData: FormComponentDefinitionFrame = {
@@ -2408,7 +2471,7 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
           const viewComponentClassName =
             currentData.component.class === RichTextEditorComponentName
               ? ContentComponentName
-              : currentData.component.class as ComponentClassNamesType;
+              : (currentData.component.class as ComponentClassNamesType);
           currentData.overrides = {
             ...(currentData.overrides ?? {}),
             formModeClasses: {
@@ -2440,7 +2503,7 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     currentData.constraints.authorization.allowRoles = [];
     const roles = Array.isArray(field?.roles) ? field.roles : [];
     if (roles.length > 0) {
-      currentData.constraints.authorization.allowRoles.push(...roles as string[]);
+      currentData.constraints.authorization.allowRoles.push(...(roles as string[]));
     }
 
     // TODO: Set the expressions
@@ -2469,19 +2532,20 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
   protected async constructLegacyNameBindingCompanion(
     field: Record<string, unknown>,
     v4FormPathMore: LineagePath
-  ): Promise<{
-    component: AllFormComponentDefinitionOutlines;
-    sourceName: string;
-    allowRoles: string[];
-    v4FormPathMore: string[];
-  } | undefined> {
+  ): Promise<
+    | {
+        component: AllFormComponentDefinitionOutlines;
+        sourceName: string;
+        allowRoles: string[];
+        v4FormPathMore: string[];
+      }
+    | undefined
+  > {
     const definition = (field?.definition ?? {}) as Record<string, unknown>;
     const sourceName = typeof definition.name === 'string' ? definition.name.trim() : '';
     const sourceType = typeof definition.type === 'string' ? definition.type.trim().toLowerCase() : '';
     const sourceValue = definition.value;
-    const isLegacyLinkValue =
-      `${field?.class ?? ''}`.trim() === 'LinkValueComponent' &&
-      sourceName.length > 0;
+    const isLegacyLinkValue = `${field?.class ?? ''}`.trim() === 'LinkValueComponent' && sourceName.length > 0;
     const isLegacyHeadingTextBlock =
       `${field?.class ?? ''}`.trim() === 'Container' &&
       `${field?.compClass ?? ''}`.trim() === 'TextBlockComponent' &&
@@ -2525,7 +2589,10 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     };
   }
 
-  protected async enforceLegacyHiddenBindingConfig(component: AllFormComponentDefinitionOutlines, allowRoles: string[] = []): Promise<void> {
+  protected async enforceLegacyHiddenBindingConfig(
+    component: AllFormComponentDefinitionOutlines,
+    allowRoles: string[] = []
+  ): Promise<void> {
     if (component.component?.config) {
       const hiddenComponentConfig = component.component.config as Record<string, unknown>;
       hiddenComponentConfig.type = 'hidden';
@@ -2591,7 +2658,10 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     if (isLegacyContributor) {
       const innerFields = definition.fields;
       if (Array.isArray(innerFields) && innerFields.length > 0) {
-        const firstDefinition = ((innerFields[0] as Record<string, unknown>)?.definition ?? {}) as Record<string, unknown>;
+        const firstDefinition = ((innerFields[0] as Record<string, unknown>)?.definition ?? {}) as Record<
+          string,
+          unknown
+        >;
         fallbackLabel = typeof firstDefinition.label === 'string' ? firstDefinition.label : undefined;
       }
       if (!fallbackLabel) {
@@ -2599,12 +2669,11 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
       }
     }
 
-    const label =
-      hasExplicitLabel
-        ? (definition.label as string)
-        : isLegacyDataLocation
-          ? fallbackLabel
-          : (typeof definition.name === 'string' ? definition.name : undefined) || fallbackLabel;
+    const label = hasExplicitLabel
+      ? (definition.label as string)
+      : isLegacyDataLocation
+        ? fallbackLabel
+        : (typeof definition.name === 'string' ? definition.name : undefined) || fallbackLabel;
 
     const config = {
       label,
@@ -2643,7 +2712,10 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     if (isLegacyContributor) {
       const innerFields = definition.fields;
       if (Array.isArray(innerFields) && innerFields.length > 0) {
-        const firstDefinition = ((innerFields[0] as Record<string, unknown>)?.definition ?? {}) as Record<string, unknown>;
+        const firstDefinition = ((innerFields[0] as Record<string, unknown>)?.definition ?? {}) as Record<
+          string,
+          unknown
+        >;
         fallbackLabel = typeof firstDefinition.label === 'string' ? firstDefinition.label : undefined;
       }
       if (!fallbackLabel) {
@@ -2651,27 +2723,27 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
       }
     }
     const migratedLabel =
-      (this.shouldSuppressLegacyTextBlockLayoutLabel(field) ||
-        this.isLegacyLinkValueControl(field) ||
-        this.isLegacyPDFListControl(field))
+      this.shouldSuppressLegacyTextBlockLayoutLabel(field) ||
+      this.isLegacyLinkValueControl(field) ||
+      this.isLegacyPDFListControl(field)
         ? undefined
         : hasExplicitLabel
           ? (definition.label as string)
           : isLegacyDataLocation
             ? fallbackLabel
             : // RepeatableContributor often only defines 'name'; preserve a section label on migration.
-            fallbackLabel ||
-            (typeof definition.name === 'string' ? definition.name : undefined) ||
-            (this.shouldPromoteLegacyTextBlockSpanToLayoutLabel(field) && typeof definition.value === 'string'
-              ? definition.value
-              : undefined);
+              fallbackLabel ||
+              (typeof definition.name === 'string' ? definition.name : undefined) ||
+              (this.shouldPromoteLegacyTextBlockSpanToLayoutLabel(field) && typeof definition.value === 'string'
+                ? definition.value
+                : undefined);
     const legacyCssClasses = typeof definition.cssClasses === 'string' ? definition.cssClasses.trim() : '';
     const cssClassesMap =
       this.shouldPromoteLegacyTextBlockSpanToLayoutLabel(field) && legacyCssClasses
         ? { label: legacyCssClasses }
         : undefined;
     const config = {
-      label: (this.isInsideButtonBarContainer || this.isInsideLegacyInlineContainer()) ? undefined : migratedLabel,
+      label: this.isInsideButtonBarContainer || this.isInsideLegacyInlineContainer() ? undefined : migratedLabel,
       helpText: typeof definition.help === 'string' ? definition.help : undefined,
       cssClassesMap,
     };
@@ -2698,9 +2770,9 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
       !path || path.length < 1
         ? data
         : _get(
-          data,
-          path.map(i => i.toString())
-        );
+            data,
+            path.map(i => i.toString())
+          );
 
     // this.logger.info(JSON.stringify({path, result}));
     return result;
@@ -2726,7 +2798,7 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     if (!this.isLegacyTextBlockSpanField(field)) {
       return false;
     }
-    const definition = ((field?.definition ?? {}) as Record<string, unknown>);
+    const definition = (field?.definition ?? {}) as Record<string, unknown>;
     const hasHelpText = typeof definition.help === 'string' && definition.help.trim().length > 0;
     const hasLegacyCssClass = typeof definition.cssClasses === 'string' && definition.cssClasses.trim().length > 0;
     return hasHelpText || hasLegacyCssClass;
@@ -2736,20 +2808,21 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     if (!field) {
       return false;
     }
-    const definition = ((field.definition ?? {}) as Record<string, unknown>);
+    const definition = (field.definition ?? {}) as Record<string, unknown>;
     const isLegacyTextBlock =
       `${field.class ?? ''}`.trim() === 'Container' && `${field.compClass ?? ''}`.trim() === 'TextBlockComponent';
     const hasExplicitLabel = typeof definition.label === 'string' && definition.label.trim().length > 0;
     const hasLegacyNameBinding = typeof definition.name === 'string' && definition.name.trim().length > 0;
-    return isLegacyTextBlock && hasLegacyNameBinding && !hasExplicitLabel && !this.shouldPromoteLegacyTextBlockSpanToLayoutLabel(field);
+    return (
+      isLegacyTextBlock &&
+      hasLegacyNameBinding &&
+      !hasExplicitLabel &&
+      !this.shouldPromoteLegacyTextBlockSpanToLayoutLabel(field)
+    );
   }
 
   private getLegacyContributorReusableFormName(fieldDefinition: Record<string, unknown>): string {
-    const forceLookupOnly = this.parseLegacyTypeaheadBoolean(
-      fieldDefinition.forceLookupOnly,
-      false,
-      'forceLookupOnly'
-    );
+    const forceLookupOnly = this.parseLegacyTypeaheadBoolean(fieldDefinition.forceLookupOnly, false, 'forceLookupOnly');
     return forceLookupOnly ? 'standard-contributor-fields-lookup-only-group' : 'standard-contributor-fields-group';
   }
 
@@ -2805,13 +2878,15 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
   }
 
   protected async migrateOptions(field: Record<string, unknown>) {
-    return (((field?.definition as Record<string, unknown>)?.options as Array<Record<string, unknown>>) ?? []).map((option) => {
-      return {
-        label: option?.label ?? '',
-        value: option?.value ?? '',
-        disabled: option?.disabled ?? option?.historicalOnly ?? undefined,
-      };
-    });
+    return (((field?.definition as Record<string, unknown>)?.options as Array<Record<string, unknown>>) ?? []).map(
+      option => {
+        return {
+          label: option?.label ?? '',
+          value: option?.value ?? '',
+          disabled: option?.disabled ?? option?.historicalOnly ?? undefined,
+        };
+      }
+    );
   }
 
   private async applyLegacyFormCssNormalization(item: FormConfigOutline): Promise<void> {
@@ -2866,9 +2941,9 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
 
   private shouldUseInlineLayoutForAnchorButton(field: Record<string, unknown>, componentClassName: string): boolean {
     const v4ClassName = `${field?.class ?? ''}`.trim();
-    return v4ClassName === 'AnchorOrButton' && (
-      componentClassName === SaveButtonComponentName ||
-      componentClassName === ContentComponentName
+    return (
+      v4ClassName === 'AnchorOrButton' &&
+      (componentClassName === SaveButtonComponentName || componentClassName === ContentComponentName)
     );
   }
 
@@ -2901,24 +2976,23 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
       return false;
     }
     const definition = (field.definition ?? {}) as Record<string, unknown>;
-    return this.hasLegacyCssClass(definition.cssClasses, 'form-inline') || this.hasLegacyCssClass(definition.cssClass, 'form-inline');
+    return (
+      this.hasLegacyCssClass(definition.cssClasses, 'form-inline') ||
+      this.hasLegacyCssClass(definition.cssClass, 'form-inline')
+    );
   }
 
   private hasLegacyCssClass(value: unknown, token: string): boolean {
     if (typeof value !== 'string') {
       return false;
     }
-    return value
-      .trim()
-      .split(/\s+/)
-      .filter(Boolean)
-      .includes(token);
+    return value.trim().split(/\s+/).filter(Boolean).includes(token);
   }
 
   private mergeCssClassTokens(baseCssClasses: unknown, appendCssClasses: string): string {
     const classes = `${typeof baseCssClasses === 'string' ? baseCssClasses : ''} ${appendCssClasses}`
       .split(/\s+/)
-      .map((cssClass) => cssClass.trim())
+      .map(cssClass => cssClass.trim())
       .filter(Boolean);
     return Array.from(new Set(classes)).join(' ');
   }
@@ -2926,8 +3000,8 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
   private removeLegacyCssToken(cssClasses: string, tokenToRemove: string): string {
     return cssClasses
       .split(/\s+/)
-      .map((cssClass) => cssClass.trim())
-      .filter((cssClass) => cssClass.length > 0 && cssClass !== tokenToRemove)
+      .map(cssClass => cssClass.trim())
+      .filter(cssClass => cssClass.length > 0 && cssClass !== tokenToRemove)
       .join(' ');
   }
 
@@ -3222,7 +3296,9 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     return input && typeof input === 'object' && !Array.isArray(input) ? (input as Record<string, unknown>) : {};
   }
 
-  private resolveTypeaheadSourceType(definition: Record<string, unknown>): 'namedQuery' | 'vocabulary' | 'static' | 'external' | 'service' {
+  private resolveTypeaheadSourceType(
+    definition: Record<string, unknown>
+  ): 'namedQuery' | 'vocabulary' | 'static' | 'external' | 'service' {
     const legacySourceType = String(definition.sourceType ?? '')
       .trim()
       .toLowerCase();
@@ -3308,13 +3384,13 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     const source = entry as Record<string, unknown>;
     const resolvedLabel = String(
       source.label ??
-      source.name ??
-      source.title ??
-      source.text ??
-      source[labelField] ??
-      source[valueField] ??
-      source.value ??
-      ''
+        source.name ??
+        source.title ??
+        source.text ??
+        source[labelField] ??
+        source[valueField] ??
+        source.value ??
+        ''
     ).trim();
     const resolvedValue = String(
       source.value ?? source[valueField] ?? source.name ?? source[labelField] ?? source.title ?? source.label ?? ''
@@ -3441,7 +3517,7 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
         continue;
       }
 
-      const migratedRetriever = migratedComponents.find((component) => component.name === retrieverName);
+      const migratedRetriever = migratedComponents.find(component => component.name === retrieverName);
       if (migratedRetriever) {
         migratedRetriever.expressions = (migratedRetriever.expressions ?? []).concat(
           this.buildRetrieverExpressions(legacyField, legacyFields, containerPointer)
@@ -3464,7 +3540,7 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
           continue;
         }
 
-        const migratedTarget = migratedComponents.find((component) => component.name === targetName);
+        const migratedTarget = migratedComponents.find(component => component.name === targetName);
         if (!migratedTarget?.model) {
           continue;
         }
@@ -3516,7 +3592,7 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
         ? (sourceConfig.relatedObjectSelected as Record<string, unknown>[])
         : [];
 
-      if (onValueUpdate.some((action) => action?.action === 'publishMetadata')) {
+      if (onValueUpdate.some(action => action?.action === 'publishMetadata')) {
         const parameterName = this.resolveLegacyParameterRetrieverName(sourceName, siblingFields);
         if (parameterName) {
           expressions.push({
@@ -3534,7 +3610,7 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
         }
       }
 
-      if (relatedObjectSelected.some((action) => action?.action === 'publishMetadata')) {
+      if (relatedObjectSelected.some(action => action?.action === 'publishMetadata')) {
         expressions.push({
           name: `fetchOnRelatedObjectSelected-${sourceName}`,
           description: `Fetch metadata when ${sourceName} changes`,
@@ -3544,7 +3620,8 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
             condition: `${this.buildNestedComponentJsonPointer(containerPointer, sourceName)}::field.value.changed`,
             operation: 'fetchMetadata',
             hasTemplate: true,
-            template: '$exists(event.value.oid) ? event.value.oid : ($exists(event.value.redboxOid) ? event.value.redboxOid : event.value)',
+            template:
+              '$exists(event.value.oid) ? event.value.oid : ($exists(event.value.redboxOid) ? event.value.redboxOid : event.value)',
           },
         });
       }
@@ -3553,8 +3630,11 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     return expressions;
   }
 
-  private resolveLegacyParameterRetrieverName(sourceName: string, siblingFields: Record<string, unknown>[]): string | undefined {
-    const parameterRetriever = siblingFields.find((field) => {
+  private resolveLegacyParameterRetrieverName(
+    sourceName: string,
+    siblingFields: Record<string, unknown>[]
+  ): string | undefined {
+    const parameterRetriever = siblingFields.find(field => {
       if (!this.isLegacyParameterRetrieverField(field)) {
         return false;
       }
@@ -3585,9 +3665,8 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
       return containerPointer || '';
     }
 
-    const normalizedContainerPointer = containerPointer && containerPointer !== '/'
-      ? this.trimTrailingJsonPointerSlashes(containerPointer)
-      : '';
+    const normalizedContainerPointer =
+      containerPointer && containerPointer !== '/' ? this.trimTrailingJsonPointerSlashes(containerPointer) : '';
     return `${normalizedContainerPointer}/${trimmedName}`;
   }
 
@@ -3657,23 +3736,25 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     return null;
   }
 
-  private getChildComponentDefinitions(component: AllFormComponentDefinitionOutlines): AllFormComponentDefinitionOutlines[] {
+  private getChildComponentDefinitions(
+    component: AllFormComponentDefinitionOutlines
+  ): AllFormComponentDefinitionOutlines[] {
     const componentConfig = component?.component?.config as Record<string, unknown> | undefined;
     const nested = [
       ...(Array.isArray(componentConfig?.componentDefinitions)
-        ? componentConfig.componentDefinitions as AllFormComponentDefinitionOutlines[]
+        ? (componentConfig.componentDefinitions as AllFormComponentDefinitionOutlines[])
         : []),
-      ...(Array.isArray(componentConfig?.tabs)
-        ? componentConfig.tabs as AllFormComponentDefinitionOutlines[]
-        : []),
+      ...(Array.isArray(componentConfig?.tabs) ? (componentConfig.tabs as AllFormComponentDefinitionOutlines[]) : []),
       ...(Array.isArray(componentConfig?.panels)
-        ? componentConfig.panels as AllFormComponentDefinitionOutlines[]
+        ? (componentConfig.panels as AllFormComponentDefinitionOutlines[])
         : []),
     ];
     return nested;
   }
 
-  private async retargetPublishDataLocationSelectorExpressions(components: AllFormComponentDefinitionOutlines[] | undefined): Promise<void> {
+  private async retargetPublishDataLocationSelectorExpressions(
+    components: AllFormComponentDefinitionOutlines[] | undefined
+  ): Promise<void> {
     for (const component of components ?? []) {
       if (component.component?.class === PublishDataLocationSelectorComponentName) {
         for (const expression of component.expressions ?? []) {
@@ -3681,7 +3762,10 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
           if (!sourceName) {
             continue;
           }
-          const sourcePointer = this.findComponentAngularComponentsJsonPointer(this.v5FormConfig.componentDefinitions, sourceName);
+          const sourcePointer = this.findComponentAngularComponentsJsonPointer(
+            this.v5FormConfig.componentDefinitions,
+            sourceName
+          );
           if (sourcePointer) {
             expression.config.condition = `${sourcePointer}::field.value.changed`;
           }
@@ -3698,12 +3782,12 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
       return null;
     }
 
-    const segments = pointer.split('/').filter((segment) => segment.length > 0);
+    const segments = pointer.split('/').filter(segment => segment.length > 0);
     return segments.length > 0 ? segments[segments.length - 1] : null;
   }
 
   private buildEventValueTemplate(propertyName: string): string {
-    const segments = propertyName.split('.').filter((segment) => segment.length > 0);
+    const segments = propertyName.split('.').filter(segment => segment.length > 0);
     if (segments.length === 0) {
       return 'event.value';
     }

--- a/packages/redbox-core/test/services/TemplateService.test.ts
+++ b/packages/redbox-core/test/services/TemplateService.test.ts
@@ -128,6 +128,7 @@ describe('TemplateService', function () {
       const result = TemplateService.buildClientMapping(inputs);
 
       expect(result[0].value).to.include('jsonata(');
+      expect(result[0].value).to.include('registerFunction("eval"');
       expect(result[0].value).to.include('evaluate(context, extra?.libraries)');
     });
 

--- a/packages/redbox-core/test/services/TemplateService.test.ts
+++ b/packages/redbox-core/test/services/TemplateService.test.ts
@@ -1,24 +1,24 @@
 let expect: Chai.ExpectStatic;
-import("chai").then(mod => expect = mod.expect);
+import('chai').then(mod => (expect = mod.expect));
 import * as sinon from 'sinon';
 import { setupServiceTestGlobals, cleanupServiceTestGlobals, createMockSails } from './testHelper';
 
-describe('TemplateService', function() {
+describe('TemplateService', function () {
   let mockSails: any;
   let TemplateService: any;
 
-  beforeEach(function() {
+  beforeEach(function () {
     mockSails = createMockSails({
       config: {
-        appPath: '/app'
+        appPath: '/app',
       },
       log: {
         verbose: sinon.stub(),
         debug: sinon.stub(),
         info: sinon.stub(),
         warn: sinon.stub(),
-        error: sinon.stub()
-      }
+        error: sinon.stub(),
+      },
     });
 
     setupServiceTestGlobals(mockSails);
@@ -28,13 +28,13 @@ describe('TemplateService', function() {
     TemplateService = new Services.Template();
   });
 
-  afterEach(function() {
+  afterEach(function () {
     cleanupServiceTestGlobals();
     sinon.restore();
   });
 
-  describe('buildKeyString', function() {
-    it('should convert array key to string', function() {
+  describe('buildKeyString', function () {
+    it('should convert array key to string', function () {
       const result = TemplateService.buildKeyString(['report', 'columns', '0', 'render']);
 
       expect(result).to.be.a('string');
@@ -42,8 +42,8 @@ describe('TemplateService', function() {
     });
   });
 
-  describe('buildClientJsonata', function() {
-    it('should compile a valid JSONata expression', function() {
+  describe('buildClientJsonata', function () {
+    it('should compile a valid JSONata expression', function () {
       const expression = '$.firstName & " " & $.lastName';
 
       const result = TemplateService.buildClientJsonata(expression);
@@ -52,7 +52,7 @@ describe('TemplateService', function() {
       expect(result).to.include('firstName');
     });
 
-    it('should return null for invalid JSONata expression', function() {
+    it('should return null for invalid JSONata expression', function () {
       const invalidExpression = '{{{{invalid jsonata';
 
       const result = TemplateService.buildClientJsonata(invalidExpression);
@@ -60,7 +60,7 @@ describe('TemplateService', function() {
       expect(result).to.be.null;
     });
 
-    it('should normalize the expression', function() {
+    it('should normalize the expression', function () {
       // Test with unicode characters that should be normalized
       const expression = '$.name';
 
@@ -70,9 +70,8 @@ describe('TemplateService', function() {
     });
   });
 
-
-  describe('buildClientHandlebars', function() {
-    it('should precompile a valid Handlebars template', function() {
+  describe('buildClientHandlebars', function () {
+    it('should precompile a valid Handlebars template', function () {
       const template = '{{firstName}} {{lastName}}';
 
       const result = TemplateService.buildClientHandlebars(template);
@@ -82,7 +81,7 @@ describe('TemplateService', function() {
       expect(result).to.include('function');
     });
 
-    it('should register helpers once', function() {
+    it('should register helpers once', function () {
       // Call twice to test caching
       TemplateService.buildClientHandlebars('{{name}}');
       TemplateService.buildClientHandlebars('{{other}}');
@@ -92,8 +91,8 @@ describe('TemplateService', function() {
     });
   });
 
-  describe('buildServerHandlebars', function() {
-    it('should compile a valid Handlebars template', function() {
+  describe('buildServerHandlebars', function () {
+    it('should compile a valid Handlebars template', function () {
       const template = '{{firstName}} {{lastName}}';
 
       const result = TemplateService.buildServerHandlebars(template);
@@ -101,7 +100,7 @@ describe('TemplateService', function() {
       expect(result).to.be.a('function');
     });
 
-    it('should execute the compiled template', function() {
+    it('should execute the compiled template', function () {
       const template = '{{firstName}} {{lastName}}';
 
       const compiled = TemplateService.buildServerHandlebars(template);
@@ -111,11 +110,9 @@ describe('TemplateService', function() {
     });
   });
 
-  describe('buildClientMapping', function() {
-    it('should build mapping for JSONata inputs', function() {
-      const inputs = [
-        { key: ['field1'], kind: 'jsonata', value: '$.name' }
-      ];
+  describe('buildClientMapping', function () {
+    it('should build mapping for JSONata inputs', function () {
+      const inputs = [{ key: ['field1'], kind: 'jsonata', value: '$.name' }];
 
       const result = TemplateService.buildClientMapping(inputs);
 
@@ -125,10 +122,16 @@ describe('TemplateService', function() {
       expect(result[0]).to.have.property('value');
     });
 
-    it('should build mapping for Handlebars inputs', function() {
-      const inputs = [
-        { key: ['field1'], kind: 'handlebars', value: '{{name}}' }
-      ];
+    it('should pass client JSONata library bindings through extra', function () {
+      const inputs = [{ key: ['field1'], kind: 'jsonata', value: '$helper($.name)' }];
+
+      const result = TemplateService.buildClientMapping(inputs);
+
+      expect(result[0].value).to.include('evaluate(context, extra?.libraries)');
+    });
+
+    it('should build mapping for Handlebars inputs', function () {
+      const inputs = [{ key: ['field1'], kind: 'handlebars', value: '{{name}}' }];
 
       const result = TemplateService.buildClientMapping(inputs);
 
@@ -136,26 +139,24 @@ describe('TemplateService', function() {
       expect(result).to.have.lengthOf(1);
     });
 
-    it('should throw for duplicate keys', function() {
+    it('should throw for duplicate keys', function () {
       const inputs = [
         { key: ['field1'], kind: 'jsonata', value: '$.name' },
-        { key: ['field1'], kind: 'jsonata', value: '$.other' }
+        { key: ['field1'], kind: 'jsonata', value: '$.other' },
       ];
 
       expect(() => TemplateService.buildClientMapping(inputs)).to.throw('Keys must be unique');
     });
 
-    it('should throw for unknown input kind', function() {
-      const inputs = [
-        { key: ['field1'], kind: 'unknown' as any, value: 'test' }
-      ];
+    it('should throw for unknown input kind', function () {
+      const inputs = [{ key: ['field1'], kind: 'unknown' as any, value: 'test' }];
 
       expect(() => TemplateService.buildClientMapping(inputs)).to.throw('Unknown input kind');
     });
   });
 
-  describe('exports', function() {
-    it('should export all public methods', function() {
+  describe('exports', function () {
+    it('should export all public methods', function () {
       const exported = TemplateService.exports();
 
       expect(exported).to.have.property('buildClientMapping');

--- a/packages/redbox-core/test/services/TemplateService.test.ts
+++ b/packages/redbox-core/test/services/TemplateService.test.ts
@@ -127,6 +127,7 @@ describe('TemplateService', function () {
 
       const result = TemplateService.buildClientMapping(inputs);
 
+      expect(result[0].value).to.include('jsonata(');
       expect(result[0].value).to.include('evaluate(context, extra?.libraries)');
     });
 

--- a/packages/redbox-core/test/unit/migrate-config-v4-v5.visitor.test.ts
+++ b/packages/redbox-core/test/unit/migrate-config-v4-v5.visitor.test.ts
@@ -1,24 +1,29 @@
-import path from "path";
-import { logger } from "./helpers";
+import path from 'path';
+import { logger } from './helpers';
 import {
   MigrationV4ToV5FormConfigVisitor,
   migrateDataClassification,
   migrateFormConfigFile,
   migrateFormConfigVerify,
-  reusableFormDefinitions
-} from "../../src";
+  reusableFormDefinitions,
+} from '../../src';
 
 let expect: Chai.ExpectStatic;
-import("chai").then(mod => expect = mod.expect);
+import('chai').then(mod => (expect = mod.expect));
 
-describe("Migrate v4 to v5 Visitor", async () => {
+describe('Migrate v4 to v5 Visitor', async () => {
   const relPath = path.relative(path.join(__dirname, 'packages/sails-ng-common'), __dirname);
 
-  describe("full migration", async () => {
+  describe('full migration', async () => {
     beforeEach(() => {
       (globalThis as any).sails = { config: { auth: { defaultBrand: 'default' } } };
       (globalThis as any).VocabularyService = {
-        getEntries: async () => ({ entries: [{ label: 'Open', value: 'open' }, { label: 'Closed', value: 'closed' }] })
+        getEntries: async () => ({
+          entries: [
+            { label: 'Open', value: 'open' },
+            { label: 'Closed', value: 'closed' },
+          ],
+        }),
       };
     });
 
@@ -30,12 +35,12 @@ describe("Migrate v4 to v5 Visitor", async () => {
     // Full form config migration tests
     [
       {
-        "in": "support/ng19-forms-migration/inputFiles/test-only-dataRecord-1.0-draft.js",
+        in: 'support/ng19-forms-migration/inputFiles/test-only-dataRecord-1.0-draft.js',
       },
       {
-        "in": "support/ng19-forms-migration/inputFiles/test-only-tab-citation-1.0.js",
-      }
-    ].forEach((item: { in: string}) => {
+        in: 'support/ng19-forms-migration/inputFiles/test-only-tab-citation-1.0.js',
+      },
+    ].forEach((item: { in: string }) => {
       it(`should migrate from ${item.in}`, async function () {
         const inputFile = path.resolve(relPath, item.in);
 
@@ -54,8 +59,8 @@ describe("Migrate v4 to v5 Visitor", async () => {
     // Data classification to question tree migration tests.
     [
       {
-        "in":"support/ng19-forms-migration/inputFiles/definition.js",
-      }
+        in: 'support/ng19-forms-migration/inputFiles/definition.js',
+      },
     ].forEach((item: { in: string }) => {
       it(`should migrate data classification from ${item.in} to question tree config`, async function () {
         const inputFile = path.resolve(relPath, item.in);
@@ -73,1626 +78,1698 @@ describe("Migrate v4 to v5 Visitor", async () => {
     });
   });
 
-    it("maps MarkdownTextArea to RichTextEditor with markdown output format", async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "rich-text-migration",
-                fields: [
-                    {
-                        class: "MarkdownTextArea",
-                        compClass: "MarkdownTextAreaComponent",
-                        definition: {
-                            name: "description",
-                            label: "Description",
-                            rows: "6"
-                        }
-                    }
-                ]
-            }
-        });
-
-        expect((migrated.componentDefinitions ?? []).length).to.be.greaterThan(0);
-        const field = (migrated.componentDefinitions ?? []).find(
-            (component) => component?.name === "description"
-        ) ?? migrated.componentDefinitions[0];
-        expect(field.component.class).to.equal("RichTextEditorComponent");
-        expect(field.model?.class).to.equal("RichTextEditorModel");
-        expect((field.component.config as Record<string, unknown>)?.outputFormat).to.equal("markdown");
+  it('maps MarkdownTextArea to RichTextEditor with markdown output format', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'rich-text-migration',
+        fields: [
+          {
+            class: 'MarkdownTextArea',
+            compClass: 'MarkdownTextAreaComponent',
+            definition: {
+              name: 'description',
+              label: 'Description',
+              rows: '6',
+            },
+          },
+        ],
+      },
     });
 
-    it("normalizes legacy top-level form css classes to rb-form classes", async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "legacy-css-migration",
-                viewCssClasses: "row col-md-offset-1 col-md-10",
-                editCssClasses: "row col-md-12",
-                fields: []
-            }
-        });
-
-        expect(migrated.viewCssClasses).to.equal("redbox-form form rb-form-view");
-        expect(migrated.editCssClasses).to.equal("redbox-form form rb-form-edit");
-    });
-
-    it('applies checkbox tree migration edge-case fallbacks and coercions', async function () {
-        const warnings: string[] = [];
-        const testLogger = {
-            ...logger,
-            warn: (message: unknown) => warnings.push(String(message ?? ''))
-        };
-        const visitor = new MigrationV4ToV5FormConfigVisitor(testLogger);
-        const migrated = await visitor.start({
-          data: {
-            name: 'checkbox-tree-edge',
-            fields: [
-              {
-                class: 'ANDSVocab',
-                compClass: 'ANDSVocabComponent',
-                definition: {
-                  name: 'dc:subject_anzsrc:for',
-                  leafOnly: 'definitely',
-                  maxDepth: 'not-a-number',
-                  regex: '[',
-                  value: {bad: 'shape'}
-                }
-              }
-            ]
-          }
-        });
-        expect(migrated.componentDefinitions).to.have.length.greaterThan(0);
-        const migratedField = migrated.componentDefinitions[0];
-        const migratedFieldConfig = migratedField.component.config as Record<string, unknown> | undefined;
-        expect(migratedField.component.class).to.equal('CheckboxTreeComponent');
-        expect(migratedFieldConfig?.vocabRef).to.equal(undefined);
-        expect(migratedFieldConfig?.leafOnly).to.equal(true);
-        expect(migratedFieldConfig?.maxDepth).to.equal(undefined);
-        expect(migratedFieldConfig?.labelTemplate).to.equal("{{default (split notation \"/\" -1) notation}} - {{label}}");
-        expect(migratedField.model?.class).to.equal('CheckboxTreeModel');
-        expect(Array.isArray(migratedField.model?.config?.defaultValue)).to.equal(true);
-        expect((migratedField.model?.config?.defaultValue as unknown[]).length).to.equal(0);
-        expect(warnings.some((msg) => msg.includes('missing vocabId/vocabRef'))).to.equal(true);
-        expect(warnings.some((msg) => msg.includes("malformed 'leafOnly'"))).to.equal(true);
-        expect(warnings.some((msg) => msg.includes("invalid 'maxDepth'"))).to.equal(true);
-        expect(warnings.some((msg) => msg.includes('malformed regex'))).to.equal(true);
-        expect(warnings.some((msg) => msg.includes('coerced non-array default value'))).to.equal(true);
+    expect((migrated.componentDefinitions ?? []).length).to.be.greaterThan(0);
+    const field =
+      (migrated.componentDefinitions ?? []).find(component => component?.name === 'description') ??
+      migrated.componentDefinitions[0];
+    expect(field.component.class).to.equal('RichTextEditorComponent');
+    expect(field.model?.class).to.equal('RichTextEditorModel');
+    expect((field.component.config as Record<string, unknown>)?.outputFormat).to.equal('markdown');
   });
 
-    it('omits boolean defaults for legacy toggle fields migrated to CheckboxInput', async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: 'legacy-toggle-migration',
-                fields: [
-                    {
-                        class: 'Toggle',
-                        compClass: 'ToggleComponent',
-                        definition: {
-                            name: 'embargoByDate',
-                            defaultValue: false,
-                            label: '@dataPublication-embargoEnabled',
-                            controlType: 'checkbox'
-                        }
-                    }
-                ]
-            }
-        });
-
-        const migratedField = migrated.componentDefinitions[0];
-        expect(migratedField.component.class).to.equal('CheckboxInputComponent');
-        expect(migratedField.model?.class).to.equal('CheckboxInputModel');
-        expect((migratedField.model?.config as Record<string, unknown>)?.defaultValue).to.equal(undefined);
+  it('normalizes legacy top-level form css classes to rb-form classes', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'legacy-css-migration',
+        viewCssClasses: 'row col-md-offset-1 col-md-10',
+        editCssClasses: 'row col-md-12',
+        fields: [],
+      },
     });
 
-    it('builds nested component JSON pointers without regex-based trailing slash trimming', async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger) as unknown as {
-            buildNestedComponentJsonPointer(containerPointer: string, componentName: string): string;
-        };
+    expect(migrated.viewCssClasses).to.equal('redbox-form form rb-form-view');
+    expect(migrated.editCssClasses).to.equal('redbox-form form rb-form-edit');
+  });
 
-        expect(visitor.buildNestedComponentJsonPointer('', 'child')).to.equal('/child');
-        expect(visitor.buildNestedComponentJsonPointer('/', 'child')).to.equal('/child');
-        expect(visitor.buildNestedComponentJsonPointer('/parent/', 'child')).to.equal('/parent/child');
-        expect(visitor.buildNestedComponentJsonPointer('/parent//', 'child')).to.equal('/parent/child');
+  it('applies checkbox tree migration edge-case fallbacks and coercions', async function () {
+    const warnings: string[] = [];
+    const testLogger = {
+      ...logger,
+      warn: (message: unknown) => warnings.push(String(message ?? '')),
+    };
+    const visitor = new MigrationV4ToV5FormConfigVisitor(testLogger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'checkbox-tree-edge',
+        fields: [
+          {
+            class: 'ANDSVocab',
+            compClass: 'ANDSVocabComponent',
+            definition: {
+              name: 'dc:subject_anzsrc:for',
+              leafOnly: 'definitely',
+              maxDepth: 'not-a-number',
+              regex: '[',
+              value: { bad: 'shape' },
+            },
+          },
+        ],
+      },
+    });
+    expect(migrated.componentDefinitions).to.have.length.greaterThan(0);
+    const migratedField = migrated.componentDefinitions[0];
+    const migratedFieldConfig = migratedField.component.config as Record<string, unknown> | undefined;
+    expect(migratedField.component.class).to.equal('CheckboxTreeComponent');
+    expect(migratedFieldConfig?.vocabRef).to.equal(undefined);
+    expect(migratedFieldConfig?.leafOnly).to.equal(true);
+    expect(migratedFieldConfig?.maxDepth).to.equal(undefined);
+    expect(migratedFieldConfig?.labelTemplate).to.equal('{{default (split notation "/" -1) notation}} - {{label}}');
+    expect(migratedField.model?.class).to.equal('CheckboxTreeModel');
+    expect(Array.isArray(migratedField.model?.config?.defaultValue)).to.equal(true);
+    expect((migratedField.model?.config?.defaultValue as unknown[]).length).to.equal(0);
+    expect(warnings.some(msg => msg.includes('missing vocabId/vocabRef'))).to.equal(true);
+    expect(warnings.some(msg => msg.includes("malformed 'leafOnly'"))).to.equal(true);
+    expect(warnings.some(msg => msg.includes("invalid 'maxDepth'"))).to.equal(true);
+    expect(warnings.some(msg => msg.includes('malformed regex'))).to.equal(true);
+    expect(warnings.some(msg => msg.includes('coerced non-array default value'))).to.equal(true);
+  });
+
+  it('omits boolean defaults for legacy toggle fields migrated to CheckboxInput', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'legacy-toggle-migration',
+        fields: [
+          {
+            class: 'Toggle',
+            compClass: 'ToggleComponent',
+            definition: {
+              name: 'embargoByDate',
+              defaultValue: false,
+              label: '@dataPublication-embargoEnabled',
+              controlType: 'checkbox',
+            },
+          },
+        ],
+      },
     });
 
-    it('maps LinkValueComponent to ContentComponent with a legacy-compatible link template', async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: 'link-value-migration',
-                fields: [
-                    {
-                        class: 'LinkValueComponent',
-                        definition: {
-                            name: 'citation_url',
-                            label: '@dataPublication-citation-url',
-                            help: '@dataPublication-citation-url-help',
-                            type: 'text',
-                            target: '_self'
-                        }
-                    }
-                ]
-            }
-        });
+    const migratedField = migrated.componentDefinitions[0];
+    expect(migratedField.component.class).to.equal('CheckboxInputComponent');
+    expect(migratedField.model?.class).to.equal('CheckboxInputModel');
+    expect((migratedField.model?.config as Record<string, unknown>)?.defaultValue).to.equal(undefined);
+  });
 
-        const migratedField = migrated.componentDefinitions.find((component) => component.name === 'citation_url-link-value');
-        const hiddenBindingField = migrated.componentDefinitions.find((component) => component.name === 'citation_url');
-        expect(migratedField).to.not.equal(undefined);
-        expect(hiddenBindingField).to.not.equal(undefined);
-        const migratedFieldResolved = migratedField!;
-        const hiddenBindingFieldResolved = hiddenBindingField!;
-        const componentConfig = migratedFieldResolved.component.config as Record<string, unknown>;
-        expect(migratedFieldResolved.name).to.equal('citation_url-link-value');
-        expect(migratedFieldResolved.component.class).to.equal('ContentComponent');
-        expect(migratedFieldResolved.model).to.equal(undefined);
-        expect(componentConfig?.label).to.equal(undefined);
-        expect((migratedFieldResolved.layout?.config as Record<string, unknown>)?.label).to.equal(undefined);
-        expect(componentConfig?.content).to.deep.equal({
-            label: '@dataPublication-citation-url',
-            valuePath: 'citation_url',
-            target: '_self'
-        });
-        expect(componentConfig?.template).to.equal(
-            '{{#if (get formData content.valuePath "")}}<li class="key-value-pair padding-bottom-10">{{#if content.label}}<span class="key">{{t content.label}}</span>{{/if}}<span class="value"><a href="{{get formData content.valuePath ""}}" target="{{default content.target "_blank"}}">{{get formData content.valuePath ""}}</a></span></li>{{/if}}'
-        );
-        expect(hiddenBindingFieldResolved.name).to.equal('citation_url');
-        expect(hiddenBindingFieldResolved.component.class).to.equal('SimpleInputComponent');
-        expect(hiddenBindingFieldResolved.constraints?.allowModes).to.deep.equal(['view']);
-        expect((hiddenBindingFieldResolved.component.config as Record<string, unknown>)?.type).to.equal('hidden');
-        expect((hiddenBindingFieldResolved.component.config as Record<string, unknown>)?.visible).to.equal(false);
+  it('builds nested component JSON pointers without regex-based trailing slash trimming', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger) as unknown as {
+      buildNestedComponentJsonPointer(containerPointer: string, componentName: string): string;
+    };
+
+    expect(visitor.buildNestedComponentJsonPointer('', 'child')).to.equal('/child');
+    expect(visitor.buildNestedComponentJsonPointer('/', 'child')).to.equal('/child');
+    expect(visitor.buildNestedComponentJsonPointer('/parent/', 'child')).to.equal('/parent/child');
+    expect(visitor.buildNestedComponentJsonPointer('/parent//', 'child')).to.equal('/parent/child');
+  });
+
+  it('maps LinkValueComponent to ContentComponent with a legacy-compatible link template', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'link-value-migration',
+        fields: [
+          {
+            class: 'LinkValueComponent',
+            definition: {
+              name: 'citation_url',
+              label: '@dataPublication-citation-url',
+              help: '@dataPublication-citation-url-help',
+              type: 'text',
+              target: '_self',
+            },
+          },
+        ],
+      },
     });
 
-    it('defaults migrated LinkValueComponent link targets to _blank when the legacy definition omits target', async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: 'link-value-default-target-migration',
-                fields: [
-                    {
-                        class: 'LinkValueComponent',
-                        definition: {
-                            name: 'landing_page',
-                            label: 'Landing page',
-                            type: 'text'
-                        }
-                    }
-                ]
-            }
-        });
+    const migratedField = migrated.componentDefinitions.find(component => component.name === 'citation_url-link-value');
+    const hiddenBindingField = migrated.componentDefinitions.find(component => component.name === 'citation_url');
+    expect(migratedField).to.not.equal(undefined);
+    expect(hiddenBindingField).to.not.equal(undefined);
+    const migratedFieldResolved = migratedField!;
+    const hiddenBindingFieldResolved = hiddenBindingField!;
+    const componentConfig = migratedFieldResolved.component.config as Record<string, unknown>;
+    expect(migratedFieldResolved.name).to.equal('citation_url-link-value');
+    expect(migratedFieldResolved.component.class).to.equal('ContentComponent');
+    expect(migratedFieldResolved.model).to.equal(undefined);
+    expect(componentConfig?.label).to.equal(undefined);
+    expect((migratedFieldResolved.layout?.config as Record<string, unknown>)?.label).to.equal(undefined);
+    expect(componentConfig?.content).to.deep.equal({
+      label: '@dataPublication-citation-url',
+      valuePath: 'citation_url',
+      target: '_self',
+    });
+    expect(componentConfig?.template).to.equal(
+      '{{#if (get formData content.valuePath "")}}<li class="key-value-pair padding-bottom-10">{{#if content.label}}<span class="key">{{t content.label}}</span>{{/if}}<span class="value"><a href="{{get formData content.valuePath ""}}" target="{{default content.target "_blank"}}">{{get formData content.valuePath ""}}</a></span></li>{{/if}}'
+    );
+    expect(hiddenBindingFieldResolved.name).to.equal('citation_url');
+    expect(hiddenBindingFieldResolved.component.class).to.equal('SimpleInputComponent');
+    expect(hiddenBindingFieldResolved.constraints?.allowModes).to.deep.equal(['view']);
+    expect((hiddenBindingFieldResolved.component.config as Record<string, unknown>)?.type).to.equal('hidden');
+    expect((hiddenBindingFieldResolved.component.config as Record<string, unknown>)?.visible).to.equal(false);
+  });
 
-        const migratedField = migrated.componentDefinitions.find((component) => component.name === 'landing_page-link-value');
-        expect(migratedField).to.not.equal(undefined);
-
-        const componentConfig = migratedField!.component.config as Record<string, unknown>;
-        expect(componentConfig?.content).to.deep.equal({
-            label: 'Landing page',
-            valuePath: 'landing_page'
-        });
-        expect(componentConfig?.template).to.contain('target="{{default content.target "_blank"}}"');
+  it('defaults migrated LinkValueComponent link targets to _blank when the legacy definition omits target', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'link-value-default-target-migration',
+        fields: [
+          {
+            class: 'LinkValueComponent',
+            definition: {
+              name: 'landing_page',
+              label: 'Landing page',
+              type: 'text',
+            },
+          },
+        ],
+      },
     });
 
-    it('maps HtmlRawComponent to ContentComponent', async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: 'html-raw-migration',
-                fields: [
-                    {
-                        class: 'HtmlRaw',
-                        compClass: 'HtmlRawComponent',
-                        definition: {
-                            name: 'raw_html',
-                            value: '@dataPublication-data-manager'
-                        }
-                    }
-                ]
-            }
-        });
+    const migratedField = migrated.componentDefinitions.find(component => component.name === 'landing_page-link-value');
+    expect(migratedField).to.not.equal(undefined);
 
-        const migratedField = migrated.componentDefinitions[0];
-        expect(migratedField.component.class).to.equal('ContentComponent');
-        expect(migratedField.model).to.equal(undefined);
-        const componentConfig = migratedField.component.config as Record<string, unknown>;
-        expect(componentConfig.content).to.equal('@dataPublication-data-manager');
-        expect(componentConfig.template).to.equal('<div>{{{t content}}}</div>');
+    const componentConfig = migratedField!.component.config as Record<string, unknown>;
+    expect(componentConfig?.content).to.deep.equal({
+      label: 'Landing page',
+      valuePath: 'landing_page',
+    });
+    expect(componentConfig?.template).to.contain('target="{{default content.target "_blank"}}"');
+  });
+
+  it('maps HtmlRawComponent to ContentComponent', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'html-raw-migration',
+        fields: [
+          {
+            class: 'HtmlRaw',
+            compClass: 'HtmlRawComponent',
+            definition: {
+              name: 'raw_html',
+              value: '@dataPublication-data-manager',
+            },
+          },
+        ],
+      },
     });
 
-    it('maps legacy VocabField to TypeaheadInput with value coercion', async function () {
-        const warnings: string[] = [];
-        const testLogger = {
-            ...logger,
-            warn: (message: unknown) => warnings.push(String(message ?? ''))
-        };
-        const visitor = new MigrationV4ToV5FormConfigVisitor(testLogger);
-        const migrated = await visitor.start({
-            data: {
-                name: "typeahead-edge",
-                fields: [
+    const migratedField = migrated.componentDefinitions[0];
+    expect(migratedField.component.class).to.equal('ContentComponent');
+    expect(migratedField.model).to.equal(undefined);
+    const componentConfig = migratedField.component.config as Record<string, unknown>;
+    expect(componentConfig.content).to.equal('@dataPublication-data-manager');
+    expect(componentConfig.template).to.equal('<div>{{{t content}}}</div>');
+  });
+
+  it('maps legacy VocabField to TypeaheadInput with value coercion', async function () {
+    const warnings: string[] = [];
+    const testLogger = {
+      ...logger,
+      warn: (message: unknown) => warnings.push(String(message ?? '')),
+    };
+    const visitor = new MigrationV4ToV5FormConfigVisitor(testLogger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'typeahead-edge',
+        fields: [
+          {
+            class: 'VocabField',
+            compClass: 'VocabFieldComponent',
+            definition: {
+              name: 'contributor',
+              sourceType: 'query',
+              vocabQueryId: 'lookup-contributor',
+              titleFieldName: 'displayName',
+              storeLabelOnly: false,
+              disableEditAfterSelect: true,
+              forceClone: true,
+            },
+            value: 'Jane Doe',
+          },
+        ],
+      },
+    });
+
+    const migratedField = migrated.componentDefinitions[0];
+    expect(migratedField.component.class).to.equal('TypeaheadInputComponent');
+    expect(migratedField.model?.class).to.equal('TypeaheadInputModel');
+    const componentConfig = migratedField.component.config as Record<string, unknown>;
+    expect(componentConfig.sourceType).to.equal('namedQuery');
+    expect(componentConfig.queryId).to.equal('lookup-contributor');
+    expect(componentConfig.labelField).to.equal('displayName');
+    expect(componentConfig.valueMode).to.equal('optionObject');
+    expect(componentConfig.readOnlyAfterSelect).to.equal(true);
+
+    const modelConfig = migratedField.model?.config as Record<string, unknown>;
+    expect(modelConfig).to.not.equal(undefined);
+    expect(warnings.some(msg => msg.includes("dropped legacy property 'forceClone'"))).to.equal(true);
+  });
+
+  it('migrates static typeahead options and prefers legacy options over staticOptions', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'typeahead-static-options',
+        fields: [
+          {
+            class: 'VocabField',
+            compClass: 'VocabFieldComponent',
+            definition: {
+              name: 'contributorRole',
+              sourceType: 'static',
+              titleFieldName: 'name',
+              valueFieldName: 'id',
+              options: [
+                'Researcher',
+                { name: 'Data steward', id: 'steward' },
+                { label: 'Librarian', value: 'librarian' },
+              ],
+              staticOptions: [{ label: 'Should not be used', value: 'ignore' }],
+            },
+          },
+        ],
+      },
+    });
+
+    const migratedField = migrated.componentDefinitions[0];
+    expect(migratedField.component.class).to.equal('TypeaheadInputComponent');
+    const componentConfig = migratedField.component.config as Record<string, unknown>;
+    expect(componentConfig.sourceType).to.equal('static');
+
+    const staticOptions = componentConfig.staticOptions as Array<Record<string, unknown>>;
+    expect(staticOptions).to.deep.equal([
+      { label: 'Researcher', value: 'Researcher' },
+      { label: 'Data steward', value: 'steward' },
+      { label: 'Librarian', value: 'librarian' },
+    ]);
+  });
+
+  it('omits legacy ParameterRetriever fields and logs the runtime-context replacement', async function () {
+    const warnings: string[] = [];
+    const testLogger = {
+      ...logger,
+      warn: (message: unknown) => warnings.push(String(message ?? '')),
+    };
+    const visitor = new MigrationV4ToV5FormConfigVisitor(testLogger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'parameter-retriever-migration',
+        fields: [
+          {
+            class: 'ParameterRetriever',
+            compClass: 'ParameterRetrieverComponent',
+            definition: {
+              name: 'parameterRetriever',
+              label: 'Legacy Param',
+            },
+          },
+          {
+            class: 'TextField',
+            definition: {
+              name: 'title',
+              label: 'Title',
+            },
+          },
+        ],
+      },
+    });
+
+    expect((migrated.componentDefinitions ?? []).some(component => component?.name === 'parameterRetriever')).to.equal(
+      false
+    );
+    expect((migrated.componentDefinitions ?? []).some(component => component?.name === 'title')).to.equal(true);
+    expect(warnings.some(msg => msg.includes("ParameterRetriever 'parameterRetriever'"))).to.equal(true);
+    expect(warnings.some(msg => msg.includes('requestParams runtime context'))).to.equal(true);
+  });
+
+  it('maps legacy RecordMetadataRetriever subscriptions into fetch expressions and downstream listeners', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'record-metadata-retriever-migration',
+        fields: [
+          {
+            class: 'ParameterRetriever',
+            compClass: 'ParameterRetrieverComponent',
+            definition: {
+              name: 'parameterRetriever',
+              parameterName: 'dataRecordOid',
+            },
+          },
+          {
+            class: 'RecordMetadataRetriever',
+            compClass: 'RecordMetadataRetrieverComponent',
+            definition: {
+              name: 'dataRecordGetter',
+              subscribe: {
+                parameterRetriever: {
+                  onValueUpdate: [{ action: 'publishMetadata' }],
+                },
+                dataRecord: {
+                  relatedObjectSelected: [{ action: 'publishMetadata' }],
+                },
+              },
+            },
+          },
+          {
+            class: 'TextField',
+            definition: {
+              name: 'title',
+              subscribe: {
+                dataRecordGetter: {
+                  onValueUpdate: [
                     {
-                        class: "VocabField",
-                        compClass: "VocabFieldComponent",
+                      action: 'utilityService.getPropertyFromObject',
+                      field: 'title',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const retriever = migrated.componentDefinitions.find(component => component.name === 'dataRecordGetter');
+    expect(retriever?.component.class).to.equal('RecordMetadataRetrieverComponent');
+    expect(retriever?.model).to.equal(undefined);
+    expect(retriever?.component?.config?.visible).to.equal(false);
+    expect(retriever?.component?.config?.label).to.equal(undefined);
+    expect(retriever?.layout?.config?.visible).to.equal(false);
+    expect(retriever?.layout?.config?.label).to.equal(undefined);
+    expect(retriever?.expressions).to.deep.include({
+      name: 'fetchOnFormReady-dataRecordOid',
+      description: 'Fetch metadata on form load using request params',
+      config: {
+        runOnFormReady: true,
+        conditionKind: 'jsonata_query',
+        condition: '$exists(runtimeContext.requestParams.dataRecordOid)',
+        operation: 'fetchMetadata',
+        hasTemplate: true,
+        template: 'runtimeContext.requestParams.dataRecordOid',
+      },
+    });
+    expect(retriever?.expressions).to.deep.include({
+      name: 'fetchOnRelatedObjectSelected-dataRecord',
+      description: 'Fetch metadata when dataRecord changes',
+      config: {
+        conditionKind: 'jsonpointer',
+        runOnFormReady: false,
+        condition: '/dataRecord::field.value.changed',
+        operation: 'fetchMetadata',
+        hasTemplate: true,
+        template:
+          '$exists(event.value.oid) ? event.value.oid : ($exists(event.value.redboxOid) ? event.value.redboxOid : event.value)',
+      },
+    });
+
+    const titleField = migrated.componentDefinitions.find(component => component.name === 'title');
+    expect(titleField?.expressions).to.deep.include({
+      name: 'dataRecordGetter-title-title',
+      description: 'Populate title from dataRecordGetter metadata',
+      config: {
+        conditionKind: 'jsonpointer',
+        runOnFormReady: false,
+        condition: '/dataRecordGetter::field.value.changed',
+        target: 'model.value',
+        hasTemplate: true,
+        template: 'event.value.title',
+      },
+    });
+  });
+
+  it('migrates legacy PDFList fields to PDFListComponent and survives visitor verification', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'pdf-list-migration',
+        fields: [
+          {
+            class: 'PDFList',
+            compClass: 'PDFListComponent',
+            definition: {
+              name: 'planPdf',
+              startsWith: 'rdmp-pdf',
+              recentPdfLimit: 3,
+              showVersionCounter: true,
+              showVersionColumn: true,
+              versionColumnValueField: 'planVersion',
+              versionColumnLabelKey: 'Version ',
+              useVersionLabelForFileName: true,
+              downloadBtnLabel: '@download-current',
+              downloadPreviousBtnLabel: '@download-previous',
+              downloadPrefix: 'rdmp',
+              fileNameTemplate: '<%= versionLabel %>.pdf',
+            },
+          },
+        ],
+      },
+    });
+
+    const migratedField = migrated.componentDefinitions[0];
+    const componentConfig = migratedField.component.config as Record<string, unknown>;
+
+    expect(migratedField.component.class).to.equal('PDFListComponent');
+    expect(migratedField.model?.class).to.equal('PDFListModel');
+    expect(componentConfig?.startsWith).to.equal('rdmp-pdf');
+    expect(componentConfig?.recentPdfLimit).to.equal(3);
+    expect(componentConfig?.showVersionCounter).to.equal(true);
+    expect(componentConfig?.showVersionColumn).to.equal(true);
+    expect(componentConfig?.versionColumnValueField).to.equal('planVersion');
+    expect(componentConfig?.versionColumnLabelKey).to.equal('Version ');
+    expect(componentConfig?.useVersionLabelForFileName).to.equal(true);
+    expect(componentConfig?.downloadBtnLabel).to.equal('@download-current');
+    expect(componentConfig?.downloadPreviousBtnLabel).to.equal('@download-previous');
+    expect(componentConfig?.downloadPrefix).to.equal('rdmp');
+    expect(componentConfig?.fileNameTemplate).to.equal('{{versionLabel}}.pdf');
+    expect(migratedField.layout?.config?.label).to.equal(undefined);
+
+    await migrateFormConfigVerify(migrated, logger);
+  });
+
+  it('maps legacy RecordMetadataRetriever request-param fetch expressions inside tab content containers', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'record-metadata-retriever-tab-migration',
+        fields: [
+          {
+            class: 'TabOrAccordionContainer',
+            compClass: 'TabOrAccordionContainerComponent',
+            definition: {
+              id: 'main_tab',
+              label: 'Main tab',
+              fields: [
+                {
+                  class: 'Container',
+                  definition: {
+                    id: 'aim',
+                    label: 'Aim',
+                    fields: [
+                      {
+                        class: 'ParameterRetriever',
+                        compClass: 'ParameterRetrieverComponent',
                         definition: {
-                            name: "contributor",
-                            sourceType: "query",
-                            vocabQueryId: "lookup-contributor",
-                            titleFieldName: "displayName",
-                            storeLabelOnly: false,
-                            disableEditAfterSelect: true,
-                            forceClone: true
+                          name: 'parameterRetriever',
+                          parameterName: 'rdmpOid',
                         },
-                        value: "Jane Doe"
-                    }
-                ]
-            }
-        });
-
-        const migratedField = migrated.componentDefinitions[0];
-        expect(migratedField.component.class).to.equal("TypeaheadInputComponent");
-        expect(migratedField.model?.class).to.equal("TypeaheadInputModel");
-        const componentConfig = migratedField.component.config as Record<string, unknown>;
-        expect(componentConfig.sourceType).to.equal("namedQuery");
-        expect(componentConfig.queryId).to.equal("lookup-contributor");
-        expect(componentConfig.labelField).to.equal("displayName");
-        expect(componentConfig.valueMode).to.equal("optionObject");
-        expect(componentConfig.readOnlyAfterSelect).to.equal(true);
-
-        const modelConfig = migratedField.model?.config as Record<string, unknown>;
-        expect(modelConfig).to.not.equal(undefined);
-        expect(warnings.some((msg) => msg.includes("dropped legacy property 'forceClone'"))).to.equal(true);
-    });
-
-    it('migrates static typeahead options and prefers legacy options over staticOptions', async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "typeahead-static-options",
-                fields: [
-                    {
-                        class: "VocabField",
-                        compClass: "VocabFieldComponent",
-                        definition: {
-                            name: "contributorRole",
-                            sourceType: "static",
-                            titleFieldName: "name",
-                            valueFieldName: "id",
-                            options: [
-                                "Researcher",
-                                { name: "Data steward", id: "steward" },
-                                { label: "Librarian", value: "librarian" }
-                            ],
-                            staticOptions: [
-                                { label: "Should not be used", value: "ignore" }
-                            ]
-                        }
-                    }
-                ]
-            }
-        });
-
-        const migratedField = migrated.componentDefinitions[0];
-        expect(migratedField.component.class).to.equal("TypeaheadInputComponent");
-        const componentConfig = migratedField.component.config as Record<string, unknown>;
-        expect(componentConfig.sourceType).to.equal("static");
-
-        const staticOptions = componentConfig.staticOptions as Array<Record<string, unknown>>;
-        expect(staticOptions).to.deep.equal([
-            { label: "Researcher", value: "Researcher" },
-            { label: "Data steward", value: "steward" },
-            { label: "Librarian", value: "librarian" }
-        ]);
-    });
-
-    it('omits legacy ParameterRetriever fields and logs the runtime-context replacement', async function () {
-        const warnings: string[] = [];
-        const testLogger = {
-            ...logger,
-            warn: (message: unknown) => warnings.push(String(message ?? ''))
-        };
-        const visitor = new MigrationV4ToV5FormConfigVisitor(testLogger);
-        const migrated = await visitor.start({
-            data: {
-                name: 'parameter-retriever-migration',
-                fields: [
-                    {
-                        class: 'ParameterRetriever',
-                        compClass: 'ParameterRetrieverComponent',
-                        definition: {
-                            name: 'parameterRetriever',
-                            label: 'Legacy Param'
-                        }
-                    },
-                    {
+                      },
+                      {
                         class: 'TextField',
                         definition: {
-                            name: 'title',
-                            label: 'Title'
-                        }
-                    }
-                ]
-            }
-        });
-
-        expect((migrated.componentDefinitions ?? []).some((component) => component?.name === 'parameterRetriever')).to.equal(false);
-        expect((migrated.componentDefinitions ?? []).some((component) => component?.name === 'title')).to.equal(true);
-        expect(warnings.some((msg) => msg.includes("ParameterRetriever 'parameterRetriever'"))).to.equal(true);
-        expect(warnings.some((msg) => msg.includes('requestParams runtime context'))).to.equal(true);
-    });
-
-    it('maps legacy RecordMetadataRetriever subscriptions into fetch expressions and downstream listeners', async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: 'record-metadata-retriever-migration',
-                fields: [
-                    {
-                        class: 'ParameterRetriever',
-                        compClass: 'ParameterRetrieverComponent',
-                        definition: {
-                            name: 'parameterRetriever',
-                            parameterName: 'dataRecordOid'
-                        }
-                    },
-                    {
+                          name: 'rdmp',
+                        },
+                      },
+                      {
                         class: 'RecordMetadataRetriever',
                         compClass: 'RecordMetadataRetrieverComponent',
                         definition: {
-                            name: 'dataRecordGetter',
-                            subscribe: {
-                                parameterRetriever: {
-                                    onValueUpdate: [{ action: 'publishMetadata' }]
-                                },
-                                dataRecord: {
-                                    relatedObjectSelected: [{ action: 'publishMetadata' }]
-                                }
-                            }
-                        }
-                    },
-                    {
-                        class: 'TextField',
-                        definition: {
-                            name: 'title',
-                            subscribe: {
-                                dataRecordGetter: {
-                                    onValueUpdate: [
-                                        {
-                                            action: 'utilityService.getPropertyFromObject',
-                                            field: 'title'
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                ]
-            }
-        });
-
-        const retriever = migrated.componentDefinitions.find((component) => component.name === 'dataRecordGetter');
-        expect(retriever?.component.class).to.equal('RecordMetadataRetrieverComponent');
-        expect(retriever?.model).to.equal(undefined);
-        expect(retriever?.component?.config?.visible).to.equal(false);
-        expect(retriever?.component?.config?.label).to.equal(undefined);
-        expect(retriever?.layout?.config?.visible).to.equal(false);
-        expect(retriever?.layout?.config?.label).to.equal(undefined);
-        expect(retriever?.expressions).to.deep.include({
-            name: 'fetchOnFormReady-dataRecordOid',
-            description: 'Fetch metadata on form load using request params',
-            config: {
-                runOnFormReady: true,
-                conditionKind: 'jsonata_query',
-                condition: '$exists(runtimeContext.requestParams.dataRecordOid)',
-                operation: 'fetchMetadata',
-                hasTemplate: true,
-                template: 'runtimeContext.requestParams.dataRecordOid'
-            }
-        });
-        expect(retriever?.expressions).to.deep.include({
-            name: 'fetchOnRelatedObjectSelected-dataRecord',
-            description: 'Fetch metadata when dataRecord changes',
-            config: {
-                conditionKind: 'jsonpointer',
-                runOnFormReady: false,
-                condition: '/dataRecord::field.value.changed',
-                operation: 'fetchMetadata',
-                hasTemplate: true,
-                template: '$exists(event.value.oid) ? event.value.oid : ($exists(event.value.redboxOid) ? event.value.redboxOid : event.value)'
-            }
-        });
-
-        const titleField = migrated.componentDefinitions.find((component) => component.name === 'title');
-        expect(titleField?.expressions).to.deep.include({
-            name: 'dataRecordGetter-title-title',
-            description: 'Populate title from dataRecordGetter metadata',
-            config: {
-                conditionKind: 'jsonpointer',
-                runOnFormReady: false,
-                condition: '/dataRecordGetter::field.value.changed',
-                target: 'model.value',
-                hasTemplate: true,
-                template: 'event.value.title'
-            }
-        });
-    });
-
-    it('migrates legacy PDFList fields to PDFListComponent and survives visitor verification', async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: 'pdf-list-migration',
-                fields: [
-                    {
-                        class: 'PDFList',
-                        compClass: 'PDFListComponent',
-                        definition: {
-                            name: 'planPdf',
-                            startsWith: 'rdmp-pdf',
-                            recentPdfLimit: 3,
-                            showVersionCounter: true,
-                            showVersionColumn: true,
-                            versionColumnValueField: 'planVersion',
-                            versionColumnLabelKey: 'Version ',
-                            useVersionLabelForFileName: true,
-                            downloadBtnLabel: '@download-current',
-                            downloadPreviousBtnLabel: '@download-previous',
-                            downloadPrefix: 'rdmp',
-                            fileNameTemplate: '<%= versionLabel %>.pdf',
-                        }
-                    }
-                ]
-            }
-        });
-
-        const migratedField = migrated.componentDefinitions[0];
-        const componentConfig = migratedField.component.config as Record<string, unknown>;
-
-        expect(migratedField.component.class).to.equal('PDFListComponent');
-        expect(migratedField.model?.class).to.equal('PDFListModel');
-        expect(componentConfig?.startsWith).to.equal('rdmp-pdf');
-        expect(componentConfig?.recentPdfLimit).to.equal(3);
-        expect(componentConfig?.showVersionCounter).to.equal(true);
-        expect(componentConfig?.showVersionColumn).to.equal(true);
-        expect(componentConfig?.versionColumnValueField).to.equal('planVersion');
-        expect(componentConfig?.versionColumnLabelKey).to.equal('Version ');
-        expect(componentConfig?.useVersionLabelForFileName).to.equal(true);
-        expect(componentConfig?.downloadBtnLabel).to.equal('@download-current');
-        expect(componentConfig?.downloadPreviousBtnLabel).to.equal('@download-previous');
-        expect(componentConfig?.downloadPrefix).to.equal('rdmp');
-        expect(componentConfig?.fileNameTemplate).to.equal('{{versionLabel}}.pdf');
-        expect(migratedField.layout?.config?.label).to.equal(undefined);
-
-        await migrateFormConfigVerify(migrated, logger);
-    });
-
-    it('maps legacy RecordMetadataRetriever request-param fetch expressions inside tab content containers', async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: 'record-metadata-retriever-tab-migration',
-                fields: [
-                    {
-                        class: 'TabOrAccordionContainer',
-                        compClass: 'TabOrAccordionContainerComponent',
-                        definition: {
-                            id: 'main_tab',
-                            label: 'Main tab',
-                            fields: [
-                                {
-                                    class: 'Container',
-                                    definition: {
-                                        id: 'aim',
-                                        label: 'Aim',
-                                        fields: [
-                                            {
-                                                class: 'ParameterRetriever',
-                                                compClass: 'ParameterRetrieverComponent',
-                                                definition: {
-                                                    name: 'parameterRetriever',
-                                                    parameterName: 'rdmpOid'
-                                                }
-                                            },
-                                            {
-                                                class: 'TextField',
-                                                definition: {
-                                                    name: 'rdmp'
-                                                }
-                                            },
-                                            {
-                                                class: 'RecordMetadataRetriever',
-                                                compClass: 'RecordMetadataRetrieverComponent',
-                                                definition: {
-                                                    name: 'rdmpGetter',
-                                                    subscribe: {
-                                                        parameterRetriever: {
-                                                            onValueUpdate: [{ action: 'publishMetadata' }]
-                                                        },
-                                                        rdmp: {
-                                                            relatedObjectSelected: [{ action: 'publishMetadata' }]
-                                                        }
-                                                    }
-                                                }
-                                            },
-                                            {
-                                                class: 'TextField',
-                                                definition: {
-                                                    name: 'aim_project_name',
-                                                    subscribe: {
-                                                        rdmpGetter: {
-                                                            onValueUpdate: [
-                                                                {
-                                                                    action: 'utilityService.getPropertyFromObject',
-                                                                    field: 'title'
-                                                                }
-                                                            ]
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        ]
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        });
-
-        const findByName = (components: any[], name: string): any => {
-            for (const component of components ?? []) {
-                if (component?.name === name) {
-                    return component;
-                }
-                const nestedTabs = component?.component?.config?.tabs ?? [];
-                const nestedTabHit = findByName(nestedTabs, name);
-                if (nestedTabHit) {
-                    return nestedTabHit;
-                }
-                const nestedComponents = component?.component?.config?.componentDefinitions ?? [];
-                const nestedComponentHit = findByName(nestedComponents, name);
-                if (nestedComponentHit) {
-                    return nestedComponentHit;
-                }
-            }
-            return undefined;
-        };
-
-        const findPointerByName = (components: any[], name: string, parentPointer = ''): string | undefined => {
-            for (const component of components ?? []) {
-                const currentPointer = `${parentPointer}/${component?.name}`;
-                if (component?.name === name) {
-                    return currentPointer;
-                }
-                const nestedTabs = component?.component?.config?.tabs ?? [];
-                const nestedTabHit = findPointerByName(nestedTabs, name, currentPointer);
-                if (nestedTabHit) {
-                    return nestedTabHit;
-                }
-                const nestedComponents = component?.component?.config?.componentDefinitions ?? [];
-                const nestedComponentHit = findPointerByName(nestedComponents, name, currentPointer);
-                if (nestedComponentHit) {
-                    return nestedComponentHit;
-                }
-            }
-            return undefined;
-        };
-
-        const retriever = findByName(migrated.componentDefinitions as any[], 'rdmpGetter');
-        const targetField = findByName(migrated.componentDefinitions as any[], 'aim_project_name');
-        const retrieverPointer = findPointerByName(migrated.componentDefinitions as any[], 'rdmpGetter');
-        const sourcePointer = findPointerByName(migrated.componentDefinitions as any[], 'rdmp');
-
-        expect(retriever?.component.class).to.equal('RecordMetadataRetrieverComponent');
-        expect(retriever?.component?.config?.visible).to.equal(false);
-        expect(retriever?.component?.config?.label).to.equal(undefined);
-        expect(retriever?.layout?.config?.visible).to.equal(false);
-        expect(retriever?.layout?.config?.label).to.equal(undefined);
-        expect(retriever?.expressions).to.deep.include({
-            name: 'fetchOnFormReady-rdmpOid',
-            description: 'Fetch metadata on form load using request params',
-            config: {
-                runOnFormReady: true,
-                conditionKind: 'jsonata_query',
-                condition: '$exists(runtimeContext.requestParams.rdmpOid)',
-                operation: 'fetchMetadata',
-                hasTemplate: true,
-                template: 'runtimeContext.requestParams.rdmpOid'
-            }
-        });
-        expect(retriever?.expressions).to.deep.include({
-            name: 'fetchOnRelatedObjectSelected-rdmp',
-            description: 'Fetch metadata when rdmp changes',
-            config: {
-                conditionKind: 'jsonpointer',
-                runOnFormReady: false,
-                condition: `${sourcePointer}::field.value.changed`,
-                operation: 'fetchMetadata',
-                hasTemplate: true,
-                template: '$exists(event.value.oid) ? event.value.oid : ($exists(event.value.redboxOid) ? event.value.redboxOid : event.value)'
-            }
-        });
-        expect(targetField?.expressions).to.deep.include({
-            name: 'rdmpGetter-aim_project_name-title',
-            description: 'Populate aim_project_name from rdmpGetter metadata',
-            config: {
-                conditionKind: 'jsonpointer',
-                runOnFormReady: false,
-                condition: `${retrieverPointer}::field.value.changed`,
-                target: 'model.value',
-                hasTemplate: true,
-                template: 'event.value.title'
-            }
-        });
-    });
-
-    it('omits the form-ready RecordMetadataRetriever fetch expression when parameter metadata is missing', async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: 'record-metadata-retriever-without-parameter',
-                fields: [
-                    {
-                        class: 'RecordMetadataRetriever',
-                        compClass: 'RecordMetadataRetrieverComponent',
-                        definition: {
-                            name: 'rdmpGetter',
-                            subscribe: {
-                                parameterRetriever: {
-                                    onValueUpdate: [{ action: 'publishMetadata' }]
-                                }
-                            }
-                        }
-                    }
-                ]
-            }
-        });
-
-        const retriever = migrated.componentDefinitions.find((component) => component.name === 'rdmpGetter');
-        const expressions = retriever?.expressions ?? [];
-        expect(expressions.some((expr) => expr.name.startsWith('fetchOnFormReady-'))).to.equal(false);
-    });
-
-    it('maps RepeatableVocabComponent to RepeatableComponent with Typeahead elementTemplate', async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "repeatable-vocab-edge",
-                fields: [
-                    {
-                        class: "RepeatableContainer",
-                        compClass: "RepeatableVocabComponent",
-                        definition: {
-                            name: "foaf:fundedBy_foaf:Agent",
-                            label: "@dmpt-foaf:fundedBy_foaf:Agent",
-                            help: "@dmpt-foaf:fundedBy_foaf:Agent-help",
-                            fields: [
-                                {
-                                    class: "VocabField",
-                                    definition: {
-                                        disableEditAfterSelect: false,
-                                        vocabQueryId: "fundingBody",
-                                        sourceType: "query",
-                                        titleFieldArr: ["dc_description"],
-                                        stringLabelToField: "dc_description",
-                                        placeHolder: "@lookup-placeholder-text"
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        });
-
-        const migratedField = migrated.componentDefinitions[0];
-        expect(migratedField.component.class).to.equal("RepeatableComponent");
-        expect(migratedField.model?.class).to.equal("RepeatableModel");
-
-        const repeatableConfig = migratedField.component.config as Record<string, unknown>;
-        const elementTemplate = repeatableConfig.elementTemplate as Record<string, unknown>;
-        expect(elementTemplate).to.not.equal(undefined);
-        expect(elementTemplate.name).to.equal("");
-        expect((elementTemplate.component as Record<string, unknown>).class).to.equal("TypeaheadInputComponent");
-        expect((elementTemplate.model as Record<string, unknown>).class).to.equal("TypeaheadInputModel");
-        expect((elementTemplate.layout as Record<string, unknown>).class).to.equal("RepeatableElementLayout");
-
-        const typeaheadConfig = (elementTemplate.component as Record<string, unknown>).config as Record<string, unknown>;
-        expect(typeaheadConfig.sourceType).to.equal("namedQuery");
-        expect(typeaheadConfig.queryId).to.equal("fundingBody");
-        expect(typeaheadConfig.labelField).to.equal("dc_description");
-    });
-
-    it('maps legacy external VocabField to external TypeaheadInput config', async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "typeahead-external",
-                fields: [
-                    {
-                        class: "VocabField",
-                        compClass: "VocabFieldComponent",
-                        definition: {
-                            name: "dc:coverage_dc:identifier",
-                            sourceType: "external",
-                            provider: "geonamesCountries",
-                            resultArrayProperty: "response.docs",
-                            titleFieldArr: ["utf8_name"],
-                            fieldNames: ["utf8_name"],
-                            stringLabelToField: "utf8_name"
-                        }
-                    }
-                ]
-            }
-        });
-
-        const migratedField = migrated.componentDefinitions[0];
-        expect(migratedField.component.class).to.equal("TypeaheadInputComponent");
-        const componentConfig = migratedField.component.config as Record<string, unknown>;
-        expect(componentConfig.sourceType).to.equal("external");
-        expect(componentConfig.provider).to.equal("geonamesCountries");
-        expect(componentConfig.resultArrayProperty).to.equal("response.docs");
-        expect(componentConfig.labelField).to.equal("utf8_name");
-        expect(componentConfig.valueField).to.equal("utf8_name");
-    });
-
-    it('maps RepeatableContributor layout label from definition name when label is missing on both parent and child', async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "repeatable-contributor-label-fallback",
-                fields: [
-                    {
-                        class: "RepeatableContributor",
-                        compClass: "RepeatableContributorComponent",
-                        definition: {
-                            name: "contributor_oi",
-                            fields: [
-                                {
-                                    class: "ContributorField",
-                                    definition: {
-                                        help: "@dmpt-people-tab-otherdatacreators-help",
-                                        nameColHdr: "@dmpt-people-tab-name-hdr",
-                                        emailColHdr: "@dmpt-people-tab-email-hdr",
-                                        orcidColHdr: "@dmpt-people-tab-orcid-hdr",
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        });
-
-        const migratedField = migrated.componentDefinitions[0];
-        expect(migratedField.component.class).to.equal("RepeatableComponent");
-        expect(migratedField.layout?.class).to.equal("DefaultLayout");
-        expect((migratedField.layout?.config as Record<string, unknown>)?.label).to.equal("contributor_oi");
-    });
-
-    it('maps RepeatableContributor layout label from inner field label when parent label is missing', async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "repeatable-contributor-label-inner-fallback",
-                fields: [
-                    {
-                        class: "RepeatableContributor",
-                        compClass: "RepeatableContributorComponent",
-                        definition: {
-                            name: "contributor_oi",
-                            fields: [
-                                {
-                                    class: "ContributorField",
-                                    definition: {
-                                        label: "@dmpt-people-tab-otherdatacreators",
-                                        help: "@dmpt-people-tab-otherdatacreators-help",
-                                        nameColHdr: "@dmpt-people-tab-name-hdr",
-                                        emailColHdr: "@dmpt-people-tab-email-hdr",
-                                        orcidColHdr: "@dmpt-people-tab-orcid-hdr",
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        });
-
-        const migratedField = migrated.componentDefinitions[0];
-        expect(migratedField.component.class).to.equal("RepeatableComponent");
-        expect(migratedField.layout?.class).to.equal("DefaultLayout");
-        expect((migratedField.layout?.config as Record<string, unknown>)?.label).to.equal("@dmpt-people-tab-otherdatacreators");
-    });
-
-    it('maps legacy ContributorField with forceLookupOnly to the lookup-only reusable definition', async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "contributor-force-lookup-only",
-                fields: [
-                    {
-                        class: "ContributorField",
-                        definition: {
-                            name: "contributor_ci",
-                            forceLookupOnly: true
-                        }
-                    }
-                ]
-            }
-        });
-
-        const migratedField = migrated.componentDefinitions[0];
-        expect(migratedField.component.class).to.equal("ReusableComponent");
-        expect(migratedField.overrides).to.deep.equal({
-            reusableFormName: "standard-contributor-fields-lookup-only-group"
-        });
-        expect(migratedField.layout).to.equal(undefined);
-    });
-
-    it('defines lookup-only contributor reusable fields with required selection and readonly email', async function () {
-        const lookupOnlyFields = reusableFormDefinitions["standard-contributor-fields-lookup-only"];
-        expect(lookupOnlyFields).to.have.length(3);
-
-        const nameField = lookupOnlyFields[0];
-        if (nameField.component?.class === "ReusableComponent") {
-          expect(nameField.component?.config?.componentDefinitions).to.have.length(1);
-          expect((nameField.component?.config?.componentDefinitions[0].component.config as Record<string, unknown>)?.requireSelection).to.be.true;
-        } else {
-          expect((nameField.component?.config as Record<string, unknown>)?.requireSelection).to.be.true;
-        }
-
-        const emailField = lookupOnlyFields[1];
-        if (emailField.component?.class === "ReusableComponent") {
-          expect(emailField.component?.config?.componentDefinitions).to.have.length(1);
-          expect((emailField.component?.config?.componentDefinitions[0].component.config as Record<string, unknown>)?.readonly).to.be.true;
-        } else {
-          expect((emailField.component?.config as Record<string, unknown>)?.requireSelection).to.be.true;
-        }
-
-        const withTitleGroup = reusableFormDefinitions["standard-contributor-fields-with-title-lookup-only-group"];
-        expect(withTitleGroup).to.have.length(1);
-        expect(
-            ((withTitleGroup[0].component?.config as Record<string, unknown>)?.componentDefinitions as Array<Record<string, unknown>>)?.[0]?.overrides
-        ).to.deep.equal({
-            reusableFormName: "standard-contributor-fields-with-title-lookup-only"
-        });
-    });
-
-    it("maps legacy MapField to MapComponent and normalizes config/value", async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "map-migration",
-                fields: [
-                    {
-                        class: "MapField",
-                        compClass: "MapComponent",
-                        definition: {
-                            name: "map_coverage",
-                            leafletOptions: {
-                                center: [-24.67, 134.07],
-                                zoom: 5
+                          name: 'rdmpGetter',
+                          subscribe: {
+                            parameterRetriever: {
+                              onValueUpdate: [{ action: 'publishMetadata' }],
                             },
-                            drawOptions: {
-                                draw: {
-                                    marker: {},
-                                    polygon: {},
-                                    polyline: false,
-                                    rectangle: {}
-                                },
-                                edit: {}
-                            }
+                            rdmp: {
+                              relatedObjectSelected: [{ action: 'publishMetadata' }],
+                            },
+                          },
                         },
-                        value: {}
-                    }
-                ]
-            }
-        });
-
-        const migratedField = migrated.componentDefinitions[0];
-        expect(migratedField.component.class).to.equal("MapComponent");
-        expect(migratedField.model?.class).to.equal("MapModel");
-        const componentConfig = migratedField.component.config as Record<string, unknown>;
-        expect(componentConfig.center).to.deep.equal([-24.67, 134.07]);
-        expect(componentConfig.zoom).to.equal(5);
-        expect(componentConfig.enabledModes).to.deep.equal(["point", "polygon", "rectangle", "select"]);
-        const modelConfig = migratedField.model?.config as Record<string, unknown>;
-        expect(modelConfig.defaultValue).to.deep.equal({
-            type: "FeatureCollection",
-            features: []
-        });
-    });
-
-    it("migrates ButtonBarContainer as expected", async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "button-bar-migration",
-                fields: [
-                    {
-                        class: "ButtonBarContainer",
-                        compClass: "ButtonBarContainerComponent",
+                      },
+                      {
+                        class: 'TextField',
                         definition: {
-                            name: "buttons",
-                            fields: [
+                          name: 'aim_project_name',
+                          subscribe: {
+                            rdmpGetter: {
+                              onValueUpdate: [
                                 {
-                                    class: "SaveButton",
-                                    definition: { name: "save" }
+                                  action: 'utilityService.getPropertyFromObject',
+                                  field: 'title',
                                 },
-                                {
-                                    class: "Spacer",
-                                    definition: { name: "spacer" }
-                                },
-                                {
-                                    class: "CancelButton",
-                                    definition: { name: "cancel" }
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        });
-
-        expect(migrated.componentDefinitions).to.have.length.greaterThan(0);
-        const migratedField = migrated.componentDefinitions[0];
-        expect(migratedField.component.class).to.equal("GroupComponent");
-        expect(migratedField.model?.class).to.equal("GroupModel");
-        expect(migratedField.layout?.class).to.equal("ActionRowLayout");
-
-        const componentConfig = migratedField.component.config as Record<string, unknown>;
-        expect(componentConfig.hostCssClasses).to.be.undefined;
-
-        const childComponents = componentConfig.componentDefinitions as any[];
-        expect(childComponents).to.have.length(2);
-        expect(childComponents[0].name).to.equal("save");
-        expect(childComponents[0].layout?.class).to.equal("InlineLayout");
-        expect(childComponents[0].layout?.config?.label).to.be.undefined;
-        expect(childComponents[1].name).to.equal("cancel");
-        expect(childComponents[1].layout?.class).to.equal("InlineLayout");
-        expect(childComponents[1].layout?.config?.label).to.be.undefined;
-        expect(childComponents.find(c => c.name === "spacer")).to.be.undefined;
-
-        const modelConfig = migratedField.model?.config as Record<string, unknown>;
-        expect(modelConfig.disabled).to.be.true;
+                              ],
+                            },
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
     });
 
-    it("migrates SaveButton targetStep into the v5 component config", async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "save-button-target-step-migration",
-                fields: [
-                    {
-                        class: "SaveButton",
-                        definition: {
-                            name: "save-and-submit",
-                            targetStep: "queued"
-                        }
-                    }
-                ]
-            }
-        });
+    const findByName = (components: any[], name: string): any => {
+      for (const component of components ?? []) {
+        if (component?.name === name) {
+          return component;
+        }
+        const nestedTabs = component?.component?.config?.tabs ?? [];
+        const nestedTabHit = findByName(nestedTabs, name);
+        if (nestedTabHit) {
+          return nestedTabHit;
+        }
+        const nestedComponents = component?.component?.config?.componentDefinitions ?? [];
+        const nestedComponentHit = findByName(nestedComponents, name);
+        if (nestedComponentHit) {
+          return nestedComponentHit;
+        }
+      }
+      return undefined;
+    };
 
-        expect(migrated.componentDefinitions).to.have.length.greaterThan(0);
-        const migratedField = migrated.componentDefinitions[0];
-        expect(migratedField.component.class).to.equal("SaveButtonComponent");
-        expect((migratedField.component.config as Record<string, unknown>)?.targetStep).to.equal("queued");
+    const findPointerByName = (components: any[], name: string, parentPointer = ''): string | undefined => {
+      for (const component of components ?? []) {
+        const currentPointer = `${parentPointer}/${component?.name}`;
+        if (component?.name === name) {
+          return currentPointer;
+        }
+        const nestedTabs = component?.component?.config?.tabs ?? [];
+        const nestedTabHit = findPointerByName(nestedTabs, name, currentPointer);
+        if (nestedTabHit) {
+          return nestedTabHit;
+        }
+        const nestedComponents = component?.component?.config?.componentDefinitions ?? [];
+        const nestedComponentHit = findPointerByName(nestedComponents, name, currentPointer);
+        if (nestedComponentHit) {
+          return nestedComponentHit;
+        }
+      }
+      return undefined;
+    };
+
+    const retriever = findByName(migrated.componentDefinitions as any[], 'rdmpGetter');
+    const targetField = findByName(migrated.componentDefinitions as any[], 'aim_project_name');
+    const retrieverPointer = findPointerByName(migrated.componentDefinitions as any[], 'rdmpGetter');
+    const sourcePointer = findPointerByName(migrated.componentDefinitions as any[], 'rdmp');
+
+    expect(retriever?.component.class).to.equal('RecordMetadataRetrieverComponent');
+    expect(retriever?.component?.config?.visible).to.equal(false);
+    expect(retriever?.component?.config?.label).to.equal(undefined);
+    expect(retriever?.layout?.config?.visible).to.equal(false);
+    expect(retriever?.layout?.config?.label).to.equal(undefined);
+    expect(retriever?.expressions).to.deep.include({
+      name: 'fetchOnFormReady-rdmpOid',
+      description: 'Fetch metadata on form load using request params',
+      config: {
+        runOnFormReady: true,
+        conditionKind: 'jsonata_query',
+        condition: '$exists(runtimeContext.requestParams.rdmpOid)',
+        operation: 'fetchMetadata',
+        hasTemplate: true,
+        template: 'runtimeContext.requestParams.rdmpOid',
+      },
+    });
+    expect(retriever?.expressions).to.deep.include({
+      name: 'fetchOnRelatedObjectSelected-rdmp',
+      description: 'Fetch metadata when rdmp changes',
+      config: {
+        conditionKind: 'jsonpointer',
+        runOnFormReady: false,
+        condition: `${sourcePointer}::field.value.changed`,
+        operation: 'fetchMetadata',
+        hasTemplate: true,
+        template:
+          '$exists(event.value.oid) ? event.value.oid : ($exists(event.value.redboxOid) ? event.value.redboxOid : event.value)',
+      },
+    });
+    expect(targetField?.expressions).to.deep.include({
+      name: 'rdmpGetter-aim_project_name-title',
+      description: 'Populate aim_project_name from rdmpGetter metadata',
+      config: {
+        conditionKind: 'jsonpointer',
+        runOnFormReady: false,
+        condition: `${retrieverPointer}::field.value.changed`,
+        target: 'model.value',
+        hasTemplate: true,
+        template: 'event.value.title',
+      },
+    });
+  });
+
+  it('omits the form-ready RecordMetadataRetriever fetch expression when parameter metadata is missing', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'record-metadata-retriever-without-parameter',
+        fields: [
+          {
+            class: 'RecordMetadataRetriever',
+            compClass: 'RecordMetadataRetrieverComponent',
+            definition: {
+              name: 'rdmpGetter',
+              subscribe: {
+                parameterRetriever: {
+                  onValueUpdate: [{ action: 'publishMetadata' }],
+                },
+              },
+            },
+          },
+        ],
+      },
     });
 
-    it("maps AnchorOrButton links to ContentComponent anchor links with InlineLayout", async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "anchor-or-button-migration",
-                fields: [
-                    {
-                        class: "Container",
-                        compClass: "GenericGroupComponent",
-                        definition: {
-                            name: "link_group",
-                            fields: [
-                                {
-                                    class: "AnchorOrButton",
-                                    definition: {
-                                        name: "edit_link",
-                                        label: "@dmp-edit-record-link",
-                                        value: "/@branding/@portal/record/edit/@oid",
-                                        cssClasses: "btn btn-info",
-                                        controlType: "anchor"
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        });
+    const retriever = migrated.componentDefinitions.find(component => component.name === 'rdmpGetter');
+    const expressions = retriever?.expressions ?? [];
+    expect(expressions.some(expr => expr.name.startsWith('fetchOnFormReady-'))).to.equal(false);
+  });
 
-        const group = migrated.componentDefinitions[0];
-        const groupConfig = group.component.config as Record<string, unknown>;
-        const childComponents = groupConfig.componentDefinitions as any[];
-        expect(childComponents).to.have.length(1);
-        expect(childComponents[0].component.class).to.equal("ContentComponent");
-        expect(childComponents[0].component.config?.label).to.be.undefined;
-        expect(childComponents[0].component.config?.template).to.equal(
-          '<a href="{{concat "/" branding "/" portal "/record/edit/" oid}}" class="{{content.cssClasses}}">{{t content.label}}</a>'
-        );
-        expect(childComponents[0].layout?.class).to.equal("InlineLayout");
+  it('maps RepeatableVocabComponent to RepeatableComponent with Typeahead elementTemplate', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'repeatable-vocab-edge',
+        fields: [
+          {
+            class: 'RepeatableContainer',
+            compClass: 'RepeatableVocabComponent',
+            definition: {
+              name: 'foaf:fundedBy_foaf:Agent',
+              label: '@dmpt-foaf:fundedBy_foaf:Agent',
+              help: '@dmpt-foaf:fundedBy_foaf:Agent-help',
+              fields: [
+                {
+                  class: 'VocabField',
+                  definition: {
+                    disableEditAfterSelect: false,
+                    vocabQueryId: 'fundingBody',
+                    sourceType: 'query',
+                    titleFieldArr: ['dc_description'],
+                    stringLabelToField: 'dc_description',
+                    placeHolder: '@lookup-placeholder-text',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
     });
 
-    it("maps legacy delete button redirectLocation tokens to a Handlebars template", async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "delete-button-migration",
-                fields: [
-                    {
-                        class: "SaveButton",
-                        definition: {
-                            name: "confirmDelete",
-                            label: "Delete this record",
-                            closeOnSave: true,
-                            redirectLocation: "/@branding/@portal/dashboard/dataPublication",
-                            isDelete: true
-                        }
-                    }
-                ]
-            }
-        });
+    const migratedField = migrated.componentDefinitions[0];
+    expect(migratedField.component.class).to.equal('RepeatableComponent');
+    expect(migratedField.model?.class).to.equal('RepeatableModel');
 
-        expect(migrated.componentDefinitions[0].component.class).to.equal("DeleteButtonComponent");
-        const deleteButtonConfig = migrated.componentDefinitions[0].component.config as any;
-        expect(deleteButtonConfig?.closeOnDelete).to.be.true;
-        expect(deleteButtonConfig?.redirectLocation).to.equal(
-          '{{concat "/" branding "/" portal "/dashboard/dataPublication"}}'
-        );
+    const repeatableConfig = migratedField.component.config as Record<string, unknown>;
+    const elementTemplate = repeatableConfig.elementTemplate as Record<string, unknown>;
+    expect(elementTemplate).to.not.equal(undefined);
+    expect(elementTemplate.name).to.equal('');
+    expect((elementTemplate.component as Record<string, unknown>).class).to.equal('TypeaheadInputComponent');
+    expect((elementTemplate.model as Record<string, unknown>).class).to.equal('TypeaheadInputModel');
+    expect((elementTemplate.layout as Record<string, unknown>).class).to.equal('RepeatableElementLayout');
+
+    const typeaheadConfig = (elementTemplate.component as Record<string, unknown>).config as Record<string, unknown>;
+    expect(typeaheadConfig.sourceType).to.equal('namedQuery');
+    expect(typeaheadConfig.queryId).to.equal('fundingBody');
+    expect(typeaheadConfig.labelField).to.equal('dc_description');
+  });
+
+  it('preserves canSort on migrated repeatable components', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'repeatable-sortable',
+        fields: [
+          {
+            class: 'RepeatableContainer',
+            compClass: 'RepeatableTextfieldComponent',
+            definition: {
+              name: 'sortable_people',
+              canSort: true,
+              fields: [
+                {
+                  class: 'TextField',
+                  definition: {
+                    name: 'name',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
     });
 
-    it("maps legacy form-inline groups to ActionRowLayout with InlineLayout children", async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "inline-group-migration",
-                fields: [
-                    {
-                        class: "Container",
-                        compClass: "GenericGroupComponent",
-                        definition: {
-                            name: "actions",
-                            cssClasses: "form-inline",
-                            fields: [
-                                {
-                                    class: "AnchorOrButton",
-                                    definition: {
-                                        name: "edit_link",
-                                        label: "@dmp-edit-record-link"
-                                    }
-                                },
-                                {
-                                    class: "PDFList",
-                                    definition: {
-                                        name: "pdf"
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        });
+    const migratedField = migrated.componentDefinitions[0];
+    expect((migratedField.component.config as Record<string, unknown>).canSort).to.equal(true);
+  });
 
-        const group = migrated.componentDefinitions[0];
-        const groupConfig = group.component.config as Record<string, unknown>;
-        const childComponents = groupConfig.componentDefinitions as any[];
-
-        expect(group.layout?.class).to.equal("ActionRowLayout");
-        const groupLayoutConfig = (group.layout?.config ?? {}) as Record<string, unknown>;
-        expect(groupLayoutConfig.alignment).to.equal("start");
-        expect(groupLayoutConfig.compact).to.equal(true);
-        expect(groupLayoutConfig.containerCssClass).to.contain("rb-form-action-row--legacy-inline");
-        expect(group.overrides?.formModeClasses?.view?.component).to.equal("GroupComponent");
-        expect(childComponents).to.have.length(2);
-        expect(childComponents[0].layout?.class).to.equal("InlineLayout");
-        expect(childComponents[1].layout?.class).to.equal("InlineLayout");
+  it('maps legacy external VocabField to external TypeaheadInput config', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'typeahead-external',
+        fields: [
+          {
+            class: 'VocabField',
+            compClass: 'VocabFieldComponent',
+            definition: {
+              name: 'dc:coverage_dc:identifier',
+              sourceType: 'external',
+              provider: 'geonamesCountries',
+              resultArrayProperty: 'response.docs',
+              titleFieldArr: ['utf8_name'],
+              fieldNames: ['utf8_name'],
+              stringLabelToField: 'utf8_name',
+            },
+          },
+        ],
+      },
     });
 
-    it("uses Handlebars translation helper for migrated TextBlock translation keys", async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "text-block-translation-key",
-                fields: [
-                    {
-                        class: "Container",
-                        compClass: "TextBlockComponent",
-                        definition: {
-                            name: "welcome_text",
-                            value: "@dmpt-welcome-par2"
-                        }
-                    }
-                ]
-            }
-        });
+    const migratedField = migrated.componentDefinitions[0];
+    expect(migratedField.component.class).to.equal('TypeaheadInputComponent');
+    const componentConfig = migratedField.component.config as Record<string, unknown>;
+    expect(componentConfig.sourceType).to.equal('external');
+    expect(componentConfig.provider).to.equal('geonamesCountries');
+    expect(componentConfig.resultArrayProperty).to.equal('response.docs');
+    expect(componentConfig.labelField).to.equal('utf8_name');
+    expect(componentConfig.valueField).to.equal('utf8_name');
+  });
 
-        const migratedField = migrated.componentDefinitions[0];
-        expect(migratedField.component.class).to.equal("ContentComponent");
-        const componentConfig = migratedField.component.config as Record<string, unknown>;
-        expect(componentConfig.content).to.equal("@dmpt-welcome-par2");
-        expect(componentConfig.template).to.equal("<div>{{{t content}}}</div>");
+  it('maps RepeatableContributor layout label from definition name when label is missing on both parent and child', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'repeatable-contributor-label-fallback',
+        fields: [
+          {
+            class: 'RepeatableContributor',
+            compClass: 'RepeatableContributorComponent',
+            definition: {
+              name: 'contributor_oi',
+              fields: [
+                {
+                  class: 'ContributorField',
+                  definition: {
+                    help: '@dmpt-people-tab-otherdatacreators-help',
+                    nameColHdr: '@dmpt-people-tab-name-hdr',
+                    emailColHdr: '@dmpt-people-tab-email-hdr',
+                    orcidColHdr: '@dmpt-people-tab-orcid-hdr',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
     });
 
-    it("uses heading wrapper from TextBlock type for heading content", async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "text-block-heading-type",
-                fields: [
-                    {
-                        class: "Container",
-                        compClass: "TextBlockComponent",
-                        definition: {
-                            name: "welcome_heading",
-                            value: "@dmpt-welcome-heading",
-                            type: "h3"
-                        }
-                    }
-                ]
-            }
-        });
+    const migratedField = migrated.componentDefinitions[0];
+    expect(migratedField.component.class).to.equal('RepeatableComponent');
+    expect(migratedField.layout?.class).to.equal('DefaultLayout');
+    expect((migratedField.layout?.config as Record<string, unknown>)?.label).to.equal('contributor_oi');
+  });
 
-        const migratedField = migrated.componentDefinitions[0];
-        expect(migratedField.component.class).to.equal("ContentComponent");
-        const componentConfig = migratedField.component.config as Record<string, unknown>;
-        expect(componentConfig.content).to.equal("@dmpt-welcome-heading");
-        expect(componentConfig.template).to.equal("<h3>{{t content}}</h3>");
+  it('maps RepeatableContributor layout label from inner field label when parent label is missing', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'repeatable-contributor-label-inner-fallback',
+        fields: [
+          {
+            class: 'RepeatableContributor',
+            compClass: 'RepeatableContributorComponent',
+            definition: {
+              name: 'contributor_oi',
+              fields: [
+                {
+                  class: 'ContributorField',
+                  definition: {
+                    label: '@dmpt-people-tab-otherdatacreators',
+                    help: '@dmpt-people-tab-otherdatacreators-help',
+                    nameColHdr: '@dmpt-people-tab-name-hdr',
+                    emailColHdr: '@dmpt-people-tab-email-hdr',
+                    orcidColHdr: '@dmpt-people-tab-orcid-hdr',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
     });
 
-    it("binds TextBlock heading content from formData when value is missing and definition.name is present", async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "text-block-heading-name-binding",
-                fields: [
-                    {
-                        class: "Container",
-                        compClass: "TextBlockComponent",
-                        viewOnly: true,
-                        definition: {
-                            name: "title",
-                            type: "h1"
-                        }
-                    }
-                ]
-            }
-        });
+    const migratedField = migrated.componentDefinitions[0];
+    expect(migratedField.component.class).to.equal('RepeatableComponent');
+    expect(migratedField.layout?.class).to.equal('DefaultLayout');
+    expect((migratedField.layout?.config as Record<string, unknown>)?.label).to.equal(
+      '@dmpt-people-tab-otherdatacreators'
+    );
+  });
 
-        const migratedField = migrated.componentDefinitions[0];
-        const hiddenBindingField = migrated.componentDefinitions[1];
-        expect(migratedField.component.class).to.equal("ContentComponent");
-        const componentConfig = migratedField.component.config as Record<string, unknown>;
-        const layoutConfig = migratedField.layout?.config as Record<string, unknown> | undefined;
-        expect(migratedField.name).to.not.equal("title");
-        expect(componentConfig.content).to.equal("title");
-        expect(componentConfig.template).to.equal('<h1>{{get formData content ""}}</h1>');
-        expect(layoutConfig?.label).to.equal(undefined);
-        expect(hiddenBindingField.name).to.equal("title");
-        expect(hiddenBindingField.component.class).to.equal("SimpleInputComponent");
-        expect((hiddenBindingField.constraints as Record<string, unknown>)?.allowModes).to.deep.equal(["view"]);
-        expect(
-            ((hiddenBindingField.constraints as Record<string, unknown>)?.authorization as Record<string, unknown>)?.allowRoles
-        ).to.deep.equal([]);
-        expect((hiddenBindingField.component.config as Record<string, unknown>)?.type).to.equal("hidden");
-        expect((hiddenBindingField.component.config as Record<string, unknown>)?.visible).to.equal(false);
-        expect((hiddenBindingField.layout?.config as Record<string, unknown>)?.visible).to.equal(false);
+  it('maps legacy ContributorField with forceLookupOnly to the lookup-only reusable definition', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'contributor-force-lookup-only',
+        fields: [
+          {
+            class: 'ContributorField',
+            definition: {
+              name: 'contributor_ci',
+              forceLookupOnly: true,
+            },
+          },
+        ],
+      },
     });
 
-    it("maps view-only markdown text areas to ContentComponent in view overrides", async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "markdown-view-only",
-                fields: [
-                    {
-                        class: "MarkdownTextArea",
-                        viewOnly: true,
-                        definition: {
-                            name: "description",
-                            label: "Description"
-                        }
-                    }
-                ]
-            }
-        });
+    const migratedField = migrated.componentDefinitions[0];
+    expect(migratedField.component.class).to.equal('ReusableComponent');
+    expect(migratedField.overrides).to.deep.equal({
+      reusableFormName: 'standard-contributor-fields-lookup-only-group',
+    });
+    expect(migratedField.layout).to.equal(undefined);
+  });
 
-        const migratedField = migrated.componentDefinitions[0];
-        expect(migratedField.component.class).to.equal("RichTextEditorComponent");
-        expect((migratedField.component.config as Record<string, unknown>)?.outputFormat).to.equal("markdown");
-        expect((migratedField.constraints as Record<string, unknown>)?.allowModes).to.deep.equal(["view"]);
-        expect(migratedField.overrides?.formModeClasses?.view?.component).to.equal("ContentComponent");
+  it('defines lookup-only contributor reusable fields with required selection and readonly email', async function () {
+    const lookupOnlyFields = reusableFormDefinitions['standard-contributor-fields-lookup-only'];
+    expect(lookupOnlyFields).to.have.length(3);
+
+    const nameField = lookupOnlyFields[0];
+    if (nameField.component?.class === 'ReusableComponent') {
+      expect(nameField.component?.config?.componentDefinitions).to.have.length(1);
+      expect(
+        (nameField.component?.config?.componentDefinitions[0].component.config as Record<string, unknown>)
+          ?.requireSelection
+      ).to.be.true;
+    } else {
+      expect((nameField.component?.config as Record<string, unknown>)?.requireSelection).to.be.true;
+    }
+
+    const emailField = lookupOnlyFields[1];
+    if (emailField.component?.class === 'ReusableComponent') {
+      expect(emailField.component?.config?.componentDefinitions).to.have.length(1);
+      expect(
+        (emailField.component?.config?.componentDefinitions[0].component.config as Record<string, unknown>)?.readonly
+      ).to.be.true;
+    } else {
+      expect((emailField.component?.config as Record<string, unknown>)?.requireSelection).to.be.true;
+    }
+
+    const withTitleGroup = reusableFormDefinitions['standard-contributor-fields-with-title-lookup-only-group'];
+    expect(withTitleGroup).to.have.length(1);
+    expect(
+      (
+        (withTitleGroup[0].component?.config as Record<string, unknown>)?.componentDefinitions as Array<
+          Record<string, unknown>
+        >
+      )?.[0]?.overrides
+    ).to.deep.equal({
+      reusableFormName: 'standard-contributor-fields-with-title-lookup-only',
+    });
+  });
+
+  it('defines citation contributor reusable fields with family and given names', async function () {
+    const citationContributor = reusableFormDefinitions['citation-contributor-fields-with-title-family-given-group'];
+    expect(citationContributor).to.have.length(1);
+
+    const group = citationContributor[0];
+    expect(group.name).to.equal('citation_contributor_fields_with_title_family_given_group');
+    expect(group.component?.class).to.equal('GroupComponent');
+    expect((group.component?.config as Record<string, unknown>)?.hostCssClasses).to.contain(
+      'rb-form-contributor-inline'
+    );
+
+    const fields = (group.component?.config as Record<string, unknown>)?.componentDefinitions as Array<any>;
+    expect(fields.map(field => field.name)).to.deep.equal([
+      'citation_contributor_field_title',
+      'citation_contributor_field_family_name',
+      'given_name',
+      'citation_contributor_field_email',
+      'citation_contributor_field_orcid',
+    ]);
+
+    const titleOverride = fields[0].component.config.componentDefinitions[0];
+    expect(titleOverride.overrides).to.deep.equal({ replaceName: 'honorific' });
+    expect(titleOverride.component.config.onItemSelect).to.deep.equal({ rawPath: 'metadata.title' });
+
+    const familyNameOverride = fields[1].component.config.componentDefinitions[0];
+    expect(familyNameOverride.overrides).to.deep.equal({ replaceName: 'family_name' });
+    expect(familyNameOverride.component.config.onItemSelect).to.deep.equal({ rawPath: 'metadata.familyName' });
+    expect(familyNameOverride.layout.config.label).to.equal('@dmpt-people-family-hdr');
+
+    expect(fields[2].name).to.equal('given_name');
+    expect(fields[2].component.config.onItemSelect).to.deep.equal({ rawPath: 'metadata.givenName' });
+    expect(fields[2].layout.config.label).to.equal('@dmpt-people-given-hdr');
+  });
+
+  it('maps legacy MapField to MapComponent and normalizes config/value', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'map-migration',
+        fields: [
+          {
+            class: 'MapField',
+            compClass: 'MapComponent',
+            definition: {
+              name: 'map_coverage',
+              leafletOptions: {
+                center: [-24.67, 134.07],
+                zoom: 5,
+              },
+              drawOptions: {
+                draw: {
+                  marker: {},
+                  polygon: {},
+                  polyline: false,
+                  rectangle: {},
+                },
+                edit: {},
+              },
+            },
+            value: {},
+          },
+        ],
+      },
     });
 
-    it("keeps plain text TextBlock values as non-translated content templates", async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "text-block-plain-text",
-                fields: [
-                    {
-                        class: "Container",
-                        compClass: "TextBlockComponent",
-                        definition: {
-                            name: "welcome_text_plain",
-                            value: "Welcome to the form"
-                        }
-                    }
-                ]
-            }
-        });
+    const migratedField = migrated.componentDefinitions[0];
+    expect(migratedField.component.class).to.equal('MapComponent');
+    expect(migratedField.model?.class).to.equal('MapModel');
+    const componentConfig = migratedField.component.config as Record<string, unknown>;
+    expect(componentConfig.center).to.deep.equal([-24.67, 134.07]);
+    expect(componentConfig.zoom).to.equal(5);
+    expect(componentConfig.enabledModes).to.deep.equal(['point', 'polygon', 'rectangle', 'select']);
+    const modelConfig = migratedField.model?.config as Record<string, unknown>;
+    expect(modelConfig.defaultValue).to.deep.equal({
+      type: 'FeatureCollection',
+      features: [],
+    });
+  });
 
-        const migratedField = migrated.componentDefinitions[0];
-        expect(migratedField.component.class).to.equal("ContentComponent");
-        const componentConfig = migratedField.component.config as Record<string, unknown>;
-        expect(componentConfig.content).to.equal("Welcome to the form");
-        expect(componentConfig.template).to.equal("<div>{{{content}}}</div>");
+  it('migrates ButtonBarContainer as expected', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'button-bar-migration',
+        fields: [
+          {
+            class: 'ButtonBarContainer',
+            compClass: 'ButtonBarContainerComponent',
+            definition: {
+              name: 'buttons',
+              fields: [
+                {
+                  class: 'SaveButton',
+                  definition: { name: 'save' },
+                },
+                {
+                  class: 'Spacer',
+                  definition: { name: 'spacer' },
+                },
+                {
+                  class: 'CancelButton',
+                  definition: { name: 'cancel' },
+                },
+              ],
+            },
+          },
+        ],
+      },
     });
 
-    it("promotes legacy TextBlock span label/help blocks into layout label config", async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "text-block-span-label-help",
-                fields: [
-                    {
-                        class: "Container",
-                        compClass: "TextBlockComponent",
-                        definition: {
-                            value: "@dmpt-people-tab-ci",
-                            help: "@dmpt-people-tab-ci-help",
-                            type: "span",
-                            cssClasses: "label-font"
-                        }
-                    }
-                ]
-            }
-        });
+    expect(migrated.componentDefinitions).to.have.length.greaterThan(0);
+    const migratedField = migrated.componentDefinitions[0];
+    expect(migratedField.component.class).to.equal('GroupComponent');
+    expect(migratedField.model?.class).to.equal('GroupModel');
+    expect(migratedField.layout?.class).to.equal('ActionRowLayout');
 
-        const migratedField = migrated.componentDefinitions[0];
-        expect(migratedField.component.class).to.equal("ContentComponent");
-        const componentConfig = migratedField.component.config as Record<string, unknown>;
-        const layoutConfig = migratedField.layout?.config as Record<string, unknown>;
+    const componentConfig = migratedField.component.config as Record<string, unknown>;
+    expect(componentConfig.hostCssClasses).to.be.undefined;
 
-        expect(componentConfig.content).to.equal("");
-        expect(layoutConfig.label).to.equal("@dmpt-people-tab-ci");
-        expect(layoutConfig.helpText).to.equal("@dmpt-people-tab-ci-help");
-        expect(layoutConfig.cssClassesMap).to.deep.equal({ label: "label-font" });
+    const childComponents = componentConfig.componentDefinitions as any[];
+    expect(childComponents).to.have.length(2);
+    expect(childComponents[0].name).to.equal('save');
+    expect(childComponents[0].layout?.class).to.equal('InlineLayout');
+    expect(childComponents[0].layout?.config?.label).to.be.undefined;
+    expect(childComponents[1].name).to.equal('cancel');
+    expect(childComponents[1].layout?.class).to.equal('InlineLayout');
+    expect(childComponents[1].layout?.config?.label).to.be.undefined;
+    expect(childComponents.find(c => c.name === 'spacer')).to.be.undefined;
+
+    const modelConfig = migratedField.model?.config as Record<string, unknown>;
+    expect(modelConfig.disabled).to.be.true;
+  });
+
+  it('migrates SaveButton targetStep into the v5 component config', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'save-button-target-step-migration',
+        fields: [
+          {
+            class: 'SaveButton',
+            definition: {
+              name: 'save-and-submit',
+              targetStep: 'queued',
+            },
+          },
+        ],
+      },
     });
 
-    it("populates attachmentFields from FileUpload components", async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "attachment-fields-migration",
-                fields: [
-                    {
-                        class: "DataLocation",
-                        compClass: "DataLocationComponent",
-                        definition: {
-                            name: "dataLocations"
-                        }
+    expect(migrated.componentDefinitions).to.have.length.greaterThan(0);
+    const migratedField = migrated.componentDefinitions[0];
+    expect(migratedField.component.class).to.equal('SaveButtonComponent');
+    expect((migratedField.component.config as Record<string, unknown>)?.targetStep).to.equal('queued');
+  });
+
+  it('maps AnchorOrButton links to ContentComponent anchor links with InlineLayout', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'anchor-or-button-migration',
+        fields: [
+          {
+            class: 'Container',
+            compClass: 'GenericGroupComponent',
+            definition: {
+              name: 'link_group',
+              fields: [
+                {
+                  class: 'AnchorOrButton',
+                  definition: {
+                    name: 'edit_link',
+                    label: '@dmp-edit-record-link',
+                    value: '/@branding/@portal/record/edit/@oid',
+                    cssClasses: 'btn btn-info',
+                    controlType: 'anchor',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    const group = migrated.componentDefinitions[0];
+    const groupConfig = group.component.config as Record<string, unknown>;
+    const childComponents = groupConfig.componentDefinitions as any[];
+    expect(childComponents).to.have.length(1);
+    expect(childComponents[0].component.class).to.equal('ContentComponent');
+    expect(childComponents[0].component.config?.label).to.be.undefined;
+    expect(childComponents[0].component.config?.template).to.equal(
+      '<a href="{{concat "/" branding "/" portal "/record/edit/" oid}}" class="{{content.cssClasses}}">{{t content.label}}</a>'
+    );
+    expect(childComponents[0].layout?.class).to.equal('InlineLayout');
+  });
+
+  it('maps legacy delete button redirectLocation tokens to a Handlebars template', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'delete-button-migration',
+        fields: [
+          {
+            class: 'SaveButton',
+            definition: {
+              name: 'confirmDelete',
+              label: 'Delete this record',
+              closeOnSave: true,
+              redirectLocation: '/@branding/@portal/dashboard/dataPublication',
+              isDelete: true,
+            },
+          },
+        ],
+      },
+    });
+
+    expect(migrated.componentDefinitions[0].component.class).to.equal('DeleteButtonComponent');
+    const deleteButtonConfig = migrated.componentDefinitions[0].component.config as any;
+    expect(deleteButtonConfig?.closeOnDelete).to.be.true;
+    expect(deleteButtonConfig?.redirectLocation).to.equal(
+      '{{concat "/" branding "/" portal "/dashboard/dataPublication"}}'
+    );
+  });
+
+  it('maps legacy form-inline groups to ActionRowLayout with InlineLayout children', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'inline-group-migration',
+        fields: [
+          {
+            class: 'Container',
+            compClass: 'GenericGroupComponent',
+            definition: {
+              name: 'actions',
+              cssClasses: 'form-inline',
+              fields: [
+                {
+                  class: 'AnchorOrButton',
+                  definition: {
+                    name: 'edit_link',
+                    label: '@dmp-edit-record-link',
+                  },
+                },
+                {
+                  class: 'PDFList',
+                  definition: {
+                    name: 'pdf',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    const group = migrated.componentDefinitions[0];
+    const groupConfig = group.component.config as Record<string, unknown>;
+    const childComponents = groupConfig.componentDefinitions as any[];
+
+    expect(group.layout?.class).to.equal('ActionRowLayout');
+    const groupLayoutConfig = (group.layout?.config ?? {}) as Record<string, unknown>;
+    expect(groupLayoutConfig.alignment).to.equal('start');
+    expect(groupLayoutConfig.compact).to.equal(true);
+    expect(groupLayoutConfig.containerCssClass).to.contain('rb-form-action-row--legacy-inline');
+    expect(group.overrides?.formModeClasses?.view?.component).to.equal('GroupComponent');
+    expect(childComponents).to.have.length(2);
+    expect(childComponents[0].layout?.class).to.equal('InlineLayout');
+    expect(childComponents[1].layout?.class).to.equal('InlineLayout');
+  });
+
+  it('uses Handlebars translation helper for migrated TextBlock translation keys', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'text-block-translation-key',
+        fields: [
+          {
+            class: 'Container',
+            compClass: 'TextBlockComponent',
+            definition: {
+              name: 'welcome_text',
+              value: '@dmpt-welcome-par2',
+            },
+          },
+        ],
+      },
+    });
+
+    const migratedField = migrated.componentDefinitions[0];
+    expect(migratedField.component.class).to.equal('ContentComponent');
+    const componentConfig = migratedField.component.config as Record<string, unknown>;
+    expect(componentConfig.content).to.equal('@dmpt-welcome-par2');
+    expect(componentConfig.template).to.equal('<div>{{{t content}}}</div>');
+  });
+
+  it('uses heading wrapper from TextBlock type for heading content', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'text-block-heading-type',
+        fields: [
+          {
+            class: 'Container',
+            compClass: 'TextBlockComponent',
+            definition: {
+              name: 'welcome_heading',
+              value: '@dmpt-welcome-heading',
+              type: 'h3',
+            },
+          },
+        ],
+      },
+    });
+
+    const migratedField = migrated.componentDefinitions[0];
+    expect(migratedField.component.class).to.equal('ContentComponent');
+    const componentConfig = migratedField.component.config as Record<string, unknown>;
+    expect(componentConfig.content).to.equal('@dmpt-welcome-heading');
+    expect(componentConfig.template).to.equal('<h3>{{t content}}</h3>');
+  });
+
+  it('binds TextBlock heading content from formData when value is missing and definition.name is present', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'text-block-heading-name-binding',
+        fields: [
+          {
+            class: 'Container',
+            compClass: 'TextBlockComponent',
+            viewOnly: true,
+            definition: {
+              name: 'title',
+              type: 'h1',
+            },
+          },
+        ],
+      },
+    });
+
+    const migratedField = migrated.componentDefinitions[0];
+    const hiddenBindingField = migrated.componentDefinitions[1];
+    expect(migratedField.component.class).to.equal('ContentComponent');
+    const componentConfig = migratedField.component.config as Record<string, unknown>;
+    const layoutConfig = migratedField.layout?.config as Record<string, unknown> | undefined;
+    expect(migratedField.name).to.not.equal('title');
+    expect(componentConfig.content).to.equal('title');
+    expect(componentConfig.template).to.equal('<h1>{{get formData content ""}}</h1>');
+    expect(layoutConfig?.label).to.equal(undefined);
+    expect(hiddenBindingField.name).to.equal('title');
+    expect(hiddenBindingField.component.class).to.equal('SimpleInputComponent');
+    expect((hiddenBindingField.constraints as Record<string, unknown>)?.allowModes).to.deep.equal(['view']);
+    expect(
+      ((hiddenBindingField.constraints as Record<string, unknown>)?.authorization as Record<string, unknown>)
+        ?.allowRoles
+    ).to.deep.equal([]);
+    expect((hiddenBindingField.component.config as Record<string, unknown>)?.type).to.equal('hidden');
+    expect((hiddenBindingField.component.config as Record<string, unknown>)?.visible).to.equal(false);
+    expect((hiddenBindingField.layout?.config as Record<string, unknown>)?.visible).to.equal(false);
+  });
+
+  it('maps view-only markdown text areas to ContentComponent in view overrides', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'markdown-view-only',
+        fields: [
+          {
+            class: 'MarkdownTextArea',
+            viewOnly: true,
+            definition: {
+              name: 'description',
+              label: 'Description',
+            },
+          },
+        ],
+      },
+    });
+
+    const migratedField = migrated.componentDefinitions[0];
+    expect(migratedField.component.class).to.equal('RichTextEditorComponent');
+    expect((migratedField.component.config as Record<string, unknown>)?.outputFormat).to.equal('markdown');
+    expect((migratedField.constraints as Record<string, unknown>)?.allowModes).to.deep.equal(['view']);
+    expect(migratedField.overrides?.formModeClasses?.view?.component).to.equal('ContentComponent');
+  });
+
+  it('keeps plain text TextBlock values as non-translated content templates', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'text-block-plain-text',
+        fields: [
+          {
+            class: 'Container',
+            compClass: 'TextBlockComponent',
+            definition: {
+              name: 'welcome_text_plain',
+              value: 'Welcome to the form',
+            },
+          },
+        ],
+      },
+    });
+
+    const migratedField = migrated.componentDefinitions[0];
+    expect(migratedField.component.class).to.equal('ContentComponent');
+    const componentConfig = migratedField.component.config as Record<string, unknown>;
+    expect(componentConfig.content).to.equal('Welcome to the form');
+    expect(componentConfig.template).to.equal('<div>{{{content}}}</div>');
+  });
+
+  it('promotes legacy TextBlock span label/help blocks into layout label config', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'text-block-span-label-help',
+        fields: [
+          {
+            class: 'Container',
+            compClass: 'TextBlockComponent',
+            definition: {
+              value: '@dmpt-people-tab-ci',
+              help: '@dmpt-people-tab-ci-help',
+              type: 'span',
+              cssClasses: 'label-font',
+            },
+          },
+        ],
+      },
+    });
+
+    const migratedField = migrated.componentDefinitions[0];
+    expect(migratedField.component.class).to.equal('ContentComponent');
+    const componentConfig = migratedField.component.config as Record<string, unknown>;
+    const layoutConfig = migratedField.layout?.config as Record<string, unknown>;
+
+    expect(componentConfig.content).to.equal('');
+    expect(layoutConfig.label).to.equal('@dmpt-people-tab-ci');
+    expect(layoutConfig.helpText).to.equal('@dmpt-people-tab-ci-help');
+    expect(layoutConfig.cssClassesMap).to.deep.equal({ label: 'label-font' });
+  });
+
+  it('populates attachmentFields from FileUpload components', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'attachment-fields-migration',
+        fields: [
+          {
+            class: 'DataLocation',
+            compClass: 'DataLocationComponent',
+            definition: {
+              name: 'dataLocations',
+            },
+          },
+          {
+            class: 'RelatedFileUpload',
+            compClass: 'RelatedFileUploadComponent',
+            definition: {
+              name: 'attachments',
+            },
+          },
+          {
+            class: 'TextField',
+            definition: {
+              name: 'title',
+            },
+          },
+        ],
+      },
+    });
+
+    expect(migrated.attachmentFields).to.be.an('array');
+    expect(migrated.attachmentFields).to.include('dataLocations');
+    expect(migrated.attachmentFields).to.include('attachments');
+    expect(migrated.attachmentFields).to.not.include('title');
+    expect(migrated.attachmentFields?.length).to.equal(2);
+  });
+
+  it('maps legacy DataLocation to DataLocationComponent with config fields', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'data-location-migration',
+        fields: [
+          {
+            class: 'DataLocation',
+            compClass: 'DataLocationComponent',
+            definition: {
+              name: 'dataLocations',
+              allowUploadWithoutSave: true,
+              locationAddText: 'Add another location',
+              typeHeader: 'Type',
+              locationHeader: 'Where',
+              notesHeader: 'Notes',
+              dataTypePlaceholder: 'Please select',
+              columns: ['type', 'location'],
+              notesEnabled: true,
+              iscEnabled: true,
+              defaultSelect: 'official',
+              securityClassificationOptions: [{ label: 'Official', value: 'official' }],
+            },
+          },
+        ],
+      },
+    });
+
+    const migratedField = migrated.componentDefinitions[0];
+    expect(migratedField.component.class).to.equal('DataLocationComponent');
+    expect(migratedField.model?.class).to.equal('DataLocationModel');
+    expect(migratedField.component.config).to.deep.include({
+      allowUploadWithoutSave: true,
+      locationAddText: 'Add another location',
+      typeHeader: 'Type',
+      locationHeader: 'Where',
+      notesHeader: 'Notes',
+      dataTypePlaceholder: 'Please select',
+      notesEnabled: true,
+      iscEnabled: true,
+      defaultSelect: 'official',
+    });
+    expect((migratedField.component.config as any).columns).to.deep.equal(['type', 'location']);
+    expect((migratedField.component.config as any).securityClassificationOptions).to.deep.equal([
+      { label: 'Official', value: 'official' },
+    ]);
+  });
+
+  it('maps legacy PublishDataLocationSelector to the v5 selector component', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'publish-data-location-selector-migration',
+        fields: [
+          {
+            class: 'PublishDataLocationSelector',
+            compClass: 'PublishDataLocationSelectorComponent',
+            definition: {
+              name: 'dataLocations',
+              iscEnabled: true,
+              notesEnabled: true,
+              typeHeader: 'Type',
+              locationHeader: 'Location',
+              notesHeader: 'Notes',
+              selectionCriteria: [{ isc: 'public', type: 'attachment' }],
+              subscribe: {
+                dataRecordGetter: {
+                  onValueUpdate: [{ action: 'utilityService.getPropertyFromObject', field: 'dataLocations' }],
+                },
+                dataPubLocationRefresher: {
+                  onValueUpdate: [{ action: 'utilityService.getPropertyFromObject', field: 'dataLocations' }],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const migratedField = migrated.componentDefinitions[0];
+    expect(migratedField.component.class).to.equal('PublishDataLocationSelectorComponent');
+    expect(migratedField.model?.class).to.equal('PublishDataLocationSelectorModel');
+    expect(migratedField.component.config).to.deep.include({
+      iscEnabled: true,
+      notesEnabled: true,
+      typeHeader: 'Type',
+      locationHeader: 'Location',
+      notesHeader: 'Notes',
+    });
+    expect((migratedField.component.config as any).selectionCriteria).to.deep.equal([
+      { isc: 'public', type: 'attachment' },
+    ]);
+    expect(migratedField.expressions).to.deep.include.members([
+      {
+        name: 'dataRecordGetter-dataLocations-dataLocations',
+        description: 'Populate dataLocations from dataRecordGetter metadata',
+        config: {
+          conditionKind: 'jsonpointer',
+          runOnFormReady: false,
+          condition: '/dataRecordGetter::field.value.changed',
+          target: 'model.value',
+          hasTemplate: true,
+          template: 'event.value.dataLocations',
+        },
+      },
+      {
+        name: 'dataPubLocationRefresher-dataLocations-dataLocations',
+        description: 'Populate dataLocations from dataPubLocationRefresher metadata',
+        config: {
+          conditionKind: 'jsonpointer',
+          runOnFormReady: false,
+          condition: '/dataPubLocationRefresher::field.value.changed',
+          target: 'model.value',
+          hasTemplate: true,
+          template: 'event.value.dataLocations',
+        },
+      },
+    ]);
+  });
+
+  it('uses the enclosing container path for migrated publish data location selector expressions', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'publish-data-location-selector-nested-migration',
+        fields: [
+          {
+            class: 'Container',
+            definition: {
+              id: 'tab_data',
+              fields: [
+                {
+                  class: 'RecordMetadataRetriever',
+                  compClass: 'RecordMetadataRetrieverComponent',
+                  definition: {
+                    name: 'dataRecordGetter',
+                  },
+                },
+                {
+                  class: 'PublishDataLocationSelector',
+                  compClass: 'PublishDataLocationSelectorComponent',
+                  definition: {
+                    name: 'dataLocations',
+                    subscribe: {
+                      dataRecordGetter: {
+                        onValueUpdate: [{ action: 'utilityService.getPropertyFromObject', field: 'dataLocations' }],
+                      },
                     },
-                    {
-                        class: "RelatedFileUpload",
-                        compClass: "RelatedFileUploadComponent",
-                        definition: {
-                            name: "attachments"
-                        }
-                    },
-                    {
-                        class: "TextField",
-                        definition: {
-                            name: "title"
-                        }
-                    }
-                ]
-            }
-        });
-
-        expect(migrated.attachmentFields).to.be.an("array");
-        expect(migrated.attachmentFields).to.include("dataLocations");
-        expect(migrated.attachmentFields).to.include("attachments");
-        expect(migrated.attachmentFields).to.not.include("title");
-        expect(migrated.attachmentFields?.length).to.equal(2);
-    });
-
-    it("maps legacy DataLocation to DataLocationComponent with config fields", async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "data-location-migration",
-                fields: [
-                    {
-                        class: "DataLocation",
-                        compClass: "DataLocationComponent",
-                        definition: {
-                            name: "dataLocations",
-                            allowUploadWithoutSave: true,
-                            locationAddText: "Add another location",
-                            typeHeader: "Type",
-                            locationHeader: "Where",
-                            notesHeader: "Notes",
-                            dataTypePlaceholder: "Please select",
-                            columns: ["type", "location"],
-                            notesEnabled: true,
-                            iscEnabled: true,
-                            defaultSelect: "official",
-                            securityClassificationOptions: [
-                                { label: "Official", value: "official" }
-                            ]
-                        }
-                    }
-                ]
-            }
-        });
-
-        const migratedField = migrated.componentDefinitions[0];
-        expect(migratedField.component.class).to.equal("DataLocationComponent");
-        expect(migratedField.model?.class).to.equal("DataLocationModel");
-        expect(migratedField.component.config).to.deep.include({
-            allowUploadWithoutSave: true,
-            locationAddText: "Add another location",
-            typeHeader: "Type",
-            locationHeader: "Where",
-            notesHeader: "Notes",
-            dataTypePlaceholder: "Please select",
-            notesEnabled: true,
-            iscEnabled: true,
-            defaultSelect: "official"
-        });
-        expect((migratedField.component.config as any).columns).to.deep.equal(["type", "location"]);
-        expect((migratedField.component.config as any).securityClassificationOptions).to.deep.equal([
-            { label: "Official", value: "official" }
-        ]);
-    });
-
-    it("maps legacy PublishDataLocationSelector to the v5 selector component", async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "publish-data-location-selector-migration",
-                fields: [
-                    {
-                        class: "PublishDataLocationSelector",
-                        compClass: "PublishDataLocationSelectorComponent",
-                        definition: {
-                            name: "dataLocations",
-                            iscEnabled: true,
-                            notesEnabled: true,
-                            typeHeader: "Type",
-                            locationHeader: "Location",
-                            notesHeader: "Notes",
-                            selectionCriteria: [{ isc: "public", type: "attachment" }],
-                            subscribe: {
-                                dataRecordGetter: {
-                                    onValueUpdate: [
-                                        { action: "utilityService.getPropertyFromObject", field: "dataLocations" }
-                                    ]
-                                },
-                                dataPubLocationRefresher: {
-                                    onValueUpdate: [
-                                        { action: "utilityService.getPropertyFromObject", field: "dataLocations" }
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                ]
-            }
-        });
-
-        const migratedField = migrated.componentDefinitions[0];
-        expect(migratedField.component.class).to.equal("PublishDataLocationSelectorComponent");
-        expect(migratedField.model?.class).to.equal("PublishDataLocationSelectorModel");
-        expect(migratedField.component.config).to.deep.include({
-            iscEnabled: true,
-            notesEnabled: true,
-            typeHeader: "Type",
-            locationHeader: "Location",
-            notesHeader: "Notes",
-        });
-        expect((migratedField.component.config as any).selectionCriteria).to.deep.equal([{ isc: "public", type: "attachment" }]);
-        expect(migratedField.expressions).to.deep.include.members([
-            {
-                name: "dataRecordGetter-dataLocations-dataLocations",
-                description: "Populate dataLocations from dataRecordGetter metadata",
-                config: {
-                    conditionKind: "jsonpointer",
-                    runOnFormReady: false,
-                    condition: "/dataRecordGetter::field.value.changed",
-                    target: "model.value",
-                    hasTemplate: true,
-                    template: "event.value.dataLocations",
+                  },
                 },
+              ],
             },
-            {
-                name: "dataPubLocationRefresher-dataLocations-dataLocations",
-                description: "Populate dataLocations from dataPubLocationRefresher metadata",
-                config: {
-                    conditionKind: "jsonpointer",
-                    runOnFormReady: false,
-                    condition: "/dataPubLocationRefresher::field.value.changed",
-                    target: "model.value",
-                    hasTemplate: true,
-                    template: "event.value.dataLocations",
+          },
+        ],
+      },
+    });
+
+    const container = migrated.componentDefinitions[0];
+    expect(container.component.class).to.equal('GroupComponent');
+    const nestedField = (container.component.config as any).componentDefinitions.find(
+      (component: Record<string, any>) => component.name === 'dataLocations'
+    );
+    expect(nestedField).to.not.equal(undefined);
+    expect(nestedField.expressions).to.deep.include({
+      name: 'dataRecordGetter-dataLocations-dataLocations',
+      description: 'Populate dataLocations from dataRecordGetter metadata',
+      config: {
+        conditionKind: 'jsonpointer',
+        runOnFormReady: false,
+        condition: '/tab_data/dataRecordGetter::field.value.changed',
+        target: 'model.value',
+        hasTemplate: true,
+        template: 'event.value.dataLocations',
+      },
+    });
+  });
+
+  it('resolves cross-tab publish data location selector sources to their real component path', async function () {
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'publish-data-location-selector-cross-tab-migration',
+        fields: [
+          {
+            class: 'TabOrAccordionContainer',
+            compClass: 'TabOrAccordionContainerComponent',
+            definition: {
+              id: 'mainTab',
+              fields: [
+                {
+                  class: 'Container',
+                  definition: {
+                    id: 'about',
+                    fields: [
+                      {
+                        class: 'RecordMetadataRetriever',
+                        compClass: 'RecordMetadataRetrieverComponent',
+                        definition: {
+                          name: 'dataRecordGetter',
+                        },
+                      },
+                    ],
+                  },
                 },
-            },
-        ]);
-    });
-
-    it("uses the enclosing container path for migrated publish data location selector expressions", async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "publish-data-location-selector-nested-migration",
-                fields: [
-                    {
-                        class: "Container",
+                {
+                  class: 'Container',
+                  definition: {
+                    id: 'data',
+                    fields: [
+                      {
+                        class: 'PublishDataLocationSelector',
+                        compClass: 'PublishDataLocationSelectorComponent',
                         definition: {
-                            id: "tab_data",
-                            fields: [
-                                {
-                                    class: "RecordMetadataRetriever",
-                                    compClass: "RecordMetadataRetrieverComponent",
-                                    definition: {
-                                        name: "dataRecordGetter",
-                                    }
-                                },
-                                {
-                                    class: "PublishDataLocationSelector",
-                                    compClass: "PublishDataLocationSelectorComponent",
-                                    definition: {
-                                        name: "dataLocations",
-                                        subscribe: {
-                                            dataRecordGetter: {
-                                                onValueUpdate: [
-                                                    { action: "utilityService.getPropertyFromObject", field: "dataLocations" }
-                                                ]
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        });
-
-        const container = migrated.componentDefinitions[0];
-        expect(container.component.class).to.equal("GroupComponent");
-        const nestedField = (container.component.config as any).componentDefinitions.find(
-            (component: Record<string, any>) => component.name === "dataLocations"
-        );
-        expect(nestedField).to.not.equal(undefined);
-        expect(nestedField.expressions).to.deep.include({
-            name: "dataRecordGetter-dataLocations-dataLocations",
-            description: "Populate dataLocations from dataRecordGetter metadata",
-            config: {
-                conditionKind: "jsonpointer",
-                runOnFormReady: false,
-                condition: "/tab_data/dataRecordGetter::field.value.changed",
-                target: "model.value",
-                hasTemplate: true,
-                template: "event.value.dataLocations",
-            },
-        });
-    });
-
-    it("resolves cross-tab publish data location selector sources to their real component path", async function () {
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "publish-data-location-selector-cross-tab-migration",
-                fields: [
-                    {
-                        class: "TabOrAccordionContainer",
-                        compClass: "TabOrAccordionContainerComponent",
-                        definition: {
-                            id: "mainTab",
-                            fields: [
-                                {
-                                    class: "Container",
-                                    definition: {
-                                        id: "about",
-                                        fields: [
-                                            {
-                                                class: "RecordMetadataRetriever",
-                                                compClass: "RecordMetadataRetrieverComponent",
-                                                definition: {
-                                                    name: "dataRecordGetter",
-                                                }
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    class: "Container",
-                                    definition: {
-                                        id: "data",
-                                        fields: [
-                                            {
-                                                class: "PublishDataLocationSelector",
-                                                compClass: "PublishDataLocationSelectorComponent",
-                                                definition: {
-                                                    name: "dataLocations",
-                                                    subscribe: {
-                                                        dataRecordGetter: {
-                                                            onValueUpdate: [
-                                                                { action: "utilityService.getPropertyFromObject", field: "dataLocations" }
-                                                            ]
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        ]
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        });
-
-        const mainTab = migrated.componentDefinitions[0];
-        expect(mainTab.component.class).to.equal("TabComponent");
-        const dataTab = ((mainTab.component.config as any).tabs as Array<Record<string, any>>).find(
-            (component) => component.name === "data"
-        );
-        expect(dataTab).to.not.equal(undefined);
-        const nestedField = (dataTab!.component.config as any).componentDefinitions.find(
-            (component: Record<string, any>) => component.name === "dataLocations"
-        );
-        expect(nestedField).to.not.equal(undefined);
-        expect(nestedField.expressions).to.deep.include.members([
-            {
-                name: "dataRecordGetter-dataLocations-dataLocations",
-                description: "Populate dataLocations from dataRecordGetter metadata",
-                config: {
-                    conditionKind: "jsonpointer",
-                    runOnFormReady: false,
-                    condition: "/mainTab/about/dataRecordGetter::field.value.changed",
-                    target: "model.value",
-                    hasTemplate: true,
-                    template: "event.value.dataLocations",
+                          name: 'dataLocations',
+                          subscribe: {
+                            dataRecordGetter: {
+                              onValueUpdate: [
+                                { action: 'utilityService.getPropertyFromObject', field: 'dataLocations' },
+                              ],
+                            },
+                          },
+                        },
+                      },
+                    ],
+                  },
                 },
-            }
-        ]);
+              ],
+            },
+          },
+        ],
+      },
     });
 
-    it("maps legacy PublishDataLocationRefresh to the v5 refresh component", async function () {
-        // The migrated output must keep the button semantics without carrying
-        // forward the old imperative-fetch implementation details.
-        const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
-        const migrated = await visitor.start({
-            data: {
-                name: "publish-data-location-refresh-migration",
-                fields: [
-                    {
-                        class: "PublishDataLocationRefresh",
-                        compClass: "PublishDataLocationRefreshComponent",
-                        definition: {
-                            name: "dataPubLocationRefresherTrigger",
-                            label: "@refresh-attachments-text"
-                        }
-                    }
-                ]
-            }
-        });
+    const mainTab = migrated.componentDefinitions[0];
+    expect(mainTab.component.class).to.equal('TabComponent');
+    const dataTab = ((mainTab.component.config as any).tabs as Array<Record<string, any>>).find(
+      component => component.name === 'data'
+    );
+    expect(dataTab).to.not.equal(undefined);
+    const nestedField = (dataTab!.component.config as any).componentDefinitions.find(
+      (component: Record<string, any>) => component.name === 'dataLocations'
+    );
+    expect(nestedField).to.not.equal(undefined);
+    expect(nestedField.expressions).to.deep.include.members([
+      {
+        name: 'dataRecordGetter-dataLocations-dataLocations',
+        description: 'Populate dataLocations from dataRecordGetter metadata',
+        config: {
+          conditionKind: 'jsonpointer',
+          runOnFormReady: false,
+          condition: '/mainTab/about/dataRecordGetter::field.value.changed',
+          target: 'model.value',
+          hasTemplate: true,
+          template: 'event.value.dataLocations',
+        },
+      },
+    ]);
+  });
 
-        const migratedField = migrated.componentDefinitions[0];
-        expect(migratedField.component.class).to.equal("PublishDataLocationRefreshComponent");
-        expect(migratedField.model).to.equal(undefined);
-        expect((migratedField.component.config as Record<string, unknown>).label).to.equal("@refresh-attachments-text");
+  it('maps legacy PublishDataLocationRefresh to the v5 refresh component', async function () {
+    // The migrated output must keep the button semantics without carrying
+    // forward the old imperative-fetch implementation details.
+    const visitor = new MigrationV4ToV5FormConfigVisitor(logger);
+    const migrated = await visitor.start({
+      data: {
+        name: 'publish-data-location-refresh-migration',
+        fields: [
+          {
+            class: 'PublishDataLocationRefresh',
+            compClass: 'PublishDataLocationRefreshComponent',
+            definition: {
+              name: 'dataPubLocationRefresherTrigger',
+              label: '@refresh-attachments-text',
+            },
+          },
+        ],
+      },
     });
+
+    const migratedField = migrated.componentDefinitions[0];
+    expect(migratedField.component.class).to.equal('PublishDataLocationRefreshComponent');
+    expect(migratedField.model).to.equal(undefined);
+    expect((migratedField.component.config as Record<string, unknown>).label).to.equal('@refresh-attachments-text');
+  });
 });

--- a/packages/sails-ng-common/src/config/component/repeatable.model.ts
+++ b/packages/sails-ng-common/src/config/component/repeatable.model.ts
@@ -1,149 +1,165 @@
+import { FieldComponentConfig, FieldComponentDefinition } from '../field-component.model';
+import { FieldModelConfig, FieldModelDefinition } from '../field-model.model';
+import { FormComponentDefinition } from '../form-component.model';
+import { FieldLayoutConfig, FieldLayoutDefinition } from '../field-layout.model';
+import { ActionRowFieldLayoutConfig } from './action-row-layout.model';
+import { FormConfigVisitorOutline } from '../visitor/base.outline';
 import {
-    FieldComponentConfig,
-    FieldComponentDefinition,
-} from "../field-component.model";
+  FieldComponentConfigKind,
+  FieldComponentDefinitionKind,
+  FieldLayoutConfigKind,
+  FieldLayoutDefinitionKind,
+  FieldModelConfigKind,
+  FieldModelDefinitionKind,
+  FormComponentDefinitionKind,
+} from '../shared.outline';
 import {
-    FieldModelConfig,
-    FieldModelDefinition
-} from "../field-model.model";
-import {FormComponentDefinition} from "../form-component.model";
+  RepeatableComponentName,
+  RepeatableElementFieldLayoutConfigOutline,
+  RepeatableElementFieldLayoutDefinitionOutline,
+  RepeatableElementLayoutName,
+  RepeatableFieldComponentConfigOutline,
+  RepeatableFieldComponentDefinitionOutline,
+  RepeatableFieldModelConfigOutline,
+  RepeatableFieldModelDefinitionOutline,
+  RepeatableFormComponentDefinitionOutline,
+  RepeatableModelName,
+  RepeatableModelValueType,
+} from './repeatable.outline';
 import {
-    FieldLayoutConfig,
-    FieldLayoutDefinition,
-} from "../field-layout.model";
-import { ActionRowFieldLayoutConfig } from "./action-row-layout.model";
-import {FormConfigVisitorOutline} from "../visitor/base.outline";
-import {
-    FieldComponentConfigKind, FieldComponentDefinitionKind,
-    FieldLayoutConfigKind,
-    FieldLayoutDefinitionKind,
-    FieldModelConfigKind,
-    FieldModelDefinitionKind, FormComponentDefinitionKind
-} from "../shared.outline";
-import {
-    RepeatableComponentName,
-    RepeatableElementFieldLayoutConfigOutline,
-    RepeatableElementFieldLayoutDefinitionOutline,
-    RepeatableElementLayoutName, RepeatableFieldComponentConfigOutline,
-    RepeatableFieldComponentDefinitionOutline,
-    RepeatableFieldModelConfigOutline, RepeatableFieldModelDefinitionOutline, RepeatableFormComponentDefinitionOutline,
-    RepeatableModelName,
-    RepeatableModelValueType
-} from "./repeatable.outline";
-import {
-    AvailableFieldLayoutDefinitionOutlines, AvailableFormComponentDefinitionOutlines
-} from "../dictionary.outline";
-
+  AvailableFieldLayoutDefinitionOutlines,
+  AvailableFormComponentDefinitionOutlines,
+} from '../dictionary.outline';
 
 /* Repeatable Component */
-export class RepeatableFieldComponentConfig extends FieldComponentConfig implements RepeatableFieldComponentConfigOutline {
-    elementTemplate!: AvailableFormComponentDefinitionOutlines;
-    addButtonShow = true;
-    allowZeroRows = false;
-    hideWhenZeroRows = false;
+export class RepeatableFieldComponentConfig
+  extends FieldComponentConfig
+  implements RepeatableFieldComponentConfigOutline
+{
+  elementTemplate!: AvailableFormComponentDefinitionOutlines;
+  addButtonShow = true;
+  allowZeroRows = false;
+  hideWhenZeroRows = false;
+  canSort?: boolean;
 
-    constructor() {
-        super();
-    }
+  constructor() {
+    super();
+  }
 
-    /**
-     * Create a unique ID using the current timestamp and a random number.
-     * This unique id must not be stored in the database.
-     * It will be different for each form load.
-     * It is for distinguishing the repeatable element entries.
-     */
-    public static getLocalUID(): string {
-        const randomNumber = Math.floor(Math.random() * 10000).toString().padStart(5, '0');
-        return `${Date.now()}-${randomNumber}`;
-    }
+  /**
+   * Create a unique ID using the current timestamp and a random number.
+   * This unique id must not be stored in the database.
+   * It will be different for each form load.
+   * It is for distinguishing the repeatable element entries.
+   */
+  public static getLocalUID(): string {
+    const randomNumber = Math.floor(Math.random() * 10000)
+      .toString()
+      .padStart(5, '0');
+    return `${Date.now()}-${randomNumber}`;
+  }
 }
 
+export class RepeatableFieldComponentDefinition
+  extends FieldComponentDefinition
+  implements RepeatableFieldComponentDefinitionOutline
+{
+  class = RepeatableComponentName;
+  config?: RepeatableFieldComponentConfigOutline;
 
-export class RepeatableFieldComponentDefinition extends FieldComponentDefinition implements RepeatableFieldComponentDefinitionOutline {
-    class = RepeatableComponentName;
-    config?: RepeatableFieldComponentConfigOutline;
+  constructor() {
+    super();
+  }
 
-    constructor() {
-        super();
-    }
-
-    async accept(visitor: FormConfigVisitorOutline) {
-        await visitor.visitRepeatableFieldComponentDefinition(this);
-    }
+  async accept(visitor: FormConfigVisitorOutline) {
+    await visitor.visitRepeatableFieldComponentDefinition(this);
+  }
 }
-
 
 /* Repeatable Model */
-export class RepeatableFieldModelConfig extends FieldModelConfig<RepeatableModelValueType> implements RepeatableFieldModelConfigOutline {
-    constructor() {
-        super();
-    }
+export class RepeatableFieldModelConfig
+  extends FieldModelConfig<RepeatableModelValueType>
+  implements RepeatableFieldModelConfigOutline
+{
+  constructor() {
+    super();
+  }
 }
 
-export class RepeatableFieldModelDefinition extends FieldModelDefinition<RepeatableModelValueType> implements RepeatableFieldModelDefinitionOutline {
-    class = RepeatableModelName;
-    config?: RepeatableFieldModelConfigOutline;
+export class RepeatableFieldModelDefinition
+  extends FieldModelDefinition<RepeatableModelValueType>
+  implements RepeatableFieldModelDefinitionOutline
+{
+  class = RepeatableModelName;
+  config?: RepeatableFieldModelConfigOutline;
 
-    constructor() {
-        super();
-    }
+  constructor() {
+    super();
+  }
 
-    async accept(visitor: FormConfigVisitorOutline) {
-        await visitor.visitRepeatableFieldModelDefinition(this);
-    }
+  async accept(visitor: FormConfigVisitorOutline) {
+    await visitor.visitRepeatableFieldModelDefinition(this);
+  }
 }
-
 
 /* Repeatable Element Layout */
-export class RepeatableElementFieldLayoutConfig extends ActionRowFieldLayoutConfig implements RepeatableElementFieldLayoutConfigOutline {
-    constructor() {
-        super();
-    }
+export class RepeatableElementFieldLayoutConfig
+  extends ActionRowFieldLayoutConfig
+  implements RepeatableElementFieldLayoutConfigOutline
+{
+  constructor() {
+    super();
+  }
 }
 
-export class RepeatableElementFieldLayoutDefinition extends FieldLayoutDefinition implements RepeatableElementFieldLayoutDefinitionOutline {
-    public class = RepeatableElementLayoutName;
-    public config?: RepeatableElementFieldLayoutConfigOutline;
+export class RepeatableElementFieldLayoutDefinition
+  extends FieldLayoutDefinition
+  implements RepeatableElementFieldLayoutDefinitionOutline
+{
+  public class = RepeatableElementLayoutName;
+  public config?: RepeatableElementFieldLayoutConfigOutline;
 
-    constructor() {
-        super();
-    }
+  constructor() {
+    super();
+  }
 
-    async accept(visitor: FormConfigVisitorOutline) {
-        await visitor.visitRepeatableElementFieldLayoutDefinition(this);
-    }
+  async accept(visitor: FormConfigVisitorOutline) {
+    await visitor.visitRepeatableElementFieldLayoutDefinition(this);
+  }
 }
-
 
 /* Repeatable Form Component */
-export class RepeatableFormComponentDefinition extends FormComponentDefinition implements RepeatableFormComponentDefinitionOutline {
-    public component!: RepeatableFieldComponentDefinitionOutline;
-    public model?: RepeatableFieldModelDefinitionOutline;
-    public layout?: AvailableFieldLayoutDefinitionOutlines;
+export class RepeatableFormComponentDefinition
+  extends FormComponentDefinition
+  implements RepeatableFormComponentDefinitionOutline
+{
+  public component!: RepeatableFieldComponentDefinitionOutline;
+  public model?: RepeatableFieldModelDefinitionOutline;
+  public layout?: AvailableFieldLayoutDefinitionOutlines;
 
-    constructor() {
-        super();
-    }
+  constructor() {
+    super();
+  }
 
-    async accept(visitor: FormConfigVisitorOutline) {
-        await visitor.visitRepeatableFormComponentDefinition(this);
-    }
+  async accept(visitor: FormConfigVisitorOutline) {
+    await visitor.visitRepeatableFormComponentDefinition(this);
+  }
 }
 
 export const RepeatableMap = [
-    {kind: FieldComponentConfigKind, def: RepeatableFieldComponentConfig},
-    {kind: FieldComponentDefinitionKind, def: RepeatableFieldComponentDefinition, class: RepeatableComponentName},
-    {kind: FieldModelConfigKind, def: RepeatableFieldModelConfig},
-    {kind: FieldModelDefinitionKind, def: RepeatableFieldModelDefinition, class: RepeatableModelName},
-    {kind: FieldLayoutConfigKind, def: RepeatableElementFieldLayoutConfig},
-    {kind: FieldLayoutDefinitionKind, def: RepeatableElementFieldLayoutDefinition, class: RepeatableElementLayoutName},
-    {kind: FormComponentDefinitionKind, def: RepeatableFormComponentDefinition, class: RepeatableComponentName},
+  { kind: FieldComponentConfigKind, def: RepeatableFieldComponentConfig },
+  { kind: FieldComponentDefinitionKind, def: RepeatableFieldComponentDefinition, class: RepeatableComponentName },
+  { kind: FieldModelConfigKind, def: RepeatableFieldModelConfig },
+  { kind: FieldModelDefinitionKind, def: RepeatableFieldModelDefinition, class: RepeatableModelName },
+  { kind: FieldLayoutConfigKind, def: RepeatableElementFieldLayoutConfig },
+  { kind: FieldLayoutDefinitionKind, def: RepeatableElementFieldLayoutDefinition, class: RepeatableElementLayoutName },
+  { kind: FormComponentDefinitionKind, def: RepeatableFormComponentDefinition, class: RepeatableComponentName },
 ];
 export const RepeatableDefaults = {
-    [FormComponentDefinitionKind]: {
-        [RepeatableComponentName]: {
-            [FieldComponentDefinitionKind]: RepeatableComponentName,
-            [FieldModelDefinitionKind]: RepeatableModelName,
-        },
+  [FormComponentDefinitionKind]: {
+    [RepeatableComponentName]: {
+      [FieldComponentDefinitionKind]: RepeatableComponentName,
+      [FieldModelDefinitionKind]: RepeatableModelName,
     },
+  },
 };

--- a/packages/sails-ng-common/src/config/component/repeatable.outline.ts
+++ b/packages/sails-ng-common/src/config/component/repeatable.outline.ts
@@ -1,41 +1,45 @@
 import {
-    FieldLayoutConfigFrame,
-    FieldLayoutConfigOutline,
-    FieldLayoutDefinitionFrame,
-    FieldLayoutDefinitionOutline
-} from "../field-layout.outline";
+  FieldLayoutConfigFrame,
+  FieldLayoutConfigOutline,
+  FieldLayoutDefinitionFrame,
+  FieldLayoutDefinitionOutline,
+} from '../field-layout.outline';
+import { ActionRowFieldLayoutConfigFrame, ActionRowFieldLayoutConfigOutline } from './action-row-layout.outline';
 import {
-    ActionRowFieldLayoutConfigFrame,
-    ActionRowFieldLayoutConfigOutline
-} from "./action-row-layout.outline";
+  AvailableFieldLayoutDefinitionFrames,
+  AvailableFieldLayoutDefinitionOutlines,
+  AvailableFormComponentDefinitionFrames,
+  AvailableFormComponentDefinitionOutlines,
+} from '../dictionary.outline';
+import { FormComponentDefinitionFrame, FormComponentDefinitionOutline } from '../form-component.outline';
 import {
-    AvailableFieldLayoutDefinitionFrames,
-    AvailableFieldLayoutDefinitionOutlines,
-    AvailableFormComponentDefinitionFrames,
-    AvailableFormComponentDefinitionOutlines
-} from "../dictionary.outline";
-import {FormComponentDefinitionFrame, FormComponentDefinitionOutline} from "../form-component.outline";
+  FieldModelConfigFrame,
+  FieldModelConfigOutline,
+  FieldModelDefinitionFrame,
+  FieldModelDefinitionOutline,
+} from '../field-model.outline';
 import {
-    FieldModelConfigFrame,
-    FieldModelConfigOutline,
-    FieldModelDefinitionFrame,
-    FieldModelDefinitionOutline
-} from "../field-model.outline";
+  FieldComponentConfigFrame,
+  FieldComponentConfigOutline,
+  FieldComponentDefinitionFrame,
+  FieldComponentDefinitionOutline,
+} from '../field-component.outline';
 import {
-    FieldComponentConfigFrame, FieldComponentConfigOutline,
-    FieldComponentDefinitionFrame,
-    FieldComponentDefinitionOutline
-} from "../field-component.outline";
-import {
-    FieldComponentConfigFrameKindType, FieldComponentConfigKindType,
-    FieldComponentDefinitionFrameKindType,
-    FieldComponentDefinitionKindType, FieldLayoutConfigFrameKindType,
-    FieldLayoutConfigKindType, FieldLayoutDefinitionFrameKindType,
-    FieldLayoutDefinitionKindType,
-    FieldModelConfigFrameKindType,
-    FieldModelConfigKindType, FieldModelDefinitionFrameKindType,
-    FieldModelDefinitionKindType, FormComponentDefinitionFrameKindType, FormComponentDefinitionKindType
-} from "../shared.outline";
+  FieldComponentConfigFrameKindType,
+  FieldComponentConfigKindType,
+  FieldComponentDefinitionFrameKindType,
+  FieldComponentDefinitionKindType,
+  FieldLayoutConfigFrameKindType,
+  FieldLayoutConfigKindType,
+  FieldLayoutDefinitionFrameKindType,
+  FieldLayoutDefinitionKindType,
+  FieldModelConfigFrameKindType,
+  FieldModelConfigKindType,
+  FieldModelDefinitionFrameKindType,
+  FieldModelDefinitionKindType,
+  FormComponentDefinitionFrameKindType,
+  FormComponentDefinitionKindType,
+} from '../shared.outline';
 
 /* Repeatable Component */
 
@@ -43,26 +47,28 @@ export const RepeatableComponentName = `RepeatableComponent` as const;
 export type RepeatableComponentNameType = typeof RepeatableComponentName;
 
 export interface RepeatableFieldComponentConfigFrame extends FieldComponentConfigFrame {
-    elementTemplate: AvailableFormComponentDefinitionFrames;
-    addButtonShow?: boolean;
-    allowZeroRows?: boolean;
-    hideWhenZeroRows?: boolean;
+  elementTemplate: AvailableFormComponentDefinitionFrames;
+  addButtonShow?: boolean;
+  allowZeroRows?: boolean;
+  hideWhenZeroRows?: boolean;
+  canSort?: boolean;
 }
 
-export interface RepeatableFieldComponentConfigOutline extends RepeatableFieldComponentConfigFrame, FieldComponentConfigOutline {
-    elementTemplate: AvailableFormComponentDefinitionOutlines;
+export interface RepeatableFieldComponentConfigOutline
+  extends RepeatableFieldComponentConfigFrame, FieldComponentConfigOutline {
+  elementTemplate: AvailableFormComponentDefinitionOutlines;
 }
 
 export interface RepeatableFieldComponentDefinitionFrame extends FieldComponentDefinitionFrame {
-    class: RepeatableComponentNameType;
-    config?: RepeatableFieldComponentConfigFrame;
+  class: RepeatableComponentNameType;
+  config?: RepeatableFieldComponentConfigFrame;
 }
 
-export interface RepeatableFieldComponentDefinitionOutline extends RepeatableFieldComponentDefinitionFrame, FieldComponentDefinitionOutline {
-    class: RepeatableComponentNameType;
-    config?: RepeatableFieldComponentConfigOutline;
+export interface RepeatableFieldComponentDefinitionOutline
+  extends RepeatableFieldComponentDefinitionFrame, FieldComponentDefinitionOutline {
+  class: RepeatableComponentNameType;
+  config?: RepeatableFieldComponentConfigOutline;
 }
-
 
 /* Repeatable Model */
 
@@ -71,75 +77,72 @@ export type RepeatableModelNameType = typeof RepeatableModelName;
 export type RepeatableModelValueType = unknown[];
 
 export interface RepeatableFieldModelConfigFrame extends FieldModelConfigFrame<RepeatableModelValueType> {
-    // TODO: Migrate JSON configurable properties from `RepeatableContainer`
+  // TODO: Migrate JSON configurable properties from `RepeatableContainer`
 }
 
-export interface RepeatableFieldModelConfigOutline extends RepeatableFieldModelConfigFrame, FieldModelConfigOutline<RepeatableModelValueType> {
-
-}
-
+export interface RepeatableFieldModelConfigOutline
+  extends RepeatableFieldModelConfigFrame, FieldModelConfigOutline<RepeatableModelValueType> {}
 
 export interface RepeatableFieldModelDefinitionFrame extends FieldModelDefinitionFrame<RepeatableModelValueType> {
-    class: RepeatableModelNameType;
-    config?: RepeatableFieldModelConfigFrame;
-    // TODO: Migrate properties from `RepeatableContainer`
+  class: RepeatableModelNameType;
+  config?: RepeatableFieldModelConfigFrame;
+  // TODO: Migrate properties from `RepeatableContainer`
 }
 
-export interface RepeatableFieldModelDefinitionOutline extends RepeatableFieldModelDefinitionFrame, FieldModelDefinitionOutline<RepeatableModelValueType> {
-    class: RepeatableModelNameType;
-    config?: RepeatableFieldModelConfigOutline;
+export interface RepeatableFieldModelDefinitionOutline
+  extends RepeatableFieldModelDefinitionFrame, FieldModelDefinitionOutline<RepeatableModelValueType> {
+  class: RepeatableModelNameType;
+  config?: RepeatableFieldModelConfigOutline;
 }
 
 /* Repeatable Element Layout */
 export const RepeatableElementLayoutName = `RepeatableElementLayout` as const;
 export type RepeatableElementLayoutNameType = typeof RepeatableElementLayoutName;
 
-export interface RepeatableElementFieldLayoutConfigFrame extends ActionRowFieldLayoutConfigFrame, FieldLayoutConfigFrame {
-}
+export interface RepeatableElementFieldLayoutConfigFrame
+  extends ActionRowFieldLayoutConfigFrame, FieldLayoutConfigFrame {}
 
-export interface RepeatableElementFieldLayoutConfigOutline extends RepeatableElementFieldLayoutConfigFrame, ActionRowFieldLayoutConfigOutline, FieldLayoutConfigOutline {
-
-}
-
+export interface RepeatableElementFieldLayoutConfigOutline
+  extends RepeatableElementFieldLayoutConfigFrame, ActionRowFieldLayoutConfigOutline, FieldLayoutConfigOutline {}
 
 export interface RepeatableElementFieldLayoutDefinitionFrame extends FieldLayoutDefinitionFrame {
-    class: RepeatableElementLayoutNameType;
-    config?: RepeatableElementFieldLayoutConfigFrame;
+  class: RepeatableElementLayoutNameType;
+  config?: RepeatableElementFieldLayoutConfigFrame;
 }
 
-export interface RepeatableElementFieldLayoutDefinitionOutline extends RepeatableElementFieldLayoutDefinitionFrame, FieldLayoutDefinitionOutline {
-    class: RepeatableElementLayoutNameType;
-    config?: RepeatableElementFieldLayoutConfigOutline;
+export interface RepeatableElementFieldLayoutDefinitionOutline
+  extends RepeatableElementFieldLayoutDefinitionFrame, FieldLayoutDefinitionOutline {
+  class: RepeatableElementLayoutNameType;
+  config?: RepeatableElementFieldLayoutConfigOutline;
 }
-
 
 /* Repeatable Form Component */
 
 export interface RepeatableFormComponentDefinitionFrame extends FormComponentDefinitionFrame {
-    component: RepeatableFieldComponentDefinitionFrame;
-    model?: RepeatableFieldModelDefinitionFrame;
-    layout?: AvailableFieldLayoutDefinitionFrames;
+  component: RepeatableFieldComponentDefinitionFrame;
+  model?: RepeatableFieldModelDefinitionFrame;
+  layout?: AvailableFieldLayoutDefinitionFrames;
 }
 
-export interface RepeatableFormComponentDefinitionOutline extends RepeatableFormComponentDefinitionFrame, FormComponentDefinitionOutline {
-    component: RepeatableFieldComponentDefinitionOutline;
-    model?: RepeatableFieldModelDefinitionOutline;
-    layout?: AvailableFieldLayoutDefinitionOutlines;
+export interface RepeatableFormComponentDefinitionOutline
+  extends RepeatableFormComponentDefinitionFrame, FormComponentDefinitionOutline {
+  component: RepeatableFieldComponentDefinitionOutline;
+  model?: RepeatableFieldModelDefinitionOutline;
+  layout?: AvailableFieldLayoutDefinitionOutlines;
 }
 
-
-export type RepeatableTypes = { kind: FieldComponentConfigFrameKindType, class: RepeatableFieldComponentConfigFrame }
-    | { kind: FieldComponentDefinitionFrameKindType, class: RepeatableFieldComponentDefinitionFrame }
-    | { kind: FieldModelConfigFrameKindType, class: RepeatableFieldModelConfigFrame }
-    | { kind: FieldModelDefinitionFrameKindType, class: RepeatableFieldModelDefinitionFrame }
-    | { kind: FieldLayoutConfigFrameKindType, class: RepeatableElementFieldLayoutConfigFrame }
-    | { kind: FieldLayoutDefinitionFrameKindType, class: RepeatableElementFieldLayoutDefinitionFrame }
-    | { kind: FormComponentDefinitionFrameKindType, class: RepeatableFormComponentDefinitionFrame }
-    | { kind: FieldComponentConfigKindType, class: RepeatableFieldComponentConfigOutline }
-    | { kind: FieldComponentDefinitionKindType, class: RepeatableFieldComponentDefinitionOutline }
-    | { kind: FieldModelConfigKindType, class: RepeatableFieldModelConfigOutline }
-    | { kind: FieldModelDefinitionKindType, class: RepeatableFieldModelDefinitionOutline }
-    | { kind: FieldLayoutConfigKindType, class: RepeatableElementFieldLayoutConfigOutline }
-    | { kind: FieldLayoutDefinitionKindType, class: RepeatableElementFieldLayoutDefinitionOutline }
-    | { kind: FormComponentDefinitionKindType, class: RepeatableFormComponentDefinitionOutline }
-    ;
+export type RepeatableTypes =
+  | { kind: FieldComponentConfigFrameKindType; class: RepeatableFieldComponentConfigFrame }
+  | { kind: FieldComponentDefinitionFrameKindType; class: RepeatableFieldComponentDefinitionFrame }
+  | { kind: FieldModelConfigFrameKindType; class: RepeatableFieldModelConfigFrame }
+  | { kind: FieldModelDefinitionFrameKindType; class: RepeatableFieldModelDefinitionFrame }
+  | { kind: FieldLayoutConfigFrameKindType; class: RepeatableElementFieldLayoutConfigFrame }
+  | { kind: FieldLayoutDefinitionFrameKindType; class: RepeatableElementFieldLayoutDefinitionFrame }
+  | { kind: FormComponentDefinitionFrameKindType; class: RepeatableFormComponentDefinitionFrame }
+  | { kind: FieldComponentConfigKindType; class: RepeatableFieldComponentConfigOutline }
+  | { kind: FieldComponentDefinitionKindType; class: RepeatableFieldComponentDefinitionOutline }
+  | { kind: FieldModelConfigKindType; class: RepeatableFieldModelConfigOutline }
+  | { kind: FieldModelDefinitionKindType; class: RepeatableFieldModelDefinitionOutline }
+  | { kind: FieldLayoutConfigKindType; class: RepeatableElementFieldLayoutConfigOutline }
+  | { kind: FieldLayoutDefinitionKindType; class: RepeatableElementFieldLayoutDefinitionOutline }
+  | { kind: FormComponentDefinitionKindType; class: RepeatableFormComponentDefinitionOutline };

--- a/packages/sails-ng-common/src/jsonata-helpers.ts
+++ b/packages/sails-ng-common/src/jsonata-helpers.ts
@@ -1,4 +1,5 @@
-import jsonata from "jsonata";
+import jsonata from 'jsonata';
+import { DateTime } from 'luxon';
 
 /**
  * A function that accepts a context and evaluates a previously compiled expression.
@@ -8,9 +9,46 @@ export type JSONataEvaluate = (context: unknown) => Promise<unknown>;
 /**
  * A function that registers a custom JSONata function.
  */
-export type JSONataRegisterFunction = (name: string, implementation: (this: jsonata.Focus, ...args: unknown[]) => unknown, signature?: string) => void;
+export type JSONataRegisterFunction = (
+  name: string,
+  implementation: (this: jsonata.Focus, ...args: unknown[]) => unknown,
+  signature?: string
+) => void;
 
-export const jsonataLibrary = {jsonata: jsonata};
+export function luxonFormatDate(value: unknown, format: unknown, sourceFormat?: unknown): string {
+  if (value === undefined || value === null || value === '') {
+    return '';
+  }
+
+  const outputFormat = typeof format === 'string' && format ? format : 'yyyy-LL-dd';
+  const inputFormat = typeof sourceFormat === 'string' && sourceFormat ? sourceFormat : undefined;
+  const valueAsString = typeof value === 'string' ? value.trim() : String(value);
+  let dateTime: DateTime;
+
+  if (value instanceof Date) {
+    dateTime = DateTime.fromJSDate(value);
+  } else if (typeof value === 'number') {
+    dateTime = DateTime.fromMillis(value);
+  } else if (inputFormat) {
+    dateTime = DateTime.fromFormat(valueAsString, inputFormat);
+  } else {
+    const candidates = [
+      DateTime.fromISO(valueAsString),
+      DateTime.fromFormat(valueAsString, 'yyyy/MM/dd'),
+      DateTime.fromFormat(valueAsString, 'yyyy-MM-dd'),
+      DateTime.fromRFC2822(valueAsString),
+      DateTime.fromHTTP(valueAsString),
+    ];
+    dateTime = candidates.find(candidate => candidate.isValid) ?? DateTime.invalid('Unparsable date');
+  }
+
+  return dateTime.isValid ? dateTime.toFormat(outputFormat) : '';
+}
+
+export const jsonataLibrary = {
+  jsonata: jsonata,
+  luxonFormatDate,
+};
 
 /**
  * Provide a JSONata expression string and return a compiled JSONata expression object.
@@ -25,10 +63,9 @@ export function jsonataCompile(expression: string, options?: jsonata.JsonataOpti
   const compiled = jsonata(expression, options);
 
   // Disable JSONata's dynamic eval function so browser/server validators only run the configured expression.
-  compiled.registerFunction("eval", () => undefined);
+  compiled.registerFunction('eval', () => undefined);
 
-  // TODO: register helper functions
-
+  compiled.registerFunction('luxonFormatDate', luxonFormatDate);
 
   // TODO: register a function for obtaining translations
   // TODO: register a function for formatting date time values
@@ -38,11 +75,19 @@ export function jsonataCompile(expression: string, options?: jsonata.JsonataOpti
   return compiled;
 }
 
-export async function jsonataEvaluate(compiled: jsonata.Expression, context: unknown, bindings?: Record<string, unknown>): Promise<unknown> {
+export async function jsonataEvaluate(
+  compiled: jsonata.Expression,
+  context: unknown,
+  bindings?: Record<string, unknown>
+): Promise<unknown> {
   return await compiled.evaluate(context, bindings);
 }
 
-export async function jsonataCompileAndEvaluate(expression: string, context: unknown, bindings?: Record<string, unknown>): Promise<unknown> {
+export async function jsonataCompileAndEvaluate(
+  expression: string,
+  context: unknown,
+  bindings?: Record<string, unknown>
+): Promise<unknown> {
   const compiled = jsonataCompile(expression);
   return await jsonataEvaluate(compiled, context, bindings);
 }
@@ -51,5 +96,5 @@ export function jsonataEvaluateFunc(expression: string, bindings?: Record<string
   const compiled = jsonataCompile(expression);
   return async function (value: unknown) {
     return await jsonataEvaluate(compiled, value, bindings);
-  }
+  };
 }

--- a/packages/sails-ng-common/src/jsonata-helpers.ts
+++ b/packages/sails-ng-common/src/jsonata-helpers.ts
@@ -46,7 +46,6 @@ export function luxonFormatDate(value: unknown, format: unknown, sourceFormat?: 
 }
 
 export const jsonataLibrary = {
-  jsonata: jsonata,
   luxonFormatDate,
 };
 
@@ -65,7 +64,7 @@ export function jsonataCompile(expression: string, options?: jsonata.JsonataOpti
   // Disable JSONata's dynamic eval function so browser/server validators only run the configured expression.
   compiled.registerFunction('eval', () => undefined);
 
-  compiled.registerFunction('luxonFormatDate', luxonFormatDate);
+  compiled.registerFunction('luxonFormatDate', luxonFormatDate, '<(snd)(sn)s?:s>');
 
   // TODO: register a function for obtaining translations
   // TODO: register a function for formatting date time values

--- a/packages/sails-ng-common/src/template.outline.ts
+++ b/packages/sails-ng-common/src/template.outline.ts
@@ -45,7 +45,7 @@ export function buildKeyString(key: TemplateCompileKey): TemplateCompileKeyForma
 
 export type DynamicScriptResponseEvaluateKey = TemplateCompileKey;
 export type DynamicScriptResponseEvaluateContext = unknown;
-export type DynamicScriptResponseEvaluateExtra = { libraries?: Record<string, unknown>, [key: string]: unknown };
+export type DynamicScriptResponseEvaluateExtra = { jsonata?: unknown, libraries?: Record<string, unknown>, [key: string]: unknown };
 export type DynamicScriptResponseEvaluateResult = unknown;
 
 export type DynamicScriptResponseEvaluate = (

--- a/packages/sails-ng-common/test/unit/jsonata-helpers.test.ts
+++ b/packages/sails-ng-common/test/unit/jsonata-helpers.test.ts
@@ -101,6 +101,14 @@ describe('JSONata helpers', function () {
     expect(actual).to.eql('2026');
   });
 
+  it('should not expose the jsonata factory to client-style JSONata library bindings', async function () {
+    expect(jsonataLibrary).not.to.have.property('jsonata');
+
+    const actual = await jsonata('$exists($jsonata)').evaluate({}, jsonataLibrary);
+
+    expect(actual).to.eql(false);
+  });
+
   it('should format RFC 2822 date string values with luxon JSONata helper', async function () {
     const actual = await jsonataCompileAndEvaluate('$luxonFormatDate(date, "yyyy")', {
       date: 'Wed, 10 Jun 2026 00:00:00 +0930',

--- a/packages/sails-ng-common/test/unit/jsonata-helpers.test.ts
+++ b/packages/sails-ng-common/test/unit/jsonata-helpers.test.ts
@@ -1,5 +1,11 @@
-import { jsonataCompile, jsonataCompileAndEvaluate, jsonataEvaluate, jsonataEvaluateFunc } from "../../src";
-
+import jsonata from 'jsonata';
+import {
+  jsonataCompile,
+  jsonataCompileAndEvaluate,
+  jsonataEvaluate,
+  jsonataEvaluateFunc,
+  jsonataLibrary,
+} from '../../src';
 
 describe('JSONata helpers', function () {
   let expect: Chai.ExpectStatic;
@@ -20,7 +26,7 @@ describe('JSONata helpers', function () {
   const cases = [
     {
       args: {
-        expression: "$sum(example.value)",
+        expression: '$sum(example.value)',
         input: { example: [{ value: 4 }, { value: 7 }, { value: 13 }] },
         bindings: undefined,
       },
@@ -28,7 +34,7 @@ describe('JSONata helpers', function () {
     },
     {
       args: {
-        expression: "$a + $b()",
+        expression: '$a + $b()',
         input: {},
         bindings: { a: 4, b: () => 78 },
       },
@@ -40,7 +46,7 @@ describe('JSONata helpers', function () {
         input: { name: 'testing' },
         bindings: undefined,
       },
-      expected: "testing",
+      expected: 'testing',
     },
     {
       args: {
@@ -79,5 +85,27 @@ describe('JSONata helpers', function () {
         compareError(error, expected);
       }
     });
+  });
+
+  it('should expose luxon date formatting to compiled JSONata expressions', async function () {
+    const actual = await jsonataCompileAndEvaluate('$luxonFormatDate(date, "yyyy")', {
+      date: '2026/06/10',
+    });
+
+    expect(actual).to.eql('2026');
+  });
+
+  it('should expose luxon date formatting to client-style JSONata library bindings', async function () {
+    const actual = await jsonata('$luxonFormatDate(date, "yyyy")').evaluate({ date: '2026-06-10' }, jsonataLibrary);
+
+    expect(actual).to.eql('2026');
+  });
+
+  it('should format RFC 2822 date string values with luxon JSONata helper', async function () {
+    const actual = await jsonataCompileAndEvaluate('$luxonFormatDate(date, "yyyy")', {
+      date: 'Wed, 10 Jun 2026 00:00:00 +0930',
+    });
+
+    expect(actual).to.eql('2026');
   });
 });

--- a/packages/sails-ng-common/test/unit/jsonata-helpers.test.ts
+++ b/packages/sails-ng-common/test/unit/jsonata-helpers.test.ts
@@ -95,6 +95,12 @@ describe('JSONata helpers', function () {
     expect(actual).to.eql('2026');
   });
 
+  it('should not allow JSONata eval to run dynamic expressions on the server side', async function () {
+    const actual = await jsonataCompileAndEvaluate('$eval("1+1")', {});
+
+    expect(actual).to.be.undefined;
+  });
+
   it('should expose luxon date formatting to client-style JSONata library bindings', async function () {
     const actual = await jsonata('$luxonFormatDate(date, "yyyy")').evaluate({ date: '2026-06-10' }, jsonataLibrary);
 

--- a/test/integration/services/TemplateService.test.ts
+++ b/test/integration/services/TemplateService.test.ts
@@ -4,6 +4,7 @@ const os = require('node:os');
 const nodePath = require('node:path');
 const ejs = require('ejs');
 const Handlebars = require('handlebars');
+const jsonata = require('jsonata');
 
 /*
  * The tests are using `require()` instead of `await import()` because this package is a commonjs type, not module.
@@ -67,13 +68,15 @@ describe('The TemplateService', function () {
                 args: {
                     inputs: [
                         { key: ['test1'], kind: "handlebars", value: "Handlebars <b>{{doesWhat}}</b> precompiled!" },
-                        { key: ['test2'], kind: "jsonata", value: "$sum(example.value)" }
+                        { key: ['test2'], kind: "jsonata", value: "$sum(example.value)" },
+                        { key: ['test3'], kind: "jsonata", value: "$exists($jsonata)" }
                     ],
                     contexts: [
                         { key: ["test1"], context: { doesWhat: "testing" } },
                         { key: ["test1"], context: { doesWhat: "another one" } },
                         { key: ["test2"], context: { example: [{ value: 4 }, { value: 7 }, { value: 13 }] }, extra: {} },
                         { key: ["test2"], context: { example: [{ value: 52 }, { value: 185 }] }, extra: {} },
+                        { key: ["test3"], context: {}, extra: {} },
                     ]
                 },
                 expected: [
@@ -81,6 +84,23 @@ describe('The TemplateService', function () {
                     "Handlebars <b>another one</b> precompiled!",
                     24,
                     237,
+                    false,
+                ],
+            },
+            {
+                args: {
+                    inputs: [
+                        { key: ['test1'], kind: "jsonata", value: "$sum(example.value)" },
+                        { key: ['test2'], kind: "jsonata", value: "$exists($jsonata)" }
+                    ],
+                    contexts: [
+                        { key: ["test1"], context: { example: [{ value: 4 }, { value: 7 }, { value: 13 }] }, extra: { jsonata: { default: jsonata } } },
+                        { key: ["test2"], context: {}, extra: { jsonata: { default: jsonata } } },
+                    ]
+                },
+                expected: [
+                    24,
+                    false,
                 ],
             },
         ];
@@ -105,7 +125,7 @@ describe('The TemplateService', function () {
                     for (let i = 0; i < args.contexts.length; i++) {
                         const context = args.contexts[i];
                         const expectedValue = expected[i];
-                        const extra = Object.assign({}, { libraries: { Handlebars: Handlebars } }, context.extra ?? {});
+                        const extra = Object.assign({}, { jsonata: jsonata, libraries: { Handlebars: Handlebars } }, context.extra ?? {});
                         const result = clientReady.evaluate(context.key, context.context, extra);
                         expect(result).to.eql(expectedValue);
                     }

--- a/test/integration/services/TemplateService.test.ts
+++ b/test/integration/services/TemplateService.test.ts
@@ -111,8 +111,9 @@ describe('The TemplateService', function () {
 
                 // Verify structure matches new implementation (key is [string], value has (context))
                 // For handlebars:
-                const handlebarsItem = clientMapping.find(i => i.key[0] === 'test1');
-                if (handlebarsItem) {
+                const handlebarsInput = args.inputs.find(i => i.kind === 'handlebars');
+                if (handlebarsInput) {
+                    const handlebarsItem = clientMapping.find(i => i.key[0] === handlebarsInput.key[0]);
                     expect(handlebarsItem.key).to.be.an('array');
                     expect(handlebarsItem.value).to.contain('(context)');
                 }

--- a/test/integration/services/TemplateService.test.ts
+++ b/test/integration/services/TemplateService.test.ts
@@ -69,7 +69,8 @@ describe('The TemplateService', function () {
                     inputs: [
                         { key: ['test1'], kind: "handlebars", value: "Handlebars <b>{{doesWhat}}</b> precompiled!" },
                         { key: ['test2'], kind: "jsonata", value: "$sum(example.value)" },
-                        { key: ['test3'], kind: "jsonata", value: "$exists($jsonata)" }
+                        { key: ['test3'], kind: "jsonata", value: "$exists($jsonata)" },
+                        { key: ['test4'], kind: "jsonata", value: "$eval(\"1+1\")" }
                     ],
                     contexts: [
                         { key: ["test1"], context: { doesWhat: "testing" } },
@@ -77,6 +78,7 @@ describe('The TemplateService', function () {
                         { key: ["test2"], context: { example: [{ value: 4 }, { value: 7 }, { value: 13 }] }, extra: {} },
                         { key: ["test2"], context: { example: [{ value: 52 }, { value: 185 }] }, extra: {} },
                         { key: ["test3"], context: {}, extra: {} },
+                        { key: ["test4"], context: {}, extra: {} },
                     ]
                 },
                 expected: [
@@ -85,22 +87,26 @@ describe('The TemplateService', function () {
                     24,
                     237,
                     false,
+                    undefined,
                 ],
             },
             {
                 args: {
                     inputs: [
                         { key: ['test1'], kind: "jsonata", value: "$sum(example.value)" },
-                        { key: ['test2'], kind: "jsonata", value: "$exists($jsonata)" }
+                        { key: ['test2'], kind: "jsonata", value: "$exists($jsonata)" },
+                        { key: ['test3'], kind: "jsonata", value: "$eval(\"1+1\")" }
                     ],
                     contexts: [
                         { key: ["test1"], context: { example: [{ value: 4 }, { value: 7 }, { value: 13 }] }, extra: { jsonata: { default: jsonata } } },
                         { key: ["test2"], context: {}, extra: { jsonata: { default: jsonata } } },
+                        { key: ["test3"], context: {}, extra: { jsonata: { default: jsonata } } },
                     ]
                 },
                 expected: [
                     24,
                     false,
+                    undefined,
                 ],
             },
         ];

--- a/views/dynamicScriptAsset.ejs
+++ b/views/dynamicScriptAsset.ejs
@@ -6,10 +6,8 @@ export function evaluate(key, context, extra) {
     // Provide libraries from context
     const Handlebars = extra?.libraries?.Handlebars ?? null;
     const jsonataModule = extra?.jsonata ?? null;
-    const jsonata = typeof jsonataModule === "function" ? jsonataModule : jsonataModule?.default ?? null;
-    if (!jsonata) {
-        throw new Error("JSONata instance not provided in extra.jsonata");
-    }
+    const jsonataFn = typeof jsonataModule === "function" ? jsonataModule : jsonataModule?.default ?? null;
+    const jsonata = jsonataFn ? jsonataFn : () => { throw new Error("JSONata instance not provided in extra.jsonata"); };
 
     switch (key) {
     <% for (const entry of entries) { %>

--- a/views/dynamicScriptAsset.ejs
+++ b/views/dynamicScriptAsset.ejs
@@ -5,7 +5,11 @@ export function evaluate(key, context, extra) {
 
     // Provide libraries from context
     const Handlebars = extra?.libraries?.Handlebars ?? null;
-    const jsonata = extra?.libraries?.jsonata ?? null;
+    const jsonataModule = extra?.jsonata ?? null;
+    const jsonata = typeof jsonataModule === "function" ? jsonataModule : jsonataModule?.default ?? null;
+    if (!jsonata) {
+        throw new Error("JSONata instance not provided in extra.jsonata");
+    }
 
     switch (key) {
     <% for (const entry of entries) { %>


### PR DESCRIPTION
## Summary

Adds configurable sorting of repeatable component elements, a `luxonFormatDate` JSONata helper for date formatting in expressions, and refactors the reusable contributor form definitions to use inline layout with corrected typeahead configuration.

---

## Context / Motivation

Repeatable components previously had no mechanism for users to reorder entries after creation, making ordered data entry workflows cumbersome. Form config authors needed date formatting capabilities within JSONata expressions for metadata transformation. The contributor form definitions required updating to match the current reusable component architecture.

---

## Key Features

### Repeatable Component Sorting

- New `canSort` boolean property on `RepeatableFieldComponentConfig` allowing form config authors to enable element reordering
- Move up / move down buttons in the repeatable element layout, visible only when `canSort` is enabled and the element is not at the boundary
- `moveElementFn` on the repeatable component swaps entries in the component map, view container, and model form control
- `updateCanSortFlags` manages per-element button state and re-evaluates on element add, remove, move, and disable transitions

### JSONata Date Formatting Helper

- New `luxonFormatDate(value, format, sourceFormat?)` custom JSONata function backed by Luxon for robust date parsing and formatting
- Supports ISO 8601, yyyy/MM/dd, RFC 2822, HTTP date, JS Date objects, and millisecond timestamps as input
- Registered in `jsonataCompile` and exposed through `jsonataLibrary` for both server and client-side evaluation
- Updated `TemplateService.buildClientMapping` to pass `extra?.libraries` to client-side JSONata evaluations, enabling custom function usage in browser validators

### Contributor Form Definition Refactoring

- Rebuilt reusable contributor field definitions (name, email, orcid, title) using the standard `ReusableComponent` pattern with `InlineLayout`
- Corrected typeahead configuration for the name field with `valueMode: 'value'`, `debounceMs` and `maxResults` settings
- Added a lookup-only variant (`standard-contributor-fields-lookup-only`) with `requireSelection` enforcement

### Date Input Robust Parsing

- Changed date input value normalization to only emit events when the incoming value is a string (triggering re-normalization), avoiding unnecessary change propagation when the internal model value is already normalized

---

## Testing

- Added unit tests for `luxonFormatDate` JSONata helper covering ISO, RFC 2822, and client-style library bindings
- Added TemplateService test verifying client JSONata library bindings are passed through `extra?.libraries`
- Form config migration visitor tests expanded with edge case coverage for checkbox tree coercions, LinkValueComponent defaults, and legacy CSS normalization
- Existing unit and integration test suites remain green

---

## Architectural / Operational Impact

### Repeatable Component Sorting

The sorting feature is opt-in via `canSort: true` in the repeatable component config. Existing repeatable configurations are unaffected. The layout component gains `moveUpFn`, `moveDownFn`, `canMoveUp`, and `canMoveDown` properties, which are dynamically managed by the parent repeatable component.

### JSONata Date Helpers

The `luxonFormatDate` function is available in all JSONata expression contexts (server validators, client validators, event conditions, metadata expressions). Client-side validators now receive the library bindings through the `extra` parameter, enabling custom function access without additional wiring.

### Migration Visitor

Continued hardening of the v4-to-v5 form config migration with improved edge-case handling for checkbox tree coercion, typeahead option resolution, and legacy CSS class normalization.

---

## Backwards Compatibility

Fully backwards compatible. All new features are opt-in (`canSort` defaults to `false`, date helpers are additive). The contributor form definition changes are structural refactors with equivalent behavior. Migration visitor changes only affect v4 configurations that were previously producing warnings or errors.

---

## Deployment Notes

Standard deployment. No database migrations or configuration changes required. The new translation keys (`move-up-button-label`, `move-down-button-label`) will need translation entries added for non-English locales.

---

## Impact

Improves form usability by enabling reordering of repeatable entries, provides a general-purpose date formatting facility for JSONata expressions, and aligns contributor form definitions with the reusable component architecture.
