### PR TITLE
Fix: remove redundant HTML style in favour of class to adhere to CSP

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/form.component.html
+++ b/angular/projects/researchdatabox/form/src/app/form.component.html
@@ -2,7 +2,7 @@
   <div class="rb-form-shell__main" [class.rb-form-shell__main--loading]="!componentsLoaded()">
     @if (!componentsLoaded()) {
       <div class="rb-form-loading">
-        <img class="center-block rb-form-loading__spinner" src="/images/loading.svg" [attr.alt]="'loading-alt-text' | i18next" style="width: 120px; height: 120px;" />
+        <img class="center-block rb-form-loading__spinner" src="/images/loading.svg" [attr.alt]="'loading-alt-text' | i18next" />
       </div>
     }
     <div class="rb-form-components" [attr.aria-hidden]="!componentsLoaded() ? 'true' : null">


### PR DESCRIPTION
## Summary

Remove redundant HTML style in favour of class, to keep secure content loading policy

Changes made:

* Maintain features while retaining secure content loading policy.

## Technical implementation details

* remove redundant HTML style in favour of class to adhere to CSP.

