### PR TITLE
Fix attachment upload and Figshare asset edge cases

### DIFF
--- a/packages/redbox-core/src/controllers/RecordController.ts
+++ b/packages/redbox-core/src/controllers/RecordController.ts
@@ -1297,6 +1297,9 @@ export namespace Controllers {
       sails.log.verbose(`Have attach Id: ${attachId}`);
       this.initTusServer();
       const method = _.toLower(req.method);
+      this.logger.verbose(
+        `TUS attachment request method=${method} oid=${oid} attachId=${attachId} contentLength=${String(req.headers['content-length'] ?? '')} uploadOffset=${String(req.headers['upload-offset'] ?? '')} uploadLength=${String(req.headers['upload-length'] ?? '')} contentType=${String(req.headers['content-type'] ?? '')}`
+      );
 
       const brandPortalPrefix = BrandingService.getBrandAndPortalPath(req);
       const defaultAttachmentPrefix = `${brandPortalPrefix}/record/${oid}`;

--- a/packages/redbox-core/src/services/FigshareService.ts
+++ b/packages/redbox-core/src/services/FigshareService.ts
@@ -218,7 +218,7 @@ export namespace Services {
 
       const syncState = this.getSyncState(config, rm);
       const client = this.makeClient(config, rm, syncState.correlationId, 'syncAssets');
-      return syncAssetsPhase(client, config, rm, article, syncState);
+      return syncAssetsPhase(client, config, rm, article, syncState, this.logger);
     }
 
     public async syncEmbargo(record: RecordModel, articleId: string): Promise<Record<string, unknown>> {

--- a/packages/redbox-core/src/services/RecordsService.ts
+++ b/packages/redbox-core/src/services/RecordsService.ts
@@ -88,10 +88,13 @@ export namespace Services {
       this.logHeader = 'RecordsService::';
     }
 
-    private describeError(error: unknown): string {
+    private describeError(error: unknown, depth = 0): string {
+      if (depth >= 5) {
+        return '[cause chain truncated]';
+      }
       if (error instanceof Error) {
         const cause = (error as Error & { cause?: unknown }).cause;
-        const causeMessage = cause == null ? '' : `; cause=${this.describeError(cause)}`;
+        const causeMessage = cause == null ? '' : `; cause=${this.describeError(cause, depth + 1)}`;
         return `${error.name}: ${error.message}${causeMessage}`;
       }
       if (typeof error === 'string') {

--- a/packages/redbox-core/src/services/RecordsService.ts
+++ b/packages/redbox-core/src/services/RecordsService.ts
@@ -88,6 +88,22 @@ export namespace Services {
       this.logHeader = 'RecordsService::';
     }
 
+    private describeError(error: unknown): string {
+      if (error instanceof Error) {
+        const cause = (error as Error & { cause?: unknown }).cause;
+        const causeMessage = cause == null ? '' : `; cause=${this.describeError(cause)}`;
+        return `${error.name}: ${error.message}${causeMessage}`;
+      }
+      if (typeof error === 'string') {
+        return error;
+      }
+      try {
+        return JSON.stringify(error);
+      } catch {
+        return String(error);
+      }
+    }
+
     private asArray(value: unknown): string[] | undefined {
       if (Array.isArray(value)) {
         return value as string[];
@@ -1946,21 +1962,22 @@ export namespace Services {
       return this.datastreamService.updateDatastream(oid, origRecord, metadata, stagingDisk, fileIdsAdded).pipe(
         concatMap((reqs: Promise<unknown>[]) => {
           if (Array.isArray(reqs) && reqs.length > 0) {
-            sails.log.verbose(`Updating data streams...`);
+            this.logger.verbose(`Updating data streams...`);
             return from(reqs);
           }
-          sails.log.verbose(`No datastreams to update...`);
+          this.logger.verbose(`No datastreams to update...`);
           return of(null);
         }),
         concatMap((promise: Promise<unknown> | null) => {
           if (promise) {
-            sails.log.verbose(`Update datastream request is...`);
-            sails.log.verbose(JSON.stringify(promise));
+            this.logger.verbose(`Update datastream request is...`);
+            this.logger.verbose(JSON.stringify(promise));
             return from(promise).pipe(
               catchError((e: unknown) => {
-                sails.log.verbose(`Error in updating stream::::`);
-                sails.log.verbose(JSON.stringify(e));
-                return throwError(new Error(TranslationService.t('attachment-upload-error')));
+                const detail = this.describeError(e);
+                this.logger.verbose(`Error in updating stream::::`);
+                this.logger.verbose(detail);
+                return throwError(() => new Error(`${TranslationService.t('attachment-upload-error')}: ${detail}`));
               })
             );
           }
@@ -1968,8 +1985,8 @@ export namespace Services {
         }),
         concatMap(updateResp => {
           if (updateResp) {
-            sails.log.verbose(`Got response from update datastream request...`);
-            sails.log.verbose(JSON.stringify(updateResp));
+            this.logger.verbose(`Got response from update datastream request...`);
+            this.logger.verbose(JSON.stringify(updateResp));
           }
           return of(updateResp);
         }),

--- a/packages/redbox-core/src/services/StandardDatastreamService.ts
+++ b/packages/redbox-core/src/services/StandardDatastreamService.ts
@@ -267,7 +267,7 @@ export namespace Services {
       };
     }
 
-    private isStorageNotFoundError(err: unknown): boolean {
+    private isStorageNotFoundError(err: unknown, depth = 0): boolean {
       if (!err || typeof err !== 'object') {
         return false;
       }
@@ -295,7 +295,7 @@ export namespace Services {
         || message.includes('no such')
         || message.includes('does not exist')
         || message.includes('enoent')
-        || (!!storageError.cause && this.isStorageNotFoundError(storageError.cause));
+        || (depth < 5 && !!storageError.cause && this.isStorageNotFoundError(storageError.cause, depth + 1));
     }
 
     private isStorageAlreadyExistsError(err: unknown): boolean {
@@ -679,6 +679,10 @@ export namespace Services {
         let primaryCheck = await this.checkPrimaryObject(primaryDisk, destKey);
         if (primaryCheck.available) {
           this.logger.verbose(`${this.logHeader} addDatastream() -> Already present: ${destKey} via ${primaryCheck.via}`);
+          // This idempotent repair path confirms that a previous promotion already
+          // made the file durable. Recording upload access again is intentional:
+          // downstream audit can see both the physical promotion and the later
+          // metadata-update acceptance that completed the retried workflow.
           await this.afterDatastreamPromoted(oid, fileId, destKey, datastream);
           return { success: true, key: destKey };
         }

--- a/packages/redbox-core/src/services/StandardDatastreamService.ts
+++ b/packages/redbox-core/src/services/StandardDatastreamService.ts
@@ -718,7 +718,16 @@ export namespace Services {
         }
         const promotedTusParts = await this.promoteTusPartsFromStaging(effectiveStagingDisk, primaryDisk, fileId, destKey);
         if (!promotedTusParts) {
+          // Re-check primary: a concurrent request may have promoted the file
+          // after the initial check but before/while the TUS attempt ran.
           primaryCheck = await this.checkPrimaryObject(primaryDisk, destKey);
+          if (primaryCheck.available) {
+            this.logger.verbose(
+              `${this.logHeader} addDatastream() -> Promoted concurrently: ${destKey} via ${primaryCheck.via}`
+            );
+            await this.afterDatastreamPromoted(oid, fileId, destKey, datastream);
+            return { success: true, key: destKey };
+          }
           throw new Error(
             `Attachment not found in staging: ${fileId}. Checked staged object '${fileId}' and TUS part prefixes: ${this
               .tusPartPrefixes(fileId)

--- a/packages/redbox-core/src/services/StandardDatastreamService.ts
+++ b/packages/redbox-core/src/services/StandardDatastreamService.ts
@@ -469,13 +469,43 @@ export namespace Services {
         }
       }
       if (populatedPrefixes.length > 1) {
-        throw new Error(
-          `Ambiguous TUS upload parts for fileId '${fileId}': found parts in ${populatedPrefixes
-            .map((selection) => `'${selection.prefix}'`)
-            .join(', ')}`
+        const [firstSelection, ...otherSelections] = populatedPrefixes;
+        const firstSignature = await this.tusPartSelectionSignature(stagingDisk, firstSelection);
+        const allEquivalent = (
+          await Promise.all(
+            otherSelections.map(async (selection) =>
+              _.isEqual(firstSignature, await this.tusPartSelectionSignature(stagingDisk, selection))
+            )
+          )
+        ).every(Boolean);
+        if (!allEquivalent) {
+          throw new Error(
+            `Ambiguous TUS upload parts for fileId '${fileId}': found parts in ${populatedPrefixes
+              .map((selection) => `'${selection.prefix}'`)
+              .join(', ')}`
+          );
+        }
+        this.logger.verbose(
+          `${this.logHeader} selectTusPartPrefix() -> Equivalent TUS part prefixes found for ${fileId}; using '${firstSelection.prefix}'`
         );
+        return firstSelection;
       }
       return populatedPrefixes[0] ?? { partKeys: [] };
+    }
+
+    private async tusPartSelectionSignature(stagingDisk: IDisk, selection: TusPartPrefixSelection): Promise<string[]> {
+      const signature = [];
+      for (const partKey of selection.partKeys) {
+        const metadata = await stagingDisk.getMetaData(partKey);
+        signature.push(`${this.tusPartRelativeKey(partKey)}:${metadata.contentLength}`);
+      }
+      return signature.sort((left, right) => left.localeCompare(right));
+    }
+
+    private tusPartRelativeKey(partKey: string): string {
+      const partsMarker = '/parts/';
+      const partsMarkerIndex = partKey.indexOf(partsMarker);
+      return partsMarkerIndex >= 0 ? partKey.substring(partsMarkerIndex + partsMarker.length) : partKey;
     }
 
     private listedObjectKey(object: unknown): string | undefined {

--- a/packages/redbox-core/src/services/StandardDatastreamService.ts
+++ b/packages/redbox-core/src/services/StandardDatastreamService.ts
@@ -13,6 +13,11 @@ import type { Services as AttachmentMetadataServices } from './AttachmentMetadat
 type IDisk = StorageManagerServices.IDisk;
 type AttachmentAccessAction = 'access' | 'download' | 'list' | 'upload' | 'remove';
 type AttachmentMetadataInput = AttachmentMetadataServices.AttachmentMetadataInput;
+type PrimaryObjectCheck = {
+  available: boolean;
+  via: 'exists' | 'metadata' | 'missing';
+  error?: string;
+};
 type AttachmentMetadataServiceContract = {
   upsert: (row: AttachmentMetadataInput) => Promise<void>;
   findByOid: (oid: string) => Promise<AttachmentMetadataAttributes[]>;
@@ -265,20 +270,28 @@ export namespace Services {
 
       const storageError = err as {
         code?: string;
+        name?: string;
         status?: number;
         statusCode?: number;
+        $metadata?: { httpStatusCode?: number };
         message?: string;
+        cause?: unknown;
       };
       const message = storageError.message?.toLowerCase() ?? '';
+      const code = storageError.code?.toLowerCase() ?? '';
+      const name = storageError.name?.toLowerCase() ?? '';
+      const statusCode = storageError.status ?? storageError.statusCode ?? storageError.$metadata?.httpStatusCode;
 
-      return storageError.code === 'ENOENT'
-        || storageError.code === 'NoSuchKey'
-        || storageError.status === 404
-        || storageError.statusCode === 404
+      return code === 'enoent'
+        || code === 'nosuchkey'
+        || name === 'notfound'
+        || name === 'notfoundexception'
+        || statusCode === 404
         || message.includes('not found')
         || message.includes('no such')
         || message.includes('does not exist')
-        || message.includes('enoent');
+        || message.includes('enoent')
+        || (!!storageError.cause && this.isStorageNotFoundError(storageError.cause));
     }
 
     private isStorageAlreadyExistsError(err: unknown): boolean {
@@ -299,6 +312,33 @@ export namespace Services {
         || storageError.statusCode === 409
         || message.includes('already exists')
         || message.includes('eexist');
+    }
+
+    private describeStorageError(err: unknown): string {
+      if (err instanceof Error) {
+        return err.message;
+      }
+      return String(err);
+    }
+
+    private async checkPrimaryObject(primaryDisk: IDisk, destKey: string): Promise<PrimaryObjectCheck> {
+      if (await primaryDisk.exists(destKey)) {
+        return { available: true, via: 'exists' };
+      }
+
+      try {
+        await primaryDisk.getMetaData(destKey);
+        return { available: true, via: 'metadata' };
+      } catch (err) {
+        if (!this.isStorageNotFoundError(err)) {
+          this.logger.warn(`${this.logHeader} primary object metadata check failed for ${destKey}`, err);
+        }
+        return {
+          available: false,
+          via: 'missing',
+          error: this.describeStorageError(err),
+        };
+      }
     }
 
     private async promoteFromStagingOnce(oid: string, fileId: string, destKey: string): Promise<boolean> {
@@ -323,15 +363,16 @@ export namespace Services {
       const stagingDisk = StorageManagerService.stagingDisk();
       const primaryDisk = StorageManagerService.primaryDisk();
 
-      if (await primaryDisk.exists(destKey)) {
-        this.logger.verbose(`${this.logHeader} promoteFromStaging() -> Already present: ${destKey}`);
+      const primaryCheck = await this.checkPrimaryObject(primaryDisk, destKey);
+      if (primaryCheck.available) {
+        this.logger.verbose(`${this.logHeader} promoteFromStaging() -> Already present: ${destKey} via ${primaryCheck.via}`);
         return true;
       }
 
       const existsInStaging = await stagingDisk.exists(fileId);
       if (!existsInStaging) {
         return await this.promoteTusPartsFromStaging(stagingDisk, primaryDisk, fileId, destKey)
-          || primaryDisk.exists(destKey);
+          || (await this.checkPrimaryObject(primaryDisk, destKey)).available;
       }
 
       const metadata = await stagingDisk.getMetaData(fileId);
@@ -341,7 +382,7 @@ export namespace Services {
         await this.putStagedObject(primaryDisk, destKey, stagingDisk, fileId, readable, metadata.contentLength);
       } catch (err) {
         readable.destroy();
-        if (!this.isStorageAlreadyExistsError(err) || !(await primaryDisk.exists(destKey))) {
+        if (!this.isStorageAlreadyExistsError(err) || !(await this.checkPrimaryObject(primaryDisk, destKey)).available) {
           throw err;
         }
       }
@@ -382,12 +423,18 @@ export namespace Services {
       const readable = Readable.from(this.streamDiskObjects(stagingDisk, partKeys));
       try {
         await primaryDisk.putStream(destKey, readable, { contentLength });
-        await stagingDisk.deleteAll(this.tusPartsPrefix(fileId));
-        await stagingDisk.delete(this.tusInfoKey(fileId)).catch((err) => {
-          if (!this.isStorageNotFoundError(err)) {
-            throw err;
-          }
-        });
+        for (const prefix of this.tusBasePrefixes(fileId)) {
+          await stagingDisk.deleteAll(this.tusPartsPrefix(prefix)).catch((err) => {
+            if (!this.isStorageNotFoundError(err)) {
+              throw err;
+            }
+          });
+          await stagingDisk.delete(this.tusInfoKey(prefix)).catch((err) => {
+            if (!this.isStorageNotFoundError(err)) {
+              throw err;
+            }
+          });
+        }
       } catch (err) {
         readable.destroy();
         throw err;
@@ -398,11 +445,16 @@ export namespace Services {
     }
 
     private async listTusPartKeys(stagingDisk: IDisk, fileId: string): Promise<string[]> {
-      const listed = await stagingDisk.listAll(this.tusPartsPrefix(fileId), { recursive: true });
-      return Array.from(listed.objects)
-        .map((object) => this.listedObjectKey(object))
-        .filter((key): key is string => typeof key === 'string' && key.length > 0)
-        .sort((left, right) => left.localeCompare(right));
+      const partKeys: string[] = [];
+      for (const prefix of this.tusPartPrefixes(fileId)) {
+        const listed = await stagingDisk.listAll(prefix, { recursive: true });
+        partKeys.push(
+          ...Array.from(listed.objects)
+            .map((object) => this.listedObjectKey(object))
+            .filter((key): key is string => typeof key === 'string' && key.length > 0)
+        );
+      }
+      return _.uniq(partKeys).sort((left, right) => left.localeCompare(right));
     }
 
     private listedObjectKey(object: unknown): string | undefined {
@@ -428,12 +480,20 @@ export namespace Services {
       return total;
     }
 
-    private tusPartsPrefix(fileId: string): string {
-      return `.tus/${fileId}/parts/`;
+    private tusBasePrefixes(fileId: string): string[] {
+      return [`.tus/${fileId}`, `tus/${fileId}`];
     }
 
-    private tusInfoKey(fileId: string): string {
-      return `.tus/${fileId}/info.json`;
+    private tusPartPrefixes(fileId: string): string[] {
+      return this.tusBasePrefixes(fileId).map((prefix) => this.tusPartsPrefix(prefix));
+    }
+
+    private tusPartsPrefix(tusBasePrefix: string): string {
+      return `${tusBasePrefix}/parts/`;
+    }
+
+    private tusInfoKey(tusBasePrefix: string): string {
+      return `${tusBasePrefix}/info.json`;
     }
 
     private async *streamDiskObjects(stagingDisk: IDisk, keys: string[]): AsyncGenerator<Buffer> {
@@ -595,9 +655,22 @@ export namespace Services {
 
       const existsInStaging = await effectiveStagingDisk.exists(fileId);
       if (!existsInStaging) {
+        let primaryCheck = await this.checkPrimaryObject(primaryDisk, destKey);
+        if (primaryCheck.available) {
+          this.logger.verbose(`${this.logHeader} addDatastream() -> Already present: ${destKey} via ${primaryCheck.via}`);
+          await this.afterDatastreamPromoted(oid, fileId, destKey, datastream);
+          return { success: true, key: destKey };
+        }
         const promotedTusParts = await this.promoteTusPartsFromStaging(effectiveStagingDisk, primaryDisk, fileId, destKey);
         if (!promotedTusParts) {
-          throw new Error(`Attachment not found in staging: ${fileId}`);
+          primaryCheck = await this.checkPrimaryObject(primaryDisk, destKey);
+          throw new Error(
+            `Attachment not found in staging: ${fileId}. Checked staged object '${fileId}' and TUS part prefixes: ${this
+              .tusPartPrefixes(fileId)
+              .join(', ')}. Primary object '${destKey}' available=${primaryCheck.available} via=${primaryCheck.via}${
+              primaryCheck.error ? ` error=${primaryCheck.error}` : ''
+            }`
+          );
         }
         await this.afterDatastreamPromoted(oid, fileId, destKey, datastream);
         this.logger.verbose(`${this.logHeader} addDatastream() -> Successfully added: ${destKey}`);

--- a/packages/redbox-core/src/services/StandardDatastreamService.ts
+++ b/packages/redbox-core/src/services/StandardDatastreamService.ts
@@ -18,6 +18,10 @@ type PrimaryObjectCheck = {
   via: 'exists' | 'metadata' | 'missing';
   error?: string;
 };
+type TusPartPrefixSelection = {
+  prefix?: string;
+  partKeys: string[];
+};
 type AttachmentMetadataServiceContract = {
   upsert: (row: AttachmentMetadataInput) => Promise<void>;
   findByOid: (oid: string) => Promise<AttachmentMetadataAttributes[]>;
@@ -330,6 +334,9 @@ export namespace Services {
         await primaryDisk.getMetaData(destKey);
         return { available: true, via: 'metadata' };
       } catch (err) {
+        // This is only a primary-availability probe. A missing object is expected
+        // before staging/TUS promotion; callers decide whether absence is fatal
+        // after checking staging and TUS parts.
         if (!this.isStorageNotFoundError(err)) {
           this.logger.warn(`${this.logHeader} primary object metadata check failed for ${destKey}`, err);
         }
@@ -445,16 +452,30 @@ export namespace Services {
     }
 
     private async listTusPartKeys(stagingDisk: IDisk, fileId: string): Promise<string[]> {
-      const partKeys: string[] = [];
+      return (await this.selectTusPartPrefix(stagingDisk, fileId)).partKeys;
+    }
+
+    private async selectTusPartPrefix(stagingDisk: IDisk, fileId: string): Promise<TusPartPrefixSelection> {
+      const populatedPrefixes: TusPartPrefixSelection[] = [];
       for (const prefix of this.tusPartPrefixes(fileId)) {
         const listed = await stagingDisk.listAll(prefix, { recursive: true });
-        partKeys.push(
-          ...Array.from(listed.objects)
+        const partKeys = _.uniq(
+          Array.from(listed.objects)
             .map((object) => this.listedObjectKey(object))
             .filter((key): key is string => typeof key === 'string' && key.length > 0)
+        ).sort((left, right) => left.localeCompare(right));
+        if (partKeys.length) {
+          populatedPrefixes.push({ prefix, partKeys });
+        }
+      }
+      if (populatedPrefixes.length > 1) {
+        throw new Error(
+          `Ambiguous TUS upload parts for fileId '${fileId}': found parts in ${populatedPrefixes
+            .map((selection) => `'${selection.prefix}'`)
+            .join(', ')}`
         );
       }
-      return _.uniq(partKeys).sort((left, right) => left.localeCompare(right));
+      return populatedPrefixes[0] ?? { partKeys: [] };
     }
 
     private listedObjectKey(object: unknown): string | undefined {

--- a/packages/redbox-core/src/services/figshare-v2/assets.ts
+++ b/packages/redbox-core/src/services/figshare-v2/assets.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import _ from 'lodash';
 import { randomUUID } from 'node:crypto';
 import { Readable } from 'node:stream';
+import type { ILogger } from '../../Logger';
 import { FigsharePublishingConfigData } from '../../configmodels/FigsharePublishing';
 import { RBValidationError } from '../../model/RBValidationError';
 import type { Services as StorageManagerServices } from '../StorageManagerService';
@@ -64,8 +65,22 @@ async function getAttachmentStream(oid: string, fileId: string): Promise<Datastr
   return response;
 }
 
+async function ensureAttachmentDatastream(oid: string, fileId: string): Promise<void> {
+  const response = await getAttachmentStream(oid, fileId);
+  const stream = response.readstream as Readable | undefined;
+  if (typeof stream?.destroy === 'function') {
+    stream.destroy();
+  }
+}
+
 function sanitizePathComponent(value: string): string {
-  return value.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'item';
+  return (
+    value
+      .replace(/[^A-Za-z0-9._-]+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/-\./g, '.')
+      .replace(/^-+|-+$/g, '') || 'item'
+  );
 }
 
 function getStagingDisk(config: FigsharePublishingConfigData): IDisk {
@@ -95,23 +110,30 @@ function buildStagingKey(
   articleId: string,
   oid: string,
   fileId: string,
-  fileName: string
+  fileName: string,
+  logger?: ILogger
 ): string {
   const prefix = (config.assets.staging.keyPrefix ?? 'figshare/').replace(/^\/+|\/+$/g, '') || 'figshare';
-  const safeFileName = path.basename(fileName).trim();
-  if (safeFileName === '') {
+  const originalFileName = path.basename(fileName).trim();
+  if (originalFileName === '') {
     throw validationError(`Attachment '${fileName}' does not contain a valid file name`);
   }
   // basename() can still yield the reserved '.'/'..' segments, which would point the
   // staging key at the directory itself or escape it on an fs-backed disk.
-  if (safeFileName === '.' || safeFileName === '..') {
+  if (originalFileName === '.' || originalFileName === '..') {
     throw validationError(`Attachment '${fileName}' does not contain a valid file name`);
+  }
+  const storageFileName = sanitizePathComponent(originalFileName);
+  if (storageFileName !== originalFileName) {
+    logger?.verbose(
+      `FigService - sanitized staging filename '${originalFileName}' to '${storageFileName}' for attachment '${fileId}'`
+    );
   }
   // Append a per-attempt random segment so concurrent or retried uploads of the
   // same attachment never share a staging key (which would let one attempt
   // overwrite or delete the object another attempt is still streaming).
   const dir = `${sanitizePathComponent(articleId)}-${sanitizePathComponent(oid)}-${sanitizePathComponent(fileId)}-${randomUUID()}`;
-  return `${prefix}/${dir}/${safeFileName}`;
+  return `${prefix}/${dir}/${storageFileName}`;
 }
 
 async function stageAttachmentToDisk(disk: IDisk, key: string, response: DatastreamResponse): Promise<number> {
@@ -189,7 +211,8 @@ async function uploadAttachment(
   config: FigsharePublishingConfigData,
   articleId: string,
   oid: string,
-  attachment: DataLocationEntry
+  attachment: DataLocationEntry,
+  logger?: ILogger
 ): Promise<FigshareFile> {
   const fileId = attachment.fileId ?? '';
   const fileName = attachment.name ?? '';
@@ -198,7 +221,7 @@ async function uploadAttachment(
   }
 
   const disk = getStagingDisk(config);
-  const stagingKey = buildStagingKey(config, articleId, oid, fileId, fileName);
+  const stagingKey = buildStagingKey(config, articleId, oid, fileId, fileName, logger);
   const datastream = await getAttachmentStream(oid, fileId);
 
   let uploadSucceeded = false;
@@ -320,7 +343,8 @@ export async function syncAssetsPhase(
   config: ResolvedFigsharePublishingConfigData,
   record: RecordModel,
   article: FigshareArticle,
-  syncState: FigshareSyncState
+  syncState: FigshareSyncState,
+  logger?: ILogger
 ): Promise<AssetSyncResult> {
   const selectedDataLocations = getSelectedDataLocations(config, record);
   const selectedAttachments = selectedDataLocations.filter(entry => entry.type === 'attachment');
@@ -371,10 +395,11 @@ export async function syncAssetsPhase(
       const fileName = attachment.name ?? '';
       const alreadyUploaded = currentFiles.find(entry => entry.name === fileName);
       if (alreadyUploaded != null) {
+        await ensureAttachmentDatastream(oid, attachment.fileId ?? '');
         uploadedAttachments.push(alreadyUploaded);
         continue;
       }
-      uploadedAttachments.push(await uploadAttachment(client, config, articleId, oid, attachment));
+      uploadedAttachments.push(await uploadAttachment(client, config, articleId, oid, attachment, logger));
       uploadedAttachmentCountThisRun += 1;
     }
   }

--- a/packages/redbox-core/src/services/figshare-v2/assets.ts
+++ b/packages/redbox-core/src/services/figshare-v2/assets.ts
@@ -70,9 +70,14 @@ async function ensureAttachmentDatastream(oid: string, fileId: string): Promise<
   const stream = response.readstream as Readable | undefined;
   if (typeof stream?.destroy === 'function') {
     const ignoreDestroyError = () => undefined;
-    const removeDestroyErrorHandler = () => stream.off('error', ignoreDestroyError);
+    const removeDestroyErrorHandler = () => {
+      stream.off('error', ignoreDestroyError);
+      stream.off('close', removeDestroyErrorHandler);
+      stream.off('finish', removeDestroyErrorHandler);
+    };
     stream.once('error', ignoreDestroyError);
     stream.once('close', removeDestroyErrorHandler);
+    stream.once('finish', removeDestroyErrorHandler);
     stream.destroy();
   }
 }

--- a/packages/redbox-core/src/services/figshare-v2/assets.ts
+++ b/packages/redbox-core/src/services/figshare-v2/assets.ts
@@ -69,6 +69,10 @@ async function ensureAttachmentDatastream(oid: string, fileId: string): Promise<
   const response = await getAttachmentStream(oid, fileId);
   const stream = response.readstream as Readable | undefined;
   if (typeof stream?.destroy === 'function') {
+    const ignoreDestroyError = () => undefined;
+    const removeDestroyErrorHandler = () => stream.off('error', ignoreDestroyError);
+    stream.once('error', ignoreDestroyError);
+    stream.once('close', removeDestroyErrorHandler);
     stream.destroy();
   }
 }

--- a/packages/redbox-core/src/services/figshare-v2/context.ts
+++ b/packages/redbox-core/src/services/figshare-v2/context.ts
@@ -8,7 +8,7 @@ function inferRecordOid(record: RecordModel, jobId?: string): string {
   if (fromRecord) {
     return fromRecord;
   }
-  const fromJobId = String(jobId ?? '').match(/^([A-Za-z0-9]+):/)?.[1] ?? '';
+  const fromJobId = String(jobId ?? '').match(/^([^:]+):/)?.[1] ?? '';
   return fromJobId.trim();
 }
 

--- a/packages/redbox-core/src/services/figshare-v2/context.ts
+++ b/packages/redbox-core/src/services/figshare-v2/context.ts
@@ -2,9 +2,19 @@ import { FigsharePublishingConfigData } from '../../configmodels/FigsharePublish
 import { FigshareRunContext, RecordModel, getRecordField } from './types';
 import { getBrandName } from './config';
 
+function inferRecordOid(record: RecordModel, jobId?: string): string {
+  const rm = record as RecordModel & { redboxOid?: unknown; id?: unknown; oid?: unknown };
+  const fromRecord = String(rm.redboxOid ?? rm.id ?? rm.oid ?? '').trim();
+  if (fromRecord) {
+    return fromRecord;
+  }
+  const fromJobId = String(jobId ?? '').match(/^([A-Za-z0-9]+):/)?.[1] ?? '';
+  return fromJobId.trim();
+}
+
 export function createRunContext(record: RecordModel, config: FigsharePublishingConfigData, jobId?: string, triggerSource: string = 'manual'): FigshareRunContext {
   const rm = record as RecordModel;
-  const recordOid = rm.redboxOid ?? rm.id ?? '';
+  const recordOid = inferRecordOid(rm, jobId);
   const articleId = getRecordField(rm, config.record.articleIdPath);
   const correlationId = jobId || `${recordOid || 'record'}-${Date.now()}`;
   return {

--- a/packages/redbox-core/src/storage/TusStorageManagerDataStore.ts
+++ b/packages/redbox-core/src/storage/TusStorageManagerDataStore.ts
@@ -55,6 +55,9 @@ export class TusStorageManagerDataStore extends DataStore {
     const storedUpload = this.toStoredUpload(file);
     await this.writeUploadInfo(file.id, storedUpload);
     file.storage = { type: 'storage-manager', path: this.finalKey(file.id) };
+    this.logger?.verbose(
+      `TusStorageManagerDataStore: create id='${file.id}' size=${file.size ?? 'deferred'} offset=${file.offset} infoKey='${this.infoKey(file.id)}' finalKey='${this.finalKey(file.id)}'`
+    );
     return file;
   }
 
@@ -69,9 +72,15 @@ export class TusStorageManagerDataStore extends DataStore {
   public override async write(readable: Readable, id: string, offset: number): Promise<number> {
     const collected = await this.readStream(readable);
     this.validateWriteInputs(offset, collected.length);
+    this.logger?.verbose(
+      `TusStorageManagerDataStore: write received id='${id}' requestOffset=${offset} bytes=${collected.length}`
+    );
 
     return this.withUploadLock(id, async () => {
       const upload = await this.readStoredUpload(id);
+      this.logger?.verbose(
+        `TusStorageManagerDataStore: write state id='${id}' storedOffset=${upload.offset} size=${upload.size ?? 'deferred'}`
+      );
       if (upload.offset !== offset) {
         throw ERRORS.INVALID_OFFSET;
       }
@@ -86,9 +95,15 @@ export class TusStorageManagerDataStore extends DataStore {
 
       const partKey = this.partKey(id, offset);
       try {
+        this.logger?.verbose(
+          `TusStorageManagerDataStore: writing part id='${id}' partKey='${partKey}' bytes=${collected.length}`
+        );
         await this.disk.put(partKey, collected, { contentLength: collected.length });
         upload.offset = newOffset;
         await this.writeUploadInfo(id, upload);
+        this.logger?.verbose(
+          `TusStorageManagerDataStore: wrote part id='${id}' newOffset=${newOffset} infoKey='${this.infoKey(id)}'`
+        );
       } catch (error) {
         this.logger?.error(`TusStorageManagerDataStore: failed writing upload '${id}'`, error);
         throw ERRORS.FILE_WRITE_ERROR;
@@ -96,6 +111,9 @@ export class TusStorageManagerDataStore extends DataStore {
 
       if (upload.size !== undefined && newOffset === upload.size) {
         try {
+          this.logger?.verbose(
+            `TusStorageManagerDataStore: upload complete id='${id}' size=${upload.size}; materializing to '${this.finalKey(id)}'`
+          );
           await this.materializeUpload(id, upload, { deleteParts: true });
         } catch (error) {
           upload.offset = offset;
@@ -127,6 +145,9 @@ export class TusStorageManagerDataStore extends DataStore {
     const upload = await this.readStoredUpload(id);
     upload.size = uploadLength;
     await this.writeUploadInfo(id, upload);
+    this.logger?.verbose(
+      `TusStorageManagerDataStore: declareUploadLength id='${id}' uploadLength=${uploadLength} offset=${upload.offset}`
+    );
 
     if (upload.offset === uploadLength) {
       await this.materializeUpload(id, upload, { deleteParts: true });
@@ -223,12 +244,24 @@ export class TusStorageManagerDataStore extends DataStore {
 
   private async materializeUpload(id: string, upload: TusStoredUpload, options: { deleteParts: boolean }): Promise<void> {
     const partKeys = await this.listPartKeys(id);
+    this.logger?.verbose(
+      `TusStorageManagerDataStore: materialize id='${id}' partCount=${partKeys.length} partsPrefix='${this.partsPrefix(id)}' finalKey='${this.finalKey(id)}' contentLength=${upload.offset}`
+    );
+    if (!partKeys.length && upload.offset > 0) {
+      throw new Error(`No TUS parts found for '${id}' while materializing ${upload.offset} bytes`);
+    }
     const composed = Readable.from(this.streamPartsSequential(partKeys));
 
     try {
       await this.disk.putStream(this.finalKey(id), composed, { contentLength: upload.offset });
+      this.logger?.verbose(
+        `TusStorageManagerDataStore: materialized id='${id}' finalKey='${this.finalKey(id)}' contentLength=${upload.offset}`
+      );
       if (options.deleteParts) {
         await this.disk.deleteAll(this.partsPrefix(id));
+        this.logger?.verbose(
+          `TusStorageManagerDataStore: deleted parts id='${id}' partsPrefix='${this.partsPrefix(id)}'`
+        );
       }
     } catch (error) {
       this.logger?.error(`TusStorageManagerDataStore: failed composing upload '${id}'`, error);

--- a/packages/redbox-core/src/utilities/ContextVariableUtils.ts
+++ b/packages/redbox-core/src/utilities/ContextVariableUtils.ts
@@ -4,19 +4,16 @@ import { RecordContextVariableConfig } from '../config/record.config';
 type ContextVariablesConfigMap = Record<string, RecordContextVariableConfig>;
 
 export class ContextVariableUtils {
-  public static evaluateContextVariables(req: Sails.Req, _recordData: unknown): Record<string, string> {
+  public static evaluateContextVariables(req: Sails.Req, recordData: unknown): Record<string, string> {
     const result: Record<string, string> = {};
     const contextVariablesConfig = _get(sails, 'config.record.contextVariables', {}) as ContextVariablesConfigMap;
     for (const [fieldKey, fieldConfig] of Object.entries(contextVariablesConfig)) {
-      if (!fieldConfig || fieldConfig.source !== 'request') {
-        if (fieldConfig?.source && fieldConfig.source !== 'request') {
-          sails.log.warn(`Unsupported context variable source for ${fieldKey}: ${fieldConfig.source}`);
-        }
+      if (!fieldConfig) {
         continue;
       }
 
       try {
-        const rawValue = this.resolveFromRequest(req, fieldConfig);
+        const rawValue = this.resolveValue(req, recordData, fieldConfig);
         result[fieldKey] = this.sanitizeContextVariableValue(rawValue);
       } catch (error) {
         const errorType = error instanceof Error ? error.name : 'UnknownError';
@@ -25,6 +22,28 @@ export class ContextVariableUtils {
       }
     }
     return result;
+  }
+
+  private static resolveValue(req: Sails.Req, recordData: unknown, config: RecordContextVariableConfig): unknown {
+    if (config.source === 'request') {
+      return this.resolveFromRequest(req, config);
+    }
+    if (config.source === 'metadata') {
+      return this.resolveFromRecord(recordData, config, 'metadata');
+    }
+    if (config.source === 'record') {
+      return this.resolveFromRecord(recordData, config);
+    }
+    return '';
+  }
+
+  private static resolveFromRecord(recordData: unknown, config: RecordContextVariableConfig, basePath?: string): unknown {
+    const field = String(config.field ?? '').trim();
+    if (!field) {
+      return '';
+    }
+    const path = basePath ? `${basePath}.${field}` : field;
+    return _get(recordData, path);
   }
 
   private static resolveFromRequest(req: Sails.Req, config: RecordContextVariableConfig): unknown {

--- a/packages/redbox-core/src/utilities/ContextVariableUtils.ts
+++ b/packages/redbox-core/src/utilities/ContextVariableUtils.ts
@@ -13,7 +13,7 @@ export class ContextVariableUtils {
       }
 
       try {
-        const rawValue = this.resolveValue(req, recordData, fieldConfig);
+        const rawValue = this.resolveValue(req, recordData, fieldKey, fieldConfig);
         result[fieldKey] = this.sanitizeContextVariableValue(rawValue);
       } catch (error) {
         const errorType = error instanceof Error ? error.name : 'UnknownError';
@@ -24,7 +24,7 @@ export class ContextVariableUtils {
     return result;
   }
 
-  private static resolveValue(req: Sails.Req, recordData: unknown, config: RecordContextVariableConfig): unknown {
+  private static resolveValue(req: Sails.Req, recordData: unknown, fieldKey: string, config: RecordContextVariableConfig): unknown {
     if (config.source === 'request') {
       return this.resolveFromRequest(req, config);
     }
@@ -34,6 +34,7 @@ export class ContextVariableUtils {
     if (config.source === 'record') {
       return this.resolveFromRecord(recordData, config);
     }
+    sails.log.warn(`Unsupported context variable source for ${fieldKey}: ${String((config as { source?: unknown }).source ?? '')}`);
     return '';
   }
 

--- a/packages/redbox-core/test/services/FigshareService.test.ts
+++ b/packages/redbox-core/test/services/FigshareService.test.ts
@@ -1700,6 +1700,61 @@ describe('FigshareService', function () {
       expect(syncState.partialProgress?.uploadedAttachmentCountThisRun).to.equal(1);
     });
 
+    it('sanitizes the internal staging filename without changing the Figshare filename', async function () {
+      const fakeDisk = makeFakeDisk();
+      (global as any).StorageManagerService = {
+        disk: sinon.stub().returns(fakeDisk.disk),
+        stagingDisk: sinon.stub().returns(fakeDisk.disk),
+      };
+      const payload = Buffer.from('abcdefgh');
+      installDatastreamStub(payload, payload.length);
+      const client = buildAssetClient([{ partNo: 1, startOffset: 0, endOffset: 7 }]);
+      const config = buildLiveAssetConfig();
+      const record = buildAssetRecord([{ type: 'attachment', fileId: 'file-1', name: 'rdmp (2).pdf', selected: true }]);
+
+      await syncAssetsPhase(client, config, record, { id: 'article-1' }, { status: 'syncing' });
+
+      const stagingKey = fakeDisk.calls.put[0].key;
+      expect(stagingKey).to.match(/^figshare\/article-1-oid-1-file-1-[0-9a-f-]{36}\/rdmp-2\.pdf$/);
+      expect((client.createArticleFile as sinon.SinonStub).firstCall.args[1]).to.deep.equal({
+        name: 'rdmp (2).pdf',
+        size: payload.length,
+      });
+      expect(fakeDisk.calls.deleted).to.deep.equal([stagingKey]);
+    });
+
+    it('promotes local datastreams even when Figshare already has a same-named file', async function () {
+      const fakeDisk = makeFakeDisk();
+      (global as any).StorageManagerService = {
+        disk: sinon.stub().returns(fakeDisk.disk),
+        stagingDisk: sinon.stub().returns(fakeDisk.disk),
+      };
+      const getDatastreamStub = installDatastreamStub(Buffer.from('abcdefgh'), 8);
+      const client = buildAssetClient([{ partNo: 1, startOffset: 0, endOffset: 7 }]);
+      (client.listArticleFiles as sinon.SinonStub).resolves([
+        {
+          id: 'existing-figshare-file',
+          article_id: 'article-1',
+          name: 'file.txt',
+          status: 'available',
+          size: 8,
+        },
+      ]);
+      const config = buildLiveAssetConfig();
+      const record = buildAssetRecord([{ type: 'attachment', fileId: 'file-1', name: 'file.txt', selected: true }]);
+      const syncState: any = { status: 'syncing' };
+
+      const result = await syncAssetsPhase(client, config, record, { id: 'article-1' }, syncState);
+
+      expect(getDatastreamStub.calledOnceWithExactly('oid-1', 'file-1')).to.equal(true);
+      expect((client.createArticleFile as sinon.SinonStub).called).to.equal(false);
+      expect(fakeDisk.calls.put).to.deep.equal([]);
+      expect(result.uploadedAttachments).to.have.lengthOf(1);
+      expect(result.uploadedAttachments[0].id).to.equal('existing-figshare-file');
+      expect(syncState.partialProgress?.uploadedAttachmentCountThisRun).to.equal(0);
+      expect(syncState.partialProgress?.uploadedAttachmentCount).to.equal(1);
+    });
+
     it('streams Figshare part content without buffering each full part before upload', async function () {
       const fakeDisk = makeFakeDisk();
       let stagedSourceReads = 0;

--- a/packages/redbox-core/test/services/FigshareService.test.ts
+++ b/packages/redbox-core/test/services/FigshareService.test.ts
@@ -1,20 +1,21 @@
 import * as sinon from 'sinon';
 import { Readable } from 'node:stream';
-import { Services } from '../../src/services/FigshareService';
-import { ServiceExports } from '../../src/services';
-import { agendaQueue } from '../../src/config/agendaQueue.config';
-import { FigsharePublishing, FIGSHARE_PUBLISHING_SCHEMA } from '../../src/configmodels/FigsharePublishing';
-import { cleanupServiceTestGlobals, createMockSails, setupServiceTestGlobals } from './testHelper';
-import { resolveFigsharePublishingConfig } from '../../src/services/figshare-v2/config';
-import { createRunContext } from '../../src/services/figshare-v2/context';
-import { mapCreateArticleResponse } from '../../src/services/figshare-v2/http';
-import { buildMetadataPayload, syncMetadataPhase } from '../../src/services/figshare-v2/metadata';
-import { syncAssetsPhase } from '../../src/services/figshare-v2/assets';
-import { getRecordField, setRecordField } from '../../src/services/figshare-v2/types';
-import { RBValidationError } from '../../src/model/RBValidationError';
+import { createRequire } from 'node:module';
 import type { RecordModel } from '../../src/services/figshare-v2/types';
 import type { FigshareClient } from '../../src/services/figshare-v2/http';
 import type { FigsharePublishingConfigData } from '../../src/configmodels/FigsharePublishing';
+
+const testRequire = createRequire(import.meta.url);
+const { agendaQueue } = testRequire('../../src/config/agendaQueue.config');
+const { FigsharePublishing, FIGSHARE_PUBLISHING_SCHEMA } = testRequire('../../src/configmodels/FigsharePublishing');
+const { cleanupServiceTestGlobals, createMockSails, setupServiceTestGlobals } = testRequire('./testHelper');
+const { resolveFigsharePublishingConfig } = testRequire('../../src/services/figshare-v2/config');
+const { createRunContext } = testRequire('../../src/services/figshare-v2/context');
+const { mapCreateArticleResponse } = testRequire('../../src/services/figshare-v2/http');
+const { buildMetadataPayload, syncMetadataPhase } = testRequire('../../src/services/figshare-v2/metadata');
+const { syncAssetsPhase } = testRequire('../../src/services/figshare-v2/assets');
+const { getRecordField, setRecordField } = testRequire('../../src/services/figshare-v2/types');
+const { RBValidationError } = testRequire('../../src/model/RBValidationError');
 
 let expect!: Chai.ExpectStatic;
 
@@ -317,7 +318,8 @@ function buildAssetClient(
 }
 
 describe('FigshareService', function () {
-  let service: InstanceType<typeof Services.FigshareService>;
+  let service: any;
+  let ServiceExports: typeof import('../../src/services').ServiceExports;
   let getConfigStub: sinon.SinonStub;
   let appConfigByBrandStub: sinon.SinonStub;
 
@@ -348,6 +350,8 @@ describe('FigshareService', function () {
 
     setupServiceTestGlobals(mockSails);
     (global as any).AgendaQueueService = mockQueueService;
+    const { Services } = testRequire('../../src/services/FigshareService');
+    ({ ServiceExports } = testRequire('../../src/services'));
 
     appConfigByBrandStub = sinon.stub().callsFake((brand: string) => ({
       figsharePublishing: buildFigsharePublishingConfig({

--- a/packages/redbox-core/test/services/FigshareService.test.ts
+++ b/packages/redbox-core/test/services/FigshareService.test.ts
@@ -1776,6 +1776,40 @@ describe('FigshareService', function () {
       expect(syncState.partialProgress?.uploadedAttachmentCount).to.equal(1);
     });
 
+    it('removes the temporary destroy error handler when an ensured datastream emits finish', async function () {
+      const fakeDisk = makeFakeDisk();
+      (global as any).StorageManagerService = {
+        disk: sinon.stub().returns(fakeDisk.disk),
+        stagingDisk: sinon.stub().returns(fakeDisk.disk),
+      };
+      const readstream = new Readable({ read() { /* intentionally empty */ }, emitClose: false });
+      (global as any).sails.config.record = { datastreamService: 'datastreamservice' };
+      (global as any).sails.services.datastreamservice = {
+        getDatastream: sinon.stub().resolves({ readstream, size: 8 }),
+      };
+      const client = buildAssetClient([{ partNo: 1, startOffset: 0, endOffset: 7 }]);
+      (client.listArticleFiles as sinon.SinonStub).resolves([
+        {
+          id: 'existing-figshare-file',
+          article_id: 'article-1',
+          name: 'file.txt',
+          status: 'available',
+          size: 8,
+        },
+      ]);
+      const config = buildLiveAssetConfig();
+      const record = buildAssetRecord([{ type: 'attachment', fileId: 'file-1', name: 'file.txt', selected: true }]);
+
+      await syncAssetsPhase(client, config, record, { id: 'article-1' }, { status: 'syncing' });
+      expect(readstream.listenerCount('error')).to.equal(1);
+
+      readstream.emit('finish');
+
+      expect(readstream.listenerCount('error')).to.equal(0);
+      expect(readstream.listenerCount('finish')).to.equal(0);
+      expect(readstream.listenerCount('close')).to.equal(0);
+    });
+
     it('streams Figshare part content without buffering each full part before upload', async function () {
       const fakeDisk = makeFakeDisk();
       let stagedSourceReads = 0;

--- a/packages/redbox-core/test/services/FigshareService.test.ts
+++ b/packages/redbox-core/test/services/FigshareService.test.ts
@@ -6,6 +6,7 @@ import { agendaQueue } from '../../src/config/agendaQueue.config';
 import { FigsharePublishing, FIGSHARE_PUBLISHING_SCHEMA } from '../../src/configmodels/FigsharePublishing';
 import { cleanupServiceTestGlobals, createMockSails, setupServiceTestGlobals } from './testHelper';
 import { resolveFigsharePublishingConfig } from '../../src/services/figshare-v2/config';
+import { createRunContext } from '../../src/services/figshare-v2/context';
 import { mapCreateArticleResponse } from '../../src/services/figshare-v2/http';
 import { buildMetadataPayload, syncMetadataPhase } from '../../src/services/figshare-v2/metadata';
 import { syncAssetsPhase } from '../../src/services/figshare-v2/assets';
@@ -423,6 +424,26 @@ describe('FigshareService', function () {
     expect(exports).to.have.property('publishAfterUploadFilesJob');
     expect(exports).to.have.property('transitionRecordWorkflowFromFigshareArticlePropertiesJob');
     expect(exports).to.have.property('syncRecordWithFigshare');
+  });
+
+  it('infers record oid from the full job id prefix when record fields are empty', function () {
+    const context = createRunContext(
+      { redboxOid: '', id: '', oid: '', metaMetadata: { brandId: 'default' }, metadata: {} } as RecordModel,
+      buildFigsharePublishingConfig() as FigsharePublishingConfigData,
+      ' rdmp-1_0.test:publish-job '
+    );
+
+    expect(context.recordOid).to.equal('rdmp-1_0.test');
+  });
+
+  it('keeps record oid field precedence over the job id fallback', function () {
+    const context = createRunContext(
+      { redboxOid: 'record-oid', id: 'id-oid', oid: 'legacy-oid', metaMetadata: { brandId: 'default' }, metadata: {} } as RecordModel,
+      buildFigsharePublishingConfig() as FigsharePublishingConfigData,
+      'job-id:publish-job'
+    );
+
+    expect(context.recordOid).to.equal('record-oid');
   });
 
   it('honours triggerCondition before Figshare lifecycle sync', async function () {

--- a/packages/redbox-core/test/services/RecordsService.test.ts
+++ b/packages/redbox-core/test/services/RecordsService.test.ts
@@ -174,6 +174,18 @@ describe('RecordsService', function () {
     });
   });
 
+  describe('describeError', function () {
+    it('should truncate circular cause chains', function () {
+      const error = Object.assign(new Error('upload failed'), { name: 'UploadError' }) as Error & { cause?: unknown };
+      error.cause = error;
+
+      const result = RecordsService.describeError(error);
+
+      expect(result).to.include('UploadError: upload failed');
+      expect(result).to.include('[cause chain truncated]');
+    });
+  });
+
   describe('getStorageService', function () {
     it('should use configured storage service', function () {
       RecordsService.getStorageService();

--- a/packages/redbox-core/test/services/StandardDatastreamService.test.ts
+++ b/packages/redbox-core/test/services/StandardDatastreamService.test.ts
@@ -328,6 +328,71 @@ describe('StandardDatastreamService', function () {
       expect(mockPrimaryDisk.putStream.called).to.be.false;
       expect(mockStagingDisk.delete.called).to.be.false;
     });
+
+    it('should promote TUS parts when legacy and current prefixes contain equivalent parts', async function () {
+      const { Services } = require('../../src/services/StandardDatastreamService');
+      const service = new Services.StandardDatastream();
+
+      mockStagingDisk.exists.resolves(false);
+      mockPrimaryDisk.exists.resolves(false);
+      mockPrimaryDisk.getMetaData.rejects(Object.assign(new Error('not found'), { code: 'ENOENT' }));
+      mockStagingDisk.listAll.callsFake((prefix: string) => {
+        if (prefix === '.tus/tus-file/parts/') {
+          return Promise.resolve({ objects: [{ key: 'tus/tus-file/parts/00000000000000000000' }] });
+        }
+        if (prefix === 'tus/tus-file/parts/') {
+          return Promise.resolve({ objects: [{ key: 'tus/tus-file/parts/00000000000000000000' }] });
+        }
+        return Promise.resolve({ objects: [] });
+      });
+      mockStagingDisk.getMetaData.callsFake((key: string) => {
+        if (key.endsWith('/parts/00000000000000000000')) {
+          return Promise.resolve({ contentLength: 9 });
+        }
+        return Promise.reject(Object.assign(new Error('not found'), { code: 'ENOENT' }));
+      });
+      mockStagingDisk.getStream.callsFake(() => Readable.from(Buffer.from('test-data')));
+      mockPrimaryDisk.putStream.callsFake(async (_key: string, stream: Readable) => {
+        for await (const _chunk of stream) {
+          // Consume the lazy stream so part reads happen in the test.
+        }
+      });
+
+      const ds = new Datastream({ fileId: 'tus-file' });
+      const result = await service.addDatastream('oid-123', ds);
+
+      expect(result).to.deep.equal({ success: true, key: 'attachments/oid-123/tus-file' });
+      expect(mockPrimaryDisk.putStream.calledOnce).to.be.true;
+      expect(mockPrimaryDisk.putStream.firstCall.args[0]).to.equal('attachments/oid-123/tus-file');
+      expect(mockStagingDisk.getStream.calledOnceWithExactly('tus/tus-file/parts/00000000000000000000')).to.be.true;
+    });
+
+    it('should reject TUS parts when legacy and current prefixes contain different parts', async function () {
+      const { Services } = require('../../src/services/StandardDatastreamService');
+      const service = new Services.StandardDatastream();
+
+      mockStagingDisk.exists.resolves(false);
+      mockPrimaryDisk.exists.resolves(false);
+      mockPrimaryDisk.getMetaData.rejects(Object.assign(new Error('not found'), { code: 'ENOENT' }));
+      mockStagingDisk.listAll.callsFake((prefix: string) => {
+        if (prefix === '.tus/tus-file/parts/') {
+          return Promise.resolve({ objects: [{ key: '.tus/tus-file/parts/0' }] });
+        }
+        if (prefix === 'tus/tus-file/parts/') {
+          return Promise.resolve({ objects: [{ key: 'tus/tus-file/parts/1' }] });
+        }
+        return Promise.resolve({ objects: [] });
+      });
+      mockStagingDisk.getMetaData.resolves({ contentLength: 9 });
+
+      const ds = new Datastream({ fileId: 'tus-file' });
+      try {
+        await service.addDatastream('oid-123', ds);
+        expect.fail('Should have thrown');
+      } catch (err: any) {
+        expect(err.message).to.include('Ambiguous TUS upload parts');
+      }
+    });
   });
 
   describe('addDatastreams', function () {

--- a/packages/redbox-core/test/services/StandardDatastreamService.test.ts
+++ b/packages/redbox-core/test/services/StandardDatastreamService.test.ts
@@ -269,6 +269,27 @@ describe('StandardDatastreamService', function () {
       expect(mockSails.log.warn.called).to.be.false;
     });
 
+    it('should bound recursive storage not found checks for circular cause chains', async function () {
+      const { Services } = require('../../src/services/StandardDatastreamService');
+      const service = new Services.StandardDatastream();
+
+      mockStagingDisk.exists.resolves(false);
+      mockPrimaryDisk.exists.resolves(false);
+      const circularError = Object.assign(new Error('wrapped storage failure'), { name: 'StorageError' }) as Error & { cause?: unknown };
+      circularError.cause = circularError;
+      mockPrimaryDisk.getMetaData.rejects(circularError);
+
+      const ds = new Datastream({ fileId: 'missing-file' });
+      try {
+        await service.addDatastream('oid-123', ds);
+        expect.fail('Should have thrown');
+      } catch (err: any) {
+        expect(err.message).to.include('Attachment not found in staging');
+      }
+
+      expect(mockSails.log.warn.called).to.be.true;
+    });
+
     it('should treat an already-promoted primary object as a successful add', async function () {
       const { Services } = require('../../src/services/StandardDatastreamService');
       const service = new Services.StandardDatastream();

--- a/packages/redbox-core/test/services/StandardDatastreamService.test.ts
+++ b/packages/redbox-core/test/services/StandardDatastreamService.test.ts
@@ -235,6 +235,8 @@ describe('StandardDatastreamService', function () {
       const service = new Services.StandardDatastream();
 
       mockStagingDisk.exists.resolves(false);
+      mockPrimaryDisk.exists.resolves(false);
+      mockPrimaryDisk.getMetaData.rejects(Object.assign(new Error('not found'), { code: 'ENOENT' }));
 
       const ds = new Datastream({ fileId: 'missing-file' });
       try {
@@ -243,6 +245,67 @@ describe('StandardDatastreamService', function () {
       } catch (err: any) {
         expect(err.message).to.include('Attachment not found in staging');
       }
+    });
+
+    it('should treat wrapped S3 not found metadata errors as a missing primary object', async function () {
+      const { Services } = require('../../src/services/StandardDatastreamService');
+      const service = new Services.StandardDatastream();
+
+      mockStagingDisk.exists.resolves(false);
+      mockPrimaryDisk.exists.resolves(false);
+      const wrappedNotFound = Object.assign(new Error('Unable to retrieve metadata: UnknownError'), {
+        cause: Object.assign(new Error('UnknownError'), { name: 'NotFound' }),
+      });
+      mockPrimaryDisk.getMetaData.rejects(wrappedNotFound);
+
+      const ds = new Datastream({ fileId: 'missing-file' });
+      try {
+        await service.addDatastream('oid-123', ds);
+        expect.fail('Should have thrown');
+      } catch (err: any) {
+        expect(err.message).to.include('Attachment not found in staging');
+      }
+
+      expect(mockSails.log.warn.called).to.be.false;
+    });
+
+    it('should treat an already-promoted primary object as a successful add', async function () {
+      const { Services } = require('../../src/services/StandardDatastreamService');
+      const service = new Services.StandardDatastream();
+
+      mockStagingDisk.exists.resolves(false);
+      mockPrimaryDisk.exists.withArgs('attachments/oid-123/already-promoted-file').resolves(true);
+
+      const ds = new Datastream({ fileId: 'already-promoted-file' });
+      const result = await service.addDatastream('oid-123', ds);
+
+      expect(result).to.deep.equal({ success: true, key: 'attachments/oid-123/already-promoted-file' });
+      expect(mockStagingDisk.getStream.called).to.be.false;
+      expect(mockPrimaryDisk.putStream.called).to.be.false;
+      expect(mockStagingDisk.delete.called).to.be.false;
+    });
+
+    it('should treat primary metadata as proof of an already-promoted object', async function () {
+      const { Services } = require('../../src/services/StandardDatastreamService');
+      const service = new Services.StandardDatastream();
+
+      mockStagingDisk.exists.resolves(false);
+      mockPrimaryDisk.exists.withArgs('attachments/oid-123/metadata-visible-file').resolves(false);
+      mockPrimaryDisk.getMetaData.withArgs('attachments/oid-123/metadata-visible-file').resolves({
+        contentType: 'text/plain',
+        contentLength: 373,
+        etag: 'metadata-etag',
+        lastModified: new Date(),
+      });
+
+      const ds = new Datastream({ fileId: 'metadata-visible-file' });
+      const result = await service.addDatastream('oid-123', ds);
+
+      expect(result).to.deep.equal({ success: true, key: 'attachments/oid-123/metadata-visible-file' });
+      expect(mockPrimaryDisk.getMetaData.calledWith('attachments/oid-123/metadata-visible-file')).to.be.true;
+      expect(mockStagingDisk.getStream.called).to.be.false;
+      expect(mockPrimaryDisk.putStream.called).to.be.false;
+      expect(mockStagingDisk.delete.called).to.be.false;
     });
   });
 
@@ -353,6 +416,7 @@ describe('StandardDatastreamService', function () {
 
       mockPrimaryDisk.exists.resolves(false);
       mockStagingDisk.exists.resolves(false);
+      mockPrimaryDisk.getMetaData.rejects(Object.assign(new Error('not found'), { code: 'ENOENT' }));
 
       try {
         await service.getDatastream('oid-123', 'missing-file');
@@ -368,6 +432,7 @@ describe('StandardDatastreamService', function () {
 
       mockPrimaryDisk.exists.onFirstCall().resolves(false);
       mockPrimaryDisk.exists.onSecondCall().resolves(false);
+      mockPrimaryDisk.getMetaData.rejects(Object.assign(new Error('not found'), { code: 'ENOENT' }));
       mockStagingDisk.exists.resolves(true);
 
       const result = await service.getDatastream('oid-123', 'file-123');
@@ -385,6 +450,7 @@ describe('StandardDatastreamService', function () {
 
       mockPrimaryDisk.exists.resolves(false);
       mockStagingDisk.exists.resolves(true);
+      mockPrimaryDisk.getMetaData.rejects(Object.assign(new Error('not found'), { code: 'ENOENT' }));
       mockPrimaryDisk.putStream.rejects(new Error('primary promotion failed'));
 
       try {
@@ -418,6 +484,7 @@ describe('StandardDatastreamService', function () {
       mockPrimaryDisk.exists.onCall(0).resolves(false);
       mockPrimaryDisk.exists.onCall(1).resolves(false);
       mockPrimaryDisk.exists.onCall(2).resolves(false);
+      mockPrimaryDisk.getMetaData.rejects(Object.assign(new Error('not found'), { code: 'ENOENT' }));
       mockStagingDisk.exists.resolves(true);
       mockPrimaryDisk.putStream.callsFake(() => new Promise<void>((resolve) => {
         resolvePromotion = resolve;
@@ -447,6 +514,7 @@ describe('StandardDatastreamService', function () {
       mockPrimaryDisk.exists.onCall(0).resolves(false);
       mockPrimaryDisk.exists.onCall(1).resolves(false);
       mockPrimaryDisk.exists.onCall(2).resolves(true);
+      mockPrimaryDisk.getMetaData.rejects(Object.assign(new Error('not found'), { code: 'ENOENT' }));
       mockStagingDisk.exists.resolves(true);
       mockPrimaryDisk.putStream.rejects(new Error('already exists'));
 
@@ -462,6 +530,7 @@ describe('StandardDatastreamService', function () {
 
       mockPrimaryDisk.exists.onFirstCall().resolves(false);
       mockPrimaryDisk.exists.onSecondCall().resolves(false);
+      mockPrimaryDisk.getMetaData.rejects(Object.assign(new Error('not found'), { code: 'ENOENT' }));
       mockStagingDisk.exists.resolves(true);
       mockStagingDisk.delete.rejects(new Error('ENOENT'));
 

--- a/packages/redbox-core/test/services/StandardDatastreamService.test.ts
+++ b/packages/redbox-core/test/services/StandardDatastreamService.test.ts
@@ -306,6 +306,24 @@ describe('StandardDatastreamService', function () {
       expect(mockStagingDisk.delete.called).to.be.false;
     });
 
+    it('should succeed when a concurrent promotion completes during the TUS parts attempt', async function () {
+      const { Services } = require('../../src/services/StandardDatastreamService');
+      const service = new Services.StandardDatastream();
+
+      mockStagingDisk.exists.resolves(false);
+      // First primary check loses the race; the re-check after the TUS attempt wins.
+      mockPrimaryDisk.exists.onFirstCall().resolves(false);
+      mockPrimaryDisk.exists.onSecondCall().resolves(true);
+      mockPrimaryDisk.getMetaData.rejects(Object.assign(new Error('not found'), { code: 'ENOENT' }));
+
+      const ds = new Datastream({ fileId: 'raced-file' });
+      const result = await service.addDatastream('oid-123', ds);
+
+      expect(result).to.deep.equal({ success: true, key: 'attachments/oid-123/raced-file' });
+      expect(mockPrimaryDisk.putStream.called).to.be.false;
+      expect(mockStagingDisk.getStream.called).to.be.false;
+    });
+
     it('should treat primary metadata as proof of an already-promoted object', async function () {
       const { Services } = require('../../src/services/StandardDatastreamService');
       const service = new Services.StandardDatastream();

--- a/packages/redbox-core/test/utilities/ContextVariableUtils.test.ts
+++ b/packages/redbox-core/test/utilities/ContextVariableUtils.test.ts
@@ -80,6 +80,27 @@ describe('ContextVariableUtils', () => {
     expect((globalThis as any).sails.log.warn.called).to.equal(false);
   });
 
+  it('warns when a context variable source is not supported', () => {
+    (globalThis as any).sails.config.record.contextVariables = {
+      '@bad_source': { source: 'Record', field: 'workflow.stage' } as any
+    };
+    const req = {
+      headers: {},
+      get: sinon.stub(),
+      param: sinon.stub()
+    } as unknown as Sails.Req;
+
+    const result = ContextVariableUtils.evaluateContextVariables(req, {
+      workflow: { stage: 'queued' }
+    });
+
+    expect(result['@bad_source']).to.equal('');
+    expect((globalThis as any).sails.log.warn.calledOnce).to.equal(true);
+    expect((globalThis as any).sails.log.warn.firstCall.args[0]).to.equal(
+      'Unsupported context variable source for @bad_source: Record'
+    );
+  });
+
   it('returns empty value and warns on malformed URL parsing without leaking raw values', () => {
     (globalThis as any).sails.config.record.contextVariables = {
       '@referrer_rdmp': {

--- a/packages/redbox-core/test/utilities/ContextVariableUtils.test.ts
+++ b/packages/redbox-core/test/utilities/ContextVariableUtils.test.ts
@@ -51,7 +51,33 @@ describe('ContextVariableUtils', () => {
     expect(result['@branding']).to.equal('default');
     expect(result['@oid']).to.equal('x&lt;y&gt;');
     expect(result['@referrer_rdmp']).to.equal('&lt;unsafe&gt;');
-    expect(result).to.not.have.property('@record');
+    expect(result['@record']).to.equal('');
+    expect((globalThis as any).sails.log.warn.called).to.equal(false);
+  });
+
+  it('evaluates record and metadata backed context variables', () => {
+    (globalThis as any).sails.config.record.contextVariables = {
+      '@title': { source: 'metadata', field: 'title' },
+      '@stage': { source: 'record', field: 'workflow.stage' },
+      '@metadata': { source: 'metadata' },
+      '@record': { source: 'record' }
+    };
+    const req = {
+      headers: {},
+      get: sinon.stub(),
+      param: sinon.stub()
+    } as unknown as Sails.Req;
+
+    const result = ContextVariableUtils.evaluateContextVariables(req, {
+      metadata: { title: '<Dataset>' },
+      workflow: { stage: 'queued' }
+    });
+
+    expect(result['@title']).to.equal('&lt;Dataset&gt;');
+    expect(result['@stage']).to.equal('queued');
+    expect(result['@metadata']).to.equal('');
+    expect(result['@record']).to.equal('');
+    expect((globalThis as any).sails.log.warn.called).to.equal(false);
   });
 
   it('returns empty value and warns on malformed URL parsing without leaking raw values', () => {


### PR DESCRIPTION
## Summary

Fixes attachment upload and promotion edge cases across standard datastream storage, TUS-backed uploads, and Figshare asset synchronisation.

---

## Context / Motivation

Attachment uploads can move through several storage states: direct staging objects, TUS part uploads, already-promoted primary objects, and Figshare asset staging. This PR hardens those transitions so records do not fail when uploads have already been promoted, when primary storage only exposes metadata, or when Figshare staging keys need safer filenames.

---

## Key Features

### Attachment promotion and diagnostics

- Treats primary storage metadata as proof that an attachment has already been promoted when `exists()` does not report it directly.
- Handles wrapped storage not-found errors, including S3-style causes, without logging expected misses as warnings.
- Adds clearer attachment promotion failure messages that include checked staging keys, TUS part prefixes, and primary object availability.
- Improves datastream update logging and preserves underlying error details in attachment upload failures.

### TUS upload handling

- Adds detailed TUS upload lifecycle logging for create, write, length declaration, materialisation, and cleanup.
- Supports both `.tus/<id>` and `tus/<id>` staging prefixes when promoting uploaded parts.
- Detects ambiguous TUS part locations instead of silently promoting from the wrong prefix.
- Fails materialisation when an upload claims bytes were received but no parts are present.

### Figshare asset sync

- Sanitizes internal Figshare staging filenames while preserving the original filename sent to Figshare.
- Verifies local attachment datastream availability even when Figshare already has a same-named file.
- Passes service logging into Figshare asset staging so filename sanitisation is visible during sync.
- Infers Figshare run context record OIDs from job IDs when record identifiers are unavailable.

### Context variables

- Extends context variable evaluation to support values sourced from record data and record metadata.
- Keeps unsupported or missing context variables as sanitized empty values without noisy warnings.

---

## Testing

- Added/updated service coverage for attachment promotion, wrapped not-found storage errors, already-promoted primary objects, metadata-visible primary objects, Figshare staging filename sanitisation, existing Figshare file handling, and Figshare run context OID inference.
- Added utility coverage for metadata-backed and record-backed context variables.
- Verified:
  - `TS_NODE_PROJECT=test/tsconfig.json npx mocha --no-config --require ts-node/register --require test/setup.ts test/services/StandardDatastreamService.test.ts` (36 passing)
  - `TS_NODE_PROJECT=test/tsconfig.json npx mocha --no-config --require ts-node/register --require test/setup.ts test/utilities/ContextVariableUtils.test.ts` (3 passing)
- Attempted `FigshareService.test.ts`, but the local runner fails before executing tests with `ERR_MODULE_NOT_FOUND` for the extensionless `src/services/FigshareService` import under the current Node/Mocha ESM loader.

---

## Architectural / Operational Impact

### Storage reliability

Attachment promotion now handles more of the real storage states produced by staging disks, TUS uploads, and already-promoted primary objects. This reduces false upload failures and improves recovery when uploads are retried or completed by a prior request.

### Operational diagnostics

Upload and promotion logs now include the storage keys, offsets, lengths, and checked paths needed to diagnose failed or stranded attachments without exposing file contents.

---

## Backwards Compatibility

Existing direct attachment uploads, TUS uploads, and Figshare asset sync workflows remain supported. The TUS ambiguity check intentionally fails when the same upload ID has parts in multiple supported prefixes, because promoting from either prefix would be unsafe.

---

## Deployment Notes

No database migrations or new configuration are required.

---

## Impact

Attachment uploads and Figshare asset publishing should be more resilient to retry, promotion, and storage visibility edge cases, with clearer diagnostics when a file still cannot be found.
