### PR TITLE
Fix: update jsonata function signature to match ts function signature

### DIFF
--- a/packages/sails-ng-common/src/jsonata-helpers.ts
+++ b/packages/sails-ng-common/src/jsonata-helpers.ts
@@ -13,7 +13,11 @@ export type JSONataEvaluate = (context: unknown) => Promise<unknown>;
  * @param format The format to use.
  * @param sourceFormat The optional format of the value, if known.
  */
-export function luxonFormatDate(value: unknown, format: unknown, sourceFormat?: unknown): string {
+export function luxonFormatDate(
+  value: undefined | null | string | number | Date,
+  format: undefined | null | string,
+  sourceFormat?: null | string
+): string {
   if (value === undefined || value === null || value === '') {
     return '';
   }
@@ -80,7 +84,11 @@ export function jsonataCompile(expression: string, options?: jsonata.JsonataOpti
   compiled.registerFunction('eval', () => {throw new Error('Attempted to invoke eval')});
 
   // Register a function for formatting date time values.
-  compiled.registerFunction('luxonFormatDate', luxonFormatDate, '<(snd)(sn)s?:s>');
+  // First param 'value': string, number, null, object (to allow Date)
+  // Second param 'format': string, null
+  // Third param 'sourceFormat': string, null, optional
+  // Return type: string
+  compiled.registerFunction('luxonFormatDate', luxonFormatDate, '<(snlo)(sl)(sl)?:s>');
 
   // TODO: consider registering a function for translations
   // TODO: consider replacing regex with google's re2?

--- a/packages/sails-ng-common/test/unit/jsonata-helpers.test.ts
+++ b/packages/sails-ng-common/test/unit/jsonata-helpers.test.ts
@@ -57,10 +57,67 @@ describe('JSONata helpers', function () {
     {
       args: {
         expression: '$luxonFormatDate(date, "yyyy")',
+        input: {date: null},
+        bindings: undefined,
+      },
+      expected: '',
+    },
+    {
+      args: {
+        expression: '$luxonFormatDate(date, "yyyy")',
+        input: {date: undefined},
+        bindings: undefined,
+      },
+      expected: '',
+    },
+    {
+      args: {
+        expression: '$luxonFormatDate(date, format)',
+        input: {date: undefined, format: undefined},
+        bindings: undefined,
+      },
+      expected: '',
+    },
+    {
+      // unparsable date
+      args: {
+        expression: '$luxonFormatDate(date, "yyyy")',
+        input: {date: 'abc'},
+        bindings: undefined,
+      },
+      expected: '',
+    },
+    {
+      args: {
+        expression: '$luxonFormatDate(date, "yyyy-MM-dd")',
+        input: {date: 1781581963000},
+        bindings: undefined,
+      },
+      expected: '2026-06-16',
+    },
+    {
+      args: {
+        expression: '$luxonFormatDate(date, "yyyy/MM/dd")',
+        input: {date: new Date('2025-08-10T10:00:00Z')},
+        bindings: undefined,
+      },
+      expected: '2025/08/10',
+    },
+    {
+      args: {
+        expression: '$luxonFormatDate(date, "yyyy")',
         input: {date: '2026/06/10'},
         bindings: undefined,
       },
       expected: '2026',
+    },
+    {
+      args: {
+        expression: '$luxonFormatDate(date, "yyyy/MM/dd", "MM/dd/yyyy")',
+        input: {date: '06/10/2026'},
+        bindings: undefined,
+      },
+      expected: '2026/06/10',
     },
     {
       args: {
@@ -78,6 +135,14 @@ describe('JSONata helpers', function () {
         bindings: undefined,
       },
       expected: '2026',
+    },
+    {
+      args: {
+        expression: '$luxonFormatDate(date, "yyyy")',
+        input: {date: ['Wed, 10 Jun 2026 00:00:00 +0930']},
+        bindings: undefined,
+      },
+      expected: new Error("Argument 1 of function \"luxonFormatDate\" does not match function signature"),
     },
     {
       args: {

--- a/packages/sails-ng-common/test/unit/jsonata-helpers.test.ts
+++ b/packages/sails-ng-common/test/unit/jsonata-helpers.test.ts
@@ -89,21 +89,21 @@ describe('JSONata helpers', function () {
     },
     {
       args: {
-        expression: '$luxonFormatDate(date, "yyyy-MM-dd")',
+        expression: '$luxonFormatDate(date, "yyyy-MM")',
         input: {date: 1781092138000},
         bindings: undefined,
       },
-      expected: '2026-06-10',
+      expected: '2026-06',
     },
     {
       args: {
-        expression: '$luxonFormatDate(date, "yyyy/MM/dd")',
+        expression: '$luxonFormatDate(date, "yyyy/MM")',
         // We want to use local timezones in the browser.
         // Use Z timezone to try to avoid rolling over to next or previous day.
         input: {date: new Date('2025-08-10T10:00:00Z')},
         bindings: undefined,
       },
-      expected: '2025/08/10',
+      expected: '2025/08',
     },
     {
       args: {
@@ -135,7 +135,7 @@ describe('JSONata helpers', function () {
         // We want to use local timezones in the browser.
         // Use a timezone near midday UTC to try to avoid rolling over to next or previous day.
         // should format RFC 2822 date string values with luxon JSONata helper
-        input: {date: 'Wed, 10 Jun 2026 00:00:00 +0030'},
+        input: {date: 'Wed, 10 Jun 2026 11:00:00 +0030'},
         bindings: undefined,
       },
       expected: '2026',
@@ -143,7 +143,7 @@ describe('JSONata helpers', function () {
     {
       args: {
         expression: '$luxonFormatDate(date, "yyyy")',
-        input: {date: ['Wed, 10 Jun 2026 00:00:00 +0030']},
+        input: {date: ['Wed, 10 Jun 2026 11:00:00 +0030']},
         bindings: undefined,
       },
       expected: new Error("Argument 1 of function \"luxonFormatDate\" does not match function signature"),

--- a/packages/sails-ng-common/test/unit/jsonata-helpers.test.ts
+++ b/packages/sails-ng-common/test/unit/jsonata-helpers.test.ts
@@ -17,7 +17,7 @@ describe('JSONata helpers', function () {
     if ('message' in (error as Record<string, unknown>) && expected instanceof Error) {
       expect((error as Record<string, unknown>).message).to.eql(expected.message);
     } else {
-      expect.fail(`Threw unexpected error ${JSON.stringify({ error, type: typeof error })}`);
+      expect.fail(`Threw unexpected error ${JSON.stringify({error, type: typeof error})}`);
     }
   }
 
@@ -25,7 +25,7 @@ describe('JSONata helpers', function () {
     {
       args: {
         expression: '$sum(example.value)',
-        input: { example: [{ value: 4 }, { value: 7 }, { value: 13 }] },
+        input: {example: [{value: 4}, {value: 7}, {value: 13}]},
         bindings: undefined,
       },
       expected: 24,
@@ -34,14 +34,14 @@ describe('JSONata helpers', function () {
       args: {
         expression: '$a + $b()',
         input: {},
-        bindings: { a: 4, b: () => 78 },
+        bindings: {a: 4, b: () => 78},
       },
       expected: 82,
     },
     {
       args: {
         expression: '$.name',
-        input: { name: 'testing' },
+        input: {name: 'testing'},
         bindings: undefined,
       },
       expected: 'testing',
@@ -49,7 +49,7 @@ describe('JSONata helpers', function () {
     {
       args: {
         expression: '{{{{invalid',
-        input: { name: 'testing' },
+        input: {name: 'testing'},
         bindings: undefined,
       },
       expected: new Error('Expected ":" before end of expression'),
@@ -90,14 +90,16 @@ describe('JSONata helpers', function () {
     {
       args: {
         expression: '$luxonFormatDate(date, "yyyy-MM-dd")',
-        input: {date: 1781581963000},
+        input: {date: 1781092138000},
         bindings: undefined,
       },
-      expected: '2026-06-16',
+      expected: '2026-06-10',
     },
     {
       args: {
         expression: '$luxonFormatDate(date, "yyyy/MM/dd")',
+        // We want to use local timezones in the browser.
+        // Use Z timezone to try to avoid rolling over to next or previous day.
         input: {date: new Date('2025-08-10T10:00:00Z')},
         bindings: undefined,
       },
@@ -130,8 +132,10 @@ describe('JSONata helpers', function () {
     {
       args: {
         expression: '$luxonFormatDate(date, "yyyy")',
+        // We want to use local timezones in the browser.
+        // Use a timezone near midday UTC to try to avoid rolling over to next or previous day.
         // should format RFC 2822 date string values with luxon JSONata helper
-        input: {date: 'Wed, 10 Jun 2026 00:00:00 +0930'},
+        input: {date: 'Wed, 10 Jun 2026 00:00:00 +0030'},
         bindings: undefined,
       },
       expected: '2026',
@@ -139,7 +143,7 @@ describe('JSONata helpers', function () {
     {
       args: {
         expression: '$luxonFormatDate(date, "yyyy")',
-        input: {date: ['Wed, 10 Jun 2026 00:00:00 +0930']},
+        input: {date: ['Wed, 10 Jun 2026 00:00:00 +0030']},
         bindings: undefined,
       },
       expected: new Error("Argument 1 of function \"luxonFormatDate\" does not match function signature"),
@@ -171,7 +175,7 @@ describe('JSONata helpers', function () {
       expected: new Error('Attempted to invoke eval'),
     },
   ];
-  cases.forEach(({ args, expected }) => {
+  cases.forEach(({args, expected}) => {
     it(`should have expected result using args "${JSON.stringify(args)}" expected "${JSON.stringify(expected)}"`, async function () {
       try {
         const compiled = jsonataCompile(args.expression);


### PR DESCRIPTION
## Summary

Update jsonata function signature to match ts function signature.

Changes made:

* Expression evaluation should fail gracefully.

## Testing

* Add more tests for possible values.

## Future work

* Consider whether the jsonata function should accept any value instead of throw on invalid argument types?
