### PR TITLE
Bugfix: Fix self-nesting and stale field persistence in value-binding editor

### DIFF
--- a/angular/projects/researchdatabox/app-config/src/app/fieldTypes/value-binding-editor/value-binding-editor.type.html
+++ b/angular/projects/researchdatabox/app-config/src/app/fieldTypes/value-binding-editor/value-binding-editor.type.html
@@ -19,7 +19,7 @@
     </div>
     @if (collapsed) { @if (isConfigured) {
     <span class="binding-source text-muted ms-auto d-flex align-items-center gap-2">
-      <span class="text-truncate" style="max-width: 400px">&larr; {{ summarySource }}</span>
+      <span class="text-truncate binding-summary">&larr; {{ summarySource }}</span>
       @if (kind !== 'path') {
       <span class="badge bg-secondary binding-badge">{{ kind }}</span>
       } @if (hasDefault) {

--- a/angular/projects/researchdatabox/app-config/src/app/fieldTypes/value-binding-editor/value-binding-editor.type.ts
+++ b/angular/projects/researchdatabox/app-config/src/app/fieldTypes/value-binding-editor/value-binding-editor.type.ts
@@ -274,8 +274,8 @@ export class ValueBindingEditorTypeComponent extends FieldType<FieldTypeConfig> 
         defaultValue: next['defaultValue'] ?? ''
       };
       const control = this.formControl as {
-        patchValue?: (val: unknown) => void;
-        setValue?: (val: unknown) => void;
+        patchValue?: (val: unknown, options?: { emitEvent?: boolean; onlySelf?: boolean }) => void;
+        setValue?: (val: unknown, options?: { emitEvent?: boolean; onlySelf?: boolean }) => void;
       };
       if (typeof control.patchValue === 'function') {
         control.patchValue(patch, { emitEvent: false });

--- a/angular/projects/researchdatabox/app-config/src/app/fieldTypes/value-binding-editor/value-binding-editor.type.ts
+++ b/angular/projects/researchdatabox/app-config/src/app/fieldTypes/value-binding-editor/value-binding-editor.type.ts
@@ -199,7 +199,7 @@ export class ValueBindingEditorTypeComponent extends FieldType<FieldTypeConfig> 
     // itself, and this.model is the binding object (NOT the parent). The FormGroup
     // value is the source of truth; fall back to the model object directly.
     const controlValue = this.formControl?.value as ValueBindingValue | undefined;
-    if (controlValue && typeof controlValue === 'object') {
+    if (controlValue && typeof controlValue === 'object' && Object.keys(controlValue).length > 0) {
       return controlValue;
     }
     return (this.model as ValueBindingValue | undefined) ?? {};
@@ -278,9 +278,9 @@ export class ValueBindingEditorTypeComponent extends FieldType<FieldTypeConfig> 
         setValue?: (val: unknown) => void;
       };
       if (typeof control.patchValue === 'function') {
-        control.patchValue(patch);
+        control.patchValue(patch, { emitEvent: false });
       } else if (typeof control.setValue === 'function') {
-        control.setValue(patch);
+        control.setValue(patch, { emitEvent: false });
       }
       if (markChanged) {
         this.formControl.markAsDirty();

--- a/angular/projects/researchdatabox/app-config/src/app/fieldTypes/value-binding-editor/value-binding-editor.type.ts
+++ b/angular/projects/researchdatabox/app-config/src/app/fieldTypes/value-binding-editor/value-binding-editor.type.ts
@@ -104,6 +104,9 @@ const HUMAN_LABELS: Record<string, string> = {
       font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
       font-size: 0.8rem;
     }
+    .binding-summary {
+      max-width: 400px;
+    }
     .binding-badge { font-size: 0.7rem; font-weight: 500; }
   `],
   standalone: false

--- a/angular/projects/researchdatabox/app-config/src/app/fieldTypes/value-binding-editor/value-binding-editor.type.ts
+++ b/angular/projects/researchdatabox/app-config/src/app/fieldTypes/value-binding-editor/value-binding-editor.type.ts
@@ -191,9 +191,15 @@ export class ValueBindingEditorTypeComponent extends FieldType<FieldTypeConfig> 
   }
 
   private resolveCurrentValue(): ValueBindingValue {
-    const modelValue = typeof this.key === 'string' ? (this.model?.[this.key] as ValueBindingValue | undefined) : undefined;
+    // The schema models each binding as a JSON Schema object, so formly builds an
+    // object field: this.formControl is a FormGroup whose value is the binding
+    // itself, and this.model is the binding object (NOT the parent). The FormGroup
+    // value is the source of truth; fall back to the model object directly.
     const controlValue = this.formControl?.value as ValueBindingValue | undefined;
-    return modelValue ?? controlValue ?? {};
+    if (controlValue && typeof controlValue === 'object') {
+      return controlValue;
+    }
+    return (this.model as ValueBindingValue | undefined) ?? {};
   }
 
   private normaliseValue(value: ValueBindingValue): ValueBindingValue {
@@ -210,16 +216,68 @@ export class ValueBindingEditorTypeComponent extends FieldType<FieldTypeConfig> 
     return nextValue;
   }
 
-  private syncValue(value: ValueBindingValue, markChanged = false): void {
-    if (typeof this.key === 'string' && this.model) {
-      (this.model as Record<string, ValueBindingValue>)[this.key] = value;
+  /**
+   * Reduce the editor's working value to the keys that belong in the persisted
+   * binding, dropping empty source fields and the source fields that do not apply
+   * to the active kind. This mirrors what formly's parsers would do for rendered
+   * controls and keeps the saved config free of empty/stale entries.
+   */
+  private toModelValue(value: ValueBindingValue): Record<string, unknown> {
+    const kind: BindingKind = value.kind || 'path';
+    const next: Record<string, unknown> = { kind };
+
+    const hasText = (val: unknown): boolean => val != null && String(val).trim() !== '';
+
+    if (kind === 'path' && hasText(value.path)) {
+      next['path'] = value.path;
+    } else if (kind === 'handlebars' && hasText(value.template)) {
+      next['template'] = value.template;
+    } else if (kind === 'jsonata' && hasText(value.expression)) {
+      next['expression'] = value.expression;
     }
 
+    if (hasText(value.defaultValue)) {
+      next['defaultValue'] = value.defaultValue;
+    }
+
+    return next;
+  }
+
+  private syncValue(value: ValueBindingValue, markChanged = false): void {
+    // this.model IS the binding object (the schema models each binding as a JSON
+    // Schema object, so formly builds an object field whose model is the object
+    // itself, not the parent). The binding's child controls (kind/path/...) are
+    // never rendered as formly-fields, so formly never wires them back into the
+    // model; we must mutate the model object in place. Writing the whole value to
+    // this.model[this.key] (the previous behaviour) self-nested it, e.g. created
+    // description.description. Reusing the same object reference keeps formly's
+    // model binding intact.
+    const next = this.toModelValue(value);
+
+    const model = this.model as Record<string, unknown> | undefined;
+    if (model && typeof model === 'object') {
+      Object.keys(model).forEach(key => delete model[key]);
+      Object.assign(model, next);
+    }
+
+    // Keep the FormGroup in sync for completeness; child controls cover all five
+    // source fields, so a full patch clears any that no longer apply.
     if (this.formControl) {
-      if (typeof (this.formControl as { patchValue?: (val: ValueBindingValue) => void }).patchValue === 'function') {
-        (this.formControl as { patchValue: (val: ValueBindingValue) => void }).patchValue(value);
-      } else if (typeof (this.formControl as { setValue?: (val: ValueBindingValue) => void }).setValue === 'function') {
-        (this.formControl as { setValue: (val: ValueBindingValue) => void }).setValue(value);
+      const patch: Record<string, unknown> = {
+        kind: next['kind'] ?? 'path',
+        path: next['path'] ?? '',
+        template: next['template'] ?? '',
+        expression: next['expression'] ?? '',
+        defaultValue: next['defaultValue'] ?? ''
+      };
+      const control = this.formControl as {
+        patchValue?: (val: unknown) => void;
+        setValue?: (val: unknown) => void;
+      };
+      if (typeof control.patchValue === 'function') {
+        control.patchValue(patch);
+      } else if (typeof control.setValue === 'function') {
+        control.setValue(patch);
       }
       if (markChanged) {
         this.formControl.markAsDirty();


### PR DESCRIPTION
## Summary

Fixes a self-nesting bug in the value-binding editor's model synchronisation and moves an inline style to a CSS class for consistency.

---

## Context / Motivation

When formly models each binding as a JSON Schema object, the previous `syncValue` implementation wrote to `this.model[this.key]`, which self-nested the binding (e.g. `description.description`). The editor also left empty or kind-irrelevant source fields in the persisted config and used an inline style in the template.

---

## Key Features

### Fix self-nesting in model sync

- Mutates the model object in place via `Object.assign` instead of indexing by key, preserving formly's model binding intact
- The previous approach of writing to `this.model[this.key]` created nested binding objects on every sync

### Prune empty and stale source fields on save

- Added `toModelValue()` that only includes source fields relevant to the active binding kind (path, handlebars, jsonata)
- Empty fields and fields that don't apply to the selected kind are dropped from the persisted value
- FormGroup is patched with empty strings for all child controls to keep the form state complete

### Clean up styling

- Moved `style="max-width: 400px"` from the template into a `.binding-summary` CSS class in the component styles array

---

## Testing

- Existing test suite for the app-config Angular app covers the value-binding editor
- Manual verification of binding creation, switching kinds, and saving configurations

---

## Architectural / Operational Impact

### Model mutation pattern

The component now treats `this.model` as the binding object itself (not the parent), which is correct for formly object-field schemas. The pattern of clearing and reassigning keys via `Object.assign` avoids reference breaks that would disconnect formly's model binding.

### Config hygiene

Stale and empty source fields are no longer persisted, keeping stored app config smaller and more predictable.

---

## Backwards Compatibility

Existing saved bindings with extra empty fields remain valid — the reader path is unchanged. Newly saved bindings will be leaner.

---

## Deployment Notes

None. This is purely a frontend change to the app-config Angular application.

---

## Impact

Resolves a data corruption bug in the value-binding editor where repeated edits could produce deeply nested binding objects, and improves config cleanliness by omitting irrelevant source fields on save.
