### PR TITLE
Bugfix: View-mode rendering fixes for option labels, typeahead fields, line breaks, and attachment links

### DIFF
--- a/angular/package-lock.json
+++ b/angular/package-lock.json
@@ -86,7 +86,7 @@
       "version": "0.2.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@jsonjoy.com/json-pointer": "18.24.0",
+        "@jsonjoy.com/json-pointer": "18.28.0",
         "lodash": "4.18.1",
         "lodash-es": "4.18.1",
         "luxon": "3.7.2",

--- a/angular/projects/researchdatabox/form/src/app/component/content.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/content.component.spec.ts
@@ -46,6 +46,11 @@ describe('ContentComponent', () => {
               if (context?.content === 'USE_MISSING_TRANSLATION_TEMPLATE') {
                 return context?.translationService?.t?.('@missing.translation.key') ?? '';
               }
+              if (context?.content === 'USE_MARKDOWN_TEMPLATE') {
+                return context?.outputFormat === 'markdown'
+                  ? '<h2>Hi <strong>How does this render</strong></h2><table><tbody><tr><td>and</td><td>not</td><td>something</td></tr></tbody></table>'
+                  : context?.content;
+              }
               return Handlebars.compile('<h3>{{content}}</h3>')(context);
             default:
               throw new Error(`Unknown key: ${keyStr}`);
@@ -95,6 +100,40 @@ describe('ContentComponent', () => {
     const compiled = fixture.nativeElement as HTMLElement;
     const element = compiled.querySelector('h3');
     expect((element as HTMLHeadingElement)?.textContent).toEqual('My first text block component!!!');
+    expect(compiled.querySelector('.rb-form-content')?.classList.contains('rb-form-rich-text-content')).toBeFalse();
+  });
+
+  it('should expose outputFormat to content templates for markdown rich text view rendering', async () => {
+    const formConfig: FormConfigFrame = {
+      name: 'testing',
+      debugValue: true,
+      defaultComponentConfig: {
+        defaultComponentCssClasses: 'row',
+      },
+      editCssClasses: "redbox-form form",
+      componentDefinitions: [
+        {
+          name: 'markdown_content',
+          component: {
+            class: 'ContentComponent',
+            config: {
+              content: 'USE_MARKDOWN_TEMPLATE',
+              outputFormat: 'markdown',
+              template: '{{{markdownToHtml content outputFormat}}}'
+            }
+          }
+        }
+      ]
+    };
+
+    const {fixture} = await createFormAndWaitForReady(
+      formConfig, undefined, undefined, dynamicAssetOptions);
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(lastTemplateContext?.outputFormat).toEqual('markdown');
+    expect(compiled.querySelector('.rb-form-content')?.classList.contains('rb-form-rich-text-content')).toBeTrue();
+    expect(compiled.querySelector('h2')?.innerHTML).toContain('<strong>How does this render</strong>');
+    expect(compiled.querySelector('table td')?.textContent).toEqual('and');
   });
 
   it('should render content as-is when contentIsTranslationCode is false', async () => {

--- a/angular/projects/researchdatabox/form/src/app/component/content.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/content.component.ts
@@ -39,7 +39,7 @@ import {FormService} from "../form.service";
   template: `
     @if (isVisible) {
       <ng-container *ngTemplateOutlet="getTemplateRef('before')" />
-      <span [innerHtml]="content"></span>
+      <span class="rb-form-content" [class.rb-form-rich-text-content]="isRichTextContent" [innerHtml]="content"></span>
       <ng-container *ngTemplateOutlet="getTemplateRef('after')" />
     }
   `,
@@ -48,6 +48,7 @@ import {FormService} from "../form.service";
 export class ContentComponent extends FormFieldBaseComponent<string> {
   protected override logName: string = ContentComponentName;
   public content:string = '';
+  public isRichTextContent = false;
   private formValueChangesSub?: Subscription;
   private formBindTimeoutId?: ReturnType<typeof setTimeout>;
 
@@ -69,6 +70,7 @@ export class ContentComponent extends FormFieldBaseComponent<string> {
 
     const template = config?.template ?? '';
     const content = config?.content ?? '';
+    this.isRichTextContent = !!config?.outputFormat;
     const contentIsTranslationCode = (config as { contentIsTranslationCode?: boolean } | undefined)?.contentIsTranslationCode === true;
     const translationContentFormat = (config as { translationContentFormat?: 'plain' | 'html' } | undefined)?.translationContentFormat === 'html'
       ? 'html'
@@ -91,6 +93,7 @@ export class ContentComponent extends FormFieldBaseComponent<string> {
             portal: runtimeContext.portal,
             oid: runtimeContext.oid,
             workflow: this.formComponent.formConfigMeta['workflow'] ?? {},
+            outputFormat: config?.outputFormat,
           };
           const extra = {libraries: this.handlebarsTemplateService.getLibraries()};
           this.content = compiledItems.evaluate(templateLineagePath, context, extra)?.toString() ?? "";

--- a/angular/projects/researchdatabox/form/src/styles.scss
+++ b/angular/projects/researchdatabox/form/src/styles.scss
@@ -80,6 +80,12 @@
   text-decoration: none;
 }
 
+.rb-form-host .rb-form-icon-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25em;
+}
+
 .rb-form-host .rb-form-icon-link:hover,
 .rb-form-host .rb-form-icon-link:focus {
   text-decoration: none;

--- a/angular/projects/researchdatabox/form/src/styles.scss
+++ b/angular/projects/researchdatabox/form/src/styles.scss
@@ -29,6 +29,30 @@
   vertical-align: middle;
 }
 
+.rb-form-host .rb-form-rich-text-content table {
+  width: auto;
+  max-width: 100%;
+  margin: 0.75rem 0 1rem;
+  border-collapse: collapse;
+  border: 1px solid var(--bs-border-color, #dee2e6);
+}
+
+.rb-form-host .rb-form-rich-text-content th,
+.rb-form-host .rb-form-rich-text-content td {
+  padding: 0.45rem 0.65rem;
+  border: 1px solid var(--bs-border-color, #dee2e6);
+  vertical-align: top;
+}
+
+.rb-form-host .rb-form-rich-text-content th {
+  font-weight: 700;
+  background: var(--bs-tertiary-bg, #f8f9fa);
+}
+
+.rb-form-host .rb-form-rich-text-content tr:nth-child(even) td {
+  background: rgba(0, 0, 0, 0.025);
+}
+
 /* Global action-row safety rules for migrated legacy inline/button groups in view mode. */
 .rb-form-host .rb-form-action-row {
   display: flex;

--- a/angular/projects/researchdatabox/form/src/styles.scss
+++ b/angular/projects/researchdatabox/form/src/styles.scss
@@ -29,6 +29,67 @@
   vertical-align: middle;
 }
 
+.rb-form-host .fa,
+.rb-form-host .fas,
+.rb-form-host .far,
+.rb-form-host .fal,
+.rb-form-host .fab,
+.rb-form-host .fa-solid,
+.rb-form-host .fa-regular,
+.rb-form-host .fa-brands,
+.rb-form-host [class^="fa-"],
+.rb-form-host [class*=" fa-"] {
+  display: inline-block;
+  text-decoration: none;
+}
+
+.rb-form-host a:hover .fa,
+.rb-form-host a:hover .fas,
+.rb-form-host a:hover .far,
+.rb-form-host a:hover .fal,
+.rb-form-host a:hover .fab,
+.rb-form-host a:hover .fa-solid,
+.rb-form-host a:hover .fa-regular,
+.rb-form-host a:hover .fa-brands,
+.rb-form-host a:hover [class^="fa-"],
+.rb-form-host a:hover [class*=" fa-"],
+.rb-form-host a:focus .fa,
+.rb-form-host a:focus .fas,
+.rb-form-host a:focus .far,
+.rb-form-host a:focus .fal,
+.rb-form-host a:focus .fab,
+.rb-form-host a:focus .fa-solid,
+.rb-form-host a:focus .fa-regular,
+.rb-form-host a:focus .fa-brands,
+.rb-form-host a:focus [class^="fa-"],
+.rb-form-host a:focus [class*=" fa-"] {
+  text-decoration: none;
+}
+
+.rb-form-host .fa::before,
+.rb-form-host .fas::before,
+.rb-form-host .far::before,
+.rb-form-host .fal::before,
+.rb-form-host .fab::before,
+.rb-form-host .fa-solid::before,
+.rb-form-host .fa-regular::before,
+.rb-form-host .fa-brands::before,
+.rb-form-host [class^="fa-"]::before,
+.rb-form-host [class*=" fa-"]::before {
+  display: inline-block;
+  text-decoration: none;
+}
+
+.rb-form-host .rb-form-icon-link:hover,
+.rb-form-host .rb-form-icon-link:focus {
+  text-decoration: none;
+}
+
+.rb-form-host .rb-form-icon-link:hover .rb-form-icon-link__text,
+.rb-form-host .rb-form-icon-link:focus .rb-form-icon-link__text {
+  text-decoration: underline;
+}
+
 .rb-form-host .rb-form-rich-text-content table {
   width: auto;
   max-width: 100%;

--- a/packages/redbox-core/src/config/reusableViewFormDefinitions.config.ts
+++ b/packages/redbox-core/src/config/reusableViewFormDefinitions.config.ts
@@ -4,7 +4,7 @@ export const reusableViewFormDefinitions: ReusableFormDefinitions = {
   "view-template-leaf-plain": [
     {
       name: "view_template_leaf_plain",
-      component: {class: "ContentComponent", config: {template: "<span>{{content}}</span>"}},
+      component: {class: "ContentComponent", config: {template: "<span>{{{plaintextToHtml content}}}</span>"}},
     },
   ],
   "view-template-leaf-date": [

--- a/packages/redbox-core/src/config/reusableViewFormDefinitions.config.ts
+++ b/packages/redbox-core/src/config/reusableViewFormDefinitions.config.ts
@@ -52,7 +52,7 @@ export const reusableViewFormDefinitions: ReusableFormDefinitions = {
       component: {
         class: "ContentComponent",
         config: {
-          template: "<ul class=\"rb-view-file-upload\">{{#each [[valueExpr]]}}<li>{{#if this.url}}<a href=\"{{this.url}}\" target=\"_blank\" rel=\"noopener\">{{default this.name this.fileId}}</a>{{else}}{{default this.name this.fileId}}{{/if}}{{#if this.notes}}<div class=\"text-muted\"><small>{{this.notes}}</small></div>{{/if}}</li>{{/each}}</ul>"
+          template: "<ul class=\"rb-view-file-upload\">{{#each [[valueExpr]]}}<li>{{#if (attachmentDownloadUrl this oid branding portal)}}<a href=\"{{attachmentDownloadUrl this oid branding portal}}\" target=\"_blank\" rel=\"noopener noreferrer\">{{default this.name this.fileId}}</a>{{else}}{{default this.name this.fileId}}{{/if}}{{#if this.notes}}<div class=\"text-muted\"><small>{{this.notes}}</small></div>{{/if}}</li>{{/each}}</ul>"
         }
       },
     },

--- a/packages/redbox-core/src/visitor/client.visitor.ts
+++ b/packages/redbox-core/src/visitor/client.visitor.ts
@@ -74,6 +74,7 @@ import {
 import {DefaultFieldLayoutDefinitionOutline} from '@researchdatabox/sails-ng-common';
 import {ActionRowLayoutName} from '@researchdatabox/sails-ng-common';
 import {
+  CheckboxInputComponentName,
   CheckboxInputFieldComponentDefinitionOutline,
   CheckboxInputFieldModelDefinitionOutline,
   CheckboxInputFormComponentDefinitionOutline,
@@ -89,6 +90,7 @@ import {
   RecordSelectorFormComponentDefinitionOutline,
 } from '@researchdatabox/sails-ng-common';
 import {
+  DropdownInputComponentName,
   DropdownInputFieldComponentDefinitionOutline,
   DropdownInputFieldModelDefinitionOutline,
   DropdownInputFormComponentDefinitionOutline,
@@ -133,6 +135,7 @@ import {
   PublishDataLocationSelectorFormComponentDefinitionOutline,
 } from '@researchdatabox/sails-ng-common';
 import {
+  RadioInputComponentName,
   RadioInputFieldComponentDefinitionOutline,
   RadioInputFieldModelDefinitionOutline,
   RadioInputFormComponentDefinitionOutline,
@@ -281,9 +284,10 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
     const shouldTransformRepeatable = className === RepeatableComponentName;
     const shouldTransformGroup = className === GroupFieldComponentName && item?.layout?.class !== ActionRowLayoutName;
     const shouldTransformQuestionTree = className === QuestionTreeComponentName;
+    const shouldTransformInlineVocabOption = this.isInlineVocabOptionComponent(item);
     const shouldSkipViewTransform = this.hasExplicitAllowedMode(item, 'view');
 
-    if (shouldTransformRepeatable || shouldTransformGroup || shouldTransformQuestionTree) {
+    if (shouldTransformRepeatable || shouldTransformGroup || shouldTransformQuestionTree || shouldTransformInlineVocabOption) {
       if (shouldSkipViewTransform) {
         this.applyPostPruningTransformsToNestedChildren(item);
         if ('constraints' in item) {
@@ -306,6 +310,19 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
 
     this.applyPostPruningTransformsToNestedChildren(item);
     return item;
+  }
+
+  protected isInlineVocabOptionComponent(item: AvailableFormComponentDefinitionOutlines): boolean {
+    const className = item?.component?.class;
+    const componentConfig = item?.component?.config as { inlineVocab?: boolean } | undefined;
+    return (
+      componentConfig?.inlineVocab === true &&
+      (
+        className === DropdownInputComponentName ||
+        className === CheckboxInputComponentName ||
+        className === RadioInputComponentName
+      )
+    );
   }
 
   protected hasExplicitAllowedMode(item: AvailableFormComponentDefinitionOutlines, mode: FormModesConfig): boolean {

--- a/packages/redbox-core/src/visitor/construct.visitor.ts
+++ b/packages/redbox-core/src/visitor/construct.visitor.ts
@@ -2192,10 +2192,19 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   ): AllFormComponentDefinitionOutlines {
     if (this.formMode === 'view') {
       const className = formComponent?.component?.class;
+      const componentConfig = formComponent?.component?.config as { inlineVocab?: boolean } | undefined;
       const shouldDeferToClientViewTransform =
         className === QuestionTreeComponentName ||
         className === RepeatableComponentName ||
-        (className === GroupFieldComponentName && formComponent?.layout?.class !== ActionRowLayoutName);
+        (className === GroupFieldComponentName && formComponent?.layout?.class !== ActionRowLayoutName) ||
+        (
+          componentConfig?.inlineVocab === true &&
+          (
+            className === DropdownInputComponentName ||
+            className === CheckboxInputComponentName ||
+            className === RadioInputComponentName
+          )
+        );
       if (shouldDeferToClientViewTransform) {
         return formComponent;
       }

--- a/packages/redbox-core/test/unit/construct.visitor.test.ts
+++ b/packages/redbox-core/test/unit/construct.visitor.test.ts
@@ -1221,6 +1221,31 @@ describe("Construct Visitor", async () => {
             });
         });
 
+        it("should preserve text area line breaks in view mode", async function () {
+            const visitor = new ConstructFormConfigVisitor(logger);
+            const actual = await visitor.start({
+                data: {
+                    name: "form",
+                    componentDefinitions: [
+                        {
+                            name: "description",
+                            component: { class: "TextAreaComponent" },
+                            model: { class: "TextAreaModel", config: {} },
+                        }
+                    ]
+                },
+                formMode: "view",
+                reusableFormDefs: reusableFormDefinitions,
+                record: { description: "Line 1\nLine 2" }
+            });
+
+            expect(actual.componentDefinitions[0].component).to.deep.include({ class: "ContentComponent" });
+            expect(actual.componentDefinitions[0].component.config).to.deep.include({
+                content: "Line 1\nLine 2",
+                template: `<span>{{{plaintextToHtml content}}}</span>`
+            });
+        });
+
         it("should transform data location components to content in view mode", async function () {
             const visitor = new ConstructFormConfigVisitor(logger);
             const actual = await visitor.start({

--- a/packages/redbox-core/test/unit/construct.visitor.test.ts
+++ b/packages/redbox-core/test/unit/construct.visitor.test.ts
@@ -1717,6 +1717,11 @@ describe("Construct Visitor", async () => {
             expect(template).to.contain("custom-leaf");
         });
 
+        it("should preserve line breaks in the default plain reusable view fragment", async () => {
+            const leafPlainTemplate = (reusableFormDefinitions["view-template-leaf-plain"]?.[0]?.component?.config as { template?: string } | undefined)?.template;
+            expect(leafPlainTemplate).to.equal("<span>{{{plaintextToHtml content}}}</span>");
+        });
+
         it("should keep repeatable and group components untransformed in view mode during construct phase", async () => {
             const visitor = new ConstructFormConfigVisitor(logger);
             const actual = await visitor.start({

--- a/packages/redbox-core/test/visitor/vocab-inline.visitor.test.ts
+++ b/packages/redbox-core/test/visitor/vocab-inline.visitor.test.ts
@@ -11,6 +11,7 @@ import {
 import type { ILogger } from '../../src/Logger';
 import { ConstructFormConfigVisitor } from '../../src/visitor/construct.visitor';
 import { VocabInlineFormConfigVisitor } from '../../src/visitor/vocab-inline.visitor';
+import { ClientFormConfigVisitor } from '../../src/visitor/client.visitor';
 
 describe('VocabInlineFormConfigVisitor', () => {
     const logger: ILogger = {
@@ -68,6 +69,67 @@ describe('VocabInlineFormConfigVisitor', () => {
         const options = dropdown?.component?.config?.options as Array<{ label: string; value: string }>;
         expect(options).to.have.length(2);
         expect(options[0]?.label).to.equal('Open');
+    });
+
+    it('resolves inline vocab labels before view-mode option fields are transformed to content', async () => {
+        const input: FormConfigFrame = {
+            name: 'test',
+            componentDefinitions: [
+                {
+                    name: 'access_type',
+                    component: {
+                        class: 'DropdownInputComponent',
+                        config: {
+                            options: [],
+                            vocabRef: 'access-rights',
+                            inlineVocab: true,
+                        },
+                    },
+                    model: { class: 'DropdownInputModel', config: {} },
+                },
+                {
+                    name: 'themes',
+                    component: {
+                        class: 'CheckboxInputComponent',
+                        config: {
+                            options: [],
+                            vocabRef: 'access-rights',
+                            inlineVocab: true,
+                        },
+                    },
+                    model: { class: 'CheckboxInputModel', config: {} },
+                },
+            ],
+        };
+
+        const constructor = new ConstructFormConfigVisitor(logger as any);
+        const constructed = await constructor.start({
+            data: input,
+            formMode: 'view',
+            record: {
+                access_type: 'open',
+                themes: ['open', 'closed'],
+            },
+        });
+
+        expect(constructed.componentDefinitions[0]?.component?.class).to.equal('DropdownInputComponent');
+        expect(constructed.componentDefinitions[1]?.component?.class).to.equal('CheckboxInputComponent');
+
+        const vocabVisitor = new VocabInlineFormConfigVisitor(logger);
+        await vocabVisitor.resolveVocabs(constructed);
+
+        const clientVisitor = new ClientFormConfigVisitor(logger);
+        const clientForm = await clientVisitor.start({ form: constructed, formMode: 'view' });
+
+        const dropdown = clientForm.componentDefinitions[0] as any;
+        const checkbox = clientForm.componentDefinitions[1] as any;
+        expect(dropdown.component.class).to.equal('ContentComponent');
+        expect(dropdown.component.config?.content).to.deep.equal({ value: 'open', label: 'Open' });
+        expect(checkbox.component.class).to.equal('ContentComponent');
+        expect(checkbox.component.config?.content).to.deep.equal([
+            { value: 'open', label: 'Open', disabled: undefined },
+            { value: 'closed', label: 'Closed', disabled: undefined },
+        ]);
     });
 
     it('does not inline when inlineVocab is false', async () => {

--- a/packages/sails-ng-common/src/config/form-override.model.ts
+++ b/packages/sails-ng-common/src/config/form-override.model.ts
@@ -716,7 +716,10 @@ export class FormOverride {
     formMode: FormModesConfig
   ): ContentFormComponentDefinitionOutline {
     const target = this.commonContentComponent(source, formMode);
-    this.commonContentPlain(source, target);
+    if (target.component.config !== undefined && source.model?.config?.value !== undefined) {
+      target.component.config.content = source.model.config.value;
+      target.component.config.template = `<span>{{{plaintextToHtml content}}}</span>`;
+    }
     return target;
   }
 
@@ -1351,7 +1354,57 @@ export class FormOverride {
       );
       return this.substituteReusableTemplateSlots(template, { valueExpr: expression });
     }
+    if (className === TextAreaComponentName) {
+      return `<span>{{{plaintextToHtml ${expression}}}}</span>`;
+    }
+    if (
+      className === DropdownInputComponentName ||
+      className === CheckboxInputComponentName ||
+      className === RadioInputComponentName
+    ) {
+      const options = this.getOptionLabelPairs(component);
+      if (className === CheckboxInputComponentName) {
+        return this.renderOptionListValue(expression, options);
+      }
+      return this.renderOptionSingleValue(expression, options);
+    }
     return `{{default ${expression} ""}}`;
+  }
+
+  private getOptionLabelPairs(component: AllFormComponentDefinitionOutlines): Array<{ value: string; label: string }> {
+    const componentConfig = component?.component?.config as { options?: Array<{ value?: unknown; label?: unknown }> } | undefined;
+    return (componentConfig?.options ?? [])
+      .filter(option => option?.value !== undefined && option?.label !== undefined)
+      .map(option => ({
+        value: String(option.value),
+        label: String(option.label),
+      }));
+  }
+
+  private renderOptionSingleValue(expression: string, options: Array<{ value: string; label: string }>): string {
+    if (options.length === 0) {
+      return `{{default ${expression} ""}}`;
+    }
+    const optionBranches = options.map(option =>
+      `{{#if (eq ${expression} "${this.escapeForHandlebarsLiteral(option.value)}")}}` +
+      `<span data-value="{{default ${expression} ""}}">{{t "${this.escapeForHandlebarsLiteral(option.label)}"}}</span>` +
+      '{{else}}'
+    ).join('');
+    return `${optionBranches}<span>{{default ${expression} ""}}</span>${'{{/if}}'.repeat(options.length)}`;
+  }
+
+  private renderOptionListValue(expression: string, options: Array<{ value: string; label: string }>): string {
+    if (options.length === 0) {
+      return `{{default ${expression} ""}}`;
+    }
+    const singleValue = this.renderOptionSingleValue(expression, options);
+    const optionBranches = options.map(option =>
+      `{{#if (eq this "${this.escapeForHandlebarsLiteral(option.value)}")}}` +
+      `<li data-value="{{this}}">{{t "${this.escapeForHandlebarsLiteral(option.label)}"}}</li>` +
+      '{{else}}'
+    ).join('');
+    return `{{#if ${expression}}}{{#if (isArray ${expression})}}<ul>{{#each ${expression}}}${optionBranches}` +
+      `<li>{{this}}</li>${'{{/if}}'.repeat(options.length)}{{/each}}</ul>{{else}}${singleValue}{{/if}}{{/if}}`;
   }
 
   private getGroupChildren(component: AllFormComponentDefinitionOutlines): AllFormComponentDefinitionOutlines[] | null {

--- a/packages/sails-ng-common/src/config/form-override.model.ts
+++ b/packages/sails-ng-common/src/config/form-override.model.ts
@@ -863,7 +863,7 @@ export class FormOverride {
     target.component.config.content = source.model.config.value;
     const uploadTemplate = this.resolveReusableViewTemplate(
       this.reusableViewTemplateKeys.leafFileUpload,
-      `<ul class="rb-view-file-upload">{{#each [[valueExpr]]}<li>{{default this.name this.fileId}}</li>{{/each}}</ul>`
+      `<ul class="rb-view-file-upload">{{#each [[valueExpr]]}<li>{{#if (attachmentDownloadUrl this oid branding portal)}}<a href="{{attachmentDownloadUrl this oid branding portal}}" target="_blank" rel="noopener noreferrer">{{default this.name this.fileId}}</a>{{else}}{{default this.name this.fileId}}{{/if}}{{#if this.notes}}<div class="text-muted"><small>{{this.notes}}</small></div>{{/if}}</li>{{/each}}</ul>`
     );
     target.component.config.template = this.substituteReusableTemplateSlots(uploadTemplate, { valueExpr: 'content' });
     return target;
@@ -1284,7 +1284,7 @@ export class FormOverride {
     if (className === FileUploadComponentName) {
       const fileTemplate = this.resolveReusableViewTemplate(
         this.reusableViewTemplateKeys.leafFileUpload,
-        `<ul class="rb-view-file-upload">{{#each [[valueExpr]]}<li>{{default this.name this.fileId}}</li>{{/each}}</ul>`
+        `<ul class="rb-view-file-upload">{{#each [[valueExpr]]}<li>{{#if (attachmentDownloadUrl this oid branding portal)}}<a href="{{attachmentDownloadUrl this oid branding portal}}" target="_blank" rel="noopener noreferrer">{{default this.name this.fileId}}</a>{{else}}{{default this.name this.fileId}}{{/if}}{{#if this.notes}}<div class="text-muted"><small>{{this.notes}}</small></div>{{/if}}</li>{{/each}}</ul>`
       );
       return this.substituteReusableTemplateSlots(fileTemplate, { valueExpr: expression });
     }
@@ -1418,7 +1418,7 @@ export class FormOverride {
   }
 
   private getCommonDisplayFields(): string[] {
-    return ['label', 'name', 'title', 'dc_title', 'dc_description', 'value'];
+    return ['label', 'name', 'title', 'dc_title', 'dc_description', 'utf8_name', 'value'];
   }
 
   private getOptionLabelPairs(component: AllFormComponentDefinitionOutlines): Array<{ value: string; label: string }> {

--- a/packages/sails-ng-common/src/config/form-override.model.ts
+++ b/packages/sails-ng-common/src/config/form-override.model.ts
@@ -1343,9 +1343,9 @@ export class FormOverride {
         trimmedTemplate === '{{{content}}}' ||
         trimmedTemplate === '<span>{{content}}</span>'
       ) {
-        return `{{default ${expression} ""}}`;
+        return this.renderDisplayValue(expression);
       }
-      return `{{default ${expression} ""}}`;
+      return this.renderDisplayValue(expression);
     }
     if (className === CheckboxTreeComponentName) {
       const template = this.resolveReusableViewTemplate(
@@ -1356,6 +1356,9 @@ export class FormOverride {
     }
     if (className === TextAreaComponentName) {
       return `<span>{{{plaintextToHtml ${expression}}}}</span>`;
+    }
+    if (className === TypeaheadInputComponentName) {
+      return this.renderTypeaheadValue(expression, component);
     }
     if (
       className === DropdownInputComponentName ||
@@ -1369,6 +1372,53 @@ export class FormOverride {
       return this.renderOptionSingleValue(expression, options);
     }
     return `{{default ${expression} ""}}`;
+  }
+
+  private renderTypeaheadValue(expression: string, component: AllFormComponentDefinitionOutlines): string {
+    const arrayItem = this.renderTypeaheadScalarValue('this', component);
+    const singleValue = this.renderTypeaheadScalarValue(expression, component);
+    return `{{#if ${expression}}}{{#if (isArray ${expression})}}<ul>{{#each ${expression}}}<li>${arrayItem}</li>{{/each}}</ul>{{else}}${singleValue}{{/if}}{{/if}}`;
+  }
+
+  private renderTypeaheadScalarValue(expression: string, component: AllFormComponentDefinitionOutlines): string {
+    const fields = this.getTypeaheadDisplayFields(component);
+    return this.renderDisplayScalarValue(expression, fields);
+  }
+
+  private renderDisplayValue(expression: string): string {
+    const fields = this.getCommonDisplayFields();
+    const arrayItem = this.renderDisplayScalarValue('this', fields);
+    const singleValue = this.renderDisplayScalarValue(expression, fields);
+    return `{{#if ${expression}}}{{#if (isArray ${expression})}}<ul>{{#each ${expression}}}<li>${arrayItem}</li>{{/each}}</ul>{{else}}${singleValue}{{/if}}{{/if}}`;
+  }
+
+  private renderDisplayScalarValue(expression: string, fields: string[]): string {
+    const objectBranches = fields.map(field =>
+      `{{#if (get ${expression} "${this.escapeForHandlebarsLiteral(field)}" "")}}` +
+      `<span>{{{plaintextToHtml (get ${expression} "${this.escapeForHandlebarsLiteral(field)}" "")}}}</span>` +
+      '{{else}}'
+    ).join('');
+
+    return `{{#if (isObject ${expression})}}${objectBranches}` +
+      `{{{renderMetadataValue ${expression}}}}${'{{/if}}'.repeat(fields.length)}` +
+      `{{else}}<span>{{{plaintextToHtml ${expression}}}}</span>{{/if}}`;
+  }
+
+  private getTypeaheadDisplayFields(component: AllFormComponentDefinitionOutlines): string[] {
+    const componentConfig =
+      component?.component?.config as { labelField?: string; valueField?: string } | undefined;
+    const fields = [
+      componentConfig?.labelField,
+      ...this.getCommonDisplayFields(),
+      componentConfig?.valueField,
+    ];
+    return Array.from(
+      new Set(fields.filter((field): field is string => typeof field === 'string' && field.trim().length > 0))
+    );
+  }
+
+  private getCommonDisplayFields(): string[] {
+    return ['label', 'name', 'title', 'dc_title', 'dc_description', 'value'];
   }
 
   private getOptionLabelPairs(component: AllFormComponentDefinitionOutlines): Array<{ value: string; label: string }> {

--- a/packages/sails-ng-common/src/handlebars-helpers.ts
+++ b/packages/sails-ng-common/src/handlebars-helpers.ts
@@ -178,7 +178,12 @@ function renderMetadataValue(value: unknown): string {
 }
 
 function trimSlashes(value: unknown): string {
-  return String(value ?? '').replace(/^\/+|\/+$/g, '');
+  const text = String(value ?? '');
+  let start = 0;
+  let end = text.length;
+  while (start < end && text[start] === '/') start++;
+  while (end > start && text[end - 1] === '/') end--;
+  return text.slice(start, end);
 }
 
 function isSafeDownloadUrl(value: string): boolean {

--- a/packages/sails-ng-common/src/handlebars-helpers.ts
+++ b/packages/sails-ng-common/src/handlebars-helpers.ts
@@ -177,6 +177,80 @@ function renderMetadataValue(value: unknown): string {
   return renderMetadataPrimitive(value);
 }
 
+function trimSlashes(value: unknown): string {
+  return String(value ?? '').replace(/^\/+|\/+$/g, '');
+}
+
+function isSafeDownloadUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value) || value.startsWith('/');
+}
+
+function resolveAttachmentLocation(location: string, branding: unknown, portal: unknown): string {
+  if (!location) {
+    return '';
+  }
+  if (/^https?:\/\//i.test(location)) {
+    return location;
+  }
+  const recordRelativeMatch = location.match(/^([^/]+)\/attach\/([^/?#]+)$/);
+  if (recordRelativeMatch) {
+    const prefix = [trimSlashes(branding), trimSlashes(portal)].filter(Boolean).join('/');
+    const path = `record/${encodeURIComponent(recordRelativeMatch[1])}/attach/${encodeURIComponent(recordRelativeMatch[2])}`;
+    return `/${[prefix, path].filter(Boolean).join('/')}`;
+  }
+  if (!isSafeDownloadUrl(location)) {
+    return '';
+  }
+  if (location.startsWith('/record/')) {
+    const prefix = [trimSlashes(branding), trimSlashes(portal)].filter(Boolean).join('/');
+    return prefix ? `/${prefix}${location}` : location;
+  }
+  return location;
+}
+
+function buildAttachmentDownloadUrl(attachment: unknown, oid: unknown, branding: unknown, portal: unknown): string {
+  if (!_isPlainObject(attachment)) {
+    return '';
+  }
+
+  const item = attachment as Record<string, unknown>;
+  const url = String(item.url ?? '').trim();
+  if (url && isSafeDownloadUrl(url)) {
+    return url;
+  }
+
+  const uploadUrl = String(item.uploadUrl ?? '').trim();
+  if (uploadUrl) {
+    try {
+      const parsedUploadUrl = new URL(uploadUrl);
+      const uploadPath = resolveAttachmentLocation(parsedUploadUrl.pathname, branding, portal);
+      if (uploadPath) {
+        return uploadPath;
+      }
+    } catch {
+      const uploadPath = resolveAttachmentLocation(uploadUrl, branding, portal);
+      if (uploadPath) {
+        return uploadPath;
+      }
+    }
+  }
+
+  const location = resolveAttachmentLocation(String(item.location ?? '').trim(), branding, portal);
+  if (location) {
+    return location;
+  }
+
+  const fileId = String(item.fileId ?? '').trim();
+  const recordOid = String(oid ?? '').trim();
+  if (!fileId || !recordOid) {
+    return '';
+  }
+
+  const prefix = [trimSlashes(branding), trimSlashes(portal)].filter(Boolean).join('/');
+  const path = `record/${encodeURIComponent(recordOid)}/attach/${encodeURIComponent(fileId)}`;
+  return `/${[prefix, path].filter(Boolean).join('/')}`;
+}
+
 /**
  * Shared Handlebars helper definitions for use in both server and client contexts.
  * These helpers provide CSP-safe alternatives to lodash template expressions.
@@ -628,6 +702,20 @@ export const handlebarsHelperDefinitions = {
    */
   renderMetadataValue: function (value: unknown): string {
     return renderMetadataValue(value);
+  },
+
+  /**
+   * Build a view-mode download URL for a file upload attachment value.
+   *
+   * @example {{attachmentDownloadUrl this oid branding portal}}
+   */
+  attachmentDownloadUrl: function (
+    attachment: unknown,
+    oid: unknown,
+    branding: unknown,
+    portal: unknown
+  ): string {
+    return buildAttachmentDownloadUrl(attachment, oid, branding, portal);
   },
 };
 

--- a/packages/sails-ng-common/src/handlebars-helpers.ts
+++ b/packages/sails-ng-common/src/handlebars-helpers.ts
@@ -59,9 +59,9 @@ let cachedMarkedParser: ((value: string) => string) | null | undefined;
 
 void import('marked')
   .then(markedModule => {
-    const parseFn = markedModule?.marked?.parse ?? markedModule?.parse;
-    if (typeof parseFn === 'function') {
-      cachedMarkedParser = (value: string): string => {
+      const parseFn = markedModule?.marked?.parse ?? markedModule?.parse;
+      if (typeof parseFn === 'function') {
+        cachedMarkedParser = (value: string): string => {
         const result = parseFn(value);
         return typeof result === 'string' ? result : value;
       };
@@ -597,6 +597,15 @@ export const handlebarsHelperDefinitions = {
       }
     }
     return input;
+  },
+
+  /**
+   * Render plain text as escaped HTML while preserving line breaks.
+   *
+   * @example {{{plaintextToHtml content}}}
+   */
+  plaintextToHtml: function (value: unknown): string {
+    return escapeHtmlText(value).replace(/\r\n|\r|\n/g, '<br>');
   },
 
   /**

--- a/packages/sails-ng-common/test/unit/form-override.test.ts
+++ b/packages/sails-ng-common/test/unit/form-override.test.ts
@@ -7,6 +7,8 @@ import {
 import { ReusableComponentName } from '../../src/config/component/reusable.outline';
 import { SimpleInputComponentName } from '../../src/config/component/simple-input.outline';
 import { GroupFieldComponentName } from '../../src/config/component/group.outline';
+import { DropdownInputComponentName } from '../../src/config/component/dropdown-input.outline';
+import { CheckboxInputComponentName } from '../../src/config/component/checkbox-input.outline';
 import { isTypeFieldDefinitionName } from '../../src/config/form-types.outline';
 import { ILogger } from '../../src/logger.interface';
 
@@ -157,6 +159,54 @@ describe('FormOverride reusable expansion', () => {
     );
 
     expect(result).to.equal('<span data-value="{{default (get project "startDate" "") ""}}">{{formatDate (get project "startDate" "") "DD/MM/YYYY"}}</span>');
+  });
+
+  it('renders dropdown leaf option labels in generated view templates', () => {
+    const formOverride = new FormOverride(createLogger());
+
+    const result = (formOverride as any).renderLeafValue(
+      {
+        component: {
+          class: DropdownInputComponentName,
+          config: {
+            options: [
+              { value: 'dataset', label: 'Dataset' },
+              { value: 'software', label: 'Software' },
+            ],
+          },
+        },
+      } as never,
+      'content',
+      ['datatype']
+    );
+
+    expect(result).to.equal(
+      '{{#if (eq (get content "datatype" "") "dataset")}}<span data-value="{{default (get content "datatype" "") ""}}">{{t "Dataset"}}</span>{{else}}{{#if (eq (get content "datatype" "") "software")}}<span data-value="{{default (get content "datatype" "") ""}}">{{t "Software"}}</span>{{else}}<span>{{default (get content "datatype" "") ""}}</span>{{/if}}{{/if}}'
+    );
+  });
+
+  it('renders checkbox leaf option labels in generated view templates', () => {
+    const formOverride = new FormOverride(createLogger());
+
+    const result = (formOverride as any).renderLeafValue(
+      {
+        component: {
+          class: CheckboxInputComponentName,
+          config: {
+            options: [
+              { value: 'tropicalEcoSystems', label: 'Tropical Eco Systems' },
+              { value: 'industriesEconomies', label: 'Industries and Economies' },
+            ],
+          },
+        },
+      } as never,
+      'content',
+      ['research_themes']
+    );
+
+    expect(result).to.equal(
+      '{{#if (get content "research_themes" "")}}{{#if (isArray (get content "research_themes" ""))}}<ul>{{#each (get content "research_themes" "")}}{{#if (eq this "tropicalEcoSystems")}}<li data-value="{{this}}">{{t "Tropical Eco Systems"}}</li>{{else}}{{#if (eq this "industriesEconomies")}}<li data-value="{{this}}">{{t "Industries and Economies"}}</li>{{else}}<li>{{this}}</li>{{/if}}{{/if}}{{/each}}</ul>{{else}}{{#if (eq (get content "research_themes" "") "tropicalEcoSystems")}}<span data-value="{{default (get content "research_themes" "") ""}}">{{t "Tropical Eco Systems"}}</span>{{else}}{{#if (eq (get content "research_themes" "") "industriesEconomies")}}<span data-value="{{default (get content "research_themes" "") ""}}">{{t "Industries and Economies"}}</span>{{else}}<span>{{default (get content "research_themes" "") ""}}</span>{{/if}}{{/if}}{{/if}}{{/if}}'
+    );
   });
 
   it('expands contributor_dmp_permissions wrapper with replaceName, wrapper expressions, and syncSources', () => {

--- a/packages/sails-ng-common/test/unit/form-override.test.ts
+++ b/packages/sails-ng-common/test/unit/form-override.test.ts
@@ -9,6 +9,7 @@ import { SimpleInputComponentName } from '../../src/config/component/simple-inpu
 import { GroupFieldComponentName } from '../../src/config/component/group.outline';
 import { DropdownInputComponentName } from '../../src/config/component/dropdown-input.outline';
 import { CheckboxInputComponentName } from '../../src/config/component/checkbox-input.outline';
+import { TypeaheadInputComponentName } from '../../src/config/component/typeahead-input.outline';
 import { isTypeFieldDefinitionName } from '../../src/config/form-types.outline';
 import { ILogger } from '../../src/logger.interface';
 
@@ -207,6 +208,87 @@ describe('FormOverride reusable expansion', () => {
     expect(result).to.equal(
       '{{#if (get content "research_themes" "")}}{{#if (isArray (get content "research_themes" ""))}}<ul>{{#each (get content "research_themes" "")}}{{#if (eq this "tropicalEcoSystems")}}<li data-value="{{this}}">{{t "Tropical Eco Systems"}}</li>{{else}}{{#if (eq this "industriesEconomies")}}<li data-value="{{this}}">{{t "Industries and Economies"}}</li>{{else}}<li>{{this}}</li>{{/if}}{{/if}}{{/each}}</ul>{{else}}{{#if (eq (get content "research_themes" "") "tropicalEcoSystems")}}<span data-value="{{default (get content "research_themes" "") ""}}">{{t "Tropical Eco Systems"}}</span>{{else}}{{#if (eq (get content "research_themes" "") "industriesEconomies")}}<span data-value="{{default (get content "research_themes" "") ""}}">{{t "Industries and Economies"}}</span>{{else}}<span>{{default (get content "research_themes" "") ""}}</span>{{/if}}{{/if}}{{/if}}{{/if}}'
     );
+  });
+
+  it('renders typeahead leaf values using the configured label field', () => {
+    const formOverride = new FormOverride(createLogger());
+
+    const result = (formOverride as any).renderLeafValue(
+      {
+        component: {
+          class: TypeaheadInputComponentName,
+          config: {
+            labelField: 'dc_description',
+            valueField: 'value',
+          },
+        },
+      } as never,
+      'content',
+      ['fundingSource']
+    );
+
+    expect(result).to.contain('(get (get content "fundingSource" "") "dc_description" "")');
+    expect(result).to.contain('{{{renderMetadataValue (get content "fundingSource" "")}}}');
+    expect(result).to.not.equal('{{default (get content "fundingSource" "") ""}}');
+  });
+
+  it('renders repeatable typeahead objects without stringifying them', () => {
+    const formOverride = new FormOverride(createLogger());
+
+    const result = (formOverride as any).generateTemplateForComponent(
+      {
+        name: 'foaf:fundedBy_foaf:Agent',
+        component: {
+          class: RepeatableComponentName,
+          config: {
+            elementTemplate: {
+              name: '',
+              component: {
+                class: TypeaheadInputComponentName,
+                config: {
+                  labelField: 'dc_description',
+                  valueField: 'value',
+                },
+              },
+            },
+          },
+        },
+      } as never,
+      'content'
+    );
+
+    expect(result).to.contain('(get this "dc_description" "")');
+    expect(result).to.contain('{{{renderMetadataValue this}}}');
+    expect(result).to.not.contain('{{default this ""}}');
+  });
+
+  it('renders repeatable content objects using display fields after child transforms', () => {
+    const formOverride = new FormOverride(createLogger());
+
+    const result = (formOverride as any).generateTemplateForComponent(
+      {
+        name: 'foaf:fundedBy_vivo:Grant',
+        component: {
+          class: RepeatableComponentName,
+          config: {
+            elementTemplate: {
+              name: '',
+              component: {
+                class: ContentComponentName,
+                config: {
+                  template: '<span>{{content}}</span>',
+                },
+              },
+            },
+          },
+        },
+      } as never,
+      'content'
+    );
+
+    expect(result).to.contain('(get this "dc_title" "")');
+    expect(result).to.contain('{{{renderMetadataValue this}}}');
+    expect(result).to.not.contain('{{default this ""}}');
   });
 
   it('expands contributor_dmp_permissions wrapper with replaceName, wrapper expressions, and syncSources', () => {

--- a/packages/sails-ng-common/test/unit/form-override.test.ts
+++ b/packages/sails-ng-common/test/unit/form-override.test.ts
@@ -10,6 +10,7 @@ import { GroupFieldComponentName } from '../../src/config/component/group.outlin
 import { DropdownInputComponentName } from '../../src/config/component/dropdown-input.outline';
 import { CheckboxInputComponentName } from '../../src/config/component/checkbox-input.outline';
 import { TypeaheadInputComponentName } from '../../src/config/component/typeahead-input.outline';
+import { FileUploadComponentName } from '../../src/config/component/file-upload.outline';
 import { isTypeFieldDefinitionName } from '../../src/config/form-types.outline';
 import { ILogger } from '../../src/logger.interface';
 
@@ -289,6 +290,34 @@ describe('FormOverride reusable expansion', () => {
     expect(result).to.contain('(get this "dc_title" "")');
     expect(result).to.contain('{{{renderMetadataValue this}}}');
     expect(result).to.not.contain('{{default this ""}}');
+  });
+
+  it('renders utf8_name object values as display labels', () => {
+    const formOverride = new FormOverride(createLogger());
+
+    const result = (formOverride as any).renderDisplayValue('content');
+
+    expect(result).to.contain('(get content "utf8_name" "")');
+    expect(result).to.contain('{{{plaintextToHtml (get content "utf8_name" "")}}}');
+  });
+
+  it('renders file upload leaf values as attachment download links', () => {
+    const formOverride = new FormOverride(createLogger());
+
+    const result = (formOverride as any).renderLeafValue(
+      {
+        component: {
+          class: FileUploadComponentName,
+        },
+      } as never,
+      'content',
+      ['contractualObligations_licences']
+    );
+
+    expect(result).to.contain('attachmentDownloadUrl this oid branding portal');
+    expect(result).to.contain('<a href="{{attachmentDownloadUrl this oid branding portal}}"');
+    expect(result).to.contain('target="_blank"');
+    expect(result).to.contain('rel="noopener noreferrer"');
   });
 
   it('expands contributor_dmp_permissions wrapper with replaceName, wrapper expressions, and syncSources', () => {

--- a/packages/sails-ng-common/test/unit/handlebars-helpers.test.ts
+++ b/packages/sails-ng-common/test/unit/handlebars-helpers.test.ts
@@ -261,6 +261,74 @@ describe('Shared Handlebars Helpers', function () {
         });
     });
 
+    describe('attachmentDownloadUrl', function () {
+        it('should build a branded attachment download URL from fileId and oid', function () {
+            const result = handlebarsHelperDefinitions.attachmentDownloadUrl(
+                { fileId: 'content 1.txt', name: 'content1.txt' },
+                'oid/1',
+                'default',
+                'rdmp'
+            );
+
+            expect(result).to.equal('/default/rdmp/record/oid%2F1/attach/content%201.txt');
+        });
+
+        it('should prefix record-relative attachment locations with branding and portal', function () {
+            const result = handlebarsHelperDefinitions.attachmentDownloadUrl(
+                { location: '/record/oid-1/attach/file-1' },
+                'oid-1',
+                'default',
+                'rdmp'
+            );
+
+            expect(result).to.equal('/default/rdmp/record/oid-1/attach/file-1');
+        });
+
+        it('should normalize migrated attachment locations without a leading record segment', function () {
+            const result = handlebarsHelperDefinitions.attachmentDownloadUrl(
+                { location: 'oid-1/attach/file-1' },
+                '',
+                'default',
+                'rdmp'
+            );
+
+            expect(result).to.equal('/default/rdmp/record/oid-1/attach/file-1');
+        });
+
+        it('should derive a branded attachment path from uploadUrl', function () {
+            const result = handlebarsHelperDefinitions.attachmentDownloadUrl(
+                { uploadUrl: 'https://researchdata.example/default/rdmp/record/oid-1/attach/file-1' },
+                '',
+                'default',
+                'rdmp'
+            );
+
+            expect(result).to.equal('/default/rdmp/record/oid-1/attach/file-1');
+        });
+
+        it('should keep safe absolute URLs', function () {
+            const result = handlebarsHelperDefinitions.attachmentDownloadUrl(
+                { url: 'https://example.test/download/file-1' },
+                'oid-1',
+                'default',
+                'rdmp'
+            );
+
+            expect(result).to.equal('https://example.test/download/file-1');
+        });
+
+        it('should reject unsafe attachment URLs', function () {
+            const result = handlebarsHelperDefinitions.attachmentDownloadUrl(
+                { url: 'javascript:alert(1)', location: 'javascript:alert(2)' },
+                'oid-1',
+                'default',
+                'rdmp'
+            );
+
+            expect(result).to.equal('');
+        });
+    });
+
     describe('default', function () {
         it('should return value if truthy', function () {
             const result = handlebarsHelperDefinitions.default('hello', 'default');

--- a/packages/sails-ng-common/test/unit/handlebars-helpers.test.ts
+++ b/packages/sails-ng-common/test/unit/handlebars-helpers.test.ts
@@ -291,6 +291,13 @@ describe('Shared Handlebars Helpers', function () {
         });
     });
 
+    describe('plaintextToHtml', function () {
+        it('should escape text and preserve line breaks', function () {
+            const result = handlebarsHelperDefinitions.plaintextToHtml('Line 1\n<script>alert("x")</script>\r\nLine 3');
+            expect(result).to.equal('Line 1<br>&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;<br>Line 3');
+        });
+    });
+
     describe('comparison helpers', function () {
         it('gt should return true if first > second', function () {
             expect(handlebarsHelperDefinitions.gt(5, 3)).to.be.true;


### PR DESCRIPTION
## Summary

Improves view-mode rendering quality for form field components in ReDBox, including inline-vocab option labels, typeahead display fields, plaintext line break preservation, file-attachment download URLs, rich text content formatting, and icon decoration fixes.

---

## Context / Motivation

View-mode form rendering had several gaps: dropdown/checkbox/radio values displayed raw option codes instead of labels, typeahead selections rendered as JSON, textarea line breaks were lost, file upload links were missing, and rich text content lacked proper table/inline styling. These changes elevate view-mode output to be user-readable and feature-complete.

---

## Key Features

### Option Labels in View Mode

- Dropdown, checkbox, and radio components with `inlineVocab: true` now render translated option labels in view mode instead of raw value codes
- New `renderOptionSingleValue` and `renderOptionListValue` template generators produce Handlebars branches matching each option's value to its label
- Client/construct visitors defer inline vocab components to client-side transform so labels are resolved before view-mode conversion

### Typeahead Display Fields

- Typeahead leaf values render using the configured `labelField`/`valueField` with fallback through common display fields (`label`, `name`, `title`, `utf8_name`, etc.)
- Array and scalar values are handled correctly; repeatable typeahead items render as display text without JSON dumping

### Plaintext Line Break Preservation

- New `plaintextToHtml` Handlebars helper escapes HTML and converts `\n`/`\r\n` to `<br>` tags
- TextAreaComponent and plain-text view templates use `{{{plaintextToHtml content}}}` to preserve line breaks

### File Attachment Download Links

- New `attachmentDownloadUrl` Handlebars helper builds branded download URLs from attachment metadata, supporting `url`, `uploadUrl`, `location`, and `fileId`/`oid` fallbacks
- File-upload view templates now render clickable download links with `target="_blank" rel="noopener noreferrer"`
- Resolved against branding/portal prefixes for multi-tenant environments

### Rich Text Content Formatting

- Content component exposes `outputFormat` to Handlebars template context
- Rich-text content (outputFormat set) receives `.rb-form-rich-text-content` CSS class
- Table styling added for markdown-to-HTML rendered tables (borders, striping, spacing)

### Font Awesome Icon Rendering Fixes

- CSS rules prevent Font Awesome icons from inheriting `text-decoration` from parent links in form hosts
- New `.rb-form-icon-link` class with `inline-flex` layout for consistent icon+text alignment

### Dependency Update

- `@jsonjoy.com/json-pointer` bumped from `18.24.0` to `18.28.0`

---

## Testing

- Added unit tests for `renderLeafValue` with dropdown option labels, checkbox option labels, typeahead display fields, and file-upload attachment links
- Added unit tests for `renderDisplayValue` with `utf8_name` object resolution
- Added unit tests for repeatable typeahead and content object rendering
- Added unit tests for `attachmentDownloadUrl` helper covering branded URLs, record-relative locations, uploadUrl derivation, safe absolute URLs, and unsafe URL rejection
- Added unit tests for `plaintextToHtml` helper with XSS escaping and line break conversion
- Added integration test for content component `outputFormat` rendering in markdown view mode
- Added integration test for text area line break preservation in construct visitor
- Added integration test verifying inline vocab label resolution before client view transform
- Added unit test for plain-text reusable view template containing `{{{plaintextToHtml content}}}`

---

## Architectural / Operational Impact

### Handlebars Helper Registration

- `plaintextToHtml` and `attachmentDownloadUrl` are registered as global shared helpers in `handlebars-helpers.ts`, available server-side and client-side
- `attachmentDownloadUrl` performs safe URL validation (`isSafeDownloadUrl`) to prevent XSS via `javascript:` or unsafe schemes

### Template Generation

- `FormOverride.renderLeafValue` extended with component-type-specific branches for dropdown, checkbox, radio, textarea, typeahead, and file-upload components
- New private methods `renderTypeaheadValue`, `renderDisplayValue`, `renderOptionSingleValue`, `renderOptionListValue`, `getOptionLabelPairs`, `getTypeaheadDisplayFields`, `getCommonDisplayFields` added to `FormOverride`
- `commonContentPlain` now preserves value as-is instead of always falling back to a `{{default}}` template

### Visitor Pipeline

- `ConstructFormConfigVisitor` defers inline-vocab option components to client-side view transform (same pattern as repeatable/group/question-tree)
- `ClientFormConfigVisitor` transforms inline-vocab dropdown/checkbox/radio components to `ContentComponent` in view mode
- New `isInlineVocabOptionComponent` guard method on `ClientFormConfigVisitor`

### CSS Additions

- `styles.scss` gains ~90 lines for Font Awesome decoration fixes, icon-link layout, and rich-text content table styling

---

## Backwards Compatibility

Fully backwards compatible. Existing view-mode templates continue to work unchanged. The new helpers and template branches only activate for components with the relevant configuration (e.g., `inlineVocab: true`, `labelField`, `outputFormat`). Default templates maintain identical output for plain values.

---

## Deployment Notes

No migration or configuration changes required. The `@jsonjoy.com/json-pointer` dependency bump is a patch-level update with no breaking changes.

---

## Impact

View-mode form rendering is now significantly more usable: users see human-readable labels instead of raw codes, formatted text with line breaks, clickable download links for uploads, and properly styled rich content. The changes are fully backwards-compatible and covered by new unit and integration tests.
