### PR TITLE
Bugfix: CSV UTF-8 BOM and correct content-type headers for record exports

### DIFF
--- a/packages/redbox-core/src/api-routes/groups/export.ts
+++ b/packages/redbox-core/src/api-routes/groups/export.ts
@@ -24,7 +24,7 @@ export const downloadRecsRoute = apiRoute(
         },
         content: {
           'text/csv': { schema: binaryField('CSV export file contents') },
-          'text/json': { schema: binaryField('JSON export file contents') },
+          'application/json': { schema: binaryField('JSON export file contents') },
         },
       },
       400: badRequestResponse,

--- a/packages/redbox-core/src/constants/export.ts
+++ b/packages/redbox-core/src/constants/export.ts
@@ -1,0 +1,4 @@
+export const EXPORT_CONTENT_TYPES: Record<string, string> = {
+  csv: 'text/csv; charset=utf-8',
+  json: 'application/json; charset=utf-8',
+};

--- a/packages/redbox-core/src/controllers/ExportController.ts
+++ b/packages/redbox-core/src/controllers/ExportController.ts
@@ -24,6 +24,11 @@ import { pipeline } from 'node:stream/promises';
 import { BrandingModel } from '../model';
 import { Controllers as controllers } from '../CoreController';
 
+const EXPORT_CONTENT_TYPES: Record<string, string> = {
+  csv: 'text/csv; charset=utf-8',
+  json: 'application/json; charset=utf-8',
+};
+
 export namespace Controllers {
   /**
    * Responsible for all things related to exporting anything
@@ -57,7 +62,7 @@ export namespace Controllers {
       const after = _.isEmpty(req.query.after) ? null : req.query.after;
       const filename = `${TranslationService.t(`${recType}-title`)} - Exported Records.${format}`;
       if (format == 'csv' || format == 'json') {
-        res.set('Content-Type', `text/${format}`);
+        res.set('Content-Type', EXPORT_CONTENT_TYPES[format]);
         sails.log.verbose("filename "+filename);
         res.attachment(filename);
         await pipeline(

--- a/packages/redbox-core/src/controllers/ExportController.ts
+++ b/packages/redbox-core/src/controllers/ExportController.ts
@@ -23,11 +23,7 @@ import { pipeline } from 'node:stream/promises';
  */
 import { BrandingModel } from '../model';
 import { Controllers as controllers } from '../CoreController';
-
-const EXPORT_CONTENT_TYPES: Record<string, string> = {
-  csv: 'text/csv; charset=utf-8',
-  json: 'application/json; charset=utf-8',
-};
+import { EXPORT_CONTENT_TYPES } from '../constants/export';
 
 export namespace Controllers {
   /**
@@ -62,9 +58,9 @@ export namespace Controllers {
       const after = _.isEmpty(req.query.after) ? null : req.query.after;
       const filename = `${TranslationService.t(`${recType}-title`)} - Exported Records.${format}`;
       if (format == 'csv' || format == 'json') {
+        res.attachment(filename);
         res.set('Content-Type', EXPORT_CONTENT_TYPES[format]);
         sails.log.verbose("filename "+filename);
-        res.attachment(filename);
         await pipeline(
           RecordsService.exportAllPlans(req.user!.username, req.user!.roles as globalThis.Record<string, unknown>[], brand, format, before, after, recType),
           res

--- a/packages/redbox-core/src/controllers/webservice/ExportController.ts
+++ b/packages/redbox-core/src/controllers/webservice/ExportController.ts
@@ -5,13 +5,10 @@ import {
   getValidatedApiRequest,
 } from '../../index';
 import { pipeline } from 'node:stream/promises';
+import { EXPORT_CONTENT_TYPES } from '../../constants/export';
 /**
  * Package that contains all Controllers.
  */
-const EXPORT_CONTENT_TYPES: Record<string, string> = {
-  csv: 'text/csv; charset=utf-8',
-  json: 'application/json; charset=utf-8',
-};
 
 export namespace Controllers {
   /**
@@ -39,9 +36,9 @@ export namespace Controllers {
         const after: string | null = _.isEmpty(query.after) ? null : (query.after as string);
         const filename: string = `${TranslationService.t(`${recType}-title`)} - Exported Records.${format}`;
         if (format == 'csv' || format == 'json') {
+          res.attachment(filename);
           res.set('Content-Type', EXPORT_CONTENT_TYPES[format]);
           sails.log.verbose('filename ' + filename);
-          res.attachment(filename);
           await pipeline(
             RecordsService.exportAllPlans(
               req.user!.username,

--- a/packages/redbox-core/src/controllers/webservice/ExportController.ts
+++ b/packages/redbox-core/src/controllers/webservice/ExportController.ts
@@ -8,6 +8,11 @@ import { pipeline } from 'node:stream/promises';
 /**
  * Package that contains all Controllers.
  */
+const EXPORT_CONTENT_TYPES: Record<string, string> = {
+  csv: 'text/csv; charset=utf-8',
+  json: 'application/json; charset=utf-8',
+};
+
 export namespace Controllers {
   /**
    * Responsible for exporting data
@@ -34,7 +39,7 @@ export namespace Controllers {
         const after: string | null = _.isEmpty(query.after) ? null : (query.after as string);
         const filename: string = `${TranslationService.t(`${recType}-title`)} - Exported Records.${format}`;
         if (format == 'csv' || format == 'json') {
-          res.set('Content-Type', `text/${format}`);
+          res.set('Content-Type', EXPORT_CONTENT_TYPES[format]);
           sails.log.verbose('filename ' + filename);
           res.attachment(filename);
           await pipeline(

--- a/packages/redbox-core/test/unit/api-routes.test.ts
+++ b/packages/redbox-core/test/unit/api-routes.test.ts
@@ -931,7 +931,7 @@ describe('API routes contract layer', async () => {
     const exportContent = exportResponse.content as globalThis.Record<string, globalThis.Record<string, unknown>>;
 
     expect(exportContent).to.have.property('text/csv');
-    expect(exportContent).to.have.property('text/json');
+    expect(exportContent).to.have.property('application/json');
     expect((exportContent['text/csv'].schema as globalThis.Record<string, unknown>).format).to.equal('binary');
     expect(exportResponse.headers).to.have.property('Content-Disposition');
   });

--- a/packages/sails-hook-redbox-storage-mongo/src/services/MongoStorageService.ts
+++ b/packages/sails-hook-redbox-storage-mongo/src/services/MongoStorageService.ts
@@ -34,6 +34,7 @@ import { ExportJSONTransformer } from '@researchdatabox/redbox-core';
 import { normalizeRecordRelations, NormalizedRecordRelation } from '@researchdatabox/redbox-core';
 
 const { flatten } = transforms;
+const UTF8_BOM = '\uFEFF';
 
 declare const sails: Sails.Application;
 declare const _: typeof import('lodash');
@@ -948,9 +949,11 @@ export namespace Services {
             if (isCancelled()) {
               return;
             }
+            passThrough.write(UTF8_BOM);
             if (_.isEmpty(fields)) {
               // No matching records means no columns to derive a header from; emit an empty file
-              // deterministically rather than relying on json2csv's empty-fields behaviour.
+              // deterministically rather than relying on json2csv's empty-fields behaviour. The
+              // UTF-8 BOM remains so spreadsheet apps detect the file encoding correctly.
               passThrough.end();
               return;
             }

--- a/packages/sails-hook-redbox-storage-mongo/test/services/MongoStorageService.test.ts
+++ b/packages/sails-hook-redbox-storage-mongo/test/services/MongoStorageService.test.ts
@@ -645,8 +645,8 @@ describe('MongoStorageService', function () {
       toArray: async () => pagesBySkip[opts.skip ?? 0] ?? [],
     }));
 
-  it('exports plans as csv using streamed records', async function () {
-    service.recordCol = { find: pagedFind([{ redboxOid: '1', metadata: { title: 'One' } }]) };
+  it('exports plans as UTF-8 BOM csv using streamed records', async function () {
+    service.recordCol = { find: pagedFind([{ redboxOid: '1', metadata: { title: 'Waldenström' } }]) };
 
     const exportStream = service.exportAllPlans('user', [], { id: 'brand-1' }, 'csv', null, null, 'rdmp');
     const chunks: Buffer[] = [];
@@ -654,7 +654,11 @@ describe('MongoStorageService', function () {
       chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
     }
 
-    expect(Buffer.concat(chunks).toString('utf8')).to.include('redboxOid');
+    const outputBuffer = Buffer.concat(chunks);
+    expect([...outputBuffer.subarray(0, 3)]).to.deep.equal([0xef, 0xbb, 0xbf]);
+    const output = outputBuffer.toString('utf8');
+    expect(output).to.include('redboxOid');
+    expect(output).to.include('Waldenström');
     // Two streamed passes over Mongo (column collection + CSV), each paging once for data and once
     // for the empty terminating batch.
     expect(service.recordCol.find.callCount).to.equal(4);
@@ -676,7 +680,9 @@ describe('MongoStorageService', function () {
     for await (const chunk of exportStream) {
       chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
     }
-    const output = Buffer.concat(chunks).toString('utf8');
+    const outputBuffer = Buffer.concat(chunks);
+    expect([...outputBuffer.subarray(0, 3)]).to.deep.equal([0xef, 0xbb, 0xbf]);
+    const output = outputBuffer.toString('utf8');
 
     // Header is the union of every paged record's flattened keys, so the second-page column survives.
     expect(output).to.include('metadata.extraField');
@@ -697,8 +703,9 @@ describe('MongoStorageService', function () {
     }
 
     // No matching records means no columns to derive a header from, so the stream ends cleanly with
-    // an empty file rather than hanging or emitting a malformed CSV.
-    expect(Buffer.concat(chunks).toString('utf8')).to.equal('');
+    // only the UTF-8 BOM rather than hanging or emitting a malformed CSV.
+    const outputBuffer = Buffer.concat(chunks);
+    expect([...outputBuffer]).to.deep.equal([0xef, 0xbb, 0xbf]);
     // Only the field-collection pass runs (single page, immediately empty); the CSV pass is skipped.
     expect(service.recordCol.find.callCount).to.equal(1);
   });
@@ -748,7 +755,9 @@ describe('MongoStorageService', function () {
       chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
     }
 
-    const output = Buffer.concat(chunks).toString('utf8');
+    const outputBuffer = Buffer.concat(chunks);
+    expect([...outputBuffer.subarray(0, 3)]).to.not.deep.equal([0xef, 0xbb, 0xbf]);
+    const output = outputBuffer.toString('utf8');
     expect(output).to.include('"redboxOid":"1"');
     expect(output).to.include('"redboxOid":"2"');
     expect(findStub.callCount).to.equal(3);


### PR DESCRIPTION
## Summary

Fixes CSV encoding for spreadsheet applications and corrects JSON content-type headers in record exports.

---

## Context / Motivation

CSV files exported by ReDBox were not being detected as UTF-8 encoded by spreadsheet applications (Excel, LibreOffice Calc, etc.), causing character corruption in fields containing non-ASCII characters (e.g. `Waldenström`). Additionally, the JSON export was serving `text/json` instead of the correct `application/json` content type.

---

## Key Features

### CSV UTF-8 BOM for spreadsheet compatibility

- Prepends a UTF-8 byte-order mark (`\uFEFF`) to CSV output so Excel and similar tools correctly recognise the file encoding
- BOM is written before the header row, and persists even when the result set is empty

### Corrected content-type headers

- JSON exports now use `application/json; charset=utf-8` instead of `text/json`
- CSV exports now include `charset=utf-8` in the content-type header

---

## Testing

- Updated `MongoStorageService.test.ts` to assert presence of the UTF-8 BOM (`0xEF, 0xBB, 0xBF`) at the start of CSV output
- Updated CSV test data to include a non-ASCII character (`Waldenström`) to validate encoding
- Updated empty-result test to expect only the BOM rather than a zero-length file
- Updated API routes contract test to expect `application/json` instead of `text/json`
- JSON export test explicitly asserts absence of BOM

---

## Architectural / Operational Impact

### Export pipeline

The CSV export stream in `MongoStorageService` now writes a BOM byte sequence into the pass-through transform before any data rows, ensuring all downstream consumers receive encoding context. The change is minimal — a single constant and one `passThrough.write()` call — with no impact on stream back-pressure or error handling.

---

## Backwards Compatibility

Fully backwards compatible. The BOM is a standard UTF-8 signature that UTF-8-aware consumers ignore; non-aware consumers treat the three bytes as a zero-width no-break space (invisible). Previously exported files remain valid; only newly exported files carry the BOM.

---

## Deployment Notes

No migration or configuration changes required. The fix is live as soon as the updated packages are deployed.

---

## Impact

Resolves character-encoding corruption in CSV exports opened in Excel and corrects the JSON `Content-Type` header to comply with RFC standards.
