### PR TITLE
Bugfix: Update TipTap editor editable state when RichTextEditor is disabled

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/rich-text-editor.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/rich-text-editor.component.spec.ts
@@ -264,4 +264,27 @@ describe("RichTextEditorComponent", () => {
 
     expect(component.resolveCspNonce()).toBe("injected-csp-nonce");
   });
+
+  it("updates editor editable state when disabled changes", async () => {
+    const formConfig: FormConfigFrame = {
+      name: "testing",
+      componentDefinitions: [{
+        name: "editableField",
+        component: { class: "RichTextEditorComponent" },
+        model: { class: "RichTextEditorModel", config: { value: "<p>Before</p>" } }
+      }]
+    };
+
+    const { fixture } = await createFormAndWaitForReady(formConfig, editModeProps);
+    const richTextComponent = fixture.debugElement.query(By.directive(RichTextEditorComponent)).componentInstance as RichTextEditorComponent;
+    expect(richTextComponent.editor?.isEditable).toBe(true);
+
+    richTextComponent.setDisabled(true);
+    await fixture.whenStable();
+    expect(richTextComponent.editor?.isEditable).toBe(false);
+
+    richTextComponent.setDisabled(false);
+    await fixture.whenStable();
+    expect(richTextComponent.editor?.isEditable).toBe(true);
+  });
 });

--- a/angular/projects/researchdatabox/form/src/app/component/rich-text-editor.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/rich-text-editor.component.ts
@@ -7,7 +7,7 @@ import TableRow from "@tiptap/extension-table-row";
 import { Markdown } from "@tiptap/markdown";
 import StarterKit from "@tiptap/starter-kit";
 import { Subscription } from "rxjs";
-import { FormFieldBaseComponent, FormFieldCompMapEntry, FormFieldModel } from "@researchdatabox/portal-ng-common";
+import { FormFieldBaseComponent, FormFieldCompMapEntry, FormFieldModel, ModifyOptions } from "@researchdatabox/portal-ng-common";
 import {
   escapeHtmlText,
   RichTextEditorComponentName,
@@ -193,6 +193,13 @@ export class RichTextEditorComponent extends FormFieldBaseComponent<string> impl
       this.skipNextSync = true;
       this.setEditorValue(nextValue);
     });
+  }
+
+  public override setDisabled(disabled: boolean, opts?: ModifyOptions): void {
+    super.setDisabled(disabled, opts);
+    if (this.editor) {
+      this.editor.setEditable(!this.isReadonly && !this.isDisabled);
+    }
   }
 
   public onToolbarAction(action: string): void {


### PR DESCRIPTION
## Summary

Fixes the TipTap editor not visually or functionally reflecting the RichTextEditor component's disabled state.

---

## Context / Motivation

When the `RichTextEditorComponent` was programmatically disabled (e.g. via form field interdependencies or read-only mode), the underlying TipTap editor instance remained editable — the toolbar was blocked but the content area still accepted input. This caused a mismatch between the form field's disabled state and the editor's actual behavior.

---

## Key Features

### TipTap editable state synchronisation

- Override `setDisabled()` on `RichTextEditorComponent` to propagate disabled/readonly state to the TipTap editor via `editor.setEditable()`
- The editor is only editable when both `isReadonly` and `isDisabled` are `false`

### Test coverage

- Added spec verifying that `editor.isEditable` toggles correctly when `setDisabled(true)` and `setDisabled(false)` are called

---

## Testing

- Added unit test for editor editable state transitions in `rich-text-editor.component.spec.ts`

---

## Architectural / Operational Impact

### Component lifecycle

- The fix is contained to the existing `setDisabled` override pattern used by other form field components, so no new lifecycle hooks or state management are introduced

---

## Backwards Compatibility

Fully backwards compatible — only adds an override path; existing behaviour when the component is enabled is unchanged.

---

## Deployment Notes

None required.

---

## Impact

Ensures the TipTap-based rich text editor correctly respects the form field's disabled/readonly state, both visually and functionally.
