### PR TITLE
Chore: Use built-in nodejs packages stream and util instead of npm packages

### DIFF
--- a/packages/redbox-core/src/StorageService.ts
+++ b/packages/redbox-core/src/StorageService.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import { RecordModel } from './model';
 import { StorageServiceResponse } from './StorageServiceResponse';
 import { RecordRelationshipExpandOptions, RecordRelationshipGraph } from './RecordsService';

--- a/packages/redbox-core/src/controllers/ExportController.ts
+++ b/packages/redbox-core/src/controllers/ExportController.ts
@@ -17,9 +17,7 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-import { default as util } from 'util';
-import { default as stream } from 'node:stream';
-const pipeline = util.promisify(stream.pipeline);
+import {pipeline} from 'node:stream/promises';
 /**
  * Package that contains all Controllers.
  */

--- a/packages/redbox-core/src/controllers/ExportController.ts
+++ b/packages/redbox-core/src/controllers/ExportController.ts
@@ -18,7 +18,7 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import { default as util } from 'util';
-import { default as stream } from 'stream';
+import { default as stream } from 'node:stream';
 const pipeline = util.promisify(stream.pipeline);
 /**
  * Package that contains all Controllers.

--- a/packages/redbox-core/src/controllers/webservice/ExportController.ts
+++ b/packages/redbox-core/src/controllers/webservice/ExportController.ts
@@ -6,7 +6,7 @@ import {
   downloadRecsRoute,
 } from '../../index';
 import { default as util } from 'util';
-import { default as stream } from 'stream';
+import { default as stream } from 'node:stream';
 
 const pipeline = util.promisify(stream.pipeline);
 /**

--- a/packages/redbox-core/src/controllers/webservice/ExportController.ts
+++ b/packages/redbox-core/src/controllers/webservice/ExportController.ts
@@ -3,12 +3,8 @@ import {
   BrandingModel,
   Controllers as controllers,
   getValidatedApiRequest,
-  downloadRecsRoute,
 } from '../../index';
-import { default as util } from 'util';
-import { default as stream } from 'node:stream';
-
-const pipeline = util.promisify(stream.pipeline);
+import {pipeline} from "node:stream/promises";
 /**
  * Package that contains all Controllers.
  */

--- a/packages/redbox-core/src/responses/badRequest.ts
+++ b/packages/redbox-core/src/responses/badRequest.ts
@@ -1,4 +1,5 @@
 import { resolveSiteTitle } from './siteTitle';
+import {inspect} from "node:util";
 
 declare module 'express-serve-static-core' {
     interface Response {
@@ -52,7 +53,7 @@ export function badRequest(this: { req: Sails.Req, res: Sails.Res }, data?: unkn
     let viewData = data;
     if (!(viewData instanceof Error) && 'object' == typeof viewData) {
         try {
-            viewData = require('util').inspect(data, { depth: null });
+            viewData = inspect(data, { depth: null });
         }
         catch (_e) {
             viewData = undefined;

--- a/packages/redbox-core/src/responses/created.ts
+++ b/packages/redbox-core/src/responses/created.ts
@@ -1,4 +1,5 @@
 import { resolveSiteTitle } from './siteTitle';
+import {inspect} from "node:util";
 
 declare module 'express-serve-static-core' {
     interface Response {
@@ -41,7 +42,7 @@ export function created(this: { req: Sails.Req, res: Sails.Res }, data?: unknown
     let viewData = data;
     if (!(viewData instanceof Error) && 'object' == typeof viewData) {
         try {
-            viewData = require('util').inspect(data, { depth: null });
+            viewData = inspect(data, { depth: null });
         }
         catch (_e) {
             viewData = undefined;

--- a/packages/redbox-core/src/responses/forbidden.ts
+++ b/packages/redbox-core/src/responses/forbidden.ts
@@ -1,4 +1,5 @@
 import { resolveSiteTitle } from './siteTitle';
+import {inspect} from "node:util";
 
 declare module 'express-serve-static-core' {
     interface Response {
@@ -52,7 +53,7 @@ export function forbidden(this: { req: Sails.Req, res: Sails.Res }, data?: unkno
     let viewData = data;
     if (!(viewData instanceof Error) && 'object' == typeof viewData) {
         try {
-            viewData = require('util').inspect(data, { depth: null });
+            viewData = inspect(data, { depth: null });
         }
         catch (_e) {
             viewData = undefined;

--- a/packages/redbox-core/src/responses/ok.ts
+++ b/packages/redbox-core/src/responses/ok.ts
@@ -1,4 +1,5 @@
 import { resolveSiteTitle } from './siteTitle';
+import {inspect} from "node:util";
 
 declare module 'express-serve-static-core' {
     interface Response {
@@ -45,7 +46,7 @@ export function ok(this: { req: Sails.Req, res: Sails.Res }, data?: unknown, opt
     let viewData = data;
     if (!(viewData instanceof Error) && 'object' == typeof viewData) {
         try {
-            viewData = require('util').inspect(data, { depth: null });
+            viewData = inspect(data, { depth: null });
         }
         catch (_e) {
             viewData = undefined;

--- a/packages/redbox-core/src/responses/serverError.ts
+++ b/packages/redbox-core/src/responses/serverError.ts
@@ -1,4 +1,5 @@
 import { resolveSiteTitle } from './siteTitle';
+import {inspect} from "node:util";
 
 declare module 'express-serve-static-core' {
     interface Response {
@@ -52,7 +53,7 @@ export function serverError(this: { req: Sails.Req, res: Sails.Res }, data?: unk
     let viewData = data;
     if (!(viewData instanceof Error) && 'object' == typeof viewData) {
         try {
-            viewData = require('util').inspect(data, { depth: null });
+            viewData = inspect(data, { depth: null });
         }
         catch (_e) {
             viewData = undefined;

--- a/packages/redbox-core/src/services/OniService.ts
+++ b/packages/redbox-core/src/services/OniService.ts
@@ -24,10 +24,8 @@ import { firstValueFrom } from 'rxjs';
 import { promises as fs } from 'fs';
 import path from 'node:path';
 import { createWriteStream } from 'fs';
-import { promisify } from 'util';
-import * as stream from 'node:stream';
-const finished = promisify(stream.finished);
 import * as mime from 'mime-types';
+import {finished} from "node:stream/promises";
 const { Collector, generateArcpId } = require('oni-ocfl');
 const { languageProfileURI } = require('language-data-commons-vocabs');
 

--- a/packages/redbox-core/src/services/OniService.ts
+++ b/packages/redbox-core/src/services/OniService.ts
@@ -25,7 +25,7 @@ import { promises as fs } from 'fs';
 import path from 'node:path';
 import { createWriteStream } from 'fs';
 import { promisify } from 'util';
-import * as stream from 'stream';
+import * as stream from 'node:stream';
 const finished = promisify(stream.finished);
 import * as mime from 'mime-types';
 const { Collector, generateArcpId } = require('oni-ocfl');

--- a/packages/redbox-core/src/services/RecordsService.ts
+++ b/packages/redbox-core/src/services/RecordsService.ts
@@ -50,7 +50,7 @@ import { DateTime } from 'luxon';
 
 import { isObservable } from 'rxjs';
 
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import { FormAttributes } from '../waterline-models';
 import { normalizeRecordRelations } from '../config/recordtype.config';
 import {

--- a/packages/redbox-core/src/transformers/ExportJSONTransformer.ts
+++ b/packages/redbox-core/src/transformers/ExportJSONTransformer.ts
@@ -1,4 +1,4 @@
-import { Transform } from 'stream';
+import { Transform } from 'node:stream';
 import { DateTime } from 'luxon';
 import * as _ from 'lodash';
 

--- a/packages/redbox-core/test/services/OniService.test.ts
+++ b/packages/redbox-core/test/services/OniService.test.ts
@@ -850,11 +850,11 @@ describe('OniService', function() {
   describe('writeDatasetObject (private method)', function() {
     it('should filter attachments based on accessRightsToggle and selection', async function() {
       const writeDatasetObject = OniService.writeDatasetObject.bind(OniService);
-      
+
       // Mock writeDatasetROCrate to avoid full execution
       sinon.stub(OniService, 'writeDatasetROCrate').resolves();
       sinon.stub(OniService, 'removeTempDir').resolves();
-      
+
       const creator = { email: 'creator@test.com' };
       const approver = { email: 'approver@test.com' };
       const record = {
@@ -867,9 +867,9 @@ describe('OniService', function() {
         },
         metaMetadata: {}
       };
-      
+
       await writeDatasetObject(creator, approver, 'oid', 'drid', {}, {}, record, '/tmp');
-      
+
       // writeDatasetROCrate should be called with empty attachments when mdOnly=true
       expect(OniService.writeDatasetROCrate.called).to.be.true;
       const callArgs = OniService.writeDatasetROCrate.firstCall.args;
@@ -878,13 +878,13 @@ describe('OniService', function() {
 
     it('should throw error when datastream retrieval fails', async function() {
       const writeDatasetObject = OniService.writeDatasetObject.bind(OniService);
-      
+
       // Mock datastream service to fail
       OniService.datastreamService = {
         getDatastream: sinon.stub().rejects(new Error('Datastream error'))
       };
       sinon.stub(OniService, 'removeTempDir').resolves();
-      
+
       const creator = { email: 'creator@test.com' };
       const approver = { email: 'approver@test.com' };
       const record = {
@@ -896,7 +896,7 @@ describe('OniService', function() {
         },
         metaMetadata: {}
       };
-      
+
       try {
         await writeDatasetObject(creator, approver, 'oid', 'drid', {}, {}, record, '/tmp');
         expect.fail('Should have thrown');
@@ -907,7 +907,7 @@ describe('OniService', function() {
 
     it('should handle datastream with body instead of readstream', async function() {
       const writeDatasetObject = OniService.writeDatasetObject.bind(OniService);
-      
+
       // Mock datastream service to return body instead of readstream
       OniService.datastreamService = {
         getDatastream: sinon.stub().resolves({
@@ -917,7 +917,7 @@ describe('OniService', function() {
       sinon.stub(OniService, 'writeDatasetROCrate').resolves();
       sinon.stub(OniService, 'removeTempDir').resolves();
       sinon.stub(OniService, 'writeDatastream').resolves();
-      
+
       const creator = { email: 'creator@test.com' };
       const approver = { email: 'approver@test.com' };
       const record = {
@@ -929,9 +929,9 @@ describe('OniService', function() {
         },
         metaMetadata: {}
       };
-      
+
       await writeDatasetObject(creator, approver, 'oid', 'drid', {}, {}, record, '/tmp');
-      
+
       // Should use Buffer.from for body
       expect(OniService.writeDatastream.called).to.be.true;
     });
@@ -944,7 +944,7 @@ describe('OniService', function() {
 
     it('should create RO-Crate with all metadata properties', async function() {
       const writeDatasetROCrate = OniService.writeDatasetROCrate.bind(OniService);
-      
+
       const mockTargetRepoObj = {
         crate: {
           rootId: 'arcp://name,test/oid',
@@ -957,16 +957,16 @@ describe('OniService', function() {
         addFile: sinon.stub().resolves(),
         addToRepo: sinon.stub().resolves()
       };
-      
+
       const mockTargetCollector = {
         namespace: 'test-namespace',
         newObject: sinon.stub().returns(mockTargetRepoObj)
       };
-      
+
       const mockRootCollection = {
         rootDataset: { name: 'Root Collection' }
       };
-      
+
       const creator = { email: 'creator@test.com', name: 'Creator' };
       const approver = { email: 'approver@test.com', name: 'Approver' };
       const record = {
@@ -992,9 +992,9 @@ describe('OniService', function() {
           createdOn: '2023-01-01T00:00:00Z'
         }
       };
-      
+
       await writeDatasetROCrate(creator, approver, 'test-oid', [], record, mockTargetCollector, mockRootCollection);
-      
+
       expect(mockTargetRepoObj.mintArcpId.called).to.be.true;
       expect(mockTargetRepoObj.crate.addProfile.called).to.be.true;
       expect(mockTargetRepoObj.addToRepo.called).to.be.true;
@@ -1005,7 +1005,7 @@ describe('OniService', function() {
 
     it('should handle contact point not in author list', async function() {
       const writeDatasetROCrate = OniService.writeDatasetROCrate.bind(OniService);
-      
+
       const mockTargetRepoObj = {
         crate: {
           rootId: 'arcp://name,test/oid',
@@ -1018,16 +1018,16 @@ describe('OniService', function() {
         addFile: sinon.stub().resolves(),
         addToRepo: sinon.stub().resolves()
       };
-      
+
       const mockTargetCollector = {
         namespace: 'test-namespace',
         newObject: sinon.stub().returns(mockTargetRepoObj)
       };
-      
+
       const mockRootCollection = {
         rootDataset: { name: 'Root Collection' }
       };
-      
+
       const creator = { email: 'creator@test.com', name: 'Creator' };
       const approver = { email: 'approver@test.com', name: 'Approver' };
       const record = {
@@ -1045,16 +1045,16 @@ describe('OniService', function() {
           createdOn: '2023-01-01T00:00:00Z'
         }
       };
-      
+
       await writeDatasetROCrate(creator, approver, 'test-oid', [], record, mockTargetCollector, mockRootCollection);
-      
+
       // Contact point should be added as contributor
       expect(mockTargetRepoObj.rootDataset).to.have.property('contributor');
     });
 
     it('should add extra context when spatial coverage exists', async function() {
       const writeDatasetROCrate = OniService.writeDatasetROCrate.bind(OniService);
-      
+
       const mockTargetRepoObj = {
         crate: {
           rootId: 'arcp://name,test/oid',
@@ -1067,16 +1067,16 @@ describe('OniService', function() {
         addFile: sinon.stub().resolves(),
         addToRepo: sinon.stub().resolves()
       };
-      
+
       const mockTargetCollector = {
         namespace: 'test-namespace',
         newObject: sinon.stub().returns(mockTargetRepoObj)
       };
-      
+
       const mockRootCollection = {
         rootDataset: { name: 'Root Collection' }
       };
-      
+
       const creator = { email: 'creator@test.com', name: 'Creator' };
       const approver = { email: 'approver@test.com', name: 'Approver' };
       const record = {
@@ -1095,9 +1095,9 @@ describe('OniService', function() {
           createdOn: '2023-01-01T00:00:00Z'
         }
       };
-      
+
       await writeDatasetROCrate(creator, approver, 'test-oid', [], record, mockTargetCollector, mockRootCollection);
-      
+
       // Extra context should be added
       expect(mockTargetRepoObj.crate.addContext.called).to.be.true;
     });
@@ -1105,22 +1105,22 @@ describe('OniService', function() {
 
   describe('writeToFileUsingStream (private method)', function() {
     it('should write stream to file', async function() {
-      const { Readable } = require('stream');
+      const { Readable } = require('node:stream');
       const writeToFileUsingStream = OniService.writeToFileUsingStream.bind(OniService);
-      
+
       // Create a test readable stream
       const testData = 'test file content';
       const readable = Readable.from([testData]);
-      
+
       const testFilePath = '/tmp/oni-test-file-' + Date.now() + '.txt';
-      
+
       await writeToFileUsingStream(testFilePath, readable);
-      
+
       // Verify file was created
       const fs = require('fs').promises;
       const content = await fs.readFile(testFilePath, 'utf8');
       expect(content).to.equal(testData);
-      
+
       // Cleanup
       await fs.unlink(testFilePath);
     });
@@ -1128,22 +1128,22 @@ describe('OniService', function() {
 
   describe('writeDatastream (private method)', function() {
     it('should create directory and write file', async function() {
-      const { Readable } = require('stream');
+      const { Readable } = require('node:stream');
       const writeDatastream = OniService.writeDatastream.bind(OniService);
-      
+
       const testData = 'test file content';
       const readable = Readable.from([testData]);
-      
+
       const testDir = '/tmp/oni-test-dir-' + Date.now();
       const testFilename = 'test-file.txt';
-      
+
       await writeDatastream(readable, testDir, testFilename);
-      
+
       // Verify file was created
       const fs = require('fs').promises;
       const content = await fs.readFile(testDir + '/' + testFilename, 'utf8');
       expect(content).to.equal(testData);
-      
+
       // Cleanup
       await fs.rm(testDir, { recursive: true });
     });

--- a/packages/sails-hook-redbox-storage-mongo/package-lock.json
+++ b/packages/sails-hook-redbox-storage-mongo/package-lock.json
@@ -32,7 +32,6 @@
         "sails": "1.5.17",
         "serialize-javascript": "7.0.5",
         "sinon": "22.0.0",
-        "stream": "0.0.3",
         "ts-node": "10.9.2",
         "typescript": "5.9.3",
         "util": "0.12.5"
@@ -163,13 +162,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -178,9 +177,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -188,21 +187,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -236,14 +235,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -264,14 +263,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -308,9 +307,9 @@
       "license": "ISC"
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -318,29 +317,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -350,9 +349,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -360,9 +359,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -370,9 +369,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -380,27 +379,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -410,33 +409,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -444,14 +443,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -787,9 +786,9 @@
       "license": "MIT"
     },
     "node_modules/@sailshq/router": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/@sailshq/router/-/router-1.3.10.tgz",
-      "integrity": "sha512-6h5IE0PrSEkF03Fze1lUwnDMnYMbBPkUgKaUG/mkthHpiO/VDzbD0QJXyD7xmhlD05dEzuZnGqrrUeY5oZIMAg==",
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/@sailshq/router/-/router-1.3.11.tgz",
+      "integrity": "sha512-uQSnZnFm8RBO49gyCev27RgQRpBI3KY0qd6Bh4saHMDmRGCA8IdS/SiwnuuXCychjOhovDalT46GhBjHkPIiGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -797,7 +796,7 @@
         "debug": "2.6.9",
         "methods": "~1.1.2",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.12",
+        "path-to-regexp": "0.1.13",
         "setprototypeof": "1.2.0",
         "utils-merge": "1.0.1"
       },
@@ -826,13 +825,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@sailshq/router/node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1173,9 +1165,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.13",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz",
-      "integrity": "sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==",
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1193,9 +1185,9 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1207,7 +1199,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -1251,6 +1243,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/body-parser/node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1262,7 +1271,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1278,9 +1289,9 @@
       "license": "ISC"
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
       "dev": true,
       "funding": [
         {
@@ -1298,10 +1309,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -1411,9 +1422,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001784",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001784.tgz",
-      "integrity": "sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -1722,19 +1733,6 @@
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/component-emitter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-2.0.0.tgz",
-      "integrity": "sha512-4m5s3Me2xxlVKG9PkZpQqHQR7bgpnN7joDMJ4yvVkVXngjoITG76IaZmzmywSeRTeTpc6N6r3H3+KyUurV8OYw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/compressible": {
       "version": "2.0.18",
@@ -2164,9 +2162,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.331",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
-      "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
+      "version": "1.5.379",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.379.tgz",
+      "integrity": "sha512-v/qV5aV5EUA2pGilzUCq5/eyOloZAqDZBu9UMBIzgPpLlprjSR6zswsWBTv0KpqxLGUAZEwhO95ZCt7srymNVA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2403,16 +2401,6 @@
         "node": "> 0.1.90"
       }
     },
-    "node_modules/fd-slicer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-      "integrity": "sha512-MX1ZLPIuKED51hrI4++K+1B0VX87Cs4EkybD2q12Ysuf5p4vkmHqMvQJRlDwROqFr4D2Pzyit5wGQxf30grIcw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
-    },
     "node_modules/filelist": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
@@ -2424,9 +2412,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3281,9 +3269,9 @@
       }
     },
     "node_modules/istanbul-lib-processinfo/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3509,10 +3497,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3907,9 +3905,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4093,16 +4091,18 @@
       "license": "MIT"
     },
     "node_modules/multiparty": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-4.1.3.tgz",
-      "integrity": "sha512-Qhty41IpN0IuoBstlVPhdgqtnwrsj0gE7ndajbtUVE0f2UTT/2ChmZZnS5Nsf4a5H+5C68V/tN2vi6Wcvhn00Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-4.3.0.tgz",
+      "integrity": "sha512-LD3YDFI9KrDoOGHsPM+hNraPDQQDPLe8Un/kvJfsZCsHKriA4mphg6Ctc2Cuup/59DtHMdAPm6ICXlUmhwTiug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fd-slicer": "~1.0.1"
+        "http-errors": "2.0.0",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "2.1.5"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">= 0.10"
       }
     },
     "node_modules/mute-stream": {
@@ -4136,11 +4136,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nyc": {
       "version": "18.0.0",
@@ -4205,9 +4208,9 @@
       }
     },
     "node_modules/nyc/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4702,13 +4705,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5805,15 +5801,15 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -5825,14 +5821,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5921,21 +5917,20 @@
       }
     },
     "node_modules/skipper": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/skipper/-/skipper-0.9.6.tgz",
-      "integrity": "sha512-dSFa551uu56ETCPSgtiWtEgJN+Ng5qMnphgio4GyAGh61jq7Kac/ujGa0cBv2fHt1JYjwCYPIwgcEpG/VBVRDA==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/skipper/-/skipper-0.9.8.tgz",
+      "integrity": "sha512-8Qh2HZLyabgvBubmR/KHAzRiJGrPuks1Ww0GMGWKjJgXQ8oBZfBgwhKq1Q4jDU4DGiYUK31w8IlvomSbXPes5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sailshq/lodash": "^3.10.3",
         "async": "2.6.4",
-        "body-parser": "1.20.4",
+        "body-parser": "1.20.5",
         "debug": "3.1.0",
-        "multiparty": "4.1.3",
+        "multiparty": "4.3.0",
         "semver": "7.5.2",
         "skipper-disk": "~0.5.6",
-        "string_decoder": "0.10.31",
-        "uuid": "7.0.0"
+        "string_decoder": "0.10.31"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -6047,9 +6042,9 @@
       }
     },
     "node_modules/spawn-wrap/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6184,16 +6179,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/stream": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/stream/-/stream-0.0.3.tgz",
-      "integrity": "sha512-aMsbn7VKrl4A2T7QAQQbzgN7NVc70vgF5INQrBXqn4dCXN1zy3L9HGgLO5s7PExmdrzTJ8uR/27aviW8or8/+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "component-emitter": "^2.0.0"
       }
     },
     "node_modules/streamifier": {
@@ -6390,9 +6375,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/sails-hook-redbox-storage-mongo/package.json
+++ b/packages/sails-hook-redbox-storage-mongo/package.json
@@ -56,8 +56,7 @@
     "sinon": "22.0.0",
     "serialize-javascript": "7.0.5",
     "ts-node": "10.9.2",
-    "typescript": "5.9.3",
-    "util": "0.12.5"
+    "typescript": "5.9.3"
   },
   "dependencies": {
     "@researchdatabox/redbox-core": "file:../redbox-core",

--- a/packages/sails-hook-redbox-storage-mongo/package.json
+++ b/packages/sails-hook-redbox-storage-mongo/package.json
@@ -55,7 +55,6 @@
     "sails": "1.5.17",
     "sinon": "22.0.0",
     "serialize-javascript": "7.0.5",
-    "stream": "0.0.3",
     "ts-node": "10.9.2",
     "typescript": "5.9.3",
     "util": "0.12.5"

--- a/packages/sails-hook-redbox-storage-mongo/src/services/MongoStorageService.ts
+++ b/packages/sails-hook-redbox-storage-mongo/src/services/MongoStorageService.ts
@@ -7,7 +7,7 @@ import { DateTime } from 'luxon';
 
 import mongodb = require('mongodb');
 import type { Collection, Db, Document, FindCursor, FindOptions, GridFSFile } from 'mongodb';
-import stream = require('stream');
+import stream = require('node:stream');
 import { Transform, transforms } from 'json2csv';
 import {
   Services as services,

--- a/packages/sails-hook-redbox-storage-mongo/test/services/MongoStorageService.test.ts
+++ b/packages/sails-hook-redbox-storage-mongo/test/services/MongoStorageService.test.ts
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const { of, firstValueFrom } = require('rxjs');
-const { PassThrough, Readable } = require('stream');
+const { PassThrough, Readable } = require('node:stream');
 const mongodb = require('mongodb');
 
 async function expectRejects(fn: () => Promise<unknown>, message: string) {


### PR DESCRIPTION
## Summary

Replace the npm packages `util` and `stream` with the built-in node packages.

Changes made:

* Remove unnecessary packages to reduce exposure to dependencies.


## Technical implementation details

Optional section, used for impactful changes.

* Replace `from 'stream';` with `from 'node:stream';`. Remove 'stream' package from `packages/sails-hook-redbox-storage-mongo/package.json`
* Replace `from 'util';` with `from 'node:util`;'. Remove 'stream' package from `packages/sails-hook-redbox-storage-mongo/package.json`


