### PR TITLE
Bugfix: Re-initialise draw tooling when re-enabling a disabled map component

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
@@ -264,17 +264,24 @@ describe("MapComponent", () => {
 
     const {fixture, formComponent} = await createFormAndWaitForReady(formConfig, {editMode: true} as any);
     const mapComponent = formComponent.getComponentDefByName("map_coverage")?.component as MapComponent;
+    await fixture.whenStable();
+    fixture.detectChanges();
+    const disabledModeButtons = Array.from(fixture.nativeElement.querySelectorAll(".rb-map-mode-btn")) as HTMLButtonElement[];
 
     expect(fakeDraw.start).not.toHaveBeenCalled();
+    expect(disabledModeButtons.some((button) => !button.disabled)).toBeFalse();
 
     mapComponent.setDisabled(false);
     fixture.detectChanges();
     await fixture.whenStable();
+    fixture.detectChanges();
+    const enabledModeButtons = Array.from(fixture.nativeElement.querySelectorAll(".rb-map-mode-btn")) as HTMLButtonElement[];
 
     expect(fakeDraw.start).toHaveBeenCalled();
+    expect(enabledModeButtons.length).toBeGreaterThan(0);
+    expect(enabledModeButtons.every((button) => !button.disabled)).toBeTrue();
 
-    const polygonButton = Array.from(fixture.nativeElement.querySelectorAll(".rb-map-mode-btn"))
-      .find((button) => (button as HTMLButtonElement).textContent?.trim() === "Polygon") as HTMLButtonElement;
+    const polygonButton = enabledModeButtons.find((button) => button.textContent?.trim() === "Polygon") as HTMLButtonElement;
     polygonButton.click();
     fixture.detectChanges();
 

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
@@ -227,7 +227,14 @@ describe("MapComponent", () => {
     };
 
     await createFormAndWaitForReady(formConfig, {editMode: true} as any);
-    expect(fakeDraw.addFeatures).toHaveBeenCalled();
+    expect(fakeDraw.addFeatures).toHaveBeenCalledOnceWith([
+      {
+        type: "Feature",
+        geometry: {type: "Point", coordinates: [144.96, -37.81]},
+        properties: {name: "Melbourne"}
+      }
+    ]);
+    expect(drawFeatures.length).toBe(1);
     expect(fakeMap.invalidateSize).toHaveBeenCalled();
   });
 

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
@@ -32,6 +32,7 @@ describe("MapComponent", () => {
       start: jasmine.createSpy("start"),
       stop: jasmine.createSpy("stop"),
       on: jasmine.createSpy("on"),
+      setMode: jasmine.createSpy("setMode"),
       addFeatures: jasmine.createSpy("addFeatures").and.callFake((features: unknown[]) => {
         drawFeatures.push(...features);
       }),
@@ -228,5 +229,49 @@ describe("MapComponent", () => {
     await createFormAndWaitForReady(formConfig, {editMode: true} as any);
     expect(fakeDraw.addFeatures).toHaveBeenCalled();
     expect(fakeMap.invalidateSize).toHaveBeenCalled();
+  });
+
+  it("initialises draw tooling when a disabled map is enabled after map load", async () => {
+    const formConfig: FormConfigFrame = {
+      name: "testing",
+      componentDefinitions: [
+        {
+          name: "map_coverage",
+          component: {
+            class: "MapComponent",
+            config: {
+              disabled: true,
+              enableImport: true,
+              enabledModes: ["point", "polygon"]
+            }
+          },
+          model: {
+            class: "MapModel",
+            config: {
+              defaultValue: {type: "FeatureCollection", features: []}
+            }
+          }
+        }
+      ]
+    };
+
+    const {fixture, formComponent} = await createFormAndWaitForReady(formConfig, {editMode: true} as any);
+    const mapComponent = formComponent.getComponentDefByName("map_coverage")?.component as MapComponent;
+
+    expect(fakeDraw.start).not.toHaveBeenCalled();
+
+    mapComponent.setDisabled(false);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(fakeDraw.start).toHaveBeenCalled();
+
+    const polygonButton = Array.from(fixture.nativeElement.querySelectorAll(".rb-map-mode-btn"))
+      .find((button) => (button as HTMLButtonElement).textContent?.trim() === "Polygon") as HTMLButtonElement;
+    polygonButton.click();
+    fixture.detectChanges();
+
+    expect(fakeDraw.setMode).toHaveBeenCalledWith("polygon");
+    expect(mapComponent.activeMode).toBe("polygon");
   });
 });

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.ts
@@ -329,9 +329,6 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
     const startingValue = this.currentModelValue();
     if (this.isEditMode()) {
       this.ensureDrawInitialised();
-      if (startingValue.features.length > 0) {
-        this.pushFeaturesToDraw(startingValue.features);
-      }
     } else {
       this.renderReadonlyLayer(startingValue);
     }

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.ts
@@ -1,5 +1,5 @@
 import {AfterViewInit, Component, ElementRef, InjectionToken, Input, OnDestroy, ViewChild, inject} from "@angular/core";
-import {FormFieldBaseComponent, FormFieldCompMapEntry, FormFieldModel} from "@researchdatabox/portal-ng-common";
+import {FormFieldBaseComponent, FormFieldCompMapEntry, FormFieldModel, ModifyOptions} from "@researchdatabox/portal-ng-common";
 import {
   MapComponentName,
   MapDrawingMode,
@@ -301,6 +301,13 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
     this.invalidateMap();
   }
 
+  public override setDisabled(disabled: boolean, opts?: ModifyOptions): void {
+    super.setDisabled(disabled, opts);
+    if (!disabled) {
+      this.ensureDrawInitialised();
+    }
+  }
+
   private initialiseMap(): void {
     if (!this.mapHost?.nativeElement || this.map || !this.mapDeps) {
       return;
@@ -321,7 +328,7 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
 
     const startingValue = this.currentModelValue();
     if (this.isEditMode()) {
-      this.initialiseDraw();
+      this.ensureDrawInitialised();
       if (startingValue.features.length > 0) {
         this.pushFeaturesToDraw(startingValue.features);
       }
@@ -331,6 +338,19 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
 
     this.installVisibilityObserver();
     this.invalidateMap();
+  }
+
+  private ensureDrawInitialised(): void {
+    if (this.draw || !this.map || !this.mapDeps || !this.isEditMode()) {
+      return;
+    }
+    this.featureLayer?.removeFrom(this.map);
+    this.featureLayer = undefined;
+    this.initialiseDraw();
+    const startingValue = this.currentModelValue();
+    if (startingValue.features.length > 0) {
+      this.pushFeaturesToDraw(startingValue.features);
+    }
   }
 
   private initialiseDraw(): void {


### PR DESCRIPTION
## Summary

Fixes a bug where draw tooling on the map component was not re-initialised when a disabled map field was re-enabled after the initial map load, preventing users from drawing or editing geometries.

---

## Context / Motivation

When a map component was configured as disabled on load and later re-enabled via `setDisabled(false)`, the draw controls and interaction layer were never initialised. This left the map in a read-only state even after the field became editable, requiring a page reload to restore draw functionality.

---

## Key Features

### Draw tooling resumed on re-enable

- Overrides `setDisabled` to call `ensureDrawInitialised` when transitioning from disabled to enabled
- Introduces `ensureDrawInitialised` as a guarded re-initialisation entry point that re-creates the draw layer and re-pushes existing features only when draw has not been previously initialised

### Clean-up of existing initialisation

- Replaces the inline draw initialisation in `initialiseMap` with a call to `ensureDrawInitialised`, centralising the draw setup guard logic

---

## Testing

- Added spec covering the full re-enable flow: map loads while disabled, re-enabled, draw controls start, and mode selection works
- Added `setMode` spy to the draw mock to verify mode switching after re-enable

---

## Architectural / Operational Impact

### Reduced coupling between map lifecycle and draw lifecycle

Draw initialisation is no longer solely tied to `initialiseMap`; it can be triggered independently when the component transitions from disabled to editable, making the draw setup path reusable.

---

## Backwards Compatibility

Fully backwards compatible. The change only adds a new method and an override; all existing behaviour paths remain unchanged.

---

## Deployment Notes

No deployment or migration steps required.

---

## Impact

Ensures map fields that are initially disabled become fully functional when enabled, without requiring a page reload.
