### PR TITLE
Bugfix: Refactor save button to use computed signal and fix target-step save logic

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/save-button.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/save-button.component.spec.ts
@@ -68,7 +68,7 @@ describe('SaveButtonComponent', () => {
     translationService.translationMap['@save-button-default'] = 'Save';
     translationService.translationMap['@save-button-saving'] = 'Saving';
 
-    const { fixture, formComponent } = await createFormAndWaitForReady(formConfig);
+    const { fixture } = await createFormAndWaitForReady(formConfig);
     const store = TestBed.inject(Store);
     // Dispatch validation pending action instead of direct mutation
     store.dispatch(FormActions.formValidationPending());
@@ -86,7 +86,7 @@ describe('SaveButtonComponent', () => {
     translationService.translationMap['@save-button-default'] = 'Save';
     translationService.translationMap['@save-button-saving'] = 'Saving';
 
-    const { fixture, formComponent } = await createFormAndWaitForReady(formConfig);
+    const { fixture } = await createFormAndWaitForReady(formConfig);
 
     // TODO: how to get a protected / private property?
     const saveButtonComponent = fixture.componentInstance.componentDefArr[1].component as any;
@@ -219,11 +219,13 @@ describe('SaveButtonComponent', () => {
     const saveButtonConfig = formConfig.componentDefinitions?.[1]?.component?.config as Record<string, unknown>;
     delete saveButtonConfig['forceSave'];
 
-    const { fixture } = await createFormAndWaitForReady(formConfig);
+    const { fixture, formComponent } = await createFormAndWaitForReady(formConfig);
+    const store = TestBed.inject(Store);
     const eventBus = TestBed.inject(FormComponentEventBus);
     const events: any[] = [];
     const sub = eventBus.select$('form.save.requested').subscribe(e => events.push(e));
     try {
+      store.dispatch(FormActions.formValidationSuccess());
       TestBed.flushEffects();
       fixture.detectChanges();
       await fixture.whenStable();

--- a/angular/projects/researchdatabox/form/src/app/component/save-button.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/save-button.component.spec.ts
@@ -194,6 +194,10 @@ describe('SaveButtonComponent', () => {
   });
 
   it('clicking save button should not publish when the form is unchanged', async () => {
+    const saveButtonConfig = formConfig.componentDefinitions?.[1]?.component?.config as Record<string, unknown>;
+    delete saveButtonConfig['targetStep'];
+    delete saveButtonConfig['forceSave'];
+
     const { fixture } = await createFormAndWaitForReady(formConfig);
     const eventBus = TestBed.inject(FormComponentEventBus);
     const events: any[] = [];
@@ -206,6 +210,35 @@ describe('SaveButtonComponent', () => {
       await fixture.whenStable();
       // Assert that no event was published
       expect(events.length).toBe(0);
+    } finally {
+      sub.unsubscribe();
+    }
+  });
+
+  it('clicking target step save button should publish when the form is unchanged', async () => {
+    const saveButtonConfig = formConfig.componentDefinitions?.[1]?.component?.config as Record<string, unknown>;
+    delete saveButtonConfig['forceSave'];
+
+    const { fixture } = await createFormAndWaitForReady(formConfig);
+    const eventBus = TestBed.inject(FormComponentEventBus);
+    const events: any[] = [];
+    const sub = eventBus.select$('form.save.requested').subscribe(e => events.push(e));
+    try {
+      TestBed.flushEffects();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const saveButton = fixture.nativeElement.querySelector('button');
+      expect(saveButton.disabled).toBeFalse();
+
+      saveButton.click();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(events.length).toBe(1);
+      expect(events[0].force).toBe(true);
+      expect(events[0].targetStep).toBe('next_step');
+      expect(events[0].enabledValidationGroups).toEqual(["none"]);
     } finally {
       sub.unsubscribe();
     }

--- a/angular/projects/researchdatabox/form/src/app/component/save-button.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/save-button.component.spec.ts
@@ -94,12 +94,18 @@ describe('SaveButtonComponent', () => {
     const translateSpy = spyOn(saveButtonComponent, 'translate').and.callThrough();
 
     const store = TestBed.inject(Store);
+    // Make the form dirty so saveForm doesn't immediately reject
+    const textField = fixture.nativeElement.querySelector('input');
+    textField.value = 'new value';
+    textField.dispatchEvent(new Event('input'));
+    await fixture.whenStable();
+
     // Dispatch submit action to trigger SAVING status
     store.dispatch(FormActions.submitForm({ force: false }));
     fixture.detectChanges();
     await fixture.whenStable();
 
-    TestBed.flushEffects();
+    TestBed.tick();
     const saveButton = fixture.nativeElement.querySelector('button');
     expect(saveButton.disabled).toBeTrue();
 
@@ -144,6 +150,8 @@ describe('SaveButtonComponent', () => {
       // Set status to VALIDATION_PENDING to disable button
       store.dispatch(FormActions.formValidationPending());
       fixture.detectChanges();
+      await fixture.whenStable();
+      TestBed.tick();
       const saveButton = fixture.nativeElement.querySelector('button');
       saveButton.click();
       fixture.detectChanges();
@@ -219,14 +227,11 @@ describe('SaveButtonComponent', () => {
     const saveButtonConfig = formConfig.componentDefinitions?.[1]?.component?.config as Record<string, unknown>;
     delete saveButtonConfig['forceSave'];
 
-    const { fixture, formComponent } = await createFormAndWaitForReady(formConfig);
-    const store = TestBed.inject(Store);
+    const { fixture } = await createFormAndWaitForReady(formConfig);
     const eventBus = TestBed.inject(FormComponentEventBus);
     const events: any[] = [];
     const sub = eventBus.select$('form.save.requested').subscribe(e => events.push(e));
     try {
-      store.dispatch(FormActions.formValidationSuccess());
-      TestBed.flushEffects();
       fixture.detectChanges();
       await fixture.whenStable();
 
@@ -244,6 +249,19 @@ describe('SaveButtonComponent', () => {
     } finally {
       sub.unsubscribe();
     }
+  });
+
+  it('should disable standard save button on initial load when the form is pristine', async () => {
+    const saveButtonConfig = formConfig.componentDefinitions?.[1]?.component?.config as Record<string, unknown>;
+    delete saveButtonConfig['targetStep'];
+    delete saveButtonConfig['forceSave'];
+
+    const { fixture } = await createFormAndWaitForReady(formConfig);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const saveButton = fixture.nativeElement.querySelector('button');
+    expect(saveButton.disabled).toBeTrue();
   });
 
   it('should render save button wrapper class used by action row', async () => {

--- a/angular/projects/researchdatabox/form/src/app/component/save-button.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/save-button.component.ts
@@ -1,5 +1,6 @@
 import {Component, effect, signal} from '@angular/core';
 import {SaveButtonComponentName, SaveButtonFieldComponentDefinitionOutline} from '@researchdatabox/sails-ng-common';
+import {FormFieldCompMapEntry} from '@researchdatabox/portal-ng-common';
 import {FormComponentEventType, createFormSaveRequestedEvent} from '../form-state';
 import {ButtonBaseComponent} from "./button-base.component";
 
@@ -27,31 +28,17 @@ export class SaveButtonComponent extends ButtonBaseComponent {
   disabled = signal<boolean>(true);
   public override componentDefinition?: SaveButtonFieldComponentDefinitionOutline;
   protected currentLabel = signal<string | undefined>(this.componentDefinition?.config?.label);
+  protected hasTargetStep = signal<boolean>(false);
+  private readonly validationSignal = this.eventBus.selectSignal(FormComponentEventType.FORM_VALIDATION_BROADCAST);
 
 
   protected override fallbackVariantClass: string = 'btn-primary';
 
   constructor() {
     super();
-    const validationSignal = this.eventBus.selectSignal(FormComponentEventType.FORM_VALIDATION_BROADCAST);
     // Monitor form status to update disabled state
     effect(() => {
-      const dataStatusEvent = validationSignal();
-      const isSaving = this.formStateFacade.isSaving();
-      const isValidationPending = this.formStateFacade.isValidationPending();
-      if (dataStatusEvent && dataStatusEvent.status) {
-        const dataStatus = dataStatusEvent.status;
-        this.loggerService.debug(`SaveButtonComponent effect: validation or pristine signal event: `, dataStatus);
-        // Disable when any of the following is true:
-        // - form is invalid
-        // - form has NOT been modified (i.e., not dirty)
-        // - async validation is pending
-        // - a save is currently in progress
-        const isDisabled: boolean = (!dataStatus.valid) || (!dataStatus.dirty) || isValidationPending || isSaving;
-        this.disabled.set(isDisabled);
-      } else {
-        // TODO: Decide if there's a use case for enabling the button when lacking information about the validation status of the form
-      }
+      this.updateDisabledState();
     });
     effect(() => {
       const isSaving = this.formStateFacade.isSaving();
@@ -61,13 +48,39 @@ export class SaveButtonComponent extends ButtonBaseComponent {
     });
   }
 
+  protected override setPropertiesFromComponentMapEntry(formFieldCompMapEntry: FormFieldCompMapEntry): void {
+    super.setPropertiesFromComponentMapEntry(formFieldCompMapEntry);
+    this.hasTargetStep.set(String(this.componentDefinition?.config?.targetStep ?? '').trim().length > 0);
+    this.updateDisabledState();
+  }
+
+  private updateDisabledState(): void {
+    const dataStatusEvent = this.validationSignal();
+    const isSaving = this.formStateFacade.isSaving();
+    const isValidationPending = this.formStateFacade.isValidationPending();
+    const hasTargetStep = this.hasTargetStep();
+    if (dataStatusEvent && dataStatusEvent.status) {
+      const dataStatus = dataStatusEvent.status;
+      this.loggerService.debug(`SaveButtonComponent effect: validation or pristine signal event: `, dataStatus);
+      // Disable when any of the following is true:
+      // - form is invalid
+      // - form has NOT been modified (i.e., not dirty) and this is not a workflow transition button
+      // - async validation is pending
+      // - a save is currently in progress
+      const isDisabled: boolean = (!dataStatus.valid) || (!dataStatus.dirty && !hasTargetStep) || isValidationPending || isSaving;
+      this.disabled.set(isDisabled);
+    } else {
+      // TODO: Decide if there's a use case for enabling the button when lacking information about the validation status of the form
+    }
+  }
+
   public async save() {
     if (!this.disabled()) {
       // Publish a typed event to request save; NgRx effects will orchestrate execution
       const redirectLocation = String(this.componentDefinition?.config?.redirectLocation ?? '').trim();
       this.eventBus.publish(
         createFormSaveRequestedEvent({
-          force: this.componentDefinition?.config?.forceSave,
+          force: this.componentDefinition?.config?.forceSave || this.hasTargetStep(),
           targetStep: this.componentDefinition?.config?.targetStep,
           closeOnSave: this.componentDefinition?.config?.closeOnSave,
           redirectLocation: await this.resolveRedirectLocation(redirectLocation),

--- a/angular/projects/researchdatabox/form/src/app/component/save-button.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/save-button.component.ts
@@ -1,4 +1,4 @@
-import {Component, effect, signal} from '@angular/core';
+import {Component, computed, effect, signal} from '@angular/core';
 import {SaveButtonComponentName, SaveButtonFieldComponentDefinitionOutline} from '@researchdatabox/sails-ng-common';
 import {FormFieldCompMapEntry} from '@researchdatabox/portal-ng-common';
 import {FormComponentEventType, createFormSaveRequestedEvent} from '../form-state';
@@ -25,21 +25,37 @@ import {ButtonBaseComponent} from "./button-base.component";
 })
 export class SaveButtonComponent extends ButtonBaseComponent {
   public override logName = SaveButtonComponentName;
-  disabled = signal<boolean>(true);
   public override componentDefinition?: SaveButtonFieldComponentDefinitionOutline;
   protected currentLabel = signal<string | undefined>(this.componentDefinition?.config?.label);
   protected hasTargetStep = signal<boolean>(false);
   private readonly validationSignal = this.eventBus.selectSignal(FormComponentEventType.FORM_VALIDATION_BROADCAST);
 
+  readonly disabled = computed(() => {
+    const dataStatusEvent = this.validationSignal();
+    const isSaving = this.formStateFacade.isSaving();
+    const isValidationPending = this.formStateFacade.isValidationPending();
+    const hasTargetStep = this.hasTargetStep();
+    if (dataStatusEvent && dataStatusEvent.status) {
+      const dataStatus = dataStatusEvent.status;
+      this.loggerService.debug(`SaveButtonComponent computed: validation or pristine signal event: `, dataStatus);
+      // Disable when any of the following is true:
+      // - form is invalid
+      // - form has NOT been modified (i.e., not dirty) and this is not a workflow transition button
+      // - async validation is pending
+      // - a save is currently in progress
+      return (!dataStatus.valid) || (!dataStatus.dirty && !hasTargetStep) || isValidationPending || isSaving;
+    }
+    // When validation status is not yet available (e.g. initial load before the first
+    // FORM_VALIDATION_BROADCAST), default to disabled for standard save, but enabled for
+    // target-step buttons so workflow transitions can proceed.
+    // Still respect pending/saving states.
+    return !hasTargetStep || isValidationPending || isSaving;
+  });
 
   protected override fallbackVariantClass: string = 'btn-primary';
 
   constructor() {
     super();
-    // Monitor form status to update disabled state
-    effect(() => {
-      this.updateDisabledState();
-    });
     effect(() => {
       const isSaving = this.formStateFacade.isSaving();
       const defaultLabel = this.componentDefinition?.config?.label;
@@ -51,27 +67,6 @@ export class SaveButtonComponent extends ButtonBaseComponent {
   protected override setPropertiesFromComponentMapEntry(formFieldCompMapEntry: FormFieldCompMapEntry): void {
     super.setPropertiesFromComponentMapEntry(formFieldCompMapEntry);
     this.hasTargetStep.set(String(this.componentDefinition?.config?.targetStep ?? '').trim().length > 0);
-    this.updateDisabledState();
-  }
-
-  private updateDisabledState(): void {
-    const dataStatusEvent = this.validationSignal();
-    const isSaving = this.formStateFacade.isSaving();
-    const isValidationPending = this.formStateFacade.isValidationPending();
-    const hasTargetStep = this.hasTargetStep();
-    if (dataStatusEvent && dataStatusEvent.status) {
-      const dataStatus = dataStatusEvent.status;
-      this.loggerService.debug(`SaveButtonComponent effect: validation or pristine signal event: `, dataStatus);
-      // Disable when any of the following is true:
-      // - form is invalid
-      // - form has NOT been modified (i.e., not dirty) and this is not a workflow transition button
-      // - async validation is pending
-      // - a save is currently in progress
-      const isDisabled: boolean = (!dataStatus.valid) || (!dataStatus.dirty && !hasTargetStep) || isValidationPending || isSaving;
-      this.disabled.set(isDisabled);
-    } else {
-      // TODO: Decide if there's a use case for enabling the button when lacking information about the validation status of the form
-    }
   }
 
   public async save() {

--- a/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
@@ -1,6 +1,6 @@
 import {fakeAsync, flushMicrotasks, TestBed, tick} from '@angular/core/testing';
 import { Location } from '@angular/common';
-import { FormControl, FormGroup } from '@angular/forms';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { FormComponent } from './form.component';
 import { FormConfigFrame } from '@researchdatabox/sails-ng-common';
 import { SimpleInputComponent } from './component/simple-input.component';
@@ -420,6 +420,22 @@ describe('FormComponent', () => {
     await formComponent.saveForm();
 
     expect(updateSpy).toHaveBeenCalledOnceWith('oid-123', { settled_field: 'ready' }, '');
+  });
+
+  it('does not save invalid forms when forced', async () => {
+    const fixture = TestBed.createComponent(FormComponent);
+    const formComponent = fixture.componentInstance;
+    formComponent.form = new FormGroup({
+      required_field: new FormControl('', Validators.required),
+    });
+    formComponent.form.updateValueAndValidity();
+    formComponent.oid.set('oid-123');
+    const updateSpy = spyOn(formComponent.recordService, 'update').and.resolveTo({ success: true } as any);
+
+    await formComponent.saveForm({force: true, targetStep: 'review'});
+
+    expect(formComponent.form.invalid).toBeTrue();
+    expect(updateSpy).not.toHaveBeenCalled();
   });
 
   it('fails save when pending async validation times out', async () => {

--- a/angular/projects/researchdatabox/form/src/app/form.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.ts
@@ -1143,7 +1143,7 @@ export class FormComponent extends BaseComponent implements OnDestroy {
     // Check if the form is ready, defined, modified OR forceSave is set
     // Status check will ensure saves requests will not overlap within the Angular Form app context
     const formIsModified = this.form?.dirty || forceSave;
-    if (this.form?.pending && !forceSave) {
+    if (this.form?.pending) {
       const validationSettled = await this.waitForPendingValidation();
       if (this.isDestroyed) {
         return;
@@ -1156,7 +1156,7 @@ export class FormComponent extends BaseComponent implements OnDestroy {
       }
     }
     // At this point, only the validators that we want to run will be set on the angular components.
-    const formIsValid = this.form?.valid || forceSave;
+    const formIsValid = this.form?.valid;
     const formIsSaving = _isNull(this.saveResponse());
 
     if (this.form && formIsModified) {


### PR DESCRIPTION
## Summary

Refactors the save button disabled state from `effect`-based to `computed`-based signal logic, and fixes the target-step (workflow transition) save button to correctly force-save with validation passing.

---

## Context / Motivation

Standard save buttons should remain disabled when the form is pristine and should only save if the form is valid. Target-step buttons (workflow transitions like "Next step") must always be enabled for navigation and must force-save, but should still require form validation to pass before persisting. The previous implementation allowed forced saves to bypass validation entirely, which could persist invalid data.

---

## Key Features

### Computed signal for disabled state

- Replaced `effect()` with `computed()` for the `disabled` signal, improving reactivity and readability
- Standard save buttons remain disabled when the form is pristine or invalid
- Target-step buttons are always enabled (for navigation) but still respect validation state for the actual save

### Target-step save button detection

- Added `hasTargetStep` signal, set from the component's config on init
- Target-step buttons automatically emit `force: true` in the save event

### Form validation hardening

- Forced saves no longer bypass pending validation checks
- Invalid forms are never persisted, even when `forceSave` is set
- Form validity is always checked before saving

### Test coverage

- Added test for target-step save button publishing correct event with `force: true`
- Added test for standard save button disabled on initial load when pristine
- Added test verifying invalid forms are not saved when forced
- Fixed test setup for existing tests (dirty form before submit, proper tick handling)

---

## Testing

- Updated existing save button unit tests
- Added new test cases for target-step and pristine-state scenarios
- Added form component test for forced save with invalid form data

---

## Architectural / Operational Impact

### Signal reactivity

The shift from `effect` to `computed` for the disabled state aligns with Angular idiomatic signal usage and eliminates manual signal assignment in effects.

### Workflow transition integrity

Target-step buttons no longer bypass form validation, preventing invalid data from being persisted during workflow transitions while still allowing navigation.

---

## Backwards Compatibility

Fully backwards compatible. The behaviour change for target-step buttons (requiring validation) is a correctness fix that only affects cases where validation was being incorrectly bypassed.

---

## Deployment Notes

No special deployment steps required.

---

## Impact

Improves correctness of save button behaviour for both standard save and workflow transition scenarios, and strengthens form validation enforcement across all save paths.
