### PR TITLE
Figshare Plugin Trigger Condition implementation.

### DIFF
--- a/packages/redbox-core/src/CoreService.ts
+++ b/packages/redbox-core/src/CoreService.ts
@@ -213,7 +213,7 @@ export namespace Services.Core {
      * @param  user The user that triggered the hook, optional.
      * @return {"true"|"false"} "true" if the condition passed, otherwise "false".
      */
-    protected metTriggerCondition(oid: string, record: Record<string, unknown>, options: Record<string, unknown>, user?: Record<string, unknown> | null): string {
+    protected metTriggerCondition(oid: string | null, record: Record<string, unknown>, options: Record<string, unknown>, user?: unknown): string {
       const triggerCondition = _.get(options, "triggerCondition", "") as string;
       const forceRun = _.get(options, "forceRun", false) as boolean;
       const variables = {

--- a/packages/redbox-core/src/services/FigshareService.ts
+++ b/packages/redbox-core/src/services/FigshareService.ts
@@ -69,6 +69,17 @@ export namespace Services {
       return this._msgPrefix;
     }
 
+    private hasConfiguredTriggerCondition(options: Record<string, unknown>): boolean {
+      return typeof options?.triggerCondition === 'string' && options.triggerCondition.length > 0;
+    }
+
+    private shouldRunFigshareLifecycleSync(oid: string | null, record: RecordModel, options: Record<string, unknown>, user: unknown): boolean {
+      if (!this.hasConfiguredTriggerCondition(options) && !Boolean(options?.forceRun)) {
+        return true;
+      }
+      return this.metTriggerCondition(oid, record, options, user) === 'true';
+    }
+
     private summarizeError(error: unknown): { statusCode?: number; responseSummary?: Record<string, unknown> } {
       if (error instanceof RBValidationError) {
         return {
@@ -459,7 +470,7 @@ export namespace Services {
     }
 
     public createUpdateFigshareArticle(oid: string | null, record: RecordModel, options: Record<string, unknown>, user: unknown) {
-      if (this.metTriggerCondition(oid, record, options, user) !== 'true') {
+      if (!this.shouldRunFigshareLifecycleSync(oid, record, options, user)) {
         sails.log.debug(`FigService - createUpdateFigshareArticle trigger condition not met for ${oid}`);
         return record;
       }
@@ -470,7 +481,7 @@ export namespace Services {
     }
 
     public uploadFilesToFigshareArticle(oid: string, record: RecordModel, options: Record<string, unknown>, user: UserModel) {
-      if (this.metTriggerCondition(oid, record, options, user) !== 'true') {
+      if (!this.shouldRunFigshareLifecycleSync(oid, record, options, user)) {
         sails.log.debug(`FigService - uploadFilesToFigshareArticle trigger condition not met for ${oid}`);
         return record;
       }

--- a/packages/redbox-core/src/services/FigshareService.ts
+++ b/packages/redbox-core/src/services/FigshareService.ts
@@ -458,16 +458,24 @@ export namespace Services {
       }
     }
 
-    public createUpdateFigshareArticle(oid: string, record: RecordModel, _options: Record<string, unknown>, _user: Record<string, unknown>) {
+    public createUpdateFigshareArticle(oid: string | null, record: RecordModel, options: Record<string, unknown>, user: unknown) {
+      if (this.metTriggerCondition(oid, record, options, user) !== 'true') {
+        sails.log.debug(`FigService - createUpdateFigshareArticle trigger condition not met for ${oid}`);
+        return record;
+      }
       if (this.getConfig(record) == null) {
         return record;
       }
       return this.syncRecordWithFigshare(record, `${oid}:pre`, 'pre-save');
     }
 
-    public uploadFilesToFigshareArticle(oid: string, record: RecordModel, _options: Record<string, unknown>, user: UserModel) {
+    public uploadFilesToFigshareArticle(oid: string, record: RecordModel, options: Record<string, unknown>, user: UserModel) {
+      if (this.metTriggerCondition(oid, record, options, user) !== 'true') {
+        sails.log.debug(`FigService - uploadFilesToFigshareArticle trigger condition not met for ${oid}`);
+        return record;
+      }
       if (this.getConfig(record) == null) {
-        return;
+        return record;
       }
       void this.syncRecordWithFigshare(record, `${oid}:post`, 'post-save')
         .then(async (updatedRecord: RecordModel) => {

--- a/packages/redbox-core/test/services/FigshareService.test.ts
+++ b/packages/redbox-core/test/services/FigshareService.test.ts
@@ -246,6 +246,55 @@ describe('FigshareService', function () {
     expect(exports).to.have.property('syncRecordWithFigshare');
   });
 
+  it('honours triggerCondition before Figshare lifecycle sync', async function () {
+    const options = {
+      triggerCondition:
+        '<%= _.isEqual(record.workflow.stage, "queued") && _.isEqual(_.get(record, "metadata.dataset-will-be-published"), "yes") %>'
+    };
+    const draftRecord = {
+      redboxOid: 'oid-draft',
+      harvestId: '',
+      metaMetadata: { brandId: 'default', createdBy: 'admin', type: 'dataPublication', searchCore: 'default', form: 'dataPublication-1.0-draft', attachmentFields: [] },
+      workflow: { stage: 'draft', stageLabel: 'Draft' },
+      authorization: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [], stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] } },
+      metadata: {
+        title: 'Draft dataset',
+        'dataset-will-be-published': 'yes'
+      },
+      dateCreated: '',
+      lastSaveDate: '',
+      id: ''
+    };
+    const queuedRecord = {
+      redboxOid: 'oid-queued',
+      harvestId: '',
+      metaMetadata: { brandId: 'default', createdBy: 'admin', type: 'dataPublication', searchCore: 'default', form: 'dataPublication-1.0-review', attachmentFields: [] },
+      workflow: { stage: 'queued', stageLabel: 'Queued For Review' },
+      authorization: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [], stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] } },
+      metadata: {
+        title: 'Queued dataset',
+        'dataset-will-be-published': 'yes'
+      },
+      dateCreated: '',
+      lastSaveDate: '',
+      id: ''
+    };
+    const user = { id: 'user-1', username: 'user-1', type: 'admin', name: 'User One', email: 'user-1@example.org', lastLogin: new Date(), additionalAttributes: {}, loginDisabled: false, workspaceApps: [], roles: [] };
+    const syncStub = sinon.stub(service, 'syncRecordWithFigshare').resolves(queuedRecord);
+
+    const skipped = service.createUpdateFigshareArticle('oid-draft', draftRecord, options, user);
+    expect(skipped).to.equal(draftRecord);
+    expect(syncStub.called).to.equal(false);
+
+    const uploadSkipped = service.uploadFilesToFigshareArticle('oid-draft', draftRecord, options, user);
+    expect(uploadSkipped).to.equal(draftRecord);
+    expect(syncStub.called).to.equal(false);
+
+    const synced = await service.createUpdateFigshareArticle('oid-queued', queuedRecord, options, user);
+    expect(synced).to.equal(queuedRecord);
+    expect(syncStub.calledOnceWithExactly(queuedRecord, 'oid-queued:pre', 'pre-save')).to.equal(true);
+  });
+
   it('uses fixture mode to build metadata and write back article identifiers', async function () {
     const record = {
       metaMetadata: { brandId: 'default' },

--- a/packages/redbox-core/test/services/FigshareService.test.ts
+++ b/packages/redbox-core/test/services/FigshareService.test.ts
@@ -295,6 +295,32 @@ describe('FigshareService', function () {
     expect(syncStub.calledOnceWithExactly(queuedRecord, 'oid-queued:pre', 'pre-save')).to.equal(true);
   });
 
+  it('runs Figshare lifecycle sync when no triggerCondition is configured', async function () {
+    const record = {
+      redboxOid: 'oid-no-condition',
+      harvestId: '',
+      metaMetadata: { brandId: 'default', createdBy: 'admin', type: 'dataPublication', searchCore: 'default', form: 'dataPublication-1.0-review', attachmentFields: [] },
+      workflow: { stage: 'queued', stageLabel: 'Queued For Review' },
+      authorization: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [], stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] } },
+      metadata: {
+        title: 'Queued dataset',
+        'dataset-will-be-published': 'yes'
+      },
+      dateCreated: '',
+      lastSaveDate: '',
+      id: ''
+    };
+    const user = { id: 'user-1', username: 'user-1', type: 'admin', name: 'User One', email: 'user-1@example.org', lastLogin: new Date(), additionalAttributes: {}, loginDisabled: false, workspaceApps: [], roles: [] };
+    const syncStub = sinon.stub(service, 'syncRecordWithFigshare').resolves(record);
+
+    const synced = await service.createUpdateFigshareArticle('oid-no-condition', record, {}, user);
+    expect(synced).to.equal(record);
+    expect(syncStub.calledOnceWithExactly(record, 'oid-no-condition:pre', 'pre-save')).to.equal(true);
+
+    service.uploadFilesToFigshareArticle('oid-no-condition', record, {}, user);
+    expect(syncStub.calledWithExactly(record, 'oid-no-condition:post', 'post-save')).to.equal(true);
+  });
+
   it('uses fixture mode to build metadata and write back article identifiers', async function () {
     const record = {
       metaMetadata: { brandId: 'default' },


### PR DESCRIPTION
## Summary

Applies Figshare plugin trigger-condition evaluation to the pre-save article sync and post-save file upload lifecycle methods.

---

## Context / Motivation

The Figshare plugin lifecycle hooks could run even when their configured trigger condition was false. That meant records outside the intended workflow or metadata state could still attempt article creation/update or file upload work.

---

## Key Features

### Trigger condition handling

- Evaluates `triggerCondition` before `createUpdateFigshareArticle`.
- Evaluates `triggerCondition` before `uploadFilesToFigshareArticle`.
- Returns the original record when the condition is not met, avoiding unnecessary Figshare work.
- Keeps the existing Figshare config check after the trigger-condition gate.

### Service registration

- Updates the exported service registration path so the Figshare trigger-condition helper is available to the service.

---

## Testing

- Added Figshare service coverage for records that do and do not satisfy the configured trigger condition.
- Verifies both article sync and upload lifecycle methods skip Figshare work when the condition is false.
- Verifies article sync proceeds when the condition is true.

---

## Architectural / Operational Impact

### Figshare lifecycle behavior

Figshare sync and upload operations now align with configured trigger conditions. This reduces unintended external API calls and keeps publication workflow behavior tied to the configured record state.

---

## Backwards Compatibility

Backwards compatible for configurations without a trigger condition. Configurations with a trigger condition now correctly skip Figshare work when that condition evaluates false.

---

## Deployment Notes

No database migration is required. Existing Figshare configuration can continue to use the same trigger-condition expressions.

---

## Impact

This keeps Figshare article and file operations constrained to the configured trigger condition and adds test coverage for the expected skip/sync behavior.
