### PR TITLE
Figshare refactored to use StorageManager*

### DIFF
--- a/packages/redbox-core/src/config/storage.config.ts
+++ b/packages/redbox-core/src/config/storage.config.ts
@@ -76,5 +76,11 @@ export const storage: StorageConfig = {
         root: '/attachments/primary',
       },
     },
+    'figshare-staging': {
+      driver: 'fs',
+      config: {
+        root: '/attachments/figshare-staging',
+      },
+    },
   },
 };

--- a/packages/redbox-core/src/configmodels/FigsharePublishing.ts
+++ b/packages/redbox-core/src/configmodels/FigsharePublishing.ts
@@ -776,7 +776,14 @@ export const FIGSHARE_PUBLISHING_SCHEMA = {
               enum: ['deleteAfterSuccess', 'retainForRetry'],
               default: 'deleteAfterSuccess',
             },
-            diskSpaceThresholdBytes: { type: 'integer', title: 'Disk Space Threshold Bytes', default: 1073741824 },
+            diskSpaceThresholdBytes: {
+              type: 'integer',
+              title: 'Disk Space Threshold Bytes (deprecated, no-op)',
+              deprecated: true,
+              description:
+                'Deprecated and ignored. Staging now runs through StorageManagerService, which surfaces its own capacity errors; this value no longer acts as a pre-flight disk-space guard. Retained only for compatibility with stored configs.',
+              default: 1073741824,
+            },
           },
         },
       },

--- a/packages/redbox-core/src/configmodels/FigsharePublishing.ts
+++ b/packages/redbox-core/src/configmodels/FigsharePublishing.ts
@@ -197,9 +197,18 @@ export interface FigsharePublishingConfigData {
     enableLinkFiles: boolean;
     dedupeStrategy: 'sourceId' | 'nameAndMd5' | 'url';
     staging: {
+      /**
+       * StorageManager disk name used to stage attachments before upload.
+       * Resolved via StorageManagerService.disk(name). Defaults to 'figshare-staging'.
+       */
+      disk?: string;
+      /** Key prefix for staged objects on the disk. Default: 'figshare/'. */
+      keyPrefix?: string;
+      /** @deprecated fs-only; ignored once staging runs through StorageManagerService. */
       tempDir?: string;
-      cleanupPolicy: 'deleteAfterSuccess' | 'retainForRetry';
+      /** @deprecated fs-only pre-flight guard; the disk surfaces its own capacity errors. */
       diskSpaceThresholdBytes: number;
+      cleanupPolicy: 'deleteAfterSuccess' | 'retainForRetry';
     };
   };
   embargo: {
@@ -235,7 +244,7 @@ function createDefaultBinding(path: string, defaultValue?: unknown): ValueBindin
   return {
     kind: 'path',
     path,
-    defaultValue
+    defaultValue,
   };
 }
 
@@ -251,15 +260,15 @@ export class FigsharePublishing extends AppConfig implements FigsharePublishingC
       metadataMs: 30000,
       uploadInitMs: 30000,
       uploadPartMs: 120000,
-      publishMs: 60000
+      publishMs: 60000,
     },
     retry: {
       maxAttempts: 3,
       baseDelayMs: 500,
       maxDelayMs: 4000,
       retryOnStatusCodes: [408, 429, 500, 502, 503, 504],
-      retryOnMethods: ['get', 'put', 'delete']
-    }
+      retryOnMethods: ['get', 'put', 'delete'],
+    },
   };
 
   article = {
@@ -271,8 +280,8 @@ export class FigsharePublishing extends AppConfig implements FigsharePublishingC
     curationLock: {
       enabled: false,
       statusField: '',
-      targetValue: 'public'
-    }
+      targetValue: 'public',
+    },
   };
 
   record = {
@@ -282,13 +291,13 @@ export class FigsharePublishing extends AppConfig implements FigsharePublishingC
     statusPath: 'metadata.figshareStatus',
     errorPath: 'metadata.figshareError',
     syncStatePath: 'metadata.figshareSyncState',
-    allFilesUploadedPath: ''
+    allFilesUploadedPath: '',
   };
 
   selection = {
     attachmentMode: 'selectedOnly' as 'selectedOnly' | 'all',
     urlMode: 'selectedOnly' as 'selectedOnly' | 'all',
-    selectedFlagPath: 'selected'
+    selectedFlagPath: 'selected',
   };
 
   authors = {
@@ -298,21 +307,21 @@ export class FigsharePublishing extends AppConfig implements FigsharePublishingC
       'metadata.contributor_data_manager',
       'metadata.dataOwner',
       'metadata.chiefInvestigator',
-      'metadata.contributors'
+      'metadata.contributors',
     ],
     uniqueBy: 'email' as 'email' | 'orcid' | 'username' | 'none',
     externalNameField: 'text_full_name',
     maxInlineAuthors: 50,
     emailTransform: {
       prefix: '',
-      domainOverride: ''
+      domainOverride: '',
     },
     lookup: [
       {
         matchBy: 'email' as const,
-        value: createDefaultBinding('email')
-      }
-    ]
+        value: createDefaultBinding('email'),
+      },
+    ],
   };
 
   metadata = {
@@ -323,23 +332,23 @@ export class FigsharePublishing extends AppConfig implements FigsharePublishingC
     license: {
       source: createDefaultBinding('metadata.license'),
       matchBy: 'urlContains' as 'urlContains' | 'nameExact' | 'valueExact',
-      required: true
+      required: true,
     },
     categories: {
       source: createDefaultBinding('metadata.forCodes', []),
-      mappingStrategy: 'for2020Mapping' as const
+      mappingStrategy: 'for2020Mapping' as const,
     },
     relatedResource: {
       title: createDefaultBinding('metadata.title', ''),
-      doi: createDefaultBinding('metadata.doi', '')
+      doi: createDefaultBinding('metadata.doi', ''),
     },
-    customFields: []
+    customFields: [],
   };
 
   categories = {
     strategy: 'for2020Mapping' as const,
     mappingTable: [] as Array<{ sourceCode: string; figshareCategoryId: number }>,
-    allowUnmapped: false
+    allowUnmapped: false,
   };
 
   assets = {
@@ -347,10 +356,12 @@ export class FigsharePublishing extends AppConfig implements FigsharePublishingC
     enableLinkFiles: true,
     dedupeStrategy: 'sourceId' as 'sourceId' | 'nameAndMd5' | 'url',
     staging: {
+      disk: 'figshare-staging',
+      keyPrefix: 'figshare/',
       tempDir: '',
       cleanupPolicy: 'deleteAfterSuccess' as 'deleteAfterSuccess' | 'retainForRetry',
-      diskSpaceThresholdBytes: 1073741824
-    }
+      diskSpaceThresholdBytes: 1073741824,
+    },
   };
 
   embargo = {
@@ -360,13 +371,13 @@ export class FigsharePublishing extends AppConfig implements FigsharePublishingC
       accessRights: createDefaultBinding('metadata.accessRights', ''),
       fullEmbargoUntil: createDefaultBinding('metadata.embargoUntil'),
       fileEmbargoUntil: createDefaultBinding('metadata.embargoUntil'),
-      reason: createDefaultBinding('metadata.embargoReason')
-    }
+      reason: createDefaultBinding('metadata.embargoReason'),
+    },
   };
 
   queue = {
     publishAfterUploadDelay: 'in 2 minutes',
-    uploadedFilesCleanupDelay: 'in 5 minutes'
+    uploadedFilesCleanupDelay: 'in 5 minutes',
   };
 
   workflow = {
@@ -379,14 +390,14 @@ export class FigsharePublishing extends AppConfig implements FigsharePublishingC
       figshareTargetFieldKey: '',
       figshareTargetFieldValue: '',
       username: '',
-      userType: ''
-    }
+      userType: '',
+    },
   };
 
   writeBack = {
     articleId: 'metadata.figshare_article_id',
     articleUrls: ['metadata.figshare_article_location'],
-    extraFields: [] as WriteBackBinding[]
+    extraFields: [] as WriteBackBinding[],
   };
 
   public static getFieldOrder(): string[] {
@@ -403,7 +414,7 @@ export class FigsharePublishing extends AppConfig implements FigsharePublishingC
       'embargo',
       'queue',
       'workflow',
-      'writeBack'
+      'writeBack',
     ];
   }
 }
@@ -411,17 +422,17 @@ export class FigsharePublishing extends AppConfig implements FigsharePublishingC
 const VALUE_BINDING_EDITOR_WIDGET = {
   widget: {
     formlyConfig: {
-      type: 'value-binding-editor'
-    }
-  }
+      type: 'value-binding-editor',
+    },
+  },
 };
 
 const CATEGORY_MAPPING_EDITOR_WIDGET = {
   widget: {
     formlyConfig: {
-      type: 'figshare-category-mapping-editor'
-    }
-  }
+      type: 'figshare-category-mapping-editor',
+    },
+  },
 };
 
 const VALUE_BINDING_SCHEMA = {
@@ -432,26 +443,26 @@ const VALUE_BINDING_SCHEMA = {
       type: 'string',
       title: 'Binding Type',
       enum: ['path', 'handlebars', 'jsonata'],
-      default: 'path'
+      default: 'path',
     },
     path: {
       type: 'string',
-      title: 'Record Path'
+      title: 'Record Path',
     },
     template: {
       type: 'string',
-      title: 'Handlebars Template'
+      title: 'Handlebars Template',
     },
     expression: {
       type: 'string',
-      title: 'JSONata Expression'
+      title: 'JSONata Expression',
     },
     defaultValue: {
-      title: 'Default Value'
-    }
+      title: 'Default Value',
+    },
   },
   required: ['kind'],
-  ...VALUE_BINDING_EDITOR_WIDGET
+  ...VALUE_BINDING_EDITOR_WIDGET,
 };
 
 export const FIGSHARE_PUBLISHING_SCHEMA = {
@@ -460,7 +471,7 @@ export const FIGSHARE_PUBLISHING_SCHEMA = {
     enabled: {
       type: 'boolean',
       title: 'Enabled',
-      default: false
+      default: false,
     },
     connection: {
       type: 'object',
@@ -471,7 +482,8 @@ export const FIGSHARE_PUBLISHING_SCHEMA = {
         token: {
           type: 'string',
           title: 'API Token',
-          description: 'Do not commit raw API tokens. Prefer an environment variable reference such as $FIGSHARE_TOKEN or the deployment secret manager.'
+          description:
+            'Do not commit raw API tokens. Prefer an environment variable reference such as $FIGSHARE_TOKEN or the deployment secret manager.',
         },
         timeoutMs: { type: 'integer', title: 'Request Timeout (ms)', default: 30000 },
         operationTimeouts: {
@@ -481,8 +493,8 @@ export const FIGSHARE_PUBLISHING_SCHEMA = {
             metadataMs: { type: 'integer', title: 'Metadata Timeout (ms)', default: 30000 },
             uploadInitMs: { type: 'integer', title: 'Upload Init Timeout (ms)', default: 30000 },
             uploadPartMs: { type: 'integer', title: 'Upload Part Timeout (ms)', default: 120000 },
-            publishMs: { type: 'integer', title: 'Publish Timeout (ms)', default: 60000 }
-          }
+            publishMs: { type: 'integer', title: 'Publish Timeout (ms)', default: 60000 },
+          },
         },
         retry: {
           type: 'object',
@@ -495,17 +507,17 @@ export const FIGSHARE_PUBLISHING_SCHEMA = {
               type: 'array',
               title: 'Retry On Status Codes',
               items: { type: 'integer' },
-              default: [408, 429, 500, 502, 503, 504]
+              default: [408, 429, 500, 502, 503, 504],
             },
             retryOnMethods: {
               type: 'array',
               title: 'Retry On Methods',
               items: { type: 'string' },
-              default: ['get', 'put', 'delete']
-            }
-          }
-        }
-      }
+              default: ['get', 'put', 'delete'],
+            },
+          },
+        },
+      },
     },
     article: {
       type: 'object',
@@ -514,15 +526,26 @@ export const FIGSHARE_PUBLISHING_SCHEMA = {
         itemType: {
           type: 'string',
           title: 'Item Type',
-          enum: ['dataset', 'fileset', 'figure', 'media', 'poster', 'paper', 'presentation', 'thesis', 'code', 'metadata'],
-          default: 'dataset'
+          enum: [
+            'dataset',
+            'fileset',
+            'figure',
+            'media',
+            'poster',
+            'paper',
+            'presentation',
+            'thesis',
+            'code',
+            'metadata',
+          ],
+          default: 'dataset',
         },
         groupId: { type: 'integer', title: 'Group ID' },
         publishMode: {
           type: 'string',
           title: 'Publish Mode',
           enum: ['immediate', 'afterUploadsComplete', 'manual'],
-          default: 'afterUploadsComplete'
+          default: 'afterUploadsComplete',
         },
         republishOnMetadataChange: { type: 'boolean', title: 'Republish On Metadata Change', default: true },
         republishOnAssetChange: { type: 'boolean', title: 'Republish On Asset Change', default: true },
@@ -532,10 +555,10 @@ export const FIGSHARE_PUBLISHING_SCHEMA = {
           properties: {
             enabled: { type: 'boolean', title: 'Enabled', default: false },
             statusField: { type: 'string', title: 'Status Field', default: '' },
-            targetValue: { type: 'string', title: 'Target Value', default: 'public' }
-          }
-        }
-      }
+            targetValue: { type: 'string', title: 'Target Value', default: 'public' },
+          },
+        },
+      },
     },
     record: {
       type: 'object',
@@ -546,14 +569,14 @@ export const FIGSHARE_PUBLISHING_SCHEMA = {
           type: 'array',
           title: 'Article URL Paths',
           items: { type: 'string' },
-          default: ['metadata.figshare_article_location']
+          default: ['metadata.figshare_article_location'],
         },
         dataLocationsPath: { type: 'string', title: 'Data Locations Path', default: 'metadata.dataLocations' },
         statusPath: { type: 'string', title: 'Status Path', default: 'metadata.figshareStatus' },
         errorPath: { type: 'string', title: 'Error Path', default: 'metadata.figshareError' },
         syncStatePath: { type: 'string', title: 'Sync State Path', default: 'metadata.figshareSyncState' },
-        allFilesUploadedPath: { type: 'string', title: 'All Files Uploaded Path', default: '' }
-      }
+        allFilesUploadedPath: { type: 'string', title: 'All Files Uploaded Path', default: '' },
+      },
     },
     selection: {
       type: 'object',
@@ -563,16 +586,16 @@ export const FIGSHARE_PUBLISHING_SCHEMA = {
           type: 'string',
           title: 'Attachment Mode',
           enum: ['selectedOnly', 'all'],
-          default: 'selectedOnly'
+          default: 'selectedOnly',
         },
         urlMode: {
           type: 'string',
           title: 'URL Mode',
           enum: ['selectedOnly', 'all'],
-          default: 'selectedOnly'
+          default: 'selectedOnly',
         },
-        selectedFlagPath: { type: 'string', title: 'Selected Flag Path', default: 'selected' }
-      }
+        selectedFlagPath: { type: 'string', title: 'Selected Flag Path', default: 'selected' },
+      },
     },
     authors: {
       type: 'object',
@@ -582,13 +605,13 @@ export const FIGSHARE_PUBLISHING_SCHEMA = {
           type: 'string',
           title: 'Source Strategy',
           enum: ['defaultRedboxContributors'],
-          default: 'defaultRedboxContributors'
+          default: 'defaultRedboxContributors',
         },
         uniqueBy: {
           type: 'string',
           title: 'Unique By',
           enum: ['email', 'orcid', 'username', 'none'],
-          default: 'email'
+          default: 'email',
         },
         externalNameField: { type: 'string', title: 'External Name Field', default: 'text_full_name' },
         maxInlineAuthors: { type: 'integer', title: 'Max Inline Authors', default: 50 },
@@ -601,11 +624,11 @@ export const FIGSHARE_PUBLISHING_SCHEMA = {
               matchBy: {
                 type: 'string',
                 title: 'Match By',
-                enum: ['email', 'orcid', 'username']
+                enum: ['email', 'orcid', 'username'],
               },
-              value: VALUE_BINDING_SCHEMA
-            }
-          }
+              value: VALUE_BINDING_SCHEMA,
+            },
+          },
         },
         contributorPaths: {
           type: 'array',
@@ -616,18 +639,18 @@ export const FIGSHARE_PUBLISHING_SCHEMA = {
             'metadata.contributor_data_manager',
             'metadata.dataOwner',
             'metadata.chiefInvestigator',
-            'metadata.contributors'
-          ]
+            'metadata.contributors',
+          ],
         },
         emailTransform: {
           type: 'object',
           title: 'Email Transform',
           properties: {
             prefix: { type: 'string', title: 'Prefix', default: '' },
-            domainOverride: { type: 'string', title: 'Domain Override', default: '' }
-          }
-        }
-      }
+            domainOverride: { type: 'string', title: 'Domain Override', default: '' },
+          },
+        },
+      },
     },
     metadata: {
       type: 'object',
@@ -646,10 +669,10 @@ export const FIGSHARE_PUBLISHING_SCHEMA = {
               type: 'string',
               title: 'Match By',
               enum: ['urlContains', 'nameExact', 'valueExact'],
-              default: 'urlContains'
+              default: 'urlContains',
             },
-            required: { type: 'boolean', title: 'Required', default: true }
-          }
+            required: { type: 'boolean', title: 'Required', default: true },
+          },
         },
         categories: {
           type: 'object',
@@ -660,17 +683,17 @@ export const FIGSHARE_PUBLISHING_SCHEMA = {
               type: 'string',
               title: 'Mapping Strategy',
               enum: ['for2020Mapping'],
-              default: 'for2020Mapping'
-            }
-          }
+              default: 'for2020Mapping',
+            },
+          },
         },
         relatedResource: {
           type: 'object',
           title: 'Related Resource',
           properties: {
             title: VALUE_BINDING_SCHEMA,
-            doi: VALUE_BINDING_SCHEMA
-          }
+            doi: VALUE_BINDING_SCHEMA,
+          },
         },
         customFields: {
           type: 'array',
@@ -689,19 +712,19 @@ export const FIGSHARE_PUBLISHING_SCHEMA = {
                     type: {
                       type: 'string',
                       title: 'Type',
-                      enum: ['maxLength', 'url', 'doi', 'required']
+                      enum: ['maxLength', 'url', 'doi', 'required'],
                     },
                     value: {
                       type: 'integer',
-                      title: 'Value'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                      title: 'Value',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     },
     categories: {
       type: 'object',
@@ -711,7 +734,7 @@ export const FIGSHARE_PUBLISHING_SCHEMA = {
           type: 'string',
           title: 'Strategy',
           enum: ['for2020Mapping'],
-          default: 'for2020Mapping'
+          default: 'for2020Mapping',
         },
         mappingTable: {
           type: 'array',
@@ -720,13 +743,13 @@ export const FIGSHARE_PUBLISHING_SCHEMA = {
             type: 'object',
             properties: {
               sourceCode: { type: 'string', title: 'Source Code' },
-              figshareCategoryId: { type: 'integer', title: 'Figshare Category ID' }
-            }
+              figshareCategoryId: { type: 'integer', title: 'Figshare Category ID' },
+            },
           },
-          ...CATEGORY_MAPPING_EDITOR_WIDGET
+          ...CATEGORY_MAPPING_EDITOR_WIDGET,
         },
-        allowUnmapped: { type: 'boolean', title: 'Allow Unmapped Categories', default: false }
-      }
+        allowUnmapped: { type: 'boolean', title: 'Allow Unmapped Categories', default: false },
+      },
     },
     assets: {
       type: 'object',
@@ -738,23 +761,25 @@ export const FIGSHARE_PUBLISHING_SCHEMA = {
           type: 'string',
           title: 'Dedupe Strategy',
           enum: ['sourceId', 'nameAndMd5', 'url'],
-          default: 'sourceId'
+          default: 'sourceId',
         },
         staging: {
           type: 'object',
           title: 'Staging',
           properties: {
+            disk: { type: 'string', title: 'Storage Disk', default: 'figshare-staging' },
+            keyPrefix: { type: 'string', title: 'Storage Key Prefix', default: 'figshare/' },
             tempDir: { type: 'string', title: 'Temp Directory' },
             cleanupPolicy: {
               type: 'string',
               title: 'Cleanup Policy',
               enum: ['deleteAfterSuccess', 'retainForRetry'],
-              default: 'deleteAfterSuccess'
+              default: 'deleteAfterSuccess',
             },
-            diskSpaceThresholdBytes: { type: 'integer', title: 'Disk Space Threshold Bytes', default: 1073741824 }
-          }
-        }
-      }
+            diskSpaceThresholdBytes: { type: 'integer', title: 'Disk Space Threshold Bytes', default: 1073741824 },
+          },
+        },
+      },
     },
     embargo: {
       type: 'object',
@@ -764,7 +789,7 @@ export const FIGSHARE_PUBLISHING_SCHEMA = {
           type: 'string',
           title: 'Mode',
           enum: ['none', 'recordDriven'],
-          default: 'recordDriven'
+          default: 'recordDriven',
         },
         forceSync: { type: 'boolean', title: 'Force Sync', default: false },
         accessRights: {
@@ -774,18 +799,18 @@ export const FIGSHARE_PUBLISHING_SCHEMA = {
             accessRights: VALUE_BINDING_SCHEMA,
             fullEmbargoUntil: VALUE_BINDING_SCHEMA,
             fileEmbargoUntil: VALUE_BINDING_SCHEMA,
-            reason: VALUE_BINDING_SCHEMA
-          }
-        }
-      }
+            reason: VALUE_BINDING_SCHEMA,
+          },
+        },
+      },
     },
     queue: {
       type: 'object',
       title: 'Queue',
       properties: {
         publishAfterUploadDelay: { type: 'string', title: 'Publish After Upload Delay', default: 'in 2 minutes' },
-        uploadedFilesCleanupDelay: { type: 'string', title: 'Uploaded Files Cleanup Delay', default: 'in 5 minutes' }
-      }
+        uploadedFilesCleanupDelay: { type: 'string', title: 'Uploaded Files Cleanup Delay', default: 'in 5 minutes' },
+      },
     },
     workflow: {
       type: 'object',
@@ -800,15 +825,15 @@ export const FIGSHARE_PUBLISHING_SCHEMA = {
               when: {
                 type: 'string',
                 title: 'When',
-                enum: ['published', 'republished', 'embargoUpdated', 'awaitingUploadCompletion']
+                enum: ['published', 'republished', 'embargoUpdated', 'awaitingUploadCompletion'],
               },
               targetWorkflowStageName: { type: 'string', title: 'Target Workflow Stage Name' },
               targetWorkflowStageLabel: { type: 'string', title: 'Target Workflow Stage Label' },
               targetForm: { type: 'string', title: 'Target Form' },
               ifArticleField: { type: 'string', title: 'Article Field' },
-              equals: { title: 'Equals' }
-            }
-          }
+              equals: { title: 'Equals' },
+            },
+          },
         },
         transitionJob: {
           type: 'object',
@@ -821,10 +846,10 @@ export const FIGSHARE_PUBLISHING_SCHEMA = {
             figshareTargetFieldKey: { type: 'string', title: 'Figshare Target Field Key', default: '' },
             figshareTargetFieldValue: { type: 'string', title: 'Figshare Target Field Value', default: '' },
             username: { type: 'string', title: 'Username', default: '' },
-            userType: { type: 'string', title: 'User Type', default: '' }
-          }
-        }
-      }
+            userType: { type: 'string', title: 'User Type', default: '' },
+          },
+        },
+      },
     },
     writeBack: {
       type: 'object',
@@ -835,7 +860,7 @@ export const FIGSHARE_PUBLISHING_SCHEMA = {
           type: 'array',
           title: 'Article URL Target Paths',
           items: { type: 'string' },
-          default: ['metadata.figshare_article_location']
+          default: ['metadata.figshare_article_location'],
         },
         extraFields: {
           type: 'array',
@@ -846,14 +871,14 @@ export const FIGSHARE_PUBLISHING_SCHEMA = {
               from: {
                 type: 'string',
                 title: 'From',
-                enum: ['article', 'publishResult', 'assetSyncResult']
+                enum: ['article', 'publishResult', 'assetSyncResult'],
               },
               sourcePath: { type: 'string', title: 'Source Path' },
-              targetPath: { type: 'string', title: 'Target Path' }
-            }
-          }
-        }
-      }
-    }
-  }
+              targetPath: { type: 'string', title: 'Target Path' },
+            },
+          },
+        },
+      },
+    },
+  },
 };

--- a/packages/redbox-core/src/services/figshare-v2/README.md
+++ b/packages/redbox-core/src/services/figshare-v2/README.md
@@ -1,7 +1,19 @@
 Figshare V2 uses small Effect-powered runtime programs around a branded `figsharePublishing` config.
 
 Patterns used here:
+
 - keep Sails-facing services thin
 - assemble dependencies in `runtime.ts`
 - keep binding/config/state helpers pure where practical
 - isolate external Figshare calls behind `http.ts`
+
+Hosted file uploads stage source datastreams through `StorageManagerService` before
+Figshare multipart upload. The default disk is `figshare-staging`, with object keys under
+`figshare/`; both can be overridden via `figsharePublishing.assets.staging.disk` and
+`figsharePublishing.assets.staging.keyPrefix`. Staged objects are deleted after a
+successful upload by default, or retained on success when `cleanupPolicy` is
+`retainForRetry`. Failed uploads always make a best-effort delete of the staged object.
+
+The legacy `tempDir` and `diskSpaceThresholdBytes` settings are retained for stored
+configuration compatibility, but Figshare staging no longer reads them. Capacity failures
+now surface from the configured StorageManager disk.

--- a/packages/redbox-core/src/services/figshare-v2/assets.ts
+++ b/packages/redbox-core/src/services/figshare-v2/assets.ts
@@ -23,6 +23,7 @@ type IDisk = StorageManagerServices.IDisk;
 
 const LINK_FILE_CREATE_RETRY_COUNT = 3;
 const FIGSHARE_UPLOAD_PENDING_STATUS = 'created';
+const DEFAULT_FIGSHARE_STAGING_DISK = 'figshare-staging';
 
 function getRecordOid(record: RecordModel): string {
   return record.redboxOid ?? record.id ?? '';
@@ -75,6 +76,9 @@ function getStagingDisk(config: FigsharePublishingConfigData): IDisk {
   try {
     return StorageManagerService.disk(diskName);
   } catch (error) {
+    if (diskName !== DEFAULT_FIGSHARE_STAGING_DISK) {
+      throw error;
+    }
     // A deployment that overrides storage.disks may not register the default
     // 'figshare-staging' disk. Fall back to the configured staging disk rather
     // than failing the upload before staging starts.

--- a/packages/redbox-core/src/services/figshare-v2/assets.ts
+++ b/packages/redbox-core/src/services/figshare-v2/assets.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import _ from 'lodash';
+import { randomUUID } from 'node:crypto';
 import { Readable } from 'node:stream';
 import { FigsharePublishingConfigData } from '../../configmodels/FigsharePublishing';
 import { RBValidationError } from '../../model/RBValidationError';
@@ -68,7 +69,21 @@ function sanitizePathComponent(value: string): string {
 
 function getStagingDisk(config: FigsharePublishingConfigData): IDisk {
   const diskName = config.assets.staging.disk?.trim();
-  return diskName ? StorageManagerService.disk(diskName) : StorageManagerService.stagingDisk();
+  if (!diskName) {
+    return StorageManagerService.stagingDisk();
+  }
+  try {
+    return StorageManagerService.disk(diskName);
+  } catch (error) {
+    // A deployment that overrides storage.disks may not register the default
+    // 'figshare-staging' disk. Fall back to the configured staging disk rather
+    // than failing the upload before staging starts.
+    sails.log.warn(
+      `FigService - staging disk '${diskName}' is not registered; falling back to the default staging disk`,
+      error
+    );
+    return StorageManagerService.stagingDisk();
+  }
 }
 
 function buildStagingKey(
@@ -88,7 +103,10 @@ function buildStagingKey(
   if (safeFileName === '.' || safeFileName === '..') {
     throw validationError(`Attachment '${fileName}' does not contain a valid file name`);
   }
-  const dir = `${sanitizePathComponent(articleId)}-${sanitizePathComponent(oid)}-${sanitizePathComponent(fileId)}`;
+  // Append a per-attempt random segment so concurrent or retried uploads of the
+  // same attachment never share a staging key (which would let one attempt
+  // overwrite or delete the object another attempt is still streaming).
+  const dir = `${sanitizePathComponent(articleId)}-${sanitizePathComponent(oid)}-${sanitizePathComponent(fileId)}-${randomUUID()}`;
   return `${prefix}/${dir}/${safeFileName}`;
 }
 
@@ -203,7 +221,10 @@ async function uploadAttachment(
     uploadSucceeded = true;
     return uploadedFile as unknown as FigshareFile;
   } finally {
-    const shouldDelete = !uploadSucceeded || config.assets.staging.cleanupPolicy === 'deleteAfterSuccess';
+    // Stored configs may omit cleanupPolicy; default to delete-after-success so
+    // staged objects are not retained on the staging disk indefinitely.
+    const cleanupPolicy = config.assets.staging.cleanupPolicy ?? 'deleteAfterSuccess';
+    const shouldDelete = !uploadSucceeded || cleanupPolicy === 'deleteAfterSuccess';
     if (shouldDelete) {
       await disk
         .delete(stagingKey)

--- a/packages/redbox-core/src/services/figshare-v2/assets.ts
+++ b/packages/redbox-core/src/services/figshare-v2/assets.ts
@@ -83,6 +83,11 @@ function buildStagingKey(
   if (safeFileName === '') {
     throw validationError(`Attachment '${fileName}' does not contain a valid file name`);
   }
+  // basename() can still yield the reserved '.'/'..' segments, which would point the
+  // staging key at the directory itself or escape it on an fs-backed disk.
+  if (safeFileName === '.' || safeFileName === '..') {
+    throw validationError(`Attachment '${fileName}' does not contain a valid file name`);
+  }
   const dir = `${sanitizePathComponent(articleId)}-${sanitizePathComponent(oid)}-${sanitizePathComponent(fileId)}`;
   return `${prefix}/${dir}/${safeFileName}`;
 }
@@ -109,27 +114,29 @@ async function* readPartsSequentially(
       throw validationError(`Figshare upload part ${part.partNo} starts at ${part.startOffset}; expected ${consumed}`);
     }
 
-    const chunks: Buffer[] = [];
-    let need = partSize;
-    while (need > 0) {
-      if (carry.length === 0) {
-        const { value, done } = await iterator.next();
-        if (done === true) {
-          throw validationError(
-            `Staged object truncated at offset ${consumed}; expected more bytes for part ${part.partNo}`
-          );
+    async function* partStream(): AsyncGenerator<Buffer> {
+      let need = partSize;
+      while (need > 0) {
+        if (carry.length === 0) {
+          const { value, done } = await iterator.next();
+          if (done === true) {
+            throw validationError(
+              `Staged object truncated at offset ${consumed}; expected more bytes for part ${part.partNo}`
+            );
+          }
+          carry = Buffer.isBuffer(value) ? value : Buffer.from(value);
         }
-        carry = Buffer.isBuffer(value) ? value : Buffer.from(value);
-      }
 
-      const take = Math.min(need, carry.length);
-      chunks.push(carry.subarray(0, take));
-      carry = carry.subarray(take);
-      need -= take;
-      consumed += take;
+        const take = Math.min(need, carry.length);
+        const chunk = carry.subarray(0, take);
+        carry = carry.subarray(take);
+        need -= take;
+        consumed += take;
+        yield chunk;
+      }
     }
 
-    yield { partNo: part.partNo, stream: Readable.from(chunks) };
+    yield { partNo: part.partNo, stream: Readable.from(partStream()) };
   }
 }
 

--- a/packages/redbox-core/src/services/figshare-v2/assets.ts
+++ b/packages/redbox-core/src/services/figshare-v2/assets.ts
@@ -1,15 +1,16 @@
-import fs from 'fs';
 import path from 'path';
-import checkDiskSpace from 'check-disk-space';
 import _ from 'lodash';
+import { Readable } from 'node:stream';
 import { FigsharePublishingConfigData } from '../../configmodels/FigsharePublishing';
 import { RBValidationError } from '../../model/RBValidationError';
+import type { Services as StorageManagerServices } from '../StorageManagerService';
 import { FigshareClient } from './http';
 import { ResolvedFigsharePublishingConfigData } from './config';
 import {
   RecordModel,
   FigshareArticle,
   FigshareFile,
+  FigshareUploadPart,
   FigshareSyncState,
   DataLocationEntry,
   AssetSyncResult,
@@ -17,15 +18,10 @@ import {
 import { setSyncState } from './config';
 import { getSelectedDataLocations } from './plan';
 
-const UNKNOWN_SIZE_STAGING_BUFFER_BYTES = 50 * 1024 * 1024;
+type IDisk = StorageManagerServices.IDisk;
+
 const LINK_FILE_CREATE_RETRY_COUNT = 3;
 const FIGSHARE_UPLOAD_PENDING_STATUS = 'created';
-
-function getTempDir(config: FigsharePublishingConfigData): string {
-  const configDir = config.assets.staging.tempDir;
-  if (configDir) return configDir;
-  return '/tmp';
-}
 
 function getRecordOid(record: RecordModel): string {
   return record.redboxOid ?? record.id ?? '';
@@ -34,13 +30,15 @@ function getRecordOid(record: RecordModel): string {
 function getDatastreamService(): Record<string, unknown> | undefined {
   const recordConfig = (sails.config as Record<string, unknown>).record as Record<string, unknown> | undefined;
   const serviceName = String(recordConfig?.datastreamService ?? '');
-  return serviceName ? (sails.services as Record<string, unknown>)?.[serviceName] as Record<string, unknown> | undefined : undefined;
+  return serviceName
+    ? ((sails.services as Record<string, unknown>)?.[serviceName] as Record<string, unknown> | undefined)
+    : undefined;
 }
 
 function validationError(message: string): RBValidationError {
   return new RBValidationError({
     message,
-    displayErrors: [{ title: message, detail: message }]
+    displayErrors: [{ title: message, detail: message }],
   });
 }
 
@@ -55,30 +53,84 @@ async function getAttachmentStream(oid: string, fileId: string): Promise<Datastr
     throw new Error('Datastream service is not configured');
   }
 
-  const response = await (datastreamService.getDatastream as (oid: string, fileId: string) => Promise<DatastreamResponse>)(oid, fileId);
+  const response = await (
+    datastreamService.getDatastream as (oid: string, fileId: string) => Promise<DatastreamResponse>
+  )(oid, fileId);
   if (response?.readstream == null) {
     throw new Error(`Unable to read datastream '${fileId}' for record '${oid}'`);
   }
   return response;
 }
 
-async function stageAttachmentToDisk(response: DatastreamResponse, filePath: string): Promise<number> {
-  await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
-  const readStream = response.readstream;
-  await new Promise<void>((resolve, reject) => {
-    const writeStream = fs.createWriteStream(filePath);
-    readStream.on('error', reject);
-    writeStream.on('error', reject);
-    writeStream.on('close', () => resolve());
-    readStream.pipe(writeStream);
-  });
-
-  const stat = await fs.promises.stat(filePath);
-  return stat.size;
-}
-
 function sanitizePathComponent(value: string): string {
   return value.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'item';
+}
+
+function getStagingDisk(config: FigsharePublishingConfigData): IDisk {
+  const diskName = config.assets.staging.disk?.trim();
+  return diskName ? StorageManagerService.disk(diskName) : StorageManagerService.stagingDisk();
+}
+
+function buildStagingKey(
+  config: FigsharePublishingConfigData,
+  articleId: string,
+  oid: string,
+  fileId: string,
+  fileName: string
+): string {
+  const prefix = (config.assets.staging.keyPrefix ?? 'figshare/').replace(/^\/+|\/+$/g, '') || 'figshare';
+  const safeFileName = path.basename(fileName).trim();
+  if (safeFileName === '') {
+    throw validationError(`Attachment '${fileName}' does not contain a valid file name`);
+  }
+  const dir = `${sanitizePathComponent(articleId)}-${sanitizePathComponent(oid)}-${sanitizePathComponent(fileId)}`;
+  return `${prefix}/${dir}/${safeFileName}`;
+}
+
+async function stageAttachmentToDisk(disk: IDisk, key: string, response: DatastreamResponse): Promise<number> {
+  const expectedSize = Number(response.size ?? 0);
+  await disk.putStream(key, response.readstream as Readable, expectedSize > 0 ? { contentLength: expectedSize } : {});
+  const meta = await disk.getMetaData(key);
+  return meta.contentLength;
+}
+
+async function* readPartsSequentially(
+  source: Readable,
+  parts: FigshareUploadPart[]
+): AsyncGenerator<{ partNo: number; stream: Readable }> {
+  const ordered = [...parts].sort((a, b) => a.startOffset - b.startOffset);
+  let consumed = 0;
+  let carry = Buffer.alloc(0);
+  const iterator = source[Symbol.asyncIterator]();
+
+  for (const part of ordered) {
+    const partSize = part.endOffset - part.startOffset + 1;
+    if (part.startOffset !== consumed) {
+      throw validationError(`Figshare upload part ${part.partNo} starts at ${part.startOffset}; expected ${consumed}`);
+    }
+
+    const chunks: Buffer[] = [];
+    let need = partSize;
+    while (need > 0) {
+      if (carry.length === 0) {
+        const { value, done } = await iterator.next();
+        if (done === true) {
+          throw validationError(
+            `Staged object truncated at offset ${consumed}; expected more bytes for part ${part.partNo}`
+          );
+        }
+        carry = Buffer.isBuffer(value) ? value : Buffer.from(value);
+      }
+
+      const take = Math.min(need, carry.length);
+      chunks.push(carry.subarray(0, take));
+      carry = carry.subarray(take);
+      need -= take;
+      consumed += take;
+    }
+
+    yield { partNo: part.partNo, stream: Readable.from(chunks) };
+  }
 }
 
 async function listArticleFiles(client: FigshareClient, articleId: string): Promise<FigshareFile[]> {
@@ -100,60 +152,33 @@ async function listArticleFiles(client: FigshareClient, articleId: string): Prom
 }
 
 function hasPendingUploads(files: FigshareFile[]): boolean {
-  return files.some((entry) => String(entry.status ?? '').toLowerCase() === FIGSHARE_UPLOAD_PENDING_STATUS);
+  return files.some(entry => String(entry.status ?? '').toLowerCase() === FIGSHARE_UPLOAD_PENDING_STATUS);
 }
 
-async function uploadAttachment(client: FigshareClient, config: FigsharePublishingConfigData, articleId: string, oid: string, attachment: DataLocationEntry): Promise<FigshareFile> {
+async function uploadAttachment(
+  client: FigshareClient,
+  config: FigsharePublishingConfigData,
+  articleId: string,
+  oid: string,
+  attachment: DataLocationEntry
+): Promise<FigshareFile> {
   const fileId = attachment.fileId ?? '';
   const fileName = attachment.name ?? '';
   if (fileId === '' || fileName === '') {
     throw validationError('Attachment entry is missing fileId or name');
   }
 
-  const tempDir = getTempDir(config);
-  const resolvedTempDir = path.resolve(tempDir);
-  const safeFileName = path.basename(fileName).trim();
-  if (safeFileName === '') {
-    throw validationError(`Attachment '${fileName}' does not contain a valid file name`);
-  }
-  await fs.promises.mkdir(resolvedTempDir, { recursive: true });
-  const stagingDir = await fs.promises.mkdtemp(path.join(
-    resolvedTempDir,
-    `${sanitizePathComponent(articleId)}-${sanitizePathComponent(oid)}-${sanitizePathComponent(fileId)}-`
-  ));
-  const filePath = path.resolve(stagingDir, safeFileName);
-  if (!filePath.startsWith(`${stagingDir}${path.sep}`) && filePath !== path.join(stagingDir, safeFileName)) {
-    throw validationError(`Attachment '${fileName}' resolves outside the staging directory`);
-  }
+  const disk = getStagingDisk(config);
+  const stagingKey = buildStagingKey(config, articleId, oid, fileId, fileName);
   const datastream = await getAttachmentStream(oid, fileId);
-  const expectedSize = Number(datastream.size ?? 0);
-  if (expectedSize > 0) {
-    const diskSpace = await checkDiskSpace(tempDir);
-    if (diskSpace.free < expectedSize + config.assets.staging.diskSpaceThresholdBytes) {
-      throw validationError(`Not enough free disk space to upload '${fileName}'`);
-    }
-  } else {
-    const diskSpace = await checkDiskSpace(tempDir);
-    const requiredBytes = config.assets.staging.diskSpaceThresholdBytes + UNKNOWN_SIZE_STAGING_BUFFER_BYTES;
-    if (diskSpace.free < requiredBytes) {
-      throw validationError(`Not enough free disk space to upload '${fileName}'`);
-    }
-  }
 
   let uploadSucceeded = false;
 
   try {
-    const stagedSize = await stageAttachmentToDisk(datastream, filePath);
-    if (expectedSize <= 0) {
-      const diskSpace = await checkDiskSpace(tempDir);
-      if (diskSpace.free < stagedSize + config.assets.staging.diskSpaceThresholdBytes) {
-        throw validationError(`Not enough free disk space to upload '${fileName}'`);
-      }
-    }
-
+    const stagedSize = await stageAttachmentToDisk(disk, stagingKey, datastream);
     const uploadInit = await client.createArticleFile(articleId, {
       name: fileName,
-      size: stagedSize
+      size: stagedSize,
     });
     const uploadDescriptor = await client.getLocation(uploadInit.location);
     const uploadUrl = uploadDescriptor.upload_url;
@@ -161,12 +186,9 @@ async function uploadAttachment(client: FigshareClient, config: FigsharePublishi
     const partsDescriptor = await client.getLocation(uploadUrl);
     const parts = partsDescriptor.parts ?? [];
 
-    for (const part of parts) {
-      const readStream = fs.createReadStream(filePath, {
-        start: part.startOffset,
-        end: part.endOffset
-      });
-      await client.uploadFilePart(uploadUrl, part.partNo, readStream);
+    const source = await disk.getStream(stagingKey);
+    for await (const { partNo, stream } of readPartsSequentially(source, parts)) {
+      await client.uploadFilePart(uploadUrl, partNo, stream);
     }
 
     await client.completeFileUpload(articleId, figshareFileId, {});
@@ -174,15 +196,22 @@ async function uploadAttachment(client: FigshareClient, config: FigsharePublishi
     uploadSucceeded = true;
     return uploadedFile as unknown as FigshareFile;
   } finally {
-    const shouldDeleteStagingDir = !uploadSucceeded || config.assets.staging.cleanupPolicy === 'deleteAfterSuccess';
-    if (shouldDeleteStagingDir && fs.existsSync(stagingDir)) {
-      await fs.promises.rm(stagingDir, { recursive: true, force: true });
+    const shouldDelete = !uploadSucceeded || config.assets.staging.cleanupPolicy === 'deleteAfterSuccess';
+    if (shouldDelete) {
+      await disk
+        .delete(stagingKey)
+        .catch(error => sails.log.warn(`FigService - failed to delete staged object '${stagingKey}'`, error));
     }
   }
 }
 
-async function syncLinkOnlyFiles(client: FigshareClient, articleId: string, selectedUrls: DataLocationEntry[], currentFiles: FigshareFile[]): Promise<FigshareFile[]> {
-  const existingLinkFiles = currentFiles.filter((entry) => entry.is_link_only === true);
+async function syncLinkOnlyFiles(
+  client: FigshareClient,
+  articleId: string,
+  selectedUrls: DataLocationEntry[],
+  currentFiles: FigshareFile[]
+): Promise<FigshareFile[]> {
+  const existingLinkFiles = currentFiles.filter(entry => entry.is_link_only === true);
 
   const uploadedUrls: FigshareFile[] = [];
   const creationErrors: Error[] = [];
@@ -196,7 +225,7 @@ async function syncLinkOnlyFiles(client: FigshareClient, articleId: string, sele
       attempt += 1;
       try {
         responseLocation = await client.createArticleFile(articleId, {
-          link: entry.location ?? ''
+          link: entry.location ?? '',
         });
         break;
       } catch (error) {
@@ -214,7 +243,7 @@ async function syncLinkOnlyFiles(client: FigshareClient, articleId: string, sele
           name: entry.name ?? entry.originalFileName ?? String(entry.location ?? ''),
           status: uploadedFile.status,
           download_url: uploadedFile.download_url,
-          is_link_only: true
+          is_link_only: true,
         } as FigshareFile);
       } catch (error) {
         creationErrors.push(error instanceof Error ? error : new Error(String(error)));
@@ -223,7 +252,9 @@ async function syncLinkOnlyFiles(client: FigshareClient, articleId: string, sele
   }
 
   if (creationErrors.length > 0) {
-    throw validationError(`Failed to create ${creationErrors.length} Figshare link file(s); existing link files were not deleted`);
+    throw validationError(
+      `Failed to create ${creationErrors.length} Figshare link file(s); existing link files were not deleted`
+    );
   }
 
   for (const file of existingLinkFiles) {
@@ -232,8 +263,14 @@ async function syncLinkOnlyFiles(client: FigshareClient, articleId: string, sele
   return uploadedUrls;
 }
 
-function toFixtureFigshareFile(entry: DataLocationEntry, articleId: string, index: number, isLinkOnly: boolean): FigshareFile {
-  const derivedName = entry.name ?? entry.originalFileName ?? (isLinkOnly ? `link-${index + 1}` : `attachment-${index + 1}`);
+function toFixtureFigshareFile(
+  entry: DataLocationEntry,
+  articleId: string,
+  index: number,
+  isLinkOnly: boolean
+): FigshareFile {
+  const derivedName =
+    entry.name ?? entry.originalFileName ?? (isLinkOnly ? `link-${index + 1}` : `attachment-${index + 1}`);
   return {
     id: `fixture-${isLinkOnly ? 'url' : 'attachment'}-${index + 1}`,
     name: derivedName,
@@ -242,7 +279,7 @@ function toFixtureFigshareFile(entry: DataLocationEntry, articleId: string, inde
     size: 0,
     is_link_only: isLinkOnly,
     download_url: isLinkOnly ? String(entry.location ?? '') : String(entry.download_url ?? ''),
-    computed_md5: 'fixture-md5'
+    computed_md5: 'fixture-md5',
   } as FigshareFile;
 }
 
@@ -254,8 +291,8 @@ export async function syncAssetsPhase(
   syncState: FigshareSyncState
 ): Promise<AssetSyncResult> {
   const selectedDataLocations = getSelectedDataLocations(config, record);
-  const selectedAttachments = selectedDataLocations.filter((entry) => entry.type === 'attachment');
-  const selectedUrls = selectedDataLocations.filter((entry) => entry.type === 'url');
+  const selectedAttachments = selectedDataLocations.filter(entry => entry.type === 'attachment');
+  const selectedUrls = selectedDataLocations.filter(entry => entry.type === 'url');
   const articleId = String(article.id);
 
   const attachmentCount = selectedAttachments.length;
@@ -268,16 +305,17 @@ export async function syncAssetsPhase(
 
   if (config.runtime.mode === 'fixture') {
     const uploadsComplete = !(attachmentCount > 0 && config.article.publishMode === 'afterUploadsComplete');
-    syncState.status = attachmentCount > 0 && config.article.publishMode === 'afterUploadsComplete'
-      ? 'awaiting_upload_completion'
-      : 'syncing';
+    syncState.status =
+      attachmentCount > 0 && config.article.publishMode === 'afterUploadsComplete'
+        ? 'awaiting_upload_completion'
+        : 'syncing';
     syncState.partialProgress = {
       articleId,
       attachmentCount,
       urlCount,
       uploadsComplete,
       uploadedAttachmentCount: attachmentCount,
-      uploadedUrlCount: urlCount
+      uploadedUrlCount: urlCount,
     };
     setSyncState(config, record, syncState);
     return {
@@ -285,9 +323,11 @@ export async function syncAssetsPhase(
       attachmentCount,
       urlCount,
       uploadsComplete,
-      uploadedAttachments: selectedAttachments.map((entry, index) => toFixtureFigshareFile(entry, articleId, index, false)),
+      uploadedAttachments: selectedAttachments.map((entry, index) =>
+        toFixtureFigshareFile(entry, articleId, index, false)
+      ),
       uploadedUrls: selectedUrls.map((entry, index) => toFixtureFigshareFile(entry, articleId, index, true)),
-      dataLocations: selectedDataLocations
+      dataLocations: selectedDataLocations,
     };
   }
 
@@ -297,7 +337,7 @@ export async function syncAssetsPhase(
   if (config.assets.enableHostedFiles) {
     for (const attachment of selectedAttachments) {
       const fileName = attachment.name ?? '';
-      const alreadyUploaded = currentFiles.find((entry) => entry.name === fileName);
+      const alreadyUploaded = currentFiles.find(entry => entry.name === fileName);
       if (alreadyUploaded != null) {
         uploadedAttachments.push(alreadyUploaded);
         continue;
@@ -312,15 +352,17 @@ export async function syncAssetsPhase(
     : [];
 
   const refreshedFiles = attachmentCount > 0 ? await listArticleFiles(client, articleId) : currentFiles;
-  const uploadsComplete = attachmentCount === 0
-    ? true
-    : config.article.publishMode === 'afterUploadsComplete' && uploadedAttachmentCountThisRun > 0
-      ? false
-      : !hasPendingUploads(refreshedFiles);
+  const uploadsComplete =
+    attachmentCount === 0
+      ? true
+      : config.article.publishMode === 'afterUploadsComplete' && uploadedAttachmentCountThisRun > 0
+        ? false
+        : !hasPendingUploads(refreshedFiles);
 
-  syncState.status = attachmentCount > 0 && config.article.publishMode === 'afterUploadsComplete'
-    ? 'awaiting_upload_completion'
-    : 'syncing';
+  syncState.status =
+    attachmentCount > 0 && config.article.publishMode === 'afterUploadsComplete'
+      ? 'awaiting_upload_completion'
+      : 'syncing';
   syncState.partialProgress = {
     articleId,
     attachmentCount,
@@ -328,7 +370,7 @@ export async function syncAssetsPhase(
     uploadsComplete,
     uploadedAttachmentCountThisRun,
     uploadedAttachmentCount: uploadedAttachments.length,
-    uploadedUrlCount: uploadedUrls.length
+    uploadedUrlCount: uploadedUrls.length,
   };
   setSyncState(config, record, syncState);
 
@@ -339,6 +381,6 @@ export async function syncAssetsPhase(
     uploadsComplete,
     uploadedAttachments,
     uploadedUrls,
-    dataLocations: selectedDataLocations
+    dataLocations: selectedDataLocations,
   };
 }

--- a/packages/redbox-core/test/services/FigshareService.test.ts
+++ b/packages/redbox-core/test/services/FigshareService.test.ts
@@ -1880,7 +1880,7 @@ describe('FigshareService', function () {
       expect((global as any).StorageManagerService.stagingDisk.calledOnce).to.equal(true);
     });
 
-    it('falls back to the configured staging disk when the named disk is not registered', async function () {
+    it('falls back to the configured staging disk when the built-in Figshare disk is not registered', async function () {
       const fakeDisk = makeFakeDisk();
       (global as any).StorageManagerService = {
         disk: sinon.stub().throws(new Error("disk 'figshare-staging' is not registered")),
@@ -1898,6 +1898,32 @@ describe('FigshareService', function () {
       expect((global as any).StorageManagerService.stagingDisk.calledOnce).to.equal(true);
       expect(fakeDisk.calls.put).to.have.lengthOf(1);
       expect(((global as any).sails.log.warn as sinon.SinonStub).called).to.equal(true);
+    });
+
+    it('fails fast when a custom Figshare staging disk is not registered', async function () {
+      const fakeDisk = makeFakeDisk();
+      const diskError = new Error("disk 'custom-figshare-staging' is not registered");
+      (global as any).StorageManagerService = {
+        disk: sinon.stub().throws(diskError),
+        stagingDisk: sinon.stub().returns(fakeDisk.disk),
+      };
+      installDatastreamStub(Buffer.from('abcdefgh'), 8);
+      const client = buildAssetClient([{ partNo: 1, startOffset: 0, endOffset: 7 }]);
+      const config = buildLiveAssetConfig({ staging: { disk: 'custom-figshare-staging' } });
+      const record = buildAssetRecord([{ type: 'attachment', fileId: 'file-1', name: 'file.txt', selected: true }]);
+
+      let error: Error | undefined;
+      try {
+        await syncAssetsPhase(client, config, record, { id: 'article-1' }, { status: 'syncing' });
+      } catch (err) {
+        error = err as Error;
+      }
+
+      expect(error).to.equal(diskError);
+      expect((global as any).StorageManagerService.disk.calledWith('custom-figshare-staging')).to.equal(true);
+      expect((global as any).StorageManagerService.stagingDisk.called).to.equal(false);
+      expect(fakeDisk.calls.put).to.deep.equal([]);
+      expect(((global as any).sails.log.warn as sinon.SinonStub).called).to.equal(false);
     });
 
     it('does not touch StorageManager in fixture mode', async function () {

--- a/packages/redbox-core/test/services/FigshareService.test.ts
+++ b/packages/redbox-core/test/services/FigshareService.test.ts
@@ -370,21 +370,15 @@ describe('FigshareService', function () {
       updateMeta: sinon.stub().resolves({ success: true }),
     };
     (global as any).UsersService = {
-      getUserWithUsername: sinon
-        .stub()
-        .returns({
-          toPromise: sinon
-            .stub()
-            .resolves({ username: 'figshare-job-user', type: 'admin', roles: [{ name: 'admin' }] }),
-        }),
+      getUserWithUsername: sinon.stub().returns({
+        toPromise: sinon.stub().resolves({ username: 'figshare-job-user', type: 'admin', roles: [{ name: 'admin' }] }),
+      }),
     };
     (global as any).IntegrationAuditService = {
-      startAudit: sinon
-        .stub()
-        .callsFake((_oid: string, _action: string, opts: Record<string, unknown>) => ({
-          startedAt: '2025-01-01T00:00:00.000Z',
-          ...opts,
-        })),
+      startAudit: sinon.stub().callsFake((_oid: string, _action: string, opts: Record<string, unknown>) => ({
+        startedAt: '2025-01-01T00:00:00.000Z',
+        ...opts,
+      })),
       completeAudit: sinon.stub(),
       failAudit: sinon.stub(),
     };
@@ -1659,6 +1653,10 @@ describe('FigshareService', function () {
   });
 
   describe('syncAssetsPhase (live upload)', function () {
+    // Staging keys carry a per-attempt random UUID segment, e.g.
+    // `figshare/article-1-oid-1-file-1-<uuid>/file.txt`.
+    const STAGING_KEY_PATTERN = /^figshare\/article-1-oid-1-file-1-[0-9a-f-]{36}\/file\.txt$/;
+
     it('stages attachments through StorageManager and uploads ordered Figshare parts', async function () {
       const fakeDisk = makeFakeDisk();
       (global as any).StorageManagerService = {
@@ -1681,7 +1679,8 @@ describe('FigshareService', function () {
 
       const result = await syncAssetsPhase(client, config, record, { id: 'article-1' }, syncState);
 
-      const stagingKey = 'figshare/article-1-oid-1-file-1/file.txt';
+      const stagingKey = fakeDisk.calls.put[0].key;
+      expect(stagingKey).to.match(STAGING_KEY_PATTERN);
       expect((global as any).StorageManagerService.disk.calledWith('figshare-staging')).to.equal(true);
       expect(getDatastreamStub.calledWith('oid-1', 'file-1')).to.equal(true);
       expect(fakeDisk.calls.put).to.deep.equal([{ key: stagingKey, options: { contentLength: payload.length } }]);
@@ -1765,7 +1764,8 @@ describe('FigshareService', function () {
 
       await syncAssetsPhase(client, config, record, { id: 'article-1' }, { status: 'syncing' });
 
-      const stagingKey = 'figshare/article-1-oid-1-file-1/file.txt';
+      const stagingKey = fakeDisk.calls.put[0].key;
+      expect(stagingKey).to.match(STAGING_KEY_PATTERN);
       expect(fakeDisk.calls.deleted).to.deep.equal([]);
       expect(fakeDisk.store.get(stagingKey)?.toString()).to.equal('abcdefgh');
     });
@@ -1790,7 +1790,8 @@ describe('FigshareService', function () {
         error = err as Error;
       }
 
-      const stagingKey = 'figshare/article-1-oid-1-file-1/file.txt';
+      const stagingKey = fakeDisk.calls.put[0].key;
+      expect(stagingKey).to.match(STAGING_KEY_PATTERN);
       expect(error?.message).to.equal('part upload failed');
       expect(fakeDisk.calls.deleted).to.deep.equal([stagingKey]);
       expect(fakeDisk.store.has(stagingKey)).to.equal(false);
@@ -1877,6 +1878,26 @@ describe('FigshareService', function () {
 
       expect((global as any).StorageManagerService.disk.called).to.equal(false);
       expect((global as any).StorageManagerService.stagingDisk.calledOnce).to.equal(true);
+    });
+
+    it('falls back to the configured staging disk when the named disk is not registered', async function () {
+      const fakeDisk = makeFakeDisk();
+      (global as any).StorageManagerService = {
+        disk: sinon.stub().throws(new Error("disk 'figshare-staging' is not registered")),
+        stagingDisk: sinon.stub().returns(fakeDisk.disk),
+      };
+      const payload = Buffer.from('abcdefgh');
+      installDatastreamStub(payload, payload.length);
+      const client = buildAssetClient([{ partNo: 1, startOffset: 0, endOffset: 7 }]);
+      const config = buildLiveAssetConfig();
+      const record = buildAssetRecord([{ type: 'attachment', fileId: 'file-1', name: 'file.txt', selected: true }]);
+
+      await syncAssetsPhase(client, config, record, { id: 'article-1' }, { status: 'syncing' });
+
+      expect((global as any).StorageManagerService.disk.calledWith('figshare-staging')).to.equal(true);
+      expect((global as any).StorageManagerService.stagingDisk.calledOnce).to.equal(true);
+      expect(fakeDisk.calls.put).to.have.lengthOf(1);
+      expect(((global as any).sails.log.warn as sinon.SinonStub).called).to.equal(true);
     });
 
     it('does not touch StorageManager in fixture mode', async function () {

--- a/packages/redbox-core/test/services/FigshareService.test.ts
+++ b/packages/redbox-core/test/services/FigshareService.test.ts
@@ -100,12 +100,15 @@ function buildFigsharePublishingConfig(overrides: Record<string, unknown> = {}) 
       enableHostedFiles: true,
       enableLinkFiles: true,
       dedupeStrategy: 'sourceId',
+      ...(overrides.assets as Record<string, unknown> | undefined),
+      // Deep-merge staging last so a partial `assets` override (or a partial
+      // `assets.staging` override) cannot erase defaults like disk/keyPrefix.
       staging: {
+        ...((config.assets as Record<string, unknown>).staging as Record<string, unknown>),
         cleanupPolicy: 'deleteAfterSuccess',
         diskSpaceThresholdBytes: 1000,
         ...((overrides.assets as Record<string, unknown> | undefined)?.staging as Record<string, unknown> | undefined),
       },
-      ...(overrides.assets as Record<string, unknown> | undefined),
     },
     embargo: {
       ...(config.embargo as Record<string, unknown>),
@@ -123,7 +126,11 @@ function buildFigsharePublishingConfig(overrides: Record<string, unknown> = {}) 
     workflow: {
       ...(config.workflow as Record<string, unknown>),
       transitionRules: [],
+      ...(overrides.workflow as Record<string, unknown> | undefined),
+      // Deep-merge transitionJob last so a partial `workflow` override (or a partial
+      // `workflow.transitionJob` override) cannot erase the other transitionJob settings.
       transitionJob: {
+        ...((config.workflow as Record<string, unknown>).transitionJob as Record<string, unknown>),
         enabled: false,
         namedQuery: '',
         targetStep: '',
@@ -136,7 +143,6 @@ function buildFigsharePublishingConfig(overrides: Record<string, unknown> = {}) 
           | Record<string, unknown>
           | undefined),
       },
-      ...(overrides.workflow as Record<string, unknown> | undefined),
     },
     writeBack: {
       ...(config.writeBack as Record<string, unknown>),
@@ -1693,6 +1699,56 @@ describe('FigshareService', function () {
       expect(fakeDisk.store.has(stagingKey)).to.equal(false);
       expect(result.uploadedAttachments).to.have.lengthOf(1);
       expect(syncState.partialProgress?.uploadedAttachmentCountThisRun).to.equal(1);
+    });
+
+    it('streams Figshare part content without buffering each full part before upload', async function () {
+      const fakeDisk = makeFakeDisk();
+      let stagedSourceReads = 0;
+      fakeDisk.disk.getStream = async (key: string) => {
+        const buffer = fakeDisk.store.get(key);
+        if (buffer == null) {
+          throw new Error(`Missing fake disk key ${key}`);
+        }
+        const stagedBuffer = buffer;
+
+        async function* chunks() {
+          for (let offset = 0; offset < stagedBuffer.length; offset += 2) {
+            stagedSourceReads += 1;
+            yield stagedBuffer.subarray(offset, offset + 2);
+          }
+        }
+
+        return Readable.from(chunks());
+      };
+      (global as any).StorageManagerService = {
+        disk: sinon.stub().returns(fakeDisk.disk),
+        stagingDisk: sinon.stub().returns(fakeDisk.disk),
+      };
+      const payload = Buffer.from('abcdefgh');
+      installDatastreamStub(payload, payload.length);
+      const uploadedParts: Buffer[] = [];
+      const readsAtUploadStart: number[] = [];
+      const client = buildAssetClient(
+        [
+          { partNo: 1, startOffset: 0, endOffset: 3 },
+          { partNo: 2, startOffset: 4, endOffset: 7 },
+        ],
+        uploadedParts
+      );
+      (client.uploadFilePart as sinon.SinonStub).callsFake(
+        async (_uploadUrl: string, _partNo: number, stream: Readable) => {
+          readsAtUploadStart.push(stagedSourceReads);
+          uploadedParts.push(await streamToBuffer(stream));
+          return {};
+        }
+      );
+      const config = buildLiveAssetConfig();
+      const record = buildAssetRecord([{ type: 'attachment', fileId: 'file-1', name: 'file.txt', selected: true }]);
+
+      await syncAssetsPhase(client, config, record, { id: 'article-1' }, { status: 'syncing' });
+
+      expect(readsAtUploadStart[0]).to.equal(0);
+      expect(uploadedParts.map(part => part.toString())).to.deep.equal(['abcd', 'efgh']);
     });
 
     it('retains the staged object after success when retainForRetry is configured', async function () {

--- a/packages/redbox-core/test/services/FigshareService.test.ts
+++ b/packages/redbox-core/test/services/FigshareService.test.ts
@@ -1,4 +1,5 @@
 import * as sinon from 'sinon';
+import { Readable } from 'node:stream';
 import { Services } from '../../src/services/FigshareService';
 import { ServiceExports } from '../../src/services';
 import { agendaQueue } from '../../src/config/agendaQueue.config';
@@ -7,6 +8,7 @@ import { cleanupServiceTestGlobals, createMockSails, setupServiceTestGlobals } f
 import { resolveFigsharePublishingConfig } from '../../src/services/figshare-v2/config';
 import { mapCreateArticleResponse } from '../../src/services/figshare-v2/http';
 import { buildMetadataPayload, syncMetadataPhase } from '../../src/services/figshare-v2/metadata';
+import { syncAssetsPhase } from '../../src/services/figshare-v2/assets';
 import { getRecordField, setRecordField } from '../../src/services/figshare-v2/types';
 import { RBValidationError } from '../../src/model/RBValidationError';
 import type { RecordModel } from '../../src/services/figshare-v2/types';
@@ -26,14 +28,20 @@ function buildFigsharePublishingConfig(overrides: Record<string, unknown> = {}) 
     ...overrides,
     enabled: overrides.enabled ?? true,
     connection: {
-      ...config.connection as Record<string, unknown>,
+      ...(config.connection as Record<string, unknown>),
       baseUrl: 'https://api.figshare.com',
       frontEndUrl: 'https://figshare.com',
       token: 'token',
       timeoutMs: 1000,
       operationTimeouts: { metadataMs: 1000, uploadInitMs: 1000, uploadPartMs: 1000, publishMs: 1000 },
-      retry: { maxAttempts: 1, baseDelayMs: 1, maxDelayMs: 1, retryOnStatusCodes: [], retryOnMethods: ['get', 'put', 'delete'] },
-      ...(overrides.connection as Record<string, unknown> | undefined)
+      retry: {
+        maxAttempts: 1,
+        baseDelayMs: 1,
+        maxDelayMs: 1,
+        retryOnStatusCodes: [],
+        retryOnMethods: ['get', 'put', 'delete'],
+      },
+      ...(overrides.connection as Record<string, unknown> | undefined),
     },
     article: {
       ...(config.article as Record<string, unknown>),
@@ -41,7 +49,7 @@ function buildFigsharePublishingConfig(overrides: Record<string, unknown> = {}) 
       publishMode: 'manual',
       republishOnMetadataChange: true,
       republishOnAssetChange: true,
-      ...(overrides.article as Record<string, unknown> | undefined)
+      ...(overrides.article as Record<string, unknown> | undefined),
     },
     record: {
       ...(config.record as Record<string, unknown>),
@@ -52,14 +60,14 @@ function buildFigsharePublishingConfig(overrides: Record<string, unknown> = {}) 
       errorPath: 'metadata.figshareError',
       syncStatePath: 'metadata.figshareSyncState',
       allFilesUploadedPath: '',
-      ...(overrides.record as Record<string, unknown> | undefined)
+      ...(overrides.record as Record<string, unknown> | undefined),
     },
     selection: {
       ...(config.selection as Record<string, unknown>),
       attachmentMode: 'selectedOnly',
       urlMode: 'selectedOnly',
       selectedFlagPath: 'selected',
-      ...(overrides.selection as Record<string, unknown> | undefined)
+      ...(overrides.selection as Record<string, unknown> | undefined),
     },
     authors: {
       ...(config.authors as Record<string, unknown>),
@@ -68,7 +76,7 @@ function buildFigsharePublishingConfig(overrides: Record<string, unknown> = {}) 
       externalNameField: 'text_full_name',
       maxInlineAuthors: 10,
       lookup: [],
-      ...(overrides.authors as Record<string, unknown> | undefined)
+      ...(overrides.authors as Record<string, unknown> | undefined),
     },
     metadata: {
       ...(config.metadata as Record<string, unknown>),
@@ -78,35 +86,39 @@ function buildFigsharePublishingConfig(overrides: Record<string, unknown> = {}) 
       license: { source: { kind: 'path', path: 'metadata.license' }, matchBy: 'urlContains', required: true },
       categories: { source: { kind: 'path', path: 'metadata.forCodes' }, mappingStrategy: 'for2020Mapping' },
       customFields: [],
-      ...(overrides.metadata as Record<string, unknown> | undefined)
+      ...(overrides.metadata as Record<string, unknown> | undefined),
     },
     categories: {
       ...(config.categories as Record<string, unknown>),
       strategy: 'for2020Mapping',
       mappingTable: [{ sourceCode: '0101', figshareCategoryId: 10 }],
       allowUnmapped: true,
-      ...(overrides.categories as Record<string, unknown> | undefined)
+      ...(overrides.categories as Record<string, unknown> | undefined),
     },
     assets: {
       ...(config.assets as Record<string, unknown>),
       enableHostedFiles: true,
       enableLinkFiles: true,
       dedupeStrategy: 'sourceId',
-      staging: { cleanupPolicy: 'deleteAfterSuccess', diskSpaceThresholdBytes: 1000, ...(overrides.assets as Record<string, unknown> | undefined)?.staging as Record<string, unknown> | undefined },
-      ...(overrides.assets as Record<string, unknown> | undefined)
+      staging: {
+        cleanupPolicy: 'deleteAfterSuccess',
+        diskSpaceThresholdBytes: 1000,
+        ...((overrides.assets as Record<string, unknown> | undefined)?.staging as Record<string, unknown> | undefined),
+      },
+      ...(overrides.assets as Record<string, unknown> | undefined),
     },
     embargo: {
       ...(config.embargo as Record<string, unknown>),
       mode: 'recordDriven',
       forceSync: true,
       accessRights: { accessRights: { kind: 'path', path: 'metadata.accessRights' } },
-      ...(overrides.embargo as Record<string, unknown> | undefined)
+      ...(overrides.embargo as Record<string, unknown> | undefined),
     },
     queue: {
       ...(config.queue as Record<string, unknown>),
       publishAfterUploadDelay: 'in 2 minutes',
       uploadedFilesCleanupDelay: 'in 5 minutes',
-      ...(overrides.queue as Record<string, unknown> | undefined)
+      ...(overrides.queue as Record<string, unknown> | undefined),
     },
     workflow: {
       ...(config.workflow as Record<string, unknown>),
@@ -120,17 +132,19 @@ function buildFigsharePublishingConfig(overrides: Record<string, unknown> = {}) 
         figshareTargetFieldValue: '',
         username: '',
         userType: '',
-        ...((overrides.workflow as Record<string, unknown> | undefined)?.transitionJob as Record<string, unknown> | undefined)
+        ...((overrides.workflow as Record<string, unknown> | undefined)?.transitionJob as
+          | Record<string, unknown>
+          | undefined),
       },
-      ...(overrides.workflow as Record<string, unknown> | undefined)
+      ...(overrides.workflow as Record<string, unknown> | undefined),
     },
     writeBack: {
       ...(config.writeBack as Record<string, unknown>),
       articleId: 'metadata.figshare_article_id',
       articleUrls: ['metadata.figshare_article_location'],
       extraFields: [],
-      ...(overrides.writeBack as Record<string, unknown> | undefined)
-    }
+      ...(overrides.writeBack as Record<string, unknown> | undefined),
+    },
   };
 }
 
@@ -141,13 +155,157 @@ function buildFigshareDevConfig(overrides: Record<string, unknown> = {}) {
     fixtures: {
       article: {
         id: 'fixture-123',
-        url: 'https://figshare.com/articles/fixture-123'
+        url: 'https://figshare.com/articles/fixture-123',
       },
       licenses: [{ value: 1, name: 'CC-BY', url: 'https://license.test/cc-by' }],
       categories: [{ id: 10, title: 'Category 10' }],
-      articleFiles: []
+      articleFiles: [],
     },
-    ...overrides
+    ...overrides,
+  };
+}
+
+function makeFakeDisk() {
+  const store = new Map<string, Buffer>();
+  const calls = {
+    put: [] as Array<{ key: string; options?: Record<string, unknown> }>,
+    deleted: [] as string[],
+  };
+  const disk = {
+    async putStream(key: string, stream: Readable, options?: Record<string, unknown>) {
+      const chunks: Buffer[] = [];
+      for await (const chunk of stream) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      store.set(key, Buffer.concat(chunks));
+      calls.put.push({ key, options });
+    },
+    async getMetaData(key: string) {
+      const buffer = store.get(key);
+      if (buffer == null) {
+        throw new Error(`Missing fake disk key ${key}`);
+      }
+      return { contentLength: buffer.length, etag: 'fake-etag', lastModified: new Date('2026-01-01T00:00:00.000Z') };
+    },
+    async getStream(key: string) {
+      const buffer = store.get(key);
+      if (buffer == null) {
+        throw new Error(`Missing fake disk key ${key}`);
+      }
+      return Readable.from([buffer]);
+    },
+    async delete(key: string) {
+      store.delete(key);
+      calls.deleted.push(key);
+    },
+    async exists(key: string) {
+      return store.has(key);
+    },
+  };
+  return { disk, store, calls };
+}
+
+async function streamToBuffer(stream: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+function buildLiveAssetConfig(overrides: Record<string, unknown> = {}) {
+  const base = buildFigsharePublishingConfig() as unknown as FigsharePublishingConfigData & Record<string, unknown>;
+  return {
+    ...base,
+    runtime: { mode: 'live' },
+    assets: {
+      ...base.assets,
+      staging: {
+        disk: 'figshare-staging',
+        keyPrefix: 'figshare/',
+        tempDir: '',
+        cleanupPolicy: 'deleteAfterSuccess',
+        diskSpaceThresholdBytes: 1000,
+        ...(overrides as { staging?: Record<string, unknown> }).staging,
+      },
+    },
+  } as any;
+}
+
+function buildAssetRecord(dataLocations: any[]): RecordModel {
+  return {
+    redboxOid: 'oid-1',
+    harvestId: '',
+    metaMetadata: {
+      brandId: 'default',
+      createdBy: 'admin',
+      type: 'dataPublication',
+      searchCore: 'default',
+      form: 'dataPublication-1.0-review',
+      attachmentFields: [],
+    },
+    metadata: { dataLocations },
+    workflow: { stage: 'queued', stageLabel: 'Queued For Review' },
+    authorization: {
+      view: [],
+      edit: [],
+      editRoles: [],
+      viewRoles: [],
+      editPending: [],
+      viewPending: [],
+      stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] },
+    },
+    dateCreated: '',
+    lastSaveDate: '',
+    id: '',
+  };
+}
+
+function installDatastreamStub(buffer: Buffer, size?: number) {
+  (global as any).sails.config.record = { datastreamService: 'datastreamservice' };
+  (global as any).sails.services.datastreamservice = {
+    getDatastream: sinon.stub().resolves({
+      readstream: Readable.from([buffer]),
+      ...(size === undefined ? {} : { size }),
+    }),
+  };
+  return (global as any).sails.services.datastreamservice.getDatastream as sinon.SinonStub;
+}
+
+function buildAssetClient(
+  parts: Array<{ partNo: number; startOffset: number; endOffset: number }>,
+  uploadedParts: Buffer[] = []
+): FigshareClient {
+  const uploadUrl = 'https://upload.figshare.test/file-1';
+  return {
+    createArticle: async () => ({ id: 'unused' }),
+    updateArticle: async () => ({ id: 'unused' }),
+    getArticle: async () => ({ id: 'unused' }),
+    listArticleFiles: sinon.stub().resolves([]) as any,
+    createArticleFile: sinon.stub().resolves({ location: 'https://api.figshare.test/file-1' }) as any,
+    getLocation: sinon.stub().callsFake(async (location: string) => {
+      if (location === uploadUrl) {
+        return { parts };
+      }
+      return {
+        id: 'figshare-file-1',
+        name: 'file.txt',
+        upload_url: uploadUrl,
+        status: 'available',
+        download_url: 'https://figshare.test/file.txt',
+      };
+    }) as any,
+    uploadFilePart: sinon.stub().callsFake(async (_uploadUrl: string, _partNo: number, stream: Readable) => {
+      uploadedParts.push(await streamToBuffer(stream));
+      return {};
+    }) as any,
+    completeFileUpload: sinon.stub().resolves({}) as any,
+    deleteArticleFile: sinon.stub().resolves({}) as any,
+    setEmbargo: async () => ({}),
+    clearEmbargo: async () => ({}),
+    publishArticle: async () => ({}),
+    listLicenses: async () => [],
+    searchInstitutionAccounts: async () => [],
   };
 }
 
@@ -170,14 +328,14 @@ describe('FigshareService', function () {
         silly: sinon.stub(),
         blank: sinon.stub(),
         log: sinon.stub(),
-        silent: sinon.stub()
-      }
+        silent: sinon.stub(),
+      },
     });
     mockSails.config.queue = { serviceName: 'queueservice' };
     mockSails.config.figshareDev = buildFigshareDevConfig();
     const mockQueueService = {
       now: sinon.stub(),
-      schedule: sinon.stub()
+      schedule: sinon.stub(),
     };
     mockSails.services.queueservice = mockQueueService;
 
@@ -188,47 +346,60 @@ describe('FigshareService', function () {
       figsharePublishing: buildFigsharePublishingConfig({
         queue: {
           publishAfterUploadDelay: brand === 'brand-immediate' ? 'immediate' : 'in 2 minutes',
-          uploadedFilesCleanupDelay: brand === 'brand-immediate' ? 'immediate' : 'in 5 minutes'
-        }
-      })
+          uploadedFilesCleanupDelay: brand === 'brand-immediate' ? 'immediate' : 'in 5 minutes',
+        },
+      }),
     }));
     sinon.stub(ServiceExports, 'AppConfigService').get(() => ({
-      getAppConfigurationForBrand: appConfigByBrandStub
+      getAppConfigurationForBrand: appConfigByBrandStub,
     }));
     (global as any).BrandingService = {
       getBrand: sinon.stub().returns({ id: 'default-id', name: 'default' }),
       getBrandById: sinon.stub().returns(undefined),
-      getDefault: sinon.stub().returns({ id: 'default-id', name: 'default' })
+      getDefault: sinon.stub().returns({ id: 'default-id', name: 'default' }),
     };
     (global as any).RecordsService = {
       getMeta: sinon.stub().resolves({}),
       hasEditAccess: sinon.stub().resolves(true),
-      updateMeta: sinon.stub().resolves({ success: true })
+      updateMeta: sinon.stub().resolves({ success: true }),
     };
     (global as any).UsersService = {
-      getUserWithUsername: sinon.stub().returns({ toPromise: sinon.stub().resolves({ username: 'figshare-job-user', type: 'admin', roles: [{ name: 'admin' }] }) })
+      getUserWithUsername: sinon
+        .stub()
+        .returns({
+          toPromise: sinon
+            .stub()
+            .resolves({ username: 'figshare-job-user', type: 'admin', roles: [{ name: 'admin' }] }),
+        }),
     };
     (global as any).IntegrationAuditService = {
-      startAudit: sinon.stub().callsFake((_oid: string, _action: string, opts: Record<string, unknown>) => ({ startedAt: '2025-01-01T00:00:00.000Z', ...opts })),
+      startAudit: sinon
+        .stub()
+        .callsFake((_oid: string, _action: string, opts: Record<string, unknown>) => ({
+          startedAt: '2025-01-01T00:00:00.000Z',
+          ...opts,
+        })),
       completeAudit: sinon.stub(),
       failAudit: sinon.stub(),
     };
     (global as any).TranslationService = {
-      t: sinon.stub().returnsArg(0)
+      t: sinon.stub().returnsArg(0),
     };
     (global as any).NamedQueryService = {
       getNamedQueryConfig: sinon.stub().resolves({}),
-      performNamedQueryFromConfigResults: sinon.stub().resolves([])
+      performNamedQueryFromConfigResults: sinon.stub().resolves([]),
     };
     (global as any).RecordTypesService = {
-      get: sinon.stub().returns({ toPromise: sinon.stub().resolves({}) })
+      get: sinon.stub().returns({ toPromise: sinon.stub().resolves({}) }),
     };
     (global as any).WorkflowStepsService = {
-      get: sinon.stub().returns({ toPromise: sinon.stub().resolves({}) })
+      get: sinon.stub().returns({ toPromise: sinon.stub().resolves({}) }),
     };
 
     service = new Services.FigshareService();
-    getConfigStub = sinon.stub(service, 'getConfig').callsFake((record?: any) => resolveFigsharePublishingConfig(record));
+    getConfigStub = sinon
+      .stub(service, 'getConfig')
+      .callsFake((record?: any) => resolveFigsharePublishingConfig(record));
   });
 
   afterEach(function () {
@@ -257,37 +428,78 @@ describe('FigshareService', function () {
   it('honours triggerCondition before Figshare lifecycle sync', async function () {
     const options = {
       triggerCondition:
-        '<%= _.isEqual(record.workflow.stage, "queued") && _.isEqual(_.get(record, "metadata.dataset-will-be-published"), "yes") %>'
+        '<%= _.isEqual(record.workflow.stage, "queued") && _.isEqual(_.get(record, "metadata.dataset-will-be-published"), "yes") %>',
     };
     const draftRecord = {
       redboxOid: 'oid-draft',
       harvestId: '',
-      metaMetadata: { brandId: 'default', createdBy: 'admin', type: 'dataPublication', searchCore: 'default', form: 'dataPublication-1.0-draft', attachmentFields: [] },
+      metaMetadata: {
+        brandId: 'default',
+        createdBy: 'admin',
+        type: 'dataPublication',
+        searchCore: 'default',
+        form: 'dataPublication-1.0-draft',
+        attachmentFields: [],
+      },
       workflow: { stage: 'draft', stageLabel: 'Draft' },
-      authorization: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [], stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] } },
+      authorization: {
+        view: [],
+        edit: [],
+        editRoles: [],
+        viewRoles: [],
+        editPending: [],
+        viewPending: [],
+        stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] },
+      },
       metadata: {
         title: 'Draft dataset',
-        'dataset-will-be-published': 'yes'
+        'dataset-will-be-published': 'yes',
       },
       dateCreated: '',
       lastSaveDate: '',
-      id: ''
+      id: '',
     };
     const queuedRecord = {
       redboxOid: 'oid-queued',
       harvestId: '',
-      metaMetadata: { brandId: 'default', createdBy: 'admin', type: 'dataPublication', searchCore: 'default', form: 'dataPublication-1.0-review', attachmentFields: [] },
+      metaMetadata: {
+        brandId: 'default',
+        createdBy: 'admin',
+        type: 'dataPublication',
+        searchCore: 'default',
+        form: 'dataPublication-1.0-review',
+        attachmentFields: [],
+      },
       workflow: { stage: 'queued', stageLabel: 'Queued For Review' },
-      authorization: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [], stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] } },
+      authorization: {
+        view: [],
+        edit: [],
+        editRoles: [],
+        viewRoles: [],
+        editPending: [],
+        viewPending: [],
+        stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] },
+      },
       metadata: {
         title: 'Queued dataset',
-        'dataset-will-be-published': 'yes'
+        'dataset-will-be-published': 'yes',
       },
       dateCreated: '',
       lastSaveDate: '',
-      id: ''
+      id: '',
     };
-    const user = { id: 'user-1', username: 'user-1', type: 'admin', name: 'User One', email: 'user-1@example.org', lastLogin: new Date(), additionalAttributes: {}, loginDisabled: false, workspaceApps: [], roles: [] };
+    const user = {
+      id: 'user-1',
+      username: 'user-1',
+      type: 'admin',
+      name: 'User One',
+      email: 'user-1@example.org',
+      lastLogin: new Date(),
+      additionalAttributes: {},
+      loginDisabled: false,
+      workspaceApps: [],
+      roles: [],
+    };
     const syncStub = sinon.stub(service, 'syncRecordWithFigshare').resolves(queuedRecord);
 
     const skipped = service.createUpdateFigshareArticle('oid-draft', draftRecord, options, user);
@@ -307,18 +519,44 @@ describe('FigshareService', function () {
     const record = {
       redboxOid: 'oid-no-condition',
       harvestId: '',
-      metaMetadata: { brandId: 'default', createdBy: 'admin', type: 'dataPublication', searchCore: 'default', form: 'dataPublication-1.0-review', attachmentFields: [] },
+      metaMetadata: {
+        brandId: 'default',
+        createdBy: 'admin',
+        type: 'dataPublication',
+        searchCore: 'default',
+        form: 'dataPublication-1.0-review',
+        attachmentFields: [],
+      },
       workflow: { stage: 'queued', stageLabel: 'Queued For Review' },
-      authorization: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [], stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] } },
+      authorization: {
+        view: [],
+        edit: [],
+        editRoles: [],
+        viewRoles: [],
+        editPending: [],
+        viewPending: [],
+        stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] },
+      },
       metadata: {
         title: 'Queued dataset',
-        'dataset-will-be-published': 'yes'
+        'dataset-will-be-published': 'yes',
       },
       dateCreated: '',
       lastSaveDate: '',
-      id: ''
+      id: '',
     };
-    const user = { id: 'user-1', username: 'user-1', type: 'admin', name: 'User One', email: 'user-1@example.org', lastLogin: new Date(), additionalAttributes: {}, loginDisabled: false, workspaceApps: [], roles: [] };
+    const user = {
+      id: 'user-1',
+      username: 'user-1',
+      type: 'admin',
+      name: 'User One',
+      email: 'user-1@example.org',
+      lastLogin: new Date(),
+      additionalAttributes: {},
+      loginDisabled: false,
+      workspaceApps: [],
+      roles: [],
+    };
     const syncStub = sinon.stub(service, 'syncRecordWithFigshare').resolves(record);
 
     const synced = await service.createUpdateFigshareArticle('oid-no-condition', record, {}, user);
@@ -337,8 +575,8 @@ describe('FigshareService', function () {
         description: 'Dataset description',
         keywords: ['one'],
         forCodes: ['0101'],
-        license: 'CC-BY'
-      }
+        license: 'CC-BY',
+      },
     } as any;
 
     const result = await service.syncRecordWithFigshare(record, 'job-1');
@@ -354,19 +592,26 @@ describe('FigshareService', function () {
         customFields: [
           {
             figshareField: 'Number and size of Dataset',
-            value: { kind: 'path', path: 'metadata.dataset-size', defaultValue: '' }
+            value: { kind: 'path', path: 'metadata.dataset-size', defaultValue: '' },
           },
           {
             figshareField: 'Author Research Institute',
-            value: { kind: 'path', path: 'metadata.research-centres', defaultValue: [] }
-          }
-        ]
-      }
+            value: { kind: 'path', path: 'metadata.research-centres', defaultValue: [] },
+          },
+        ],
+      },
     }) as unknown as FigsharePublishingConfigData;
     const record: RecordModel = {
       redboxOid: 'oid-1',
       harvestId: '',
-      metaMetadata: { brandId: 'default', createdBy: 'admin', type: 'dataPublication', searchCore: 'default', form: 'dataPublication-1.0-review', attachmentFields: [] },
+      metaMetadata: {
+        brandId: 'default',
+        createdBy: 'admin',
+        type: 'dataPublication',
+        searchCore: 'default',
+        form: 'dataPublication-1.0-review',
+        attachmentFields: [],
+      },
       metadata: {
         title: 'Dataset title',
         description: 'Dataset description',
@@ -374,20 +619,28 @@ describe('FigshareService', function () {
         forCodes: ['0101'],
         license: 'CC-BY',
         'dataset-size': null,
-        'research-centres': null
+        'research-centres': null,
       },
       workflow: { stage: 'queued', stageLabel: 'Queued For Review' },
-      authorization: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [], stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] } },
+      authorization: {
+        view: [],
+        edit: [],
+        editRoles: [],
+        viewRoles: [],
+        editPending: [],
+        viewPending: [],
+        stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] },
+      },
       dateCreated: '',
       lastSaveDate: '',
-      id: ''
+      id: '',
     };
 
     const payload = await buildMetadataPayload(config, record);
 
     expect(payload.custom_fields).to.deep.equal({
       'Number and size of Dataset': '',
-      'Author Research Institute': []
+      'Author Research Institute': [],
     });
   });
 
@@ -396,20 +649,27 @@ describe('FigshareService', function () {
       metadata: {
         categories: {
           source: { kind: 'path', path: 'metadata.anzsrcFor', defaultValue: [] },
-          mappingStrategy: 'for2020Mapping'
-        }
+          mappingStrategy: 'for2020Mapping',
+        },
       },
       categories: {
         mappingTable: [
           { sourceCode: '300201', figshareCategoryId: 25508 },
-          { sourceCode: '300202', figshareCategoryId: 25509 }
-        ]
-      }
+          { sourceCode: '300202', figshareCategoryId: 25509 },
+        ],
+      },
     }) as unknown as FigsharePublishingConfigData;
     const record: RecordModel = {
       redboxOid: 'oid-1',
       harvestId: '',
-      metaMetadata: { brandId: 'default', createdBy: 'admin', type: 'dataPublication', searchCore: 'default', form: 'dataPublication-1.0-review', attachmentFields: [] },
+      metaMetadata: {
+        brandId: 'default',
+        createdBy: 'admin',
+        type: 'dataPublication',
+        searchCore: 'default',
+        form: 'dataPublication-1.0-review',
+        attachmentFields: [],
+      },
       metadata: {
         title: 'Dataset title',
         description: 'Dataset description',
@@ -417,20 +677,28 @@ describe('FigshareService', function () {
         anzsrcFor: [
           {
             notation: 'https://linked.data.gov.au/def/anzsrc-for/2020/300201',
-            label: '300201 - Agricultural hydrology'
+            label: '300201 - Agricultural hydrology',
           },
           {
             notation: 'https://linked.data.gov.au/def/anzsrc-for/2020#300202',
-            label: '300202 - Agronomy'
-          }
+            label: '300202 - Agronomy',
+          },
         ],
-        license: 'CC-BY'
+        license: 'CC-BY',
       },
       workflow: { stage: 'queued', stageLabel: 'Queued For Review' },
-      authorization: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [], stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] } },
+      authorization: {
+        view: [],
+        edit: [],
+        editRoles: [],
+        viewRoles: [],
+        editPending: [],
+        viewPending: [],
+        stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] },
+      },
       dateCreated: '',
       lastSaveDate: '',
-      id: ''
+      id: '',
     };
 
     const payload = await buildMetadataPayload(config, record);
@@ -443,14 +711,21 @@ describe('FigshareService', function () {
       metadata: {
         relatedResource: {
           title: { kind: 'path', path: 'metadata.related_data', defaultValue: [] },
-          doi: { kind: 'path', path: 'metadata.related_data', defaultValue: [] }
-        }
-      }
+          doi: { kind: 'path', path: 'metadata.related_data', defaultValue: [] },
+        },
+      },
     }) as unknown as FigsharePublishingConfigData;
     const record: RecordModel = {
       redboxOid: 'oid-1',
       harvestId: '',
-      metaMetadata: { brandId: 'default', createdBy: 'admin', type: 'dataPublication', searchCore: 'default', form: 'dataPublication-1.0-review', attachmentFields: [] },
+      metaMetadata: {
+        brandId: 'default',
+        createdBy: 'admin',
+        type: 'dataPublication',
+        searchCore: 'default',
+        form: 'dataPublication-1.0-review',
+        attachmentFields: [],
+      },
       metadata: {
         title: 'Dataset title',
         description: 'Dataset description',
@@ -461,24 +736,32 @@ describe('FigshareService', function () {
           {
             related_title: 'Related dataset one',
             related_url: 'https://doi.org/10.1234/related-one',
-            related_notes: 'First related data publication'
+            related_notes: 'First related data publication',
           },
           {
             related_title: 'Related dataset two',
             related_url: 'https://doi.org/10.1234/related-two',
-            related_notes: 'Second related data publication'
+            related_notes: 'Second related data publication',
           },
           {
             related_title: 'Missing identifier',
-            related_url: ''
-          }
-        ]
+            related_url: '',
+          },
+        ],
       },
       workflow: { stage: 'queued', stageLabel: 'Queued For Review' },
-      authorization: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [], stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] } },
+      authorization: {
+        view: [],
+        edit: [],
+        editRoles: [],
+        viewRoles: [],
+        editPending: [],
+        viewPending: [],
+        stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] },
+      },
       dateCreated: '',
       lastSaveDate: '',
-      id: ''
+      id: '',
     };
 
     const payload = await buildMetadataPayload(config, record);
@@ -486,12 +769,12 @@ describe('FigshareService', function () {
     expect(payload.related_materials).to.deep.equal([
       {
         title: 'Related dataset one',
-        identifier: 'https://doi.org/10.1234/related-one'
+        identifier: 'https://doi.org/10.1234/related-one',
       },
       {
         title: 'Related dataset two',
-        identifier: 'https://doi.org/10.1234/related-two'
-      }
+        identifier: 'https://doi.org/10.1234/related-two',
+      },
     ]);
   });
 
@@ -500,14 +783,21 @@ describe('FigshareService', function () {
       metadata: {
         relatedResource: {
           title: { kind: 'path', path: 'metadata.related_titles', defaultValue: [] },
-          doi: { kind: 'path', path: 'metadata.related_data', defaultValue: [] }
-        }
-      }
+          doi: { kind: 'path', path: 'metadata.related_data', defaultValue: [] },
+        },
+      },
     }) as unknown as FigsharePublishingConfigData;
     const record: RecordModel = {
       redboxOid: 'oid-1',
       harvestId: '',
-      metaMetadata: { brandId: 'default', createdBy: 'admin', type: 'dataPublication', searchCore: 'default', form: 'dataPublication-1.0-review', attachmentFields: [] },
+      metaMetadata: {
+        brandId: 'default',
+        createdBy: 'admin',
+        type: 'dataPublication',
+        searchCore: 'default',
+        form: 'dataPublication-1.0-review',
+        attachmentFields: [],
+      },
       metadata: {
         title: 'Dataset title',
         description: 'Dataset description',
@@ -517,19 +807,27 @@ describe('FigshareService', function () {
         related_data: [
           {
             related_title: 'Related dataset one',
-            related_url: 'https://doi.org/10.1234/related-one'
+            related_url: 'https://doi.org/10.1234/related-one',
           },
           {
             related_title: 'Related dataset two',
-            related_url: 'https://doi.org/10.1234/related-two'
-          }
-        ]
+            related_url: 'https://doi.org/10.1234/related-two',
+          },
+        ],
       },
       workflow: { stage: 'queued', stageLabel: 'Queued For Review' },
-      authorization: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [], stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] } },
+      authorization: {
+        view: [],
+        edit: [],
+        editRoles: [],
+        viewRoles: [],
+        editPending: [],
+        viewPending: [],
+        stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] },
+      },
       dateCreated: '',
       lastSaveDate: '',
-      id: ''
+      id: '',
     };
 
     const payload = await buildMetadataPayload(config, record);
@@ -537,12 +835,12 @@ describe('FigshareService', function () {
     expect(payload.related_materials).to.deep.equal([
       {
         title: 'Related dataset one',
-        identifier: 'https://doi.org/10.1234/related-one'
+        identifier: 'https://doi.org/10.1234/related-one',
       },
       {
         title: 'Related dataset two',
-        identifier: 'https://doi.org/10.1234/related-two'
-      }
+        identifier: 'https://doi.org/10.1234/related-two',
+      },
     ]);
   });
 
@@ -551,14 +849,21 @@ describe('FigshareService', function () {
       metadata: {
         relatedResource: {
           title: { kind: 'path', path: 'metadata.related_titles', defaultValue: [] },
-          doi: { kind: 'path', path: 'metadata.related_identifiers', defaultValue: [] }
-        }
-      }
+          doi: { kind: 'path', path: 'metadata.related_identifiers', defaultValue: [] },
+        },
+      },
     }) as unknown as FigsharePublishingConfigData;
     const record: RecordModel = {
       redboxOid: 'oid-1',
       harvestId: '',
-      metaMetadata: { brandId: 'default', createdBy: 'admin', type: 'dataPublication', searchCore: 'default', form: 'dataPublication-1.0-review', attachmentFields: [] },
+      metaMetadata: {
+        brandId: 'default',
+        createdBy: 'admin',
+        type: 'dataPublication',
+        searchCore: 'default',
+        form: 'dataPublication-1.0-review',
+        attachmentFields: [],
+      },
       metadata: {
         title: 'Dataset title',
         description: 'Dataset description',
@@ -566,13 +871,21 @@ describe('FigshareService', function () {
         forCodes: ['0101'],
         license: 'CC-BY',
         related_titles: ['Title only', '', 'Related dataset'],
-        related_identifiers: ['', 'https://doi.org/10.1234/identifier-only', 'https://doi.org/10.1234/related']
+        related_identifiers: ['', 'https://doi.org/10.1234/identifier-only', 'https://doi.org/10.1234/related'],
       },
       workflow: { stage: 'queued', stageLabel: 'Queued For Review' },
-      authorization: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [], stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] } },
+      authorization: {
+        view: [],
+        edit: [],
+        editRoles: [],
+        viewRoles: [],
+        editPending: [],
+        viewPending: [],
+        stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] },
+      },
       dateCreated: '',
       lastSaveDate: '',
-      id: ''
+      id: '',
     };
 
     const payload = await buildMetadataPayload(config, record);
@@ -580,30 +893,35 @@ describe('FigshareService', function () {
     expect(payload.related_materials).to.deep.equal([
       {
         title: 'Related dataset',
-        identifier: 'https://doi.org/10.1234/related'
-      }
+        identifier: 'https://doi.org/10.1234/related',
+      },
     ]);
   });
 
   it('uses institution account user_id values for resolved Figshare authors', async function () {
     const config = buildFigsharePublishingConfig({
       authors: {
-        lookup: [
-          { matchBy: 'email', value: { kind: 'path', path: 'email' } }
-        ]
+        lookup: [{ matchBy: 'email', value: { kind: 'path', path: 'email' } }],
       },
       metadata: {
         license: {
           source: { kind: 'path', path: 'metadata.license' },
           matchBy: 'valueExact',
-          required: true
-        }
-      }
+          required: true,
+        },
+      },
     }) as unknown as FigsharePublishingConfigData;
     const record: RecordModel = {
       redboxOid: 'oid-1',
       harvestId: '',
-      metaMetadata: { brandId: 'default', createdBy: 'admin', type: 'dataPublication', searchCore: 'default', form: 'dataPublication-1.0-review', attachmentFields: [] },
+      metaMetadata: {
+        brandId: 'default',
+        createdBy: 'admin',
+        type: 'dataPublication',
+        searchCore: 'default',
+        form: 'dataPublication-1.0-review',
+        attachmentFields: [],
+      },
       metadata: {
         title: 'Dataset title',
         description: 'Dataset description',
@@ -612,31 +930,49 @@ describe('FigshareService', function () {
         license: '1',
         contributor_ci: {
           name: 'Patricia Hayman',
-          email: 'p.hayman@cqu.edu.au'
+          email: 'p.hayman@cqu.edu.au',
         },
         contributors: [
           {
             name: 'Mark Cottman-Fields',
-            email: 'm.cottmanfields@cqu.edu.au'
+            email: 'm.cottmanfields@cqu.edu.au',
           },
           {
             name: 'External Author',
-            email: 'external@example.org'
-          }
-        ]
+            email: 'external@example.org',
+          },
+        ],
       },
       workflow: { stage: 'queued', stageLabel: 'Queued For Review' },
-      authorization: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [], stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] } },
+      authorization: {
+        view: [],
+        edit: [],
+        editRoles: [],
+        viewRoles: [],
+        editPending: [],
+        viewPending: [],
+        stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] },
+      },
       dateCreated: '',
       lastSaveDate: '',
-      id: ''
+      id: '',
     };
-    const searchInstitutionAccounts: FigshareClient['searchInstitutionAccounts'] = async (payload) => {
+    const searchInstitutionAccounts: FigshareClient['searchInstitutionAccounts'] = async payload => {
       if (payload.email === 'p.hayman@cqu.edu.au') {
-        return [{ id: 1897685, user_id: 2544547, email: 'p.hayman@cqu.edu.au', first_name: 'Patricia', last_name: 'Hayman' }];
+        return [
+          { id: 1897685, user_id: 2544547, email: 'p.hayman@cqu.edu.au', first_name: 'Patricia', last_name: 'Hayman' },
+        ];
       }
       if (payload.email === 'm.cottmanfields@cqu.edu.au') {
-        return [{ id: 3015702, user_id: 4402702, email: 'm.cottmanfields@cqu.edu.au', first_name: 'Mark', last_name: 'Cottman-Fields' }];
+        return [
+          {
+            id: 3015702,
+            user_id: 4402702,
+            email: 'm.cottmanfields@cqu.edu.au',
+            first_name: 'Mark',
+            last_name: 'Cottman-Fields',
+          },
+        ];
       }
       return [];
     };
@@ -654,23 +990,26 @@ describe('FigshareService', function () {
       clearEmbargo: async () => ({}),
       publishArticle: async () => ({}),
       listLicenses: async () => [{ value: 1, name: 'CC-BY' }],
-      searchInstitutionAccounts
+      searchInstitutionAccounts,
     };
 
     const payload = await buildMetadataPayload(config, record, client);
 
-    expect(payload.authors).to.deep.equal([
-      { id: 2544547 },
-      { id: 4402702 },
-      { name: 'External Author' }
-    ]);
+    expect(payload.authors).to.deep.equal([{ id: 2544547 }, { id: 4402702 }, { name: 'External Author' }]);
   });
 
   it('writes a failed integration audit when syncRecordWithFigshare throws', async function () {
     const record: RecordModel = {
       redboxOid: 'oid-1',
       harvestId: '',
-      metaMetadata: { brandId: 'default', createdBy: 'admin', type: 'dataPublication', searchCore: 'default', form: 'dataPublication-1.0-review', attachmentFields: [] },
+      metaMetadata: {
+        brandId: 'default',
+        createdBy: 'admin',
+        type: 'dataPublication',
+        searchCore: 'default',
+        form: 'dataPublication-1.0-review',
+        attachmentFields: [],
+      },
       metadata: {
         title: 'Dataset title',
         description: 'Dataset description',
@@ -679,10 +1018,18 @@ describe('FigshareService', function () {
         license: 'CC-BY',
       },
       workflow: { stage: 'queued', stageLabel: 'Queued For Review' },
-      authorization: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [], stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] } },
+      authorization: {
+        view: [],
+        edit: [],
+        editRoles: [],
+        viewRoles: [],
+        editPending: [],
+        viewPending: [],
+        stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] },
+      },
       dateCreated: '',
       lastSaveDate: '',
-      id: ''
+      id: '',
     };
     sinon.stub(service, 'syncMetadata').rejects(new Error('sync exploded'));
 
@@ -704,7 +1051,14 @@ describe('FigshareService', function () {
     const record: RecordModel = {
       redboxOid: 'oid-1',
       harvestId: '',
-      metaMetadata: { brandId: 'default', createdBy: 'admin', type: 'dataPublication', searchCore: 'default', form: 'dataPublication-1.0-review', attachmentFields: [] },
+      metaMetadata: {
+        brandId: 'default',
+        createdBy: 'admin',
+        type: 'dataPublication',
+        searchCore: 'default',
+        form: 'dataPublication-1.0-review',
+        attachmentFields: [],
+      },
       metadata: {
         title: 'Dataset title',
         description: 'Dataset description',
@@ -713,17 +1067,25 @@ describe('FigshareService', function () {
         license: 'CC-BY',
       },
       workflow: { stage: 'queued', stageLabel: 'Queued For Review' },
-      authorization: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [], stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] } },
+      authorization: {
+        view: [],
+        edit: [],
+        editRoles: [],
+        viewRoles: [],
+        editPending: [],
+        viewPending: [],
+        stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] },
+      },
       dateCreated: '',
       lastSaveDate: '',
-      id: ''
+      id: '',
     };
     const httpError = Object.assign(new Error('Figshare HTTP request failed for post /account/articles'), {
       statusCode: 400,
       responseBody: {
         message: 'Invalid identifier format',
-        code: 'BadRequest'
-      }
+        code: 'BadRequest',
+      },
     });
     sinon.stub(service, 'syncMetadata').rejects(httpError);
 
@@ -731,8 +1093,9 @@ describe('FigshareService', function () {
       await service.syncRecordWithFigshare(record, 'job-1');
       expect.fail('Expected syncRecordWithFigshare to throw');
     } catch (error) {
-      expect((error as { displayErrors?: Array<{ detail?: string }> }).displayErrors?.[0]?.detail)
-        .to.equal('Invalid identifier format');
+      expect((error as { displayErrors?: Array<{ detail?: string }> }).displayErrors?.[0]?.detail).to.equal(
+        'Invalid identifier format'
+      );
     }
   });
 
@@ -748,7 +1111,9 @@ describe('FigshareService', function () {
     };
     sinon.stub(service, 'makeClient').returns(client as any);
     sinon.stub(service as any, 'ensureNoFileUploadInProgress').resolves();
-    sinon.stub(service, 'writeBack').returns({ redboxOid: 'oid-1', metaMetadata: { brandId: 'default' }, metadata: {} } as any);
+    sinon
+      .stub(service, 'writeBack')
+      .returns({ redboxOid: 'oid-1', metaMetadata: { brandId: 'default' }, metadata: {} } as any);
     sinon.stub(service, 'persistSyncRecord').resolves();
     sinon.stub(service, 'queueDeleteFiles');
 
@@ -762,7 +1127,7 @@ describe('FigshareService', function () {
     client.publishArticle.rejects(new Error('publish failed'));
     try {
       await service.publishAfterUploadFilesJob({
-      attrs: { data: { oid: 'oid-1', articleId: 'article-1', brandId: 'default', user: { username: 'user-1' } } },
+        attrs: { data: { oid: 'oid-1', articleId: 'article-1', brandId: 'default', user: { username: 'user-1' } } },
       } as any);
       expect.fail('Expected publishAfterUploadFilesJob to throw');
     } catch (error) {
@@ -785,7 +1150,9 @@ describe('FigshareService', function () {
     };
     sinon.stub(service, 'makeClient').returns(client as any);
     sinon.stub(service as any, 'ensureNoFileUploadInProgress').resolves();
-    sinon.stub(service, 'writeBack').returns({ redboxOid: 'oid-1', metaMetadata: { brandId: 'default' }, metadata: {} } as any);
+    sinon
+      .stub(service, 'writeBack')
+      .returns({ redboxOid: 'oid-1', metaMetadata: { brandId: 'default' }, metadata: {} } as any);
     sinon.stub(service, 'persistSyncRecord').resolves(false);
     const queueDeleteStub = sinon.stub(service, 'queueDeleteFiles');
 
@@ -801,8 +1168,9 @@ describe('FigshareService', function () {
     expect(queueDeleteStub.called).to.equal(false);
     expect((global as any).IntegrationAuditService.completeAudit.called).to.equal(false);
     expect((global as any).IntegrationAuditService.failAudit.calledOnce).to.equal(true);
-    expect((global as any).IntegrationAuditService.failAudit.firstCall.args[1].message)
-      .to.equal("Failed to persist Figshare publish state for record 'oid-1'.");
+    expect((global as any).IntegrationAuditService.failAudit.firstCall.args[1].message).to.equal(
+      "Failed to persist Figshare publish state for record 'oid-1'."
+    );
   });
 
   it('keeps publishAfterUploadFilesJob audit in progress when uploads are still running', async function () {
@@ -812,10 +1180,12 @@ describe('FigshareService', function () {
       metadata: {},
     });
     sinon.stub(service, 'makeClient').returns({} as any);
-    sinon.stub(service as any, 'ensureNoFileUploadInProgress').rejects(new RBValidationError({
-      message: 'uploads still running',
-      displayErrors: [{ title: 'uploads still running', detail: 'uploads still running' }]
-    }));
+    sinon.stub(service as any, 'ensureNoFileUploadInProgress').rejects(
+      new RBValidationError({
+        message: 'uploads still running',
+        displayErrors: [{ title: 'uploads still running', detail: 'uploads still running' }],
+      })
+    );
     const queuePublishStub = sinon.stub(service, 'queuePublishAfterUploadFiles');
 
     await service.publishAfterUploadFilesJob({
@@ -869,7 +1239,7 @@ describe('FigshareService', function () {
   it('includes non-object HTTP response bodies in error summaries', function () {
     const error = Object.assign(new Error('Figshare HTTP request failed'), {
       statusCode: 401,
-      responseBody: 'Unauthorized'
+      responseBody: 'Unauthorized',
     });
 
     const summary = (service as any).summarizeError(error);
@@ -878,10 +1248,12 @@ describe('FigshareService', function () {
     expect(summary.responseSummary.rawResponseBody).to.equal('Unauthorized');
     expect(summary.responseSummary.message).to.equal('Figshare HTTP request failed');
 
-    const objectBodySummary = (service as any).summarizeError(Object.assign(new Error('boom'), {
-      statusCode: 422,
-      responseBody: { message: 'Invalid embargo' }
-    }));
+    const objectBodySummary = (service as any).summarizeError(
+      Object.assign(new Error('boom'), {
+        statusCode: 422,
+        responseBody: { message: 'Invalid embargo' },
+      })
+    );
     expect(objectBodySummary.responseSummary).to.deep.equal({ message: 'Invalid embargo' });
   });
 
@@ -889,8 +1261,8 @@ describe('FigshareService', function () {
     const article = mapCreateArticleResponse<{ id?: string; location?: string }>({
       data: {},
       headers: {
-        location: 'https://api.figsh.com/v2/account/articles/123456'
-      }
+        location: 'https://api.figsh.com/v2/account/articles/123456',
+      },
     });
 
     expect(article.id).to.equal('123456');
@@ -902,7 +1274,14 @@ describe('FigshareService', function () {
     const record: RecordModel = {
       redboxOid: 'oid-1',
       harvestId: '',
-      metaMetadata: { brandId: 'default', createdBy: 'admin', type: 'dataPublication', searchCore: 'default', form: 'dataPublication-1.0-review', attachmentFields: [] },
+      metaMetadata: {
+        brandId: 'default',
+        createdBy: 'admin',
+        type: 'dataPublication',
+        searchCore: 'default',
+        form: 'dataPublication-1.0-review',
+        attachmentFields: [],
+      },
       metadata: {
         title: 'Dataset title',
         description: 'Dataset description',
@@ -911,14 +1290,22 @@ describe('FigshareService', function () {
         license: 'CC-BY',
       },
       workflow: { stage: 'queued', stageLabel: 'Queued For Review' },
-      authorization: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [], stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] } },
+      authorization: {
+        view: [],
+        edit: [],
+        editRoles: [],
+        viewRoles: [],
+        editPending: [],
+        viewPending: [],
+        stored: { view: [], edit: [], editRoles: [], viewRoles: [], editPending: [], viewPending: [] },
+      },
       dateCreated: '',
       lastSaveDate: '',
-      id: ''
+      id: '',
     };
     const client: FigshareClient = {
       createArticle: async () => ({ id: 'unused' }),
-      updateArticle: async () => ({ status: 'draft' } as any),
+      updateArticle: async () => ({ status: 'draft' }) as any,
       getArticle: async () => ({ id: 'unused' }),
       listArticleFiles: async () => [],
       createArticleFile: async () => ({ location: '' }),
@@ -930,14 +1317,14 @@ describe('FigshareService', function () {
       clearEmbargo: async () => ({}),
       publishArticle: async () => ({}),
       listLicenses: async () => [{ value: 1, name: 'CC-BY' }],
-      searchInstitutionAccounts: async () => []
+      searchInstitutionAccounts: async () => [],
     };
 
     const article = await syncMetadataPhase(client, config, record, {
       action: 'update',
       articleId: '11389474',
       sameJob: false,
-      syncState: { status: 'syncing' }
+      syncState: { status: 'syncing' },
     });
 
     expect(article.id).to.equal('11389474');
@@ -949,7 +1336,7 @@ describe('FigshareService', function () {
     (global as any).BrandingService.getBrandById = sinon.stub().returns(undefined);
 
     const resolved = service.getConfig({
-      metaMetadata: { brandId: 'ghost-brand' }
+      metaMetadata: { brandId: 'ghost-brand' },
     } as any);
 
     // Unknown brands keep the graceful fallback contract: config still resolves via the
@@ -962,7 +1349,7 @@ describe('FigshareService', function () {
   it('resolves live mode when figshareDev is disabled', function () {
     (global as any).sails.config.figshareDev = { enabled: false, mode: 'fixture' };
     const resolved = service.getConfig({
-      metaMetadata: { brandId: 'default' }
+      metaMetadata: { brandId: 'default' },
     } as any);
 
     expect(resolved?.runtime.mode).to.equal('live');
@@ -972,12 +1359,12 @@ describe('FigshareService', function () {
     (global as any).sails.config.environment = 'development';
     (global as any).sails.config.figshareDev = buildFigshareDevConfig({
       fixtures: {
-        article: { id: 'fixture-dev' }
-      }
+        article: { id: 'fixture-dev' },
+      },
     });
 
     const resolved = service.getConfig({
-      metaMetadata: { brandId: 'default' }
+      metaMetadata: { brandId: 'default' },
     } as any);
 
     expect(resolved?.runtime.mode).to.equal('fixture');
@@ -989,7 +1376,7 @@ describe('FigshareService', function () {
     (global as any).sails.config.figshareDev = buildFigshareDevConfig();
 
     const resolved = service.getConfig({
-      metaMetadata: { brandId: 'default' }
+      metaMetadata: { brandId: 'default' },
     } as any);
 
     expect(resolved?.runtime.mode).to.equal('live');
@@ -1002,15 +1389,15 @@ describe('FigshareService', function () {
         testing: {
           mode: 'fixture',
           fixtures: {
-            article: { id: 'legacy-fixture' }
-          }
-        }
-      }
+            article: { id: 'legacy-fixture' },
+          },
+        },
+      },
     }));
     (global as any).sails.config.figshareDev = { enabled: false, mode: 'live' };
 
     const resolved = service.getConfig({
-      metaMetadata: { brandId: 'default' }
+      metaMetadata: { brandId: 'default' },
     } as any);
 
     expect(resolved?.runtime.mode).to.equal('live');
@@ -1026,7 +1413,7 @@ describe('FigshareService', function () {
   });
 
   it('uses figsharePublishing queue delays when scheduling jobs', function () {
-    const scheduleStub = ((global as any).sails.services.queueservice.schedule as sinon.SinonStub);
+    const scheduleStub = (global as any).sails.services.queueservice.schedule as sinon.SinonStub;
 
     service.queuePublishAfterUploadFiles('oid-1', 'article-1', {} as any, 'default');
     service.queueDeleteFiles('oid-1', {} as any, 'default', 'article-1');
@@ -1036,7 +1423,7 @@ describe('FigshareService', function () {
   });
 
   it('uses immediate queue execution when configured', function () {
-    const nowStub = ((global as any).sails.services.queueservice.now as sinon.SinonStub);
+    const nowStub = (global as any).sails.services.queueservice.now as sinon.SinonStub;
 
     service.queuePublishAfterUploadFiles('oid-1', 'article-1', {} as any, 'brand-immediate');
     service.queueDeleteFiles('oid-1', {} as any, 'brand-immediate', 'article-1');
@@ -1045,27 +1432,32 @@ describe('FigshareService', function () {
   });
 
   it('writes the all-files-uploaded flag from figsharePublishing record config', async function () {
-    getConfigStub.callsFake(() => buildFigsharePublishingConfig({
-      record: {
-        articleIdPath: 'metadata.figshare_article_id',
-        articleUrlPaths: ['metadata.figshare_article_location'],
-        dataLocationsPath: 'metadata.dataLocations',
-        statusPath: 'metadata.figshareStatus',
-        errorPath: 'metadata.figshareError',
-        syncStatePath: 'metadata.figshareSyncState',
-        allFilesUploadedPath: 'metadata.figshare_all_files_uploaded'
-      }
-    }) as any);
+    getConfigStub.callsFake(
+      () =>
+        buildFigsharePublishingConfig({
+          record: {
+            articleIdPath: 'metadata.figshare_article_id',
+            articleUrlPaths: ['metadata.figshare_article_location'],
+            dataLocationsPath: 'metadata.dataLocations',
+            statusPath: 'metadata.figshareStatus',
+            errorPath: 'metadata.figshareError',
+            syncStatePath: 'metadata.figshareSyncState',
+            allFilesUploadedPath: 'metadata.figshare_all_files_uploaded',
+          },
+        }) as any
+    );
 
-    sinon.stub(service as any, 'getArticleFiles').resolves([{ name: 'file-1.txt', download_url: 'https://files.example/file-1.txt' }]);
+    sinon
+      .stub(service as any, 'getArticleFiles')
+      .resolves([{ name: 'file-1.txt', download_url: 'https://files.example/file-1.txt' }]);
     sinon.stub(service as any, 'makeClient').returns({});
 
     const record: any = {
       redboxOid: 'oid-1',
       metaMetadata: { brandId: 'default' },
       metadata: {
-        dataLocations: [{ type: 'attachment', fileId: 'file-1', name: 'file-1.txt', selected: true }]
-      }
+        dataLocations: [{ type: 'attachment', fileId: 'file-1', name: 'file-1.txt', selected: true }],
+      },
     };
 
     const result = await (service as any).cleanupUploadedFiles(record, 'article-1');
@@ -1074,21 +1466,24 @@ describe('FigshareService', function () {
 
   it('uses only article.curationLock when checking curation lock state', function () {
     const record: any = {
-      metaMetadata: { brandId: 'default' }
+      metaMetadata: { brandId: 'default' },
     };
-    getConfigStub.callsFake(() => buildFigsharePublishingConfig({
-      article: {
-        itemType: 'dataset',
-        publishMode: 'manual',
-        republishOnMetadataChange: true,
-        republishOnAssetChange: true,
-        curationLock: {
-          enabled: true,
-          statusField: 'status',
-          targetValue: 'public'
-        }
-      }
-    }) as any);
+    getConfigStub.callsFake(
+      () =>
+        buildFigsharePublishingConfig({
+          article: {
+            itemType: 'dataset',
+            publishMode: 'manual',
+            republishOnMetadataChange: true,
+            republishOnAssetChange: true,
+            curationLock: {
+              enabled: true,
+              statusField: 'status',
+              targetValue: 'public',
+            },
+          },
+        }) as any
+    );
 
     expect((service as any).isCurationLocked(record, { status: 'public' })).to.equal(true);
     expect((service as any).isCurationLocked(record, { status: 'draft' })).to.equal(false);
@@ -1101,7 +1496,7 @@ describe('FigshareService', function () {
     (global as any).RecordsService.getMeta.resolves({
       oid: 'oid-1',
       metadata: { title: 'Dataset title' },
-      metaMetadata: { brandId: 'named-brand', type: 'dataset' }
+      metaMetadata: { brandId: 'named-brand', type: 'dataset' },
     });
     (global as any).RecordsService.updateMeta.resolves({ isSuccessful: () => true });
     sinon.stub(service as any, 'isArticleReadyForWorkflowTransition').resolves(true);
@@ -1124,35 +1519,38 @@ describe('FigshareService', function () {
   });
 
   it('uses figsharePublishing transitionJob config when running the workflow transition job', async function () {
-    getConfigStub.callsFake(() => buildFigsharePublishingConfig({
-      record: {
-        articleIdPath: 'metadata.v2.articleId',
-        articleUrlPaths: ['metadata.figshare_article_location'],
-        dataLocationsPath: 'metadata.dataLocations',
-        statusPath: 'metadata.figshareStatus',
-        errorPath: 'metadata.figshareError',
-        syncStatePath: 'metadata.figshareSyncState',
-        allFilesUploadedPath: ''
-      },
-      workflow: {
-        transitionRules: [],
-        transitionJob: {
-          enabled: true,
-          namedQuery: 'v2-transition',
-          targetStep: 'published',
-          paramMap: {},
-          figshareTargetFieldKey: 'status',
-          figshareTargetFieldValue: 'public',
-          username: 'figshare-job-user',
-          userType: 'admin'
-        }
-      }
-    }) as any);
+    getConfigStub.callsFake(
+      () =>
+        buildFigsharePublishingConfig({
+          record: {
+            articleIdPath: 'metadata.v2.articleId',
+            articleUrlPaths: ['metadata.figshare_article_location'],
+            dataLocationsPath: 'metadata.dataLocations',
+            statusPath: 'metadata.figshareStatus',
+            errorPath: 'metadata.figshareError',
+            syncStatePath: 'metadata.figshareSyncState',
+            allFilesUploadedPath: '',
+          },
+          workflow: {
+            transitionRules: [],
+            transitionJob: {
+              enabled: true,
+              namedQuery: 'v2-transition',
+              targetStep: 'published',
+              paramMap: {},
+              figshareTargetFieldKey: 'status',
+              figshareTargetFieldValue: 'public',
+              username: 'figshare-job-user',
+              userType: 'admin',
+            },
+          },
+        }) as any
+    );
     (global as any).NamedQueryService.performNamedQueryFromConfigResults.resolves([{ oid: 'oid-1' }]);
     (global as any).RecordsService.getMeta.resolves({
       oid: 'oid-1',
       metadata: { v2: { articleId: 'v2-path-id' } },
-      metaMetadata: { brandId: 'default', type: 'dataset' }
+      metaMetadata: { brandId: 'default', type: 'dataset' },
     });
     const transitionStub = sinon.stub(service as any, 'transitionWorkflowForRecord').resolves();
 
@@ -1164,36 +1562,41 @@ describe('FigshareService', function () {
   });
 
   it('processes workflow transition records when the publishing user has no roles', async function () {
-    getConfigStub.callsFake(() => buildFigsharePublishingConfig({
-      record: {
-        articleIdPath: 'metadata.v2.articleId',
-        articleUrlPaths: ['metadata.figshare_article_location'],
-        dataLocationsPath: 'metadata.dataLocations',
-        statusPath: 'metadata.figshareStatus',
-        errorPath: 'metadata.figshareError',
-        syncStatePath: 'metadata.figshareSyncState',
-        allFilesUploadedPath: ''
-      },
-      workflow: {
-        transitionRules: [],
-        transitionJob: {
-          enabled: true,
-          namedQuery: 'v2-transition',
-          targetStep: 'published',
-          paramMap: {},
-          figshareTargetFieldKey: 'status',
-          figshareTargetFieldValue: 'public',
-          username: 'figshare-job-user',
-          userType: 'admin'
-        }
-      }
-    }) as any);
-    (global as any).UsersService.getUserWithUsername = sinon.stub().returns({ toPromise: sinon.stub().resolves({ username: 'figshare-job-user', type: 'admin', roles: [] }) });
+    getConfigStub.callsFake(
+      () =>
+        buildFigsharePublishingConfig({
+          record: {
+            articleIdPath: 'metadata.v2.articleId',
+            articleUrlPaths: ['metadata.figshare_article_location'],
+            dataLocationsPath: 'metadata.dataLocations',
+            statusPath: 'metadata.figshareStatus',
+            errorPath: 'metadata.figshareError',
+            syncStatePath: 'metadata.figshareSyncState',
+            allFilesUploadedPath: '',
+          },
+          workflow: {
+            transitionRules: [],
+            transitionJob: {
+              enabled: true,
+              namedQuery: 'v2-transition',
+              targetStep: 'published',
+              paramMap: {},
+              figshareTargetFieldKey: 'status',
+              figshareTargetFieldValue: 'public',
+              username: 'figshare-job-user',
+              userType: 'admin',
+            },
+          },
+        }) as any
+    );
+    (global as any).UsersService.getUserWithUsername = sinon
+      .stub()
+      .returns({ toPromise: sinon.stub().resolves({ username: 'figshare-job-user', type: 'admin', roles: [] }) });
     (global as any).NamedQueryService.performNamedQueryFromConfigResults.resolves([{ oid: 'oid-1' }]);
     (global as any).RecordsService.getMeta.resolves({
       oid: 'oid-1',
       metadata: { v2: { articleId: 'v2-path-id' } },
-      metaMetadata: { brandId: 'default', type: 'dataset' }
+      metaMetadata: { brandId: 'default', type: 'dataset' },
     });
     const transitionStub = sinon.stub(service as any, 'transitionWorkflowForRecord').resolves();
 
@@ -1204,45 +1607,247 @@ describe('FigshareService', function () {
   });
 
   it('audits per-record workflow transition failures', async function () {
-    getConfigStub.callsFake(() => buildFigsharePublishingConfig({
-      record: {
-        articleIdPath: 'metadata.v2.articleId',
-        articleUrlPaths: ['metadata.figshare_article_location'],
-        dataLocationsPath: 'metadata.dataLocations',
-        statusPath: 'metadata.figshareStatus',
-        errorPath: 'metadata.figshareError',
-        syncStatePath: 'metadata.figshareSyncState',
-        allFilesUploadedPath: ''
-      },
-      workflow: {
-        transitionRules: [],
-        transitionJob: {
-          enabled: true,
-          namedQuery: 'v2-transition',
-          targetStep: 'published',
-          paramMap: {},
-          figshareTargetFieldKey: 'status',
-          figshareTargetFieldValue: 'public',
-          username: 'figshare-job-user',
-          userType: 'admin'
-        }
-      }
-    }) as any);
+    getConfigStub.callsFake(
+      () =>
+        buildFigsharePublishingConfig({
+          record: {
+            articleIdPath: 'metadata.v2.articleId',
+            articleUrlPaths: ['metadata.figshare_article_location'],
+            dataLocationsPath: 'metadata.dataLocations',
+            statusPath: 'metadata.figshareStatus',
+            errorPath: 'metadata.figshareError',
+            syncStatePath: 'metadata.figshareSyncState',
+            allFilesUploadedPath: '',
+          },
+          workflow: {
+            transitionRules: [],
+            transitionJob: {
+              enabled: true,
+              namedQuery: 'v2-transition',
+              targetStep: 'published',
+              paramMap: {},
+              figshareTargetFieldKey: 'status',
+              figshareTargetFieldValue: 'public',
+              username: 'figshare-job-user',
+              userType: 'admin',
+            },
+          },
+        }) as any
+    );
     (global as any).NamedQueryService.performNamedQueryFromConfigResults.resolves([{ oid: 'oid-1' }]);
     (global as any).RecordsService.getMeta.resolves({
       oid: 'oid-1',
       metadata: { v2: { articleId: 'v2-path-id' } },
-      metaMetadata: { brandId: 'default', type: 'dataset' }
+      metaMetadata: { brandId: 'default', type: 'dataset' },
     });
     sinon.stub(service as any, 'transitionWorkflowForRecord').rejects(new Error('transition failed'));
 
     await service.transitionRecordWorkflowFromFigshareArticlePropertiesJob({});
 
-    expect((global as any).IntegrationAuditService.startAudit.firstCall.args[1])
-      .to.equal('transitionRecordWorkflowFromFigshareArticlePropertiesJob');
+    expect((global as any).IntegrationAuditService.startAudit.firstCall.args[1]).to.equal(
+      'transitionRecordWorkflowFromFigshareArticlePropertiesJob'
+    );
     expect((global as any).IntegrationAuditService.completeAudit.called).to.equal(false);
     expect((global as any).IntegrationAuditService.failAudit.calledOnce).to.equal(true);
     expect((global as any).IntegrationAuditService.failAudit.firstCall.args[1].message).to.equal('transition failed');
+  });
+
+  describe('syncAssetsPhase (live upload)', function () {
+    it('stages attachments through StorageManager and uploads ordered Figshare parts', async function () {
+      const fakeDisk = makeFakeDisk();
+      (global as any).StorageManagerService = {
+        disk: sinon.stub().returns(fakeDisk.disk),
+        stagingDisk: sinon.stub().returns(fakeDisk.disk),
+      };
+      const payload = Buffer.from('abcdefgh');
+      const getDatastreamStub = installDatastreamStub(payload, payload.length);
+      const uploadedParts: Buffer[] = [];
+      const client = buildAssetClient(
+        [
+          { partNo: 1, startOffset: 0, endOffset: 3 },
+          { partNo: 2, startOffset: 4, endOffset: 7 },
+        ],
+        uploadedParts
+      );
+      const config = buildLiveAssetConfig();
+      const record = buildAssetRecord([{ type: 'attachment', fileId: 'file-1', name: 'file.txt', selected: true }]);
+      const syncState: any = { status: 'syncing' };
+
+      const result = await syncAssetsPhase(client, config, record, { id: 'article-1' }, syncState);
+
+      const stagingKey = 'figshare/article-1-oid-1-file-1/file.txt';
+      expect((global as any).StorageManagerService.disk.calledWith('figshare-staging')).to.equal(true);
+      expect(getDatastreamStub.calledWith('oid-1', 'file-1')).to.equal(true);
+      expect(fakeDisk.calls.put).to.deep.equal([{ key: stagingKey, options: { contentLength: payload.length } }]);
+      expect((client.createArticleFile as sinon.SinonStub).firstCall.args[1]).to.deep.equal({
+        name: 'file.txt',
+        size: payload.length,
+      });
+      expect((client.uploadFilePart as sinon.SinonStub).getCall(0).args[1]).to.equal(1);
+      expect((client.uploadFilePart as sinon.SinonStub).getCall(1).args[1]).to.equal(2);
+      expect(uploadedParts.map(part => part.toString())).to.deep.equal(['abcd', 'efgh']);
+      expect((client.completeFileUpload as sinon.SinonStub).calledWith('article-1', 'figshare-file-1', {})).to.equal(
+        true
+      );
+      expect(fakeDisk.calls.deleted).to.deep.equal([stagingKey]);
+      expect(fakeDisk.store.has(stagingKey)).to.equal(false);
+      expect(result.uploadedAttachments).to.have.lengthOf(1);
+      expect(syncState.partialProgress?.uploadedAttachmentCountThisRun).to.equal(1);
+    });
+
+    it('retains the staged object after success when retainForRetry is configured', async function () {
+      const fakeDisk = makeFakeDisk();
+      (global as any).StorageManagerService = {
+        disk: sinon.stub().returns(fakeDisk.disk),
+        stagingDisk: sinon.stub().returns(fakeDisk.disk),
+      };
+      const payload = Buffer.from('abcdefgh');
+      installDatastreamStub(payload, payload.length);
+      const client = buildAssetClient([{ partNo: 1, startOffset: 0, endOffset: 7 }]);
+      const config = buildLiveAssetConfig({ staging: { cleanupPolicy: 'retainForRetry' } });
+      const record = buildAssetRecord([{ type: 'attachment', fileId: 'file-1', name: 'file.txt', selected: true }]);
+
+      await syncAssetsPhase(client, config, record, { id: 'article-1' }, { status: 'syncing' });
+
+      const stagingKey = 'figshare/article-1-oid-1-file-1/file.txt';
+      expect(fakeDisk.calls.deleted).to.deep.equal([]);
+      expect(fakeDisk.store.get(stagingKey)?.toString()).to.equal('abcdefgh');
+    });
+
+    it('deletes the staged object when a part upload fails regardless of cleanup policy', async function () {
+      const fakeDisk = makeFakeDisk();
+      (global as any).StorageManagerService = {
+        disk: sinon.stub().returns(fakeDisk.disk),
+        stagingDisk: sinon.stub().returns(fakeDisk.disk),
+      };
+      const payload = Buffer.from('abcdefgh');
+      installDatastreamStub(payload, payload.length);
+      const client = buildAssetClient([{ partNo: 1, startOffset: 0, endOffset: 7 }]);
+      (client.uploadFilePart as sinon.SinonStub).rejects(new Error('part upload failed'));
+      const config = buildLiveAssetConfig({ staging: { cleanupPolicy: 'retainForRetry' } });
+      const record = buildAssetRecord([{ type: 'attachment', fileId: 'file-1', name: 'file.txt', selected: true }]);
+
+      let error: Error | undefined;
+      try {
+        await syncAssetsPhase(client, config, record, { id: 'article-1' }, { status: 'syncing' });
+      } catch (err) {
+        error = err as Error;
+      }
+
+      const stagingKey = 'figshare/article-1-oid-1-file-1/file.txt';
+      expect(error?.message).to.equal('part upload failed');
+      expect(fakeDisk.calls.deleted).to.deep.equal([stagingKey]);
+      expect(fakeDisk.store.has(stagingKey)).to.equal(false);
+    });
+
+    it('uses metadata size when the source size is unknown', async function () {
+      const fakeDisk = makeFakeDisk();
+      (global as any).StorageManagerService = {
+        disk: sinon.stub().returns(fakeDisk.disk),
+        stagingDisk: sinon.stub().returns(fakeDisk.disk),
+      };
+      const payload = Buffer.from('abcdefgh');
+      installDatastreamStub(payload);
+      const client = buildAssetClient([{ partNo: 1, startOffset: 0, endOffset: 7 }]);
+      const config = buildLiveAssetConfig();
+      const record = buildAssetRecord([{ type: 'attachment', fileId: 'file-1', name: 'file.txt', selected: true }]);
+
+      await syncAssetsPhase(client, config, record, { id: 'article-1' }, { status: 'syncing' });
+
+      expect(fakeDisk.calls.put[0].options).to.deep.equal({});
+      expect((client.createArticleFile as sinon.SinonStub).firstCall.args[1]).to.deep.equal({
+        name: 'file.txt',
+        size: payload.length,
+      });
+    });
+
+    it('preserves uneven part boundaries and reports truncated staged objects', async function () {
+      const fakeDisk = makeFakeDisk();
+      (global as any).StorageManagerService = {
+        disk: sinon.stub().returns(fakeDisk.disk),
+        stagingDisk: sinon.stub().returns(fakeDisk.disk),
+      };
+      const payload = Buffer.from('abcdefghij');
+      installDatastreamStub(payload, payload.length);
+      const uploadedParts: Buffer[] = [];
+      const client = buildAssetClient(
+        [
+          { partNo: 1, startOffset: 0, endOffset: 6 },
+          { partNo: 2, startOffset: 7, endOffset: 9 },
+        ],
+        uploadedParts
+      );
+      const config = buildLiveAssetConfig();
+      const record = buildAssetRecord([{ type: 'attachment', fileId: 'file-1', name: 'file.txt', selected: true }]);
+
+      await syncAssetsPhase(client, config, record, { id: 'article-1' }, { status: 'syncing' });
+
+      expect(Buffer.concat(uploadedParts).equals(payload)).to.equal(true);
+      expect(uploadedParts.map(part => part.toString())).to.deep.equal(['abcdefg', 'hij']);
+
+      const truncatedDisk = makeFakeDisk();
+      truncatedDisk.disk.getStream = async () => Readable.from([Buffer.from('abc')]);
+      (global as any).StorageManagerService = {
+        disk: sinon.stub().returns(truncatedDisk.disk),
+        stagingDisk: sinon.stub().returns(truncatedDisk.disk),
+      };
+      installDatastreamStub(payload, payload.length);
+      const truncatedClient = buildAssetClient([{ partNo: 1, startOffset: 0, endOffset: 7 }]);
+
+      let error: Error | undefined;
+      try {
+        await syncAssetsPhase(truncatedClient, config, record, { id: 'article-1' }, { status: 'syncing' });
+      } catch (err) {
+        error = err as Error;
+      }
+
+      expect(error).to.be.instanceOf(RBValidationError);
+      expect(error?.message).to.contain('Staged object truncated');
+    });
+
+    it('falls back to the configured staging disk when no Figshare disk is named', async function () {
+      const fakeDisk = makeFakeDisk();
+      (global as any).StorageManagerService = {
+        disk: sinon.stub().returns(fakeDisk.disk),
+        stagingDisk: sinon.stub().returns(fakeDisk.disk),
+      };
+      const payload = Buffer.from('abcdefgh');
+      installDatastreamStub(payload, payload.length);
+      const client = buildAssetClient([{ partNo: 1, startOffset: 0, endOffset: 7 }]);
+      const config = buildLiveAssetConfig({ staging: { disk: '' } });
+      const record = buildAssetRecord([{ type: 'attachment', fileId: 'file-1', name: 'file.txt', selected: true }]);
+
+      await syncAssetsPhase(client, config, record, { id: 'article-1' }, { status: 'syncing' });
+
+      expect((global as any).StorageManagerService.disk.called).to.equal(false);
+      expect((global as any).StorageManagerService.stagingDisk.calledOnce).to.equal(true);
+    });
+
+    it('does not touch StorageManager in fixture mode', async function () {
+      const fakeDisk = makeFakeDisk();
+      (global as any).StorageManagerService = {
+        disk: sinon.stub().returns(fakeDisk.disk),
+        stagingDisk: sinon.stub().returns(fakeDisk.disk),
+      };
+      installDatastreamStub(Buffer.from('abcdefgh'), 8);
+      const client = buildAssetClient([{ partNo: 1, startOffset: 0, endOffset: 7 }]);
+      const config = {
+        ...buildLiveAssetConfig(),
+        runtime: { mode: 'fixture' },
+        article: {
+          ...buildLiveAssetConfig().article,
+          publishMode: 'afterUploadsComplete',
+        },
+      } as any;
+      const record = buildAssetRecord([{ type: 'attachment', fileId: 'file-1', name: 'file.txt', selected: true }]);
+
+      const result = await syncAssetsPhase(client, config, record, { id: 'article-1' }, { status: 'syncing' });
+
+      expect((global as any).StorageManagerService.disk.called).to.equal(false);
+      expect((global as any).StorageManagerService.stagingDisk.called).to.equal(false);
+      expect((global as any).sails.services.datastreamservice.getDatastream.called).to.equal(false);
+      expect(result.uploadedAttachments[0].id).to.equal('fixture-attachment-1');
+    });
   });
 
   it('figsharePublishing defaults include queue and transition job fields', function () {
@@ -1250,11 +1855,15 @@ describe('FigshareService', function () {
     expect(config.queue.publishAfterUploadDelay).to.equal('in 2 minutes');
     expect(config.queue.uploadedFilesCleanupDelay).to.equal('in 5 minutes');
     expect(config.record.allFilesUploadedPath).to.equal('');
+    expect(config.assets.staging.disk).to.equal('figshare-staging');
+    expect(config.assets.staging.keyPrefix).to.equal('figshare/');
     expect(config.workflow.transitionJob.enabled).to.equal(false);
     expect(config.workflow.transitionJob.namedQuery).to.equal('');
 
     const schema = FIGSHARE_PUBLISHING_SCHEMA as Record<string, any>;
     expect(schema.properties.queue.properties.publishAfterUploadDelay.default).to.equal('in 2 minutes');
+    expect(schema.properties.assets.properties.staging.properties.disk.default).to.equal('figshare-staging');
+    expect(schema.properties.assets.properties.staging.properties.keyPrefix.default).to.equal('figshare/');
     expect(schema.properties.workflow.properties.transitionJob.properties.username.default).to.equal('');
     expect(schema.properties.testing).to.equal(undefined);
   });
@@ -1274,16 +1883,20 @@ describe('Figshare record field helpers', function () {
     const record: Record<string, unknown> = {};
 
     expect(getRecordField(record as any, 'metadata..title')).to.equal(undefined);
-    expect(() => setRecordField(record as any, 'metadata..title', 'Title')).to.throw("Invalid record field path");
+    expect(() => setRecordField(record as any, 'metadata..title', 'Title')).to.throw('Invalid record field path');
   });
 
   it('should reject prototype-polluting path segments', function () {
     const record: Record<string, unknown> = {};
 
     expect(getRecordField(record as any, '__proto__.polluted')).to.equal(undefined);
-    expect(() => setRecordField(record as any, '__proto__.polluted', true)).to.throw("Invalid record field path");
-    expect(() => setRecordField(record as any, 'constructor.prototype.polluted', true)).to.throw("Invalid record field path");
-    expect(() => setRecordField(record as any, 'metadata.prototype.polluted', true)).to.throw("Invalid record field path");
+    expect(() => setRecordField(record as any, '__proto__.polluted', true)).to.throw('Invalid record field path');
+    expect(() => setRecordField(record as any, 'constructor.prototype.polluted', true)).to.throw(
+      'Invalid record field path'
+    );
+    expect(() => setRecordField(record as any, 'metadata.prototype.polluted', true)).to.throw(
+      'Invalid record field path'
+    );
     expect(({} as Record<string, unknown>).polluted).to.equal(undefined);
   });
 });


### PR DESCRIPTION
## Summary

Refactors Figshare hosted-file uploads to stage source datastreams through `StorageManagerService` instead of direct filesystem paths. This adds configurable Figshare staging disk support while preserving existing Figshare publishing behavior and stored configuration compatibility.

---

## Context / Motivation

Figshare uploads previously depended on local filesystem staging, temp directory management, and explicit disk-space checks. That made the upload path harder to run consistently across deployments where attachments may live behind StorageManager-backed disks, including S3-compatible storage.

This change moves staging behind the existing storage abstraction so Figshare uploads can use the same disk model as the rest of ReDBox.

---

## Key Features

### Storage-backed Figshare staging

- Adds a default `figshare-staging` storage disk.
- Adds `figsharePublishing.assets.staging.disk` to select the StorageManager disk used for upload staging.
- Adds `figsharePublishing.assets.staging.keyPrefix` to control staged object keys.
- Falls back to the configured StorageManager staging disk when no Figshare-specific disk is configured.

### Upload lifecycle refactor

- Stages datastream attachments using `StorageManagerService` before creating Figshare file records.
- Streams staged objects into Figshare multipart uploads in ordered part boundaries.
- Avoids fully buffering staged files in memory before upload.
- Deletes staged objects after successful uploads by default.
- Supports retaining staged objects after successful uploads via `cleanupPolicy: retainForRetry`.
- Always attempts staged-object cleanup after upload failures.
- Validates malformed or truncated staged objects before completing uploads.

### Configuration compatibility

- Keeps legacy `tempDir` and `diskSpaceThresholdBytes` fields in the Figshare publishing config for existing stored configuration compatibility.
- Marks legacy filesystem-only staging settings as deprecated because capacity and write failures now surface from the configured StorageManager disk.
- Extends the Figshare publishing schema so the staging disk and key prefix can be managed through config.

---

## Testing

- Added live-upload unit coverage for StorageManager-backed Figshare staging.
- Covered ordered multipart upload streaming, uneven part boundaries, cleanup behavior, retain-for-retry behavior, truncated staged object validation, fallback staging disk behavior, and fixture-mode isolation.
- Verified Figshare publishing defaults and schema expose the new staging disk/key prefix settings.

Validated locally with:

- `npm run build`
- `tsc --noEmit -p test/tsconfig.json`
- Targeted `FigshareService.test.ts`

---

## Architectural / Operational Impact

### Storage abstraction

Figshare upload staging now uses `StorageManagerService` instead of direct filesystem operations. This aligns Figshare publishing with deployments that use non-local storage backends and reduces environment-specific staging assumptions.

### Operational configuration

Deployments can configure a dedicated staging disk for Figshare uploads. Existing configurations that still contain `tempDir` and `diskSpaceThresholdBytes` remain loadable, but those values are no longer used by the new staging implementation.

### Failure handling

Upload failures now clean up staged objects through the configured storage disk on a best-effort basis. Storage capacity, permissions, and connectivity errors are surfaced by the StorageManager disk implementation.

---

## Backwards Compatibility

Existing Figshare publishing configuration remains compatible. The legacy staging fields are retained, but deployments should migrate operational staging behavior to `assets.staging.disk` and `assets.staging.keyPrefix`.

Fixture-mode Figshare tests and metadata-only publishing behavior are unchanged.

---

## Deployment Notes

Deployments should ensure the configured Figshare staging disk exists and is writable. The default disk is `figshare-staging`, with staged keys under `figshare/`.

If a deployment previously relied on `assets.staging.tempDir`, it should configure an equivalent StorageManager disk instead.

---

## Impact

This makes Figshare file upload staging backend-agnostic, improves support for S3-compatible storage, and keeps the upload path covered by focused lifecycle and multipart streaming tests.
