### PR TITLE
Bugfix: default map to pan mode, expand multi-geometries on import, and disable interactions during draw

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
@@ -1141,6 +1141,11 @@ describe("MapComponent", () => {
     const {formComponent} = await createFormAndWaitForReady(formConfig, {editMode: true} as any);
     const mapComponent = formComponent.getComponentDefByName("map_coverage")?.component as MapComponent;
 
+    // No tool is selected by default, so map interactions stay enabled for panning.
+    expect(fakeMapInteractions[0].setActive).not.toHaveBeenCalled();
+    expect(fakeMapInteractions[1].setActive).not.toHaveBeenCalled();
+
+    mapComponent.setDrawMode("rectangle");
     expect(fakeMapInteractions[0].setActive).toHaveBeenCalledWith(false);
     expect(fakeMapInteractions[1].setActive).toHaveBeenCalledWith(false);
 

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
@@ -6,6 +6,7 @@ import {MAP_DEPENDENCIES_LOADER, MapComponent} from "./map.component";
 import {ConfirmationDialogService} from "../confirmation-dialog.service";
 
 describe("MapComponent", () => {
+  const uuidV4Pattern = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
   let fakeMap: any;
   let fakeDraw: any;
   let drawFeatures: unknown[];
@@ -14,6 +15,7 @@ describe("MapComponent", () => {
   let fakeVectorLayer: any;
   let fakeVectorSource: any;
   let fakeGeoJSONFormat: any;
+  let fakeGeoJSONReadFeatures: jasmine.Spy;
   let fakeFromLonLat: jasmine.Spy;
   let fakeIsEmpty: jasmine.Spy;
   let fakeMapCreatesCanvas: boolean;
@@ -147,9 +149,10 @@ describe("MapComponent", () => {
       getExtent: jasmine.createSpy("getExtent").and.returnValue([0, 0, 1, 1])
     };
 
-    fakeGeoJSONFormat = jasmine.createSpy("GeoJSONFormat").and.callFake(() => ({
-      readFeatures: jasmine.createSpy("readFeatures").and.returnValue([])
-    }));
+    fakeGeoJSONReadFeatures = jasmine.createSpy("readFeatures").and.returnValue([]);
+    fakeGeoJSONFormat = function FakeGeoJSONFormat(this: any) {
+      this.readFeatures = fakeGeoJSONReadFeatures;
+    };
 
     fakeDraw = {
       start: jasmine.createSpy("start"),
@@ -160,7 +163,7 @@ describe("MapComponent", () => {
       }),
       setMode: jasmine.createSpy("setMode"),
       addFeatures: jasmine.createSpy("addFeatures").and.callFake((features: unknown[]) => {
-        drawFeatures.push(...features);
+        drawFeatures.push(...features.filter((feature: any) => feature?.id != null && feature?.properties?.mode));
       }),
       clear: jasmine.createSpy("clear").and.callFake(() => {
         drawFeatures = [];
@@ -234,8 +237,37 @@ describe("MapComponent", () => {
         features: [
           {
             type: "Feature",
-            geometry: {type: "Point", coordinates: [146.82, -19.25]},
-            properties: {name: "Townsville"}
+            geometry: {type: "Point", coordinates: [-122.681944, 45.52, 0]},
+            properties: {name: "Portland"}
+          },
+          {
+            type: "Feature",
+            geometry: {type: "Point", coordinates: [-43.196389, -22.908333, 0]},
+            properties: {name: "Rio de Janeiro"}
+          },
+          {
+            type: "Feature",
+            geometry: {type: "Point", coordinates: [28.976018, 41.01224, 0]},
+            properties: {name: "Istanbul"}
+          },
+          {
+            type: "Feature",
+            geometry: {type: "Point", coordinates: [-21.933333, 64.133333, 0]},
+            properties: {name: "Reykjavik"}
+          },
+          {
+            type: "Feature",
+            geometry: {
+              type: "Polygon",
+              coordinates: [[
+                [-122.681944, 45.52, 0],
+                [-43.196389, -22.908333, 0],
+                [28.976018, 41.01224, 0],
+                [-21.933333, 64.133333, 0],
+                [-122.681944, 45.52, 0]
+              ]]
+            },
+            properties: {name: "Simple Polygon"}
           }
         ]
       })
@@ -336,6 +368,65 @@ describe("MapComponent", () => {
     const modelValue = (formComponent as any).form.value?.map_coverage;
     expect(modelValue?.type).toBe("FeatureCollection");
     expect((modelValue?.features ?? []).length).toBe(1);
+    expect(modelValue.features[0].id).toMatch(uuidV4Pattern);
+    expect(modelValue.features[0].properties.mode).toBe("point");
+  });
+
+  it("appends imported GeoJSON without duplicating existing draw features", async () => {
+    const formConfig: FormConfigFrame = {
+      name: "testing",
+      componentDefinitions: [
+        {
+          name: "map_coverage",
+          component: {
+            class: "MapComponent",
+            config: {
+              enableImport: true
+            }
+          },
+          model: {
+            class: "MapModel",
+            config: {
+              value: {
+                type: "FeatureCollection",
+                features: [
+                  {
+                    id: "feature-1",
+                    type: "Feature",
+                    geometry: {type: "Point", coordinates: [144.96, -37.81]},
+                    properties: {name: "Melbourne", mode: "point"}
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    };
+
+    const {fixture, formComponent} = await createFormAndWaitForReady(formConfig, {editMode: true} as any);
+    fakeDraw.addFeatures.calls.reset();
+    const textarea = fixture.nativeElement.querySelector("textarea") as HTMLTextAreaElement;
+    textarea.value = JSON.stringify({
+      type: "Feature",
+      geometry: {type: "Point", coordinates: [153.02, -27.47]},
+      properties: {name: "Brisbane"}
+    });
+    textarea.dispatchEvent(new Event("input"));
+    fixture.detectChanges();
+
+    const importButton = fixture.nativeElement.querySelector(".rb-map-import-btn") as HTMLButtonElement;
+    importButton.click();
+    await fixture.whenStable();
+
+    expect(fakeDraw.addFeatures).toHaveBeenCalledOnceWith([
+      jasmine.objectContaining({
+        properties: jasmine.objectContaining({name: "Brisbane", mode: "point"})
+      })
+    ]);
+    const modelValue = (formComponent as any).form.value?.map_coverage;
+    expect(modelValue.features.map((feature: any) => feature.properties.name)).toEqual(["Melbourne", "Brisbane"]);
+    expect(modelValue.features[1].id).toMatch(uuidV4Pattern);
   });
 
   it("imports a single GeoJSON feature snippet", async () => {
@@ -378,6 +469,7 @@ describe("MapComponent", () => {
     expect(modelValue?.type).toBe("FeatureCollection");
     expect((modelValue?.features ?? []).length).toBe(1);
     expect(modelValue.features[0].properties.name).toBe("Townsville");
+    expect(modelValue.features[0].properties.mode).toBe("point");
   });
 
   it("imports a raw GeoJSON geometry snippet", async () => {
@@ -418,6 +510,7 @@ describe("MapComponent", () => {
     const modelValue = (formComponent as any).form.value?.map_coverage;
     expect((modelValue?.features ?? []).length).toBe(1);
     expect(modelValue.features[0].geometry.type).toBe("Point");
+    expect(modelValue.features[0].properties.mode).toBe("point");
   });
 
   it("imports KML and updates form model value", async () => {
@@ -443,8 +536,51 @@ describe("MapComponent", () => {
     };
 
     const {fixture, formComponent} = await createFormAndWaitForReady(formConfig, {editMode: true} as any);
+    fakeView.fit.calls.reset();
     const textarea = fixture.nativeElement.querySelector("textarea") as HTMLTextAreaElement;
-    textarea.value = "<kml><Placemark><Point><coordinates>146.82,-19.25</coordinates></Point></Placemark></kml>";
+    textarea.value = `<?xml version="1.0" encoding="utf-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Document>
+    <Placemark>
+      <name>Portland</name>
+      <Point>
+        <coordinates>-122.681944,45.52,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name>Rio de Janeiro</name>
+      <Point>
+        <coordinates>-43.196389,-22.908333,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name>Istanbul</name>
+      <Point>
+        <coordinates>28.976018,41.01224,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name>Reykjavik</name>
+      <Point>
+        <coordinates>-21.933333,64.133333,0</coordinates>
+      </Point>
+    </Placemark>
+    <Placemark>
+      <name>Simple Polygon</name>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>-122.681944,45.52,0
+            -43.196389,-22.908333,0
+            28.976018,41.01224,0
+            -21.933333,64.133333,0
+            -122.681944,45.52,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+  </Document>
+</kml>`;
     textarea.dispatchEvent(new Event("input"));
     fixture.detectChanges();
 
@@ -453,8 +589,70 @@ describe("MapComponent", () => {
     await fixture.whenStable();
 
     const modelValue = (formComponent as any).form.value?.map_coverage;
-    expect((modelValue?.features ?? []).length).toBe(1);
-    expect(modelValue.features[0].properties.name).toBe("Townsville");
+    expect((modelValue?.features ?? []).length).toBe(5);
+    expect(modelValue.features.map((feature: any) => feature.properties.name)).toEqual([
+      "Portland",
+      "Rio de Janeiro",
+      "Istanbul",
+      "Reykjavik",
+      "Simple Polygon"
+    ]);
+    expect(modelValue.features.map((feature: any) => feature.properties.mode)).toEqual([
+      "point",
+      "point",
+      "point",
+      "point",
+      "polygon"
+    ]);
+    expect(modelValue.features.every((feature: any) => uuidV4Pattern.test(feature.id))).toBeTrue();
+    expect(modelValue.features[0].geometry.coordinates).toEqual([-122.681944, 45.52]);
+    expect(modelValue.features[4].geometry.coordinates[0][0]).toEqual([-122.681944, 45.52]);
+    expect(fakeView.fit).toHaveBeenCalledWith([0, 0, 1, 1], { padding: [24, 24, 24, 24] });
+  });
+
+  it("expands GeoJSON multi-geometries into draw-compatible features", async () => {
+    const formConfig: FormConfigFrame = {
+      name: "testing",
+      componentDefinitions: [
+        {
+          name: "map_coverage",
+          component: {
+            class: "MapComponent",
+            config: {
+              enableImport: true
+            }
+          },
+          model: {
+            class: "MapModel",
+            config: {
+              defaultValue: {type: "FeatureCollection", features: []}
+            }
+          }
+        }
+      ]
+    };
+
+    const {fixture, formComponent} = await createFormAndWaitForReady(formConfig, {editMode: true} as any);
+    const textarea = fixture.nativeElement.querySelector("textarea") as HTMLTextAreaElement;
+    textarea.value = JSON.stringify({
+      type: "Feature",
+      geometry: {
+        type: "MultiPoint",
+        coordinates: [[153.02, -27.47], [146.82, -19.25]]
+      },
+      properties: {name: "Queensland sites"}
+    });
+    textarea.dispatchEvent(new Event("input"));
+    fixture.detectChanges();
+
+    const importButton = fixture.nativeElement.querySelector(".rb-map-import-btn") as HTMLButtonElement;
+    importButton.click();
+    await fixture.whenStable();
+
+    const modelValue = (formComponent as any).form.value?.map_coverage;
+    expect((modelValue?.features ?? []).length).toBe(2);
+    expect(modelValue.features.map((feature: any) => feature.geometry.type)).toEqual(["Point", "Point"]);
+    expect(modelValue.features.every((feature: any) => uuidV4Pattern.test(feature.id) && feature.properties.mode === "point")).toBeTrue();
   });
 
   it("renders translated coordinates help text", async () => {
@@ -590,11 +788,12 @@ describe("MapComponent", () => {
 
     await createFormAndWaitForReady(formConfig, {editMode: true} as any);
     expect(fakeDraw.addFeatures).toHaveBeenCalledOnceWith([
-      {
+      jasmine.objectContaining({
+        id: jasmine.stringMatching(uuidV4Pattern),
         type: "Feature",
         geometry: {type: "Point", coordinates: [144.96, -37.81]},
-        properties: {name: "Melbourne"}
-      }
+        properties: jasmine.objectContaining({name: "Melbourne", mode: "point"})
+      })
     ]);
     expect(drawFeatures.length).toBe(1);
     expect(fakeMap.updateSize).toHaveBeenCalled();
@@ -706,7 +905,11 @@ describe("MapComponent", () => {
     selectButton.click();
     fixture.detectChanges();
 
-    drawListeners["select"]?.forEach((listener) => listener("feature-1"));
+    const selectedFeatureId = (drawFeatures[0] as any).id;
+    const remainingFeatureId = (drawFeatures[1] as any).id;
+    expect(selectedFeatureId).toMatch(uuidV4Pattern);
+    expect(remainingFeatureId).toMatch(uuidV4Pattern);
+    drawListeners["select"]?.forEach((listener) => listener(selectedFeatureId));
     fixture.detectChanges();
     const deleteButton = fixture.nativeElement.querySelector(".rb-map-delete-btn") as HTMLButtonElement;
     expect(deleteButton).not.toBeNull();
@@ -716,13 +919,13 @@ describe("MapComponent", () => {
     deleteButton.click();
     fixture.detectChanges();
 
-    expect(fakeDraw.removeFeatures).toHaveBeenCalledOnceWith(["feature-1"]);
+    expect(fakeDraw.removeFeatures).toHaveBeenCalledOnceWith([selectedFeatureId]);
     expect(setValueSpy).toHaveBeenCalledTimes(1);
     expect(fakeDraw.setMode).toHaveBeenCalledWith("select");
     expect(mapComponent.activeMode).toBe("select");
     expect(mapComponent.selectedFeatureIds.size).toBe(0);
     const modelValue = (formComponent as any).form.value?.map_coverage;
-    expect((modelValue?.features ?? []).map((feature: any) => feature.id)).toEqual(["feature-2"]);
+    expect((modelValue?.features ?? []).map((feature: any) => feature.id)).toEqual([remainingFeatureId]);
   });
 
   it("clears all map features after confirmation", async () => {

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
@@ -640,7 +640,7 @@ describe("MapComponent", () => {
         type: "MultiPoint",
         coordinates: [[153.02, -27.47], [146.82, -19.25]]
       },
-      properties: {name: "Queensland sites"}
+      properties: {name: "Queensland sites", mode: "polygon"}
     });
     textarea.dispatchEvent(new Event("input"));
     fixture.detectChanges();
@@ -653,6 +653,43 @@ describe("MapComponent", () => {
     expect((modelValue?.features ?? []).length).toBe(2);
     expect(modelValue.features.map((feature: any) => feature.geometry.type)).toEqual(["Point", "Point"]);
     expect(modelValue.features.every((feature: any) => uuidV4Pattern.test(feature.id) && feature.properties.mode === "point")).toBeTrue();
+  });
+
+  it("throws a controlled error when map feature ids cannot be generated", async () => {
+    const formConfig: FormConfigFrame = {
+      name: "testing",
+      componentDefinitions: [
+        {
+          name: "map_coverage",
+          component: {
+            class: "MapComponent",
+            config: {}
+          },
+          model: {
+            class: "MapModel",
+            config: {
+              defaultValue: {type: "FeatureCollection", features: []}
+            }
+          }
+        }
+      ]
+    };
+    const cryptoDescriptor = Object.getOwnPropertyDescriptor(globalThis, "crypto");
+    const {formComponent} = await createFormAndWaitForReady(formConfig, {editMode: true} as any);
+    const mapComponent = formComponent.getComponentDefByName("map_coverage")?.component as MapComponent;
+
+    Object.defineProperty(globalThis, "crypto", {
+      configurable: true,
+      value: undefined
+    });
+
+    try {
+      expect(() => (mapComponent as any).createFeatureId()).toThrowError("Unable to generate map feature id: crypto API is unavailable");
+    } finally {
+      if (cryptoDescriptor) {
+        Object.defineProperty(globalThis, "crypto", cryptoDescriptor);
+      }
+    }
   });
 
   it("renders translated coordinates help text", async () => {

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
@@ -836,6 +836,63 @@ describe("MapComponent", () => {
     expect(fakeMap.updateSize).toHaveBeenCalled();
   });
 
+  it("shows saved features read-only when edit draw ids cannot be generated", async () => {
+    const formConfig: FormConfigFrame = {
+      name: "testing",
+      componentDefinitions: [
+        {
+          name: "map_coverage",
+          component: {
+            class: "MapComponent",
+            config: {
+              enableImport: true
+            }
+          },
+          model: {
+            class: "MapModel",
+            config: {
+              value: {
+                type: "FeatureCollection",
+                features: [
+                  {
+                    id: "feature-1",
+                    type: "Feature",
+                    geometry: {type: "Point", coordinates: [144.96, -37.81]},
+                    properties: {name: "Melbourne", mode: "point"}
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    };
+    const cryptoDescriptor = Object.getOwnPropertyDescriptor(globalThis, "crypto");
+    Object.defineProperty(globalThis, "crypto", {
+      configurable: true,
+      value: undefined
+    });
+
+    try {
+      const {fixture} = await createFormAndWaitForReady(formConfig, {editMode: true} as any);
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(fakeDraw.addFeatures).not.toHaveBeenCalled();
+      expect(fakeGeoJSONReadFeatures).toHaveBeenCalledWith(
+        jasmine.objectContaining({features: jasmine.arrayContaining([
+          jasmine.objectContaining({id: "feature-1"})
+        ])}),
+        {dataProjection: "EPSG:4326", featureProjection: "EPSG:3857"}
+      );
+      expect((fixture.nativeElement.textContent ?? "").includes("Saved map features cannot be loaded for editing")).toBeTrue();
+    } finally {
+      if (cryptoDescriptor) {
+        Object.defineProperty(globalThis, "crypto", cryptoDescriptor);
+      }
+    }
+  });
+
   it("initialises draw tooling when a disabled map is enabled after map load", async () => {
     const formConfig: FormConfigFrame = {
       name: "testing",

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.ts
@@ -507,7 +507,9 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
   public translatedModeHelpText: Record<MapDrawingMode, string> = { ...this.modeHelpTextFallbacks };
   public deleteSelectedHelpText = "Delete the selected map feature.";
   public clearAllHelpText = "Clear all points, lines, and shapes from the map.";
-  private readonly featureIdUnavailableError = "Saved map features cannot be loaded for editing because this browser does not provide the crypto API required to generate map feature IDs.";
+  // Modern browsers provide the crypto API, so users should only see this on unusual or unsupported clients.
+  private readonly featureIdUnavailableError = "Saved map features cannot be loaded for editing because this browser does not provide "
+    + "the crypto API required to generate map feature IDs. Please contact your administrator for assistance.";
 
   protected get getFormComponent(): FormComponent {
     return this.formComponent;

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.ts
@@ -1242,7 +1242,7 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
       type: "Feature",
       properties: {
         ...properties,
-        mode: properties["mode"] ?? this.modeForGeometry(geometry.type)
+        mode: this.modeForGeometry(geometry.type)
       },
       geometry
     } as MapModelValueType["features"][number];
@@ -1254,10 +1254,15 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
   }
 
   private createFeatureId(): string {
-    return globalThis.crypto?.randomUUID?.() ??
-      "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (character) =>
-        (Number(character) ^ globalThis.crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> Number(character) / 4).toString(16)
-      );
+    if (globalThis.crypto?.randomUUID) {
+      return globalThis.crypto.randomUUID();
+    }
+    if (!globalThis.crypto?.getRandomValues) {
+      throw new Error("Unable to generate map feature id: crypto API is unavailable");
+    }
+    return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (character) =>
+      (Number(character) ^ globalThis.crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> Number(character) / 4).toString(16)
+    );
   }
 
   private modeForGeometry(type: GeoJSON.Point["type"] | GeoJSON.LineString["type"] | GeoJSON.Polygon["type"]): TerraDrawModeName {

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.ts
@@ -595,8 +595,16 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
     this.importError = "";
     this.importDataString = "";
     const merged = this.mergeCollections(this.currentModelValue(), importedValue);
-    this.renderValue(merged, true);
+    let valueToFit = merged;
+    if (this.isEditMode()) {
+      this.pushFeaturesToDraw(importedValue.features);
+      valueToFit = this.draw ? this.readValueFromDraw() : merged;
+      this.updateModelValue(valueToFit);
+    } else {
+      this.renderValue(merged, true);
+    }
     this.invalidateMap();
+    this.scheduleFitToFeatureCollectionBounds(valueToFit);
   }
 
   public async onClearAllClicked(): Promise<void> {
@@ -1090,26 +1098,158 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
     if (source.type === "FeatureCollection" && Array.isArray(source.features)) {
       return {
         type: "FeatureCollection",
-        features: source.features as MapModelValueType["features"]
+        features: this.normalizeGeoJsonFeatures(source.features)
       };
     }
     if (source.type === "Feature") {
       return {
         type: "FeatureCollection",
-        features: [source as MapModelValueType["features"][number]]
+        features: this.normalizeGeoJsonFeature(source)
       };
     }
     if (this.isGeoJsonGeometry(source.type)) {
       return {
         type: "FeatureCollection",
-        features: [{
-          type: "Feature",
-          properties: {},
-          geometry: source as GeoJSON.Geometry
-        }]
+        features: this.featuresFromGeometry(source as GeoJSON.Geometry, {}, undefined)
       };
     }
     return emptyFeatureCollection();
+  }
+
+  private normalizeGeoJsonFeatures(features: unknown[]): MapModelValueType["features"] {
+    return features.flatMap((feature) => this.normalizeGeoJsonFeature(feature));
+  }
+
+  private normalizeGeoJsonFeature(feature: unknown): MapModelValueType["features"] {
+    if (!feature || typeof feature !== "object") {
+      return [];
+    }
+    const source = feature as {
+      id?: string | number;
+      type?: unknown;
+      properties?: unknown;
+      geometry?: unknown;
+    };
+    if (source.type !== "Feature" || !source.geometry || typeof source.geometry !== "object") {
+      return [];
+    }
+    const geometry = source.geometry as { type?: unknown };
+    if (!this.isGeoJsonGeometry(geometry.type)) {
+      return [];
+    }
+    const properties = source.properties && typeof source.properties === "object"
+      ? source.properties as Record<string, unknown>
+      : {};
+    return this.featuresFromGeometry(geometry as GeoJSON.Geometry, properties, source.id);
+  }
+
+  private featuresFromGeometry(
+    geometry: GeoJSON.Geometry,
+    properties: Record<string, unknown>,
+    id: string | number | undefined
+  ): MapModelValueType["features"] {
+    switch (geometry.type) {
+      case "Point": {
+        const coordinates = this.normalizePosition(geometry.coordinates);
+        return coordinates ? [this.createDrawFeature({ type: "Point", coordinates }, properties, id)] : [];
+      }
+      case "LineString": {
+        const coordinates = this.normalizeLineStringCoordinates(geometry.coordinates);
+        return coordinates.length > 0 ? [this.createDrawFeature({ type: "LineString", coordinates }, properties, id)] : [];
+      }
+      case "Polygon": {
+        const coordinates = this.normalizePolygonCoordinates(geometry.coordinates);
+        return coordinates.length > 0 ? [this.createDrawFeature({ type: "Polygon", coordinates }, properties, id)] : [];
+      }
+      case "MultiPoint":
+        return geometry.coordinates.flatMap((coordinates) => {
+          const position = this.normalizePosition(coordinates);
+          return position ? [this.createDrawFeature({ type: "Point", coordinates: position }, properties, undefined)] : [];
+        });
+      case "MultiLineString":
+        return geometry.coordinates.flatMap((coordinates) => {
+          const lineStringCoordinates = this.normalizeLineStringCoordinates(coordinates);
+          return lineStringCoordinates.length > 0
+            ? [this.createDrawFeature({ type: "LineString", coordinates: lineStringCoordinates }, properties, undefined)]
+            : [];
+        });
+      case "MultiPolygon":
+        return geometry.coordinates.flatMap((coordinates) => {
+          const polygonCoordinates = this.normalizePolygonCoordinates(coordinates);
+          return polygonCoordinates.length > 0
+            ? [this.createDrawFeature({ type: "Polygon", coordinates: polygonCoordinates }, properties, undefined)]
+            : [];
+        });
+      case "GeometryCollection":
+        return geometry.geometries.flatMap((childGeometry) =>
+          this.featuresFromGeometry(childGeometry, properties, undefined)
+        );
+      default:
+        return [];
+    }
+  }
+
+  private normalizePosition(position: GeoJSON.Position): [number, number] | null {
+    if (!Array.isArray(position) || position.length < 2) {
+      return null;
+    }
+    const [longitude, latitude] = position;
+    if (typeof longitude !== "number" || typeof latitude !== "number") {
+      return null;
+    }
+    return [longitude, latitude];
+  }
+
+  private normalizeLineStringCoordinates(coordinates: GeoJSON.Position[]): [number, number][] {
+    return coordinates.flatMap((position) => {
+      const normalized = this.normalizePosition(position);
+      return normalized ? [normalized] : [];
+    });
+  }
+
+  private normalizePolygonCoordinates(coordinates: GeoJSON.Position[][]): [number, number][][] {
+    return coordinates.flatMap((ring) => {
+      const normalizedRing = this.normalizeLineStringCoordinates(ring);
+      return normalizedRing.length > 0 ? [normalizedRing] : [];
+    });
+  }
+
+  private createDrawFeature(
+    geometry: GeoJSON.Point | GeoJSON.LineString | GeoJSON.Polygon,
+    properties: Record<string, unknown>,
+    id: string | number | undefined
+  ): MapModelValueType["features"][number] {
+    return {
+      id: this.isValidTerraDrawFeatureId(id) ? id : this.createFeatureId(),
+      type: "Feature",
+      properties: {
+        ...properties,
+        mode: properties["mode"] ?? this.modeForGeometry(geometry.type)
+      },
+      geometry
+    } as MapModelValueType["features"][number];
+  }
+
+  private isValidTerraDrawFeatureId(id: unknown): id is string {
+    return typeof id === "string" &&
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(id);
+  }
+
+  private createFeatureId(): string {
+    return globalThis.crypto?.randomUUID?.() ??
+      "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (character) =>
+        (Number(character) ^ globalThis.crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> Number(character) / 4).toString(16)
+      );
+  }
+
+  private modeForGeometry(type: GeoJSON.Point["type"] | GeoJSON.LineString["type"] | GeoJSON.Polygon["type"]): TerraDrawModeName {
+    if (type === "Point") {
+      return "point";
+    }
+    if (type === "LineString") {
+      return "linestring";
+    }
+    return "polygon";
   }
 
   private isGeoJsonGeometry(type: unknown): type is GeoJSON.Geometry["type"] {
@@ -1139,10 +1279,20 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
           throw new Error("Invalid XML");
         }
         const converted = this.mapDeps.parseKmlToGeoJson(xmlDoc);
-        return this.normalizeFeatureCollection(converted);
+        const normalized = this.normalizeFeatureCollection(converted);
+        if (normalized.features.length === 0) {
+          this.importError = "Entered text does not contain any supported map features";
+          return null;
+        }
+        return normalized;
       }
       const parsed = JSON.parse(trimmed);
-      return this.normalizeFeatureCollection(parsed);
+      const normalized = this.normalizeFeatureCollection(parsed);
+      if (normalized.features.length === 0) {
+        this.importError = "Entered text does not contain any supported map features";
+        return null;
+      }
+      return normalized;
     } catch {
       this.importError = "Entered text is not valid KML or GeoJSON";
       return null;
@@ -1193,6 +1343,25 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
     const extent = this.vectorSource.getExtent();
     if (extent != null && !this.mapDeps.extentIsEmpty(extent)) {
       this.map.getView().fit(extent, { padding: [12, 12, 12, 12] });
+    }
+  }
+
+  private scheduleFitToFeatureCollectionBounds(value: MapModelValueType): void {
+    if (!this.map || !this.mapDeps || value.features.length === 0) {
+      return;
+    }
+    globalThis.requestAnimationFrame?.(() => this.fitToFeatureCollectionBounds(value));
+    globalThis.setTimeout(() => this.fitToFeatureCollectionBounds(value), 0);
+  }
+
+  private fitToFeatureCollectionBounds(value: MapModelValueType): void {
+    if (!this.map || !this.mapDeps || value.features.length === 0) {
+      return;
+    }
+    const { source } = this.createVectorSourceFromFeatureCollection(value);
+    const extent = source.getExtent();
+    if (extent != null && !this.mapDeps.extentIsEmpty(extent)) {
+      this.map.getView().fit(extent, { padding: [24, 24, 24, 24] });
     }
   }
 

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.ts
@@ -521,7 +521,10 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
     this.canSelectFeatures = this.enabledModes.includes("select");
     this.canDeleteSelectedFeatures = this.enabledModes.includes("select");
     this.toolbarModes = this.enabledModes.filter((mode) => mode !== "select");
-    this.activeMode = this.toolbarModes[0] ?? (this.canSelectFeatures ? "select" : undefined);
+    // Default to no active drawing mode so the map starts in pan mode (terra-draw's
+    // built-in "static" mode) instead of dropping markers on click-drag. The user
+    // explicitly selects a drawing tool from the toolbar when they want to draw.
+    this.activeMode = undefined;
     this.showDrawToolbar = this.enabledModes.length > 0;
     this.enableImport = cfg.enableImport ?? true;
     const coordinatesHelp = String(cfg.coordinatesHelp ?? "");
@@ -865,8 +868,19 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
     if (!this.draw || !this.enabledModes.includes(mode)) {
       return;
     }
+    // Clicking the already-active tool toggles it off, returning the map to pan mode.
+    if (this.activeMode === mode) {
+      this.clearDrawMode();
+      return;
+    }
     this.draw.setMode?.(mode);
     this.activeMode = mode;
+    this.updateMapInteractionsForActiveDrawMode();
+  }
+
+  private clearDrawMode(): void {
+    this.activeMode = undefined;
+    this.draw?.setMode?.("static");
     this.updateMapInteractionsForActiveDrawMode();
   }
 
@@ -1047,6 +1061,10 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
   private setInitialDrawMode(): void {
     const initialMode = this.activeMode;
     if (!initialMode) {
+      // No tool selected: keep terra-draw in its "static" mode so the map pans on
+      // click-drag rather than drawing features.
+      this.draw?.setMode?.("static");
+      this.updateMapInteractionsForActiveDrawMode();
       return;
     }
     this.draw?.setMode?.(initialMode);

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.ts
@@ -280,6 +280,9 @@ function expandTileUrl(url: string, subdomains?: unknown): string | string[] {
             </div>
           }
         </div>
+        @if (mapError) {
+          <div class="text-danger small mt-2 rb-map-error">{{ mapError }}</div>
+        }
         @if (isEditMode() && enableImport) {
           <div class="rb-map-import mt-2">
             <label class="form-label">{{ importLabel }}</label>
@@ -447,6 +450,7 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
   public importLabel = "Enter KML or GeoJSON";
   public importDataString = "";
   public importError = "";
+  public mapError = "";
 
   private map?: OLMap;
   private draw?: any;
@@ -503,6 +507,7 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
   public translatedModeHelpText: Record<MapDrawingMode, string> = { ...this.modeHelpTextFallbacks };
   public deleteSelectedHelpText = "Delete the selected map feature.";
   public clearAllHelpText = "Clear all points, lines, and shapes from the map.";
+  private readonly featureIdUnavailableError = "Saved map features cannot be loaded for editing because this browser does not provide the crypto API required to generate map feature IDs.";
 
   protected get getFormComponent(): FormComponent {
     return this.formComponent;
@@ -705,11 +710,10 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
       view: olView
     });
 
-    const startingValue = this.currentModelValue();
     if (this.isEditMode()) {
       this.scheduleDrawInitialisation();
     } else {
-      this.renderReadonlyLayer(startingValue);
+      this.renderReadonlyLayer(this.currentReadonlyValue());
     }
 
     this.installVisibilityObserver();
@@ -728,9 +732,14 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
     this.drawReadyObserver = undefined;
     this.removeFeatureLayer();
     this.initialiseDraw();
-    const startingValue = this.currentModelValue();
-    if (startingValue.features.length > 0) {
-      this.pushFeaturesToDraw(startingValue.features);
+    try {
+      const startingValue = this.currentModelValue();
+      if (startingValue.features.length > 0) {
+        this.pushFeaturesToDraw(startingValue.features);
+      }
+      this.mapError = "";
+    } catch (error) {
+      this.handleInitialFeatureLoadError(error);
     }
   }
 
@@ -885,7 +894,11 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
   }
 
   public hasFeatures(): boolean {
-    return this.currentModelValue().features.length > 0;
+    try {
+      return this.currentModelValue().features.length > 0;
+    } catch {
+      return (this.currentRawFeatureCollection()?.features.length ?? 0) > 0;
+    }
   }
 
   public deleteSelectedFeatures(): void {
@@ -961,7 +974,7 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
     };
   }
 
-  private createVectorSourceFromFeatureCollection(value: MapModelValueType): { source: OLVectorSource; features: any[] } {
+  private createVectorSourceFromFeatureCollection(value: MapModelValueType | GeoJSON.FeatureCollection): { source: OLVectorSource; features: any[] } {
     const geoJsonFormat = new this.mapDeps!.GeoJSON();
     const features = geoJsonFormat.readFeatures(value as any, {
       dataProjection: "EPSG:4326",
@@ -973,7 +986,7 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
     };
   }
 
-  private renderReadonlyLayer(value: MapModelValueType): void {
+  private renderReadonlyLayer(value: MapModelValueType | GeoJSON.FeatureCollection): void {
     if (!this.map || !this.mapDeps) {
       return;
     }
@@ -1056,6 +1069,42 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
       return modelValue;
     }
     return controlValue;
+  }
+
+  private currentReadonlyValue(): MapModelValueType | GeoJSON.FeatureCollection {
+    return this.currentRawFeatureCollection() ?? this.currentModelValue();
+  }
+
+  private currentRawFeatureCollection(): GeoJSON.FeatureCollection | undefined {
+    const controlValue = this.asRawFeatureCollection(this.formControl.value);
+    if (controlValue?.features.length) {
+      return controlValue;
+    }
+    const modelValue = this.asRawFeatureCollection(this.model?.getValue());
+    if (modelValue?.features.length) {
+      return modelValue;
+    }
+    return controlValue ?? modelValue;
+  }
+
+  private asRawFeatureCollection(value: unknown): GeoJSON.FeatureCollection | undefined {
+    if (!value || typeof value !== "object") {
+      return undefined;
+    }
+    const source = value as { type?: unknown; features?: unknown };
+    if (source.type !== "FeatureCollection" || !Array.isArray(source.features)) {
+      return undefined;
+    }
+    return source as GeoJSON.FeatureCollection;
+  }
+
+  private handleInitialFeatureLoadError(error: unknown): void {
+    this.mapError = this.featureIdUnavailableError;
+    this.loggerService.warn(`${this.logName}: failed to load saved map features into draw state.`, error);
+    const rawValue = this.currentRawFeatureCollection();
+    if (rawValue) {
+      this.renderReadonlyLayer(rawValue);
+    }
   }
 
   private setInitialDrawMode(): void {


### PR DESCRIPTION
## Summary

Improves the map component's import pipeline and default interaction mode. The map now starts in pan mode instead of auto-selecting a draw tool, multi-geometries are expanded during import, and map drag interactions are suppressed while drawing.

---

## Context / Motivation

Users frequently triggered accidental marker placement when clicking the map — the auto-selected draw tool would capture click-drag motions as features. Additionally, importing KML or GeoJSON with multi-geometries (MultiPoint, MultiPolygon, etc.) silently produced invalid features because terra-draw cannot natively display multi-geometries or handle bare coordinates without a `mode` property.

---

## Key Features

### Default pan mode

- The map no longer auto-selects the first enabled draw tool on initialisation
- Users must explicitly click a toolbar button to enter a drawing mode
- Clicking the active tool again toggles it off and returns to pan mode

### Multi-geometry expansion

- Imported `MultiPoint`, `MultiLineString`, `MultiPolygon`, and `GeometryCollection` are flattened into individual single-geometry features
- Each expanded feature receives a UUID v4 ID and a terra-draw-compatible `mode` property derived from its geometry type
- Bare geometry objects (Point, LineString, Polygon) without a wrapping Feature are now wrapped correctly

### Map interaction isolation during draw

- Drag interactions (DragPan, DragRotate) are deactivated while a draw tool is active
- Interactions are restored when the user returns to pan mode

### Import UX improvements

- Features that expand to zero supported geometries trigger a user-facing error message
- After import the map automatically fits the view to the bounding box of imported features
- KML placemark parsing now correctly handles Documents with mixed geometry types and multiple placemarks

---

## Testing

- All import tests updated to verify UUID v4 IDs and `mode` property presence on output features
- New test: appends imported GeoJSON without duplicating existing draw features
- New test: expands GeoJSON multi-geometries into draw-compatible features
- KML import test expanded from 1 to 5 features covering Points and Polygons
- Select/delete test updated to use dynamically generated UUID IDs instead of hardcoded strings
- Existing interaction disabling test updated to assert default tool-off state before testing draw mode

---

## Architectural / Operational Impact

### Terra-draw integration

- Features now carry a `mode` property set to the correct terra-draw mode name for their geometry type, which is required for proper rendering inside the draw instance
- Feature IDs are generated as UUID v4 to satisfy terra-draw's internal identity constraints

### Feature collection normalisation

- `normalizeFeatureCollection` now delegates to per-feature and per-geometry normalisers that handle the full GeoJSON spec, ensuring every output feature is terra-draw-compatible
- Invalid or unsupported input silently drops features instead of crashing

---

## Backwards Compatibility

Fully backward compatible. Existing configurations that relied on the auto-selected first draw tool will need to explicitly click a toolbar button after page load, which is a deliberate UX improvement. Feature data stored in records remains unchanged.

---

## Impact

Cleaner map interaction model and robust multi-geometry import for both KML and GeoJSON inputs.
