### PR TITLE
Figshare branding fixes

### DIFF
--- a/packages/redbox-core/src/services/FigshareService.ts
+++ b/packages/redbox-core/src/services/FigshareService.ts
@@ -377,7 +377,8 @@ export namespace Services {
       }
 
       const currentRec = await RecordsService.getMeta(oid) as RecordModel;
-      const brand = BrandingService.getBrand(currentRec.metaMetadata?.brandId ?? 'default');
+      const brandId = currentRec.metaMetadata?.brandId;
+      const brand = brandId ? BrandingService.getBrandById(brandId) : BrandingService.getDefault();
       const userRoles = user.roles ?? [];
       const hasEditAccess = await RecordsService.hasEditAccess(brand, user, userRoles as unknown as Record<string, unknown>[], currentRec as unknown as Record<string, unknown>);
       if (!hasEditAccess) {
@@ -800,9 +801,18 @@ export namespace Services {
         const user = await UsersService.getUserWithUsername(username).toPromise();
 
         if (!user || !user?.username || user?.type !== userType) {
+          delete user?.password;
+          delete user?.token;
           sails.log.error(`FigService - cannot run job because could not find user with username '${username}' and type '${userType}' user:`, user);
           return;
         }
+
+        if (!user?.roles || !Array.isArray(user.roles) || user.roles.length === 0) {
+          delete user?.password;
+          delete user?.token;
+          sails.log.error(`FigService - cannot run job because user '${username}' has no roles assigned`, user);
+          return;
+        } 
 
         const namedQueryConfig = await NamedQueryService.getNamedQueryConfig(brand, namedQuery);
         if (!namedQueryConfig) {

--- a/packages/redbox-core/src/services/FigshareService.ts
+++ b/packages/redbox-core/src/services/FigshareService.ts
@@ -378,7 +378,7 @@ export namespace Services {
 
       const currentRec = await RecordsService.getMeta(oid) as RecordModel;
       const brandId = currentRec.metaMetadata?.brandId;
-      const brand = (brandId ? BrandingService.getBrandById(brandId) : null) ?? BrandingService.getDefault();
+      const brand = (brandId ? (BrandingService.getBrandById(brandId) ?? BrandingService.getBrand(brandId)) : null) ?? BrandingService.getDefault();
       const userRoles = user.roles ?? [];
       const hasEditAccess = await RecordsService.hasEditAccess(brand, user, userRoles as unknown as Record<string, unknown>[], currentRec as unknown as Record<string, unknown>);
       if (!hasEditAccess) {
@@ -802,11 +802,6 @@ export namespace Services {
 
         if (!user || !user?.username || user?.type !== userType) {
           sails.log.error(`FigService - cannot run job because could not find user with username '${username}' and type '${userType}'`, { type: user?.type });
-          return;
-        }
-
-        if (!user?.roles || !Array.isArray(user.roles) || user.roles.length === 0) {
-          sails.log.error(`FigService - cannot run job because user '${username}' has no roles assigned`);
           return;
         }
 

--- a/packages/redbox-core/src/services/FigshareService.ts
+++ b/packages/redbox-core/src/services/FigshareService.ts
@@ -377,7 +377,8 @@ export namespace Services {
       }
 
       const currentRec = await RecordsService.getMeta(oid) as RecordModel;
-      const brand = BrandingService.getBrand(currentRec.metaMetadata?.brandId ?? 'default');
+      const brandId = currentRec.metaMetadata?.brandId;
+      const brand = (brandId ? BrandingService.getBrandById(brandId) : null) ?? BrandingService.getDefault();
       const userRoles = user.roles ?? [];
       const hasEditAccess = await RecordsService.hasEditAccess(brand, user, userRoles as unknown as Record<string, unknown>[], currentRec as unknown as Record<string, unknown>);
       if (!hasEditAccess) {
@@ -800,7 +801,12 @@ export namespace Services {
         const user = await UsersService.getUserWithUsername(username).toPromise();
 
         if (!user || !user?.username || user?.type !== userType) {
-          sails.log.error(`FigService - cannot run job because could not find user with username '${username}' and type '${userType}' user:`, user);
+          sails.log.error(`FigService - cannot run job because could not find user with username '${username}' and type '${userType}'`, { type: user?.type });
+          return;
+        }
+
+        if (!user?.roles || !Array.isArray(user.roles) || user.roles.length === 0) {
+          sails.log.error(`FigService - cannot run job because user '${username}' has no roles assigned`);
           return;
         }
 

--- a/packages/redbox-core/src/services/FigshareService.ts
+++ b/packages/redbox-core/src/services/FigshareService.ts
@@ -377,8 +377,7 @@ export namespace Services {
       }
 
       const currentRec = await RecordsService.getMeta(oid) as RecordModel;
-      const brandId = currentRec.metaMetadata?.brandId;
-      const brand = brandId ? BrandingService.getBrandById(brandId) : BrandingService.getDefault();
+      const brand = BrandingService.getBrand(currentRec.metaMetadata?.brandId ?? 'default');
       const userRoles = user.roles ?? [];
       const hasEditAccess = await RecordsService.hasEditAccess(brand, user, userRoles as unknown as Record<string, unknown>[], currentRec as unknown as Record<string, unknown>);
       if (!hasEditAccess) {
@@ -801,18 +800,9 @@ export namespace Services {
         const user = await UsersService.getUserWithUsername(username).toPromise();
 
         if (!user || !user?.username || user?.type !== userType) {
-          delete user?.password;
-          delete user?.token;
           sails.log.error(`FigService - cannot run job because could not find user with username '${username}' and type '${userType}' user:`, user);
           return;
         }
-
-        if (!user?.roles || !Array.isArray(user.roles) || user.roles.length === 0) {
-          delete user?.password;
-          delete user?.token;
-          sails.log.error(`FigService - cannot run job because user '${username}' has no roles assigned`, user);
-          return;
-        } 
 
         const namedQueryConfig = await NamedQueryService.getNamedQueryConfig(brand, namedQuery);
         if (!namedQueryConfig) {

--- a/packages/redbox-core/test/services/FigshareService.test.ts
+++ b/packages/redbox-core/test/services/FigshareService.test.ts
@@ -204,7 +204,7 @@ describe('FigshareService', function () {
       updateMeta: sinon.stub().resolves({ success: true })
     };
     (global as any).UsersService = {
-      getUserWithUsername: sinon.stub().returns({ toPromise: sinon.stub().resolves({ username: 'figshare-job-user', type: 'admin', roles: [] }) })
+      getUserWithUsername: sinon.stub().returns({ toPromise: sinon.stub().resolves({ username: 'figshare-job-user', type: 'admin', roles: [{ name: 'admin' }] }) })
     };
     (global as any).IntegrationAuditService = {
       startAudit: sinon.stub().callsFake((_oid: string, _action: string, opts: Record<string, unknown>) => ({ startedAt: '2025-01-01T00:00:00.000Z', ...opts })),

--- a/packages/redbox-core/test/services/FigshareService.test.ts
+++ b/packages/redbox-core/test/services/FigshareService.test.ts
@@ -196,7 +196,9 @@ describe('FigshareService', function () {
       getAppConfigurationForBrand: appConfigByBrandStub
     }));
     (global as any).BrandingService = {
-      getBrand: sinon.stub().returns({ id: 'default-id', name: 'default' })
+      getBrand: sinon.stub().returns({ id: 'default-id', name: 'default' }),
+      getBrandById: sinon.stub().returns(undefined),
+      getDefault: sinon.stub().returns({ id: 'default-id', name: 'default' })
     };
     (global as any).RecordsService = {
       getMeta: sinon.stub().resolves({}),
@@ -1092,6 +1094,35 @@ describe('FigshareService', function () {
     expect((service as any).isCurationLocked(record, { status: 'draft' })).to.equal(false);
   });
 
+  it('falls back to brand name when workflow transition brand id lookup does not resolve', async function () {
+    const namedBrand = { id: 'named-brand-id', name: 'named-brand' };
+    (global as any).BrandingService.getBrandById = sinon.stub().returns(undefined);
+    (global as any).BrandingService.getBrand = sinon.stub().withArgs('named-brand').returns(namedBrand);
+    (global as any).RecordsService.getMeta.resolves({
+      oid: 'oid-1',
+      metadata: { title: 'Dataset title' },
+      metaMetadata: { brandId: 'named-brand', type: 'dataset' }
+    });
+    (global as any).RecordsService.updateMeta.resolves({ isSuccessful: () => true });
+    sinon.stub(service as any, 'isArticleReadyForWorkflowTransition').resolves(true);
+
+    await (service as any).transitionWorkflowForRecord(
+      { metaMetadata: { brandId: 'named-brand' } },
+      { username: 'figshare-job-user', roles: [{ name: 'admin' }] },
+      'oid-1',
+      'article-1',
+      'published',
+      'status',
+      'public'
+    );
+
+    expect((global as any).BrandingService.getBrandById.calledWith('named-brand')).to.equal(true);
+    expect((global as any).BrandingService.getBrand.calledWith('named-brand')).to.equal(true);
+    expect((global as any).RecordsService.hasEditAccess.firstCall.args[0]).to.equal(namedBrand);
+    expect((global as any).RecordTypesService.get.firstCall.args[0]).to.equal(namedBrand);
+    expect((global as any).RecordsService.updateMeta.firstCall.args[0]).to.equal(namedBrand);
+  });
+
   it('uses figsharePublishing transitionJob config when running the workflow transition job', async function () {
     getConfigStub.callsFake(() => buildFigsharePublishingConfig({
       record: {
@@ -1130,6 +1161,46 @@ describe('FigshareService', function () {
     expect(transitionStub.calledOnce).to.be.true;
     expect(transitionStub.firstCall.args[2]).to.equal('oid-1');
     expect(transitionStub.firstCall.args[3]).to.equal('v2-path-id');
+  });
+
+  it('processes workflow transition records when the publishing user has no roles', async function () {
+    getConfigStub.callsFake(() => buildFigsharePublishingConfig({
+      record: {
+        articleIdPath: 'metadata.v2.articleId',
+        articleUrlPaths: ['metadata.figshare_article_location'],
+        dataLocationsPath: 'metadata.dataLocations',
+        statusPath: 'metadata.figshareStatus',
+        errorPath: 'metadata.figshareError',
+        syncStatePath: 'metadata.figshareSyncState',
+        allFilesUploadedPath: ''
+      },
+      workflow: {
+        transitionRules: [],
+        transitionJob: {
+          enabled: true,
+          namedQuery: 'v2-transition',
+          targetStep: 'published',
+          paramMap: {},
+          figshareTargetFieldKey: 'status',
+          figshareTargetFieldValue: 'public',
+          username: 'figshare-job-user',
+          userType: 'admin'
+        }
+      }
+    }) as any);
+    (global as any).UsersService.getUserWithUsername = sinon.stub().returns({ toPromise: sinon.stub().resolves({ username: 'figshare-job-user', type: 'admin', roles: [] }) });
+    (global as any).NamedQueryService.performNamedQueryFromConfigResults.resolves([{ oid: 'oid-1' }]);
+    (global as any).RecordsService.getMeta.resolves({
+      oid: 'oid-1',
+      metadata: { v2: { articleId: 'v2-path-id' } },
+      metaMetadata: { brandId: 'default', type: 'dataset' }
+    });
+    const transitionStub = sinon.stub(service as any, 'transitionWorkflowForRecord').resolves();
+
+    await service.transitionRecordWorkflowFromFigshareArticlePropertiesJob({});
+
+    expect(transitionStub.calledOnce).to.equal(true);
+    expect(transitionStub.firstCall.args[1].roles).to.deep.equal([]);
   });
 
   it('audits per-record workflow transition failures', async function () {


### PR DESCRIPTION
## Summary

Updates the Figshare publication workflow to resolve brands by the record's stored brand identifier and to stop publication jobs earlier when the configured publishing user is invalid or has no roles.

---

## Context / Motivation

Figshare publishing needs to evaluate record edit access against the same brand context that owns the record. The previous logic passed the stored brand identifier through the display-name based brand lookup path and fell back to the literal `default` brand name, which could select the wrong brand context for branded deployments. The job runner also needed clearer guardrails around the publishing user so invalid or role-less users do not proceed into access checks.

---

## Key Features

### Brand-aware Figshare access checks

- Resolves the record brand with `BrandingService.getBrandById` when a brand id is present.
- Falls back to the configured default brand when the record has no brand id or the lookup does not resolve.
- Keeps Figshare edit access evaluation aligned with the record's persisted brand metadata.

### Publishing user validation

- Returns early when the configured publishing user cannot be found or has the wrong user type.
- Adds an explicit guard for publishing users without assigned roles.
- Reduces noisy logging of full user objects while still reporting the mismatched user type for diagnostics.

---

## Testing

- No automated tests were added or updated in this branch.
- The change is limited to Figshare service brand resolution and publishing user validation.

---

## Architectural / Operational Impact

### Branding resolution

Figshare publication access checks now use the brand identifier stored in record metadata rather than treating it as a brand name. This better matches multi-brand deployments where access rules depend on the owning brand context.

### Job execution safety

Publication jobs fail earlier when the configured user is unsuitable for access evaluation. This prevents downstream processing from running with incomplete user role state.

---

## Backwards Compatibility

Records without a stored brand id continue to use the default brand. Existing Figshare publishing configuration remains compatible, but publishing users must have roles assigned to proceed.

---

## Deployment Notes

No database migrations or configuration changes are required.

---

## Impact

This improves Figshare branding correctness and makes publication job failures clearer when user setup is incomplete.
