### PR TITLE
Support configured object storage for typeahead fields

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.spec.ts
@@ -170,6 +170,51 @@ describe("TypeaheadInputComponent", () => {
         expect((formComponent as any).form.get("external_id")?.value).toBeNull();
     });
 
+    it("stores configured free text only in label-equivalent fields", async () => {
+        const formConfig: FormConfigFrame = {
+            name: "testing",
+            componentDefinitions: [
+                {
+                    name: "research_master_project_id",
+                    component: {
+                        class: "TypeaheadInputComponent",
+                        config: {
+                            sourceType: "static",
+                            valueMode: "optionObject",
+                            requireSelection: false,
+                            labelField: "dc_title",
+                            valueField: "grant_number",
+                            optionObjectFields: {
+                                dc_title: "dc_title",
+                                grant_number: "grant_number"
+                            },
+                            staticOptions: [
+                                {
+                                    label: "Known project",
+                                    value: "RSH/4414",
+                                    raw: { dc_title: "Known project", grant_number: "RSH/4414" }
+                                }
+                            ]
+                        }
+                    },
+                    model: { class: "TypeaheadInputModel", config: {} }
+                }
+            ]
+        };
+
+        const { fixture, formComponent } = await createFormAndWaitForReady(formConfig);
+        const input = fixture.nativeElement.querySelector("input") as HTMLInputElement;
+
+        input.value = "Custom project";
+        input.dispatchEvent(new Event("input"));
+        input.dispatchEvent(new Event("blur"));
+        await fixture.whenStable();
+
+        expect((formComponent as any).form.get("research_master_project_id")?.value).toEqual({
+            dc_title: "Custom project"
+        });
+    });
+
     it("renders a pre-populated configured optionObject label", async () => {
         const formConfig: FormConfigFrame = {
             name: "testing",

--- a/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.spec.ts
@@ -124,6 +124,52 @@ describe("TypeaheadInputComponent", () => {
         );
     });
 
+    it("prevents free text for configured optionObject fields without a label or value mapping", async () => {
+        const formConfig: FormConfigFrame = {
+            name: "testing",
+            componentDefinitions: [
+                {
+                    name: "external_id",
+                    component: {
+                        class: "TypeaheadInputComponent",
+                        config: {
+                            sourceType: "static",
+                            valueMode: "optionObject",
+                            requireSelection: false,
+                            labelField: "name",
+                            valueField: "code",
+                            optionObjectFields: {
+                                identifier: "id"
+                            },
+                            staticOptions: [
+                                {
+                                    label: "Known item",
+                                    value: "known",
+                                    raw: { id: "known-id", name: "Known item", code: "known" }
+                                }
+                            ],
+                            minChars: 1
+                        }
+                    },
+                    model: { class: "TypeaheadInputModel", config: {} }
+                }
+            ]
+        };
+
+        const { fixture, formComponent } = await createFormAndWaitForReady(formConfig);
+        const component = fixture.debugElement.query(By.directive(TypeaheadInputComponent)).componentInstance as TypeaheadInputComponent;
+        const input = fixture.nativeElement.querySelector("input") as HTMLInputElement;
+
+        expect(component.allowFreeText).toBeFalse();
+
+        input.value = "Custom Entry";
+        input.dispatchEvent(new Event("input"));
+        input.dispatchEvent(new Event("blur"));
+        await fixture.whenStable();
+
+        expect((formComponent as any).form.get("external_id")?.value).toBeNull();
+    });
+
     it("renders a pre-populated configured optionObject label", async () => {
         const formConfig: FormConfigFrame = {
             name: "testing",
@@ -712,6 +758,91 @@ describe("TypeaheadInputComponent", () => {
         const component = fixture.debugElement.query(By.directive(TypeaheadInputComponent)).componentInstance as TypeaheadInputComponent;
         component.displayControl.setValue("leg");
         const options = await firstValueFrom(component.suggestions$);
+
+        expect(options.map(option => option.value)).toEqual(["legacy"]);
+        expect(searchVocabularyEntries).toHaveBeenCalledOnceWith("access-rights", "leg", 25, 0, true);
+    });
+
+    it("preserves historical vocabulary state for configured optionObject fields", async () => {
+        const typeaheadDataService = TestBed.inject(TypeaheadDataService);
+        const searchVocabularyEntries = spyOn(typeaheadDataService, "searchVocabularyEntries").and.callFake(async (
+            _vocabRef: string,
+            _search: string,
+            _limit: number,
+            _offset: number,
+            includeHistoricalValues?: boolean
+        ) => includeHistoricalValues
+            ? [{ label: "Legacy", value: "legacy", sourceType: "vocabulary", historical: true }]
+            : []
+        );
+        const config = {
+            sourceType: "vocabulary",
+            vocabRef: "access-rights",
+            valueMode: "optionObject",
+            labelField: "label",
+            valueField: "value",
+            optionObjectFields: {
+                term: "label",
+                code: "value"
+            },
+            minChars: 1,
+            historicalVocabMode: "hide"
+        } as const;
+        const formConfig: FormConfigFrame = {
+            name: "testing",
+            componentDefinitions: [
+                {
+                    name: "vocab_lookup",
+                    component: {
+                        class: "TypeaheadInputComponent",
+                        config
+                    },
+                    model: { class: "TypeaheadInputModel", config: {} }
+                }
+            ]
+        };
+
+        const { fixture, formComponent } = await createFormAndWaitForReady(formConfig);
+        const component = fixture.debugElement.query(By.directive(TypeaheadInputComponent)).componentInstance as TypeaheadInputComponent;
+        component.onSelect({
+            item: {
+                label: "Legacy",
+                value: "legacy",
+                sourceType: "vocabulary",
+                historical: true
+            }
+        } as TypeaheadMatch);
+
+        const storedValue = (formComponent as any).form.get("vocab_lookup")?.value;
+        expect(storedValue).toEqual({
+            term: "Legacy",
+            code: "legacy",
+            sourceType: "vocabulary",
+            historical: true
+        });
+
+        const reloadedConfig: FormConfigFrame = {
+            name: "testing",
+            componentDefinitions: [
+                {
+                    name: "vocab_lookup",
+                    component: {
+                        class: "TypeaheadInputComponent",
+                        config
+                    },
+                    model: {
+                        class: "TypeaheadInputModel",
+                        config: { value: storedValue }
+                    }
+                }
+            ]
+        };
+        const { fixture: reloadedFixture } = await createFormAndWaitForReady(reloadedConfig);
+        const reloadedComponent = reloadedFixture.debugElement.query(By.directive(TypeaheadInputComponent)).componentInstance as TypeaheadInputComponent;
+        searchVocabularyEntries.calls.reset();
+
+        reloadedComponent.displayControl.setValue("leg");
+        const options = await firstValueFrom(reloadedComponent.suggestions$);
 
         expect(options.map(option => option.value)).toEqual(["legacy"]);
         expect(searchVocabularyEntries).toHaveBeenCalledOnceWith("access-rights", "leg", 25, 0, true);

--- a/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.spec.ts
@@ -73,6 +73,97 @@ describe("TypeaheadInputComponent", () => {
         expect(input.value).toBe("Jane Doe");
     });
 
+    it("stores configured optionObject fields from the selected raw result", async () => {
+        const formConfig: FormConfigFrame = {
+            name: "testing",
+            componentDefinitions: [
+                {
+                    name: "research_master_project_id",
+                    component: {
+                        class: "TypeaheadInputComponent",
+                        config: {
+                            sourceType: "namedQuery",
+                            queryId: "activity",
+                            labelField: "dc_title",
+                            valueField: "grant_number",
+                            valueMode: "optionObject",
+                            optionObjectFields: {
+                                dc_title: "dc_title",
+                                grant_number: "grant_number"
+                            },
+                            minChars: 1
+                        }
+                    },
+                    model: { class: "TypeaheadInputModel", config: {} }
+                }
+            ]
+        };
+
+        const { fixture, formComponent } = await createFormAndWaitForReady(formConfig);
+        const component = fixture.debugElement.query(By.directive(TypeaheadInputComponent)).componentInstance as TypeaheadInputComponent;
+
+        // Mirrors CQU Research Master grants: persist the configured fields, not label/value.
+        component.onSelect({
+            item: {
+                label: "Improving the transition of agricultural students between vocational and higher education - RSH/4414",
+                value: "0980024219",
+                sourceType: "namedQuery",
+                raw: {
+                    dc_title: "Improving the transition of agricultural students between vocational and higher education - RSH/4414",
+                    grant_number: "0980024219"
+                }
+            }
+        } as TypeaheadMatch);
+
+        expect((formComponent as any).form.get("research_master_project_id")?.value).toEqual({
+            dc_title: "Improving the transition of agricultural students between vocational and higher education - RSH/4414",
+            grant_number: "0980024219"
+        });
+        expect((fixture.nativeElement.querySelector("input") as HTMLInputElement).value).toBe(
+            "Improving the transition of agricultural students between vocational and higher education - RSH/4414"
+        );
+    });
+
+    it("renders a pre-populated configured optionObject label", async () => {
+        const formConfig: FormConfigFrame = {
+            name: "testing",
+            componentDefinitions: [
+                {
+                    name: "research_master_project_id",
+                    component: {
+                        class: "TypeaheadInputComponent",
+                        config: {
+                            sourceType: "namedQuery",
+                            queryId: "activity",
+                            labelField: "dc_title",
+                            valueField: "grant_number",
+                            valueMode: "optionObject",
+                            optionObjectFields: {
+                                dc_title: "dc_title",
+                                grant_number: "grant_number"
+                            },
+                            minChars: 1
+                        }
+                    },
+                    model: {
+                        class: "TypeaheadInputModel",
+                        config: {
+                            value: {
+                                dc_title: "Improving nursing workforce retention in rural Central Queensland",
+                                grant_number: "14875"
+                            }
+                        }
+                    }
+                }
+            ]
+        };
+
+        const { fixture } = await createFormAndWaitForReady(formConfig);
+        const input = fixture.nativeElement.querySelector("input") as HTMLInputElement;
+        // Existing records with custom object fields must still render a readable label.
+        expect(input.value).toBe("Improving nursing workforce retention in rural Central Queensland");
+    });
+
     it("updates displayed text when the underlying model value changes after init", async () => {
         const formConfig: FormConfigFrame = {
             name: "testing",

--- a/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.ts
@@ -14,12 +14,14 @@ import {
   HistoricalVocabMode,
   TypeaheadInputComponentName,
   TypeaheadInputFieldComponentConfig,
+  TypeaheadInputModelOptionValue,
   TypeaheadInputModelName,
   TypeaheadInputModelValueType,
   TypeaheadOption,
   TypeaheadSourceType,
   TypeaheadValueMode,
 } from '@researchdatabox/sails-ng-common';
+import { get as _get } from 'lodash-es';
 import { TypeaheadMatch } from 'ngx-bootstrap/typeahead';
 import { defer, from, Observable } from 'rxjs';
 import { FormComponent } from '../form.component';
@@ -116,6 +118,7 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
   private labelField = 'label';
   private valueField = 'value';
   private valueMode: TypeaheadValueMode = 'value';
+  private optionObjectFields: Record<string, string> = {};
   private cacheResults = true;
   private historicalVocabMode: HistoricalVocabMode = 'hide';
   private hasHistoricalOrUnknownModelValue = false;
@@ -169,6 +172,7 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
     ];
     this.compiledItems = undefined;
     this.valueField = String(cfg.valueField ?? 'value').trim() || 'value';
+    this.optionObjectFields = this.normalizeOptionObjectFields(cfg.optionObjectFields);
     this.minChars = Number.isInteger(cfg.minChars) && (cfg.minChars ?? 0) >= 0 ? Number(cfg.minChars) : 2;
     this.debounceMs = Number.isInteger(cfg.debounceMs) && (cfg.debounceMs ?? 0) >= 0 ? Number(cfg.debounceMs) : 250;
     this.maxResults = Number.isInteger(cfg.maxResults) && (cfg.maxResults ?? 0) > 0 ? Number(cfg.maxResults) : 25;
@@ -406,7 +410,7 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
     const value = this.model?.getValue();
     if (this.valueMode === 'optionObject' && this.isOptionObjectValue(value)) {
       this.setHistoricalLookupState((value.sourceType as string | undefined) === 'historical');
-      this.setDisplayValue(value.label);
+      this.setDisplayValue(this.getOptionObjectLabel(value));
       return;
     }
     if (this.valueMode === 'value' && typeof value === 'string') {
@@ -443,7 +447,7 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
     }
     const value = this.model?.getValue();
     if (this.valueMode === 'optionObject' && this.isOptionObjectValue(value)) {
-      return String(value.label ?? '').trim().length > 0;
+      return this.getOptionObjectLabel(value).trim().length > 0;
     }
     return typeof value === 'string' && value.trim().length > 0;
   }
@@ -451,7 +455,7 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
   private getAutoDisplaySyncSignature(): string {
     const value = this.model?.getValue();
     if (this.valueMode === 'optionObject' && this.isOptionObjectValue(value)) {
-      return `option:${value.value}:${value.label}`;
+      return `option:${this.getOptionObjectValue(value)}:${this.getOptionObjectLabel(value)}`;
     }
     return typeof value === 'string' ? `value:${value}` : '';
   }
@@ -459,11 +463,7 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
   private setModelFromOption(option: TypeaheadOption): void {
     this.setHistoricalLookupState(this.isHistoricalOption(option));
     if (this.valueMode === 'optionObject') {
-      this.setModelValue({
-        label: option.label,
-        value: option.value,
-        sourceType: option.sourceType,
-      });
+      this.setModelValue(this.buildOptionObjectValue(option));
       return;
     }
     this.setModelValue(option.value);
@@ -472,11 +472,12 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
   private setModelFromFreeText(text: string): void {
     this.setHistoricalLookupState(this.sourceType === 'vocabulary');
     if (this.valueMode === 'optionObject') {
-      this.setModelValue({
+      const freeTextValue: TypeaheadInputModelOptionValue = {
         label: text,
         value: text,
         sourceType: 'freeText',
-      });
+      };
+      this.setModelValue(this.hasOptionObjectFields() ? this.buildConfiguredFreeTextValue(text) : freeTextValue);
       return;
     }
     this.setModelValue(text);
@@ -548,7 +549,7 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
       return values;
     }
     if (this.isOptionObjectValue(value)) {
-      values.add(String(value.value ?? ''));
+      values.add(this.getOptionObjectValue(value));
       return values;
     }
     values.add(String(value));
@@ -594,14 +595,136 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
 
   private isOptionObjectValue(
     value: TypeaheadInputModelValueType | undefined
-  ): value is { label: string; value: string } {
-    return Boolean(
-      value &&
-      typeof value === 'object' &&
-      'label' in value &&
-      'value' in value &&
-      typeof value.label === 'string' &&
-      typeof value.value === 'string'
+  ): value is TypeaheadInputModelOptionValue {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return false;
+    }
+    if (typeof value['label'] === 'string' && typeof value['value'] === 'string') {
+      return true;
+    }
+    return this.hasOptionObjectFields() && Object.keys(this.optionObjectFields).some(fieldName => fieldName in value);
+  }
+
+  private normalizeOptionObjectFields(value: unknown): Record<string, string> {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return {};
+    }
+    return Object.entries(value as Record<string, unknown>).reduce<Record<string, string>>((fields, [fieldName, sourcePath]) => {
+      const normalizedFieldName = String(fieldName ?? '').trim();
+      const normalizedSourcePath = String(sourcePath ?? '').trim();
+      if (normalizedFieldName && normalizedSourcePath) {
+        fields[normalizedFieldName] = normalizedSourcePath;
+      }
+      return fields;
+    }, {});
+  }
+
+  private hasOptionObjectFields(): boolean {
+    return Object.keys(this.optionObjectFields).length > 0;
+  }
+
+  /**
+   * Default optionObject mode keeps the historic label/value/sourceType object.
+   * Configured fields project selected raw result paths into a domain-specific object.
+   */
+  private buildOptionObjectValue(option: TypeaheadOption): TypeaheadInputModelOptionValue {
+    if (!this.hasOptionObjectFields()) {
+      return {
+        label: option.label,
+        value: option.value,
+        sourceType: option.sourceType,
+      };
+    }
+
+    const source = option.raw ?? option;
+    return Object.entries(this.optionObjectFields).reduce<TypeaheadInputModelOptionValue>((storedValue, [fieldName, sourcePath]) => {
+      const resolvedValue = this.resolveOptionFieldValue(option, source, sourcePath);
+      if (resolvedValue !== undefined) {
+        storedValue[fieldName] = resolvedValue;
+      }
+      return storedValue;
+    }, {});
+  }
+
+  /**
+   * Free text has no raw result, so only configured label/value-equivalent fields can
+   * be populated while preserving the custom object shape.
+   */
+  private buildConfiguredFreeTextValue(text: string): TypeaheadInputModelOptionValue {
+    return Object.keys(this.optionObjectFields).reduce<TypeaheadInputModelOptionValue>((storedValue, fieldName) => {
+      const sourcePath = this.optionObjectFields[fieldName];
+      if (this.isConfiguredLabelField(fieldName, sourcePath) || this.isConfiguredValueField(fieldName, sourcePath)) {
+        storedValue[fieldName] = text;
+      }
+      return storedValue;
+    }, {});
+  }
+
+  private resolveOptionFieldValue(option: TypeaheadOption, source: unknown, sourcePath: string): unknown {
+    if (sourcePath === 'label') {
+      return option.label;
+    }
+    if (sourcePath === 'value') {
+      return option.value;
+    }
+    if (sourcePath === 'sourceType') {
+      return option.sourceType;
+    }
+    return _get(source, sourcePath);
+  }
+
+  // Display helpers accept both legacy label/value objects and configured objects.
+  private getOptionObjectLabel(value: Record<string, unknown>): string {
+    return String(
+      value['label'] ??
+      this.getConfiguredStoredValue(value, this.labelField, this.isConfiguredLabelField.bind(this)) ??
+      value[this.labelField] ??
+      this.getConfiguredStoredValue(value, this.valueField, this.isConfiguredValueField.bind(this)) ??
+      value[this.valueField] ??
+      value['value'] ??
+      ''
     );
+  }
+
+  private getOptionObjectValue(value: Record<string, unknown>): string {
+    return String(
+      value['value'] ??
+      this.getConfiguredStoredValue(value, this.valueField, this.isConfiguredValueField.bind(this)) ??
+      value[this.valueField] ??
+      this.getConfiguredStoredValue(value, this.labelField, this.isConfiguredLabelField.bind(this)) ??
+      value[this.labelField] ??
+      value['label'] ??
+      ''
+    );
+  }
+
+  /**
+   * Resolve a stored configured field by exact source-path match first, then by
+   * label/value semantics so stored keys may differ from source result paths.
+   */
+  private getConfiguredStoredValue(
+    value: Record<string, unknown>,
+    sourcePath: string,
+    matchesField: (fieldName: string, configuredSourcePath: string) => boolean
+  ): unknown {
+    const directMatch = Object.entries(this.optionObjectFields).find(([fieldName, configuredSourcePath]) =>
+      configuredSourcePath === sourcePath && value[fieldName] !== undefined
+    );
+    if (directMatch) {
+      return value[directMatch[0]];
+    }
+
+    const semanticMatch = Object.entries(this.optionObjectFields).find(([fieldName, configuredSourcePath]) =>
+      matchesField(fieldName, configuredSourcePath) && value[fieldName] !== undefined
+    );
+    return semanticMatch ? value[semanticMatch[0]] : undefined;
+  }
+
+  private isConfiguredLabelField(fieldName: string, sourcePath: string): boolean {
+    return fieldName === this.labelField || sourcePath === this.labelField || fieldName === 'label' || sourcePath === 'label';
+  }
+
+  private isConfiguredValueField(fieldName: string, sourcePath: string): boolean {
+    return fieldName === this.valueField || sourcePath === this.valueField || fieldName === 'value' || sourcePath === 'value';
   }
 }

--- a/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.ts
@@ -172,6 +172,8 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
     ];
     this.compiledItems = undefined;
     this.valueField = String(cfg.valueField ?? 'value').trim() || 'value';
+    // optionObjectFields is meaningful only for valueMode: 'optionObject'; it
+    // maps persisted field names to paths on the selected option/raw lookup row.
     this.optionObjectFields = this.normalizeOptionObjectFields(cfg.optionObjectFields);
     this.minChars = Number.isInteger(cfg.minChars) && (cfg.minChars ?? 0) >= 0 ? Number(cfg.minChars) : 2;
     this.debounceMs = Number.isInteger(cfg.debounceMs) && (cfg.debounceMs ?? 0) >= 0 ? Number(cfg.debounceMs) : 250;
@@ -625,7 +627,8 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
 
   /**
    * Default optionObject mode keeps the historic label/value/sourceType object.
-   * Configured fields project selected raw result paths into a domain-specific object.
+   * Configured fields project selected raw result paths into a domain-specific object,
+   * so lookup-backed forms can persist fields such as dc_title and grant_number.
    */
   private buildOptionObjectValue(option: TypeaheadOption): TypeaheadInputModelOptionValue {
     if (!this.hasOptionObjectFields()) {

--- a/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.ts
@@ -659,13 +659,13 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
   }
 
   /**
-   * Free text has no raw result, so only configured label/value-equivalent fields can
-   * be populated while preserving the custom object shape.
+   * Free text has no raw result, so only the display label can be safely populated
+   * while preserving the configured object shape.
    */
   private buildConfiguredFreeTextValue(text: string): TypeaheadInputModelOptionValue {
     return Object.keys(this.optionObjectFields).reduce<TypeaheadInputModelOptionValue>((storedValue, fieldName) => {
       const sourcePath = this.optionObjectFields[fieldName];
-      if (this.isConfiguredLabelField(fieldName, sourcePath) || this.isConfiguredValueField(fieldName, sourcePath)) {
+      if (this.isConfiguredLabelField(fieldName, sourcePath)) {
         storedValue[fieldName] = text;
       }
       return storedValue;
@@ -677,7 +677,7 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
       return true;
     }
     return Object.entries(this.optionObjectFields).some(([fieldName, sourcePath]) =>
-      this.isConfiguredLabelField(fieldName, sourcePath) || this.isConfiguredValueField(fieldName, sourcePath)
+      this.isConfiguredLabelField(fieldName, sourcePath)
     );
   }
 

--- a/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.ts
@@ -176,8 +176,8 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
     this.minChars = Number.isInteger(cfg.minChars) && (cfg.minChars ?? 0) >= 0 ? Number(cfg.minChars) : 2;
     this.debounceMs = Number.isInteger(cfg.debounceMs) && (cfg.debounceMs ?? 0) >= 0 ? Number(cfg.debounceMs) : 250;
     this.maxResults = Number.isInteger(cfg.maxResults) && (cfg.maxResults ?? 0) > 0 ? Number(cfg.maxResults) : 25;
-    this.allowFreeText = cfg.requireSelection !== true;
     this.valueMode = cfg.valueMode === 'optionObject' ? 'optionObject' : 'value';
+    this.allowFreeText = cfg.requireSelection !== true && this.canStoreFreeTextValue();
     this.cacheResults = cfg.cacheResults ?? (this.sourceType !== 'namedQuery' && this.sourceType !== 'service');
     this.historicalVocabMode = cfg.historicalVocabMode === 'disable' ? 'disable' : 'hide';
     this.hasHistoricalOrUnknownModelValue = false;
@@ -409,7 +409,7 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
   private applyInitialDisplayFromModel(): void {
     const value = this.model?.getValue();
     if (this.valueMode === 'optionObject' && this.isOptionObjectValue(value)) {
-      this.setHistoricalLookupState((value.sourceType as string | undefined) === 'historical');
+      this.setHistoricalLookupState(this.isStoredHistoricalVocabularyValue(value));
       this.setDisplayValue(this.getOptionObjectLabel(value));
       return;
     }
@@ -435,7 +435,7 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
   private async syncDisplayFromModel(): Promise<void> {
     this.applyInitialDisplayFromModel();
     const value = this.model?.getValue();
-    this.setHistoricalLookupState(this.sourceType === 'vocabulary' && typeof value === 'string' && value.trim().length > 0);
+    this.setHistoricalLookupState(this.isHistoricalOrUnknownModelValue(value));
   }
 
   private shouldAutoSyncDisplayFromModel(): boolean {
@@ -637,13 +637,25 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
     }
 
     const source = option.raw ?? option;
-    return Object.entries(this.optionObjectFields).reduce<TypeaheadInputModelOptionValue>((storedValue, [fieldName, sourcePath]) => {
+    const storedValue = Object.entries(this.optionObjectFields).reduce<TypeaheadInputModelOptionValue>((value, [fieldName, sourcePath]) => {
       const resolvedValue = this.resolveOptionFieldValue(option, source, sourcePath);
       if (resolvedValue !== undefined) {
-        storedValue[fieldName] = resolvedValue;
+        value[fieldName] = resolvedValue;
       }
-      return storedValue;
+      return value;
     }, {});
+    this.preserveVocabularyState(option, storedValue);
+    return storedValue;
+  }
+
+  private preserveVocabularyState(option: TypeaheadOption, storedValue: TypeaheadInputModelOptionValue): void {
+    if (this.sourceType !== 'vocabulary') {
+      return;
+    }
+    storedValue['sourceType'] ??= option.sourceType;
+    if (this.isHistoricalOption(option)) {
+      storedValue['historical'] = true;
+    }
   }
 
   /**
@@ -660,6 +672,15 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
     }, {});
   }
 
+  private canStoreFreeTextValue(): boolean {
+    if (this.valueMode !== 'optionObject' || !this.hasOptionObjectFields()) {
+      return true;
+    }
+    return Object.entries(this.optionObjectFields).some(([fieldName, sourcePath]) =>
+      this.isConfiguredLabelField(fieldName, sourcePath) || this.isConfiguredValueField(fieldName, sourcePath)
+    );
+  }
+
   private resolveOptionFieldValue(option: TypeaheadOption, source: unknown, sourcePath: string): unknown {
     if (sourcePath === 'label') {
       return option.label;
@@ -671,6 +692,20 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
       return option.sourceType;
     }
     return _get(source, sourcePath);
+  }
+
+  private isHistoricalOrUnknownModelValue(value: TypeaheadInputModelValueType | undefined): boolean {
+    if (this.sourceType !== 'vocabulary') {
+      return false;
+    }
+    if (this.isOptionObjectValue(value)) {
+      return this.isStoredHistoricalVocabularyValue(value);
+    }
+    return typeof value === 'string' && value.trim().length > 0;
+  }
+
+  private isStoredHistoricalVocabularyValue(value: Record<string, unknown>): boolean {
+    return value['sourceType'] === 'historical' || value['historical'] === true;
   }
 
   // Display helpers accept both legacy label/value objects and configured objects.

--- a/packages/redbox-core/src/config/reusableContributorFormDefinitions.config.ts
+++ b/packages/redbox-core/src/config/reusableContributorFormDefinitions.config.ts
@@ -35,7 +35,6 @@ export const reusableContributorFormDefinitions: ReusableFormDefinitions = {
         config: {
           hostCssClasses: 'flex-grow-1 d-block',
           wrapperCssClasses: 'rb-form-inline-fields__field rb-form-contributor-inline__field',
-          vocabRef: 'party',
           sourceType: 'namedQuery',
           queryId: 'party',
           labelField: 'metadata.fullName',

--- a/packages/redbox-core/src/visitor/construct.visitor.ts
+++ b/packages/redbox-core/src/visitor/construct.visitor.ts
@@ -221,6 +221,7 @@ import {
   TypeaheadInputFieldModelDefinitionFrame,
   TypeaheadInputFieldModelDefinitionOutline,
   TypeaheadInputFormComponentDefinitionOutline,
+  TypeaheadInputPermissiveFieldComponentConfigOutline,
   TypeaheadInputModelName,
 } from '@researchdatabox/sails-ng-common';
 import { TypeaheadInputFieldComponentConfig, TypeaheadInputFieldModelConfig } from '@researchdatabox/sails-ng-common';
@@ -1944,62 +1945,63 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
     }
     const config = currentData?.config;
 
-    item.config = new TypeaheadInputFieldComponentConfig();
-    this.sharedProps.sharedPopulateFieldComponentConfig(item.config, config);
+    const itemConfig: TypeaheadInputPermissiveFieldComponentConfigOutline = new TypeaheadInputFieldComponentConfig();
+    this.sharedProps.sharedPopulateFieldComponentConfig(itemConfig, config);
 
-    this.sharedProps.setPropOverride('sourceType', item.config, config);
-    this.sharedProps.setPropOverride('staticOptions', item.config, config);
-    this.sharedProps.setPropOverride('vocabRef', item.config, config);
-    this.sharedProps.setPropOverride('queryId', item.config, config);
-    this.sharedProps.setPropOverride('serviceId', item.config, config);
-    this.sharedProps.setPropOverride('provider', item.config, config);
-    this.sharedProps.setPropOverride('resultArrayProperty', item.config, config);
-    this.sharedProps.setPropOverride('labelField', item.config, config);
-    this.sharedProps.setPropOverride('labelTemplate', item.config, config);
-    this.sharedProps.setPropOverride('valueField', item.config, config);
-    this.sharedProps.setPropOverride('minChars', item.config, config);
-    this.sharedProps.setPropOverride('debounceMs', item.config, config);
-    this.sharedProps.setPropOverride('maxResults', item.config, config);
-    this.sharedProps.setPropOverride('requireSelection', item.config, config);
-    this.sharedProps.setPropOverride('valueMode', item.config, config);
+    this.sharedProps.setPropOverride('sourceType', itemConfig, config);
+    this.sharedProps.setPropOverride('staticOptions', itemConfig, config);
+    this.sharedProps.setPropOverride('vocabRef', itemConfig, config);
+    this.sharedProps.setPropOverride('queryId', itemConfig, config);
+    this.sharedProps.setPropOverride('serviceId', itemConfig, config);
+    this.sharedProps.setPropOverride('provider', itemConfig, config);
+    this.sharedProps.setPropOverride('resultArrayProperty', itemConfig, config);
+    this.sharedProps.setPropOverride('labelField', itemConfig, config);
+    this.sharedProps.setPropOverride('labelTemplate', itemConfig, config);
+    this.sharedProps.setPropOverride('valueField', itemConfig, config);
+    this.sharedProps.setPropOverride('minChars', itemConfig, config);
+    this.sharedProps.setPropOverride('debounceMs', itemConfig, config);
+    this.sharedProps.setPropOverride('maxResults', itemConfig, config);
+    this.sharedProps.setPropOverride('requireSelection', itemConfig, config);
+    this.sharedProps.setPropOverride('valueMode', itemConfig, config);
     // Required for configured optionObject storage such as dc_title/grant_number.
-    this.sharedProps.setPropOverride('optionObjectFields', item.config, config);
-    this.sharedProps.setPropOverride('cacheResults', item.config, config);
-    this.sharedProps.setPropOverride('multiSelect', item.config, config);
-    this.sharedProps.setPropOverride('placeholder', item.config, config);
-    this.sharedProps.setPropOverride('readOnlyAfterSelect', item.config, config);
-    this.sharedProps.setPropOverride('historicalVocabMode', item.config, config);
+    this.sharedProps.setPropOverride('optionObjectFields', itemConfig, config);
+    this.sharedProps.setPropOverride('cacheResults', itemConfig, config);
+    this.sharedProps.setPropOverride('multiSelect', itemConfig, config);
+    this.sharedProps.setPropOverride('placeholder', itemConfig, config);
+    this.sharedProps.setPropOverride('readOnlyAfterSelect', itemConfig, config);
+    this.sharedProps.setPropOverride('historicalVocabMode', itemConfig, config);
 
-    const sourceType = String(item.config.sourceType ?? 'static');
+    const sourceType = String(itemConfig.sourceType ?? 'static');
     if (sourceType === 'namedQuery' || sourceType === 'service') {
-      if (!item.config.labelField) {
-        item.config.labelField = 'label';
+      if (!itemConfig.labelField) {
+        itemConfig.labelField = 'label';
       }
-      if (!item.config.valueField) {
-        item.config.valueField = 'value';
+      if (!itemConfig.valueField) {
+        itemConfig.valueField = 'value';
       }
       if (config?.cacheResults === undefined) {
-        item.config.cacheResults = false;
+        itemConfig.cacheResults = false;
       }
     } else if (config?.cacheResults === undefined) {
-      item.config.cacheResults = true;
+      itemConfig.cacheResults = true;
     }
 
-    const minChars = Number(item.config.minChars);
-    const debounceMs = Number(item.config.debounceMs);
-    const maxResults = Number(item.config.maxResults);
+    const minChars = Number(itemConfig.minChars);
+    const debounceMs = Number(itemConfig.debounceMs);
+    const maxResults = Number(itemConfig.maxResults);
     if (!Number.isInteger(minChars) || minChars < 0) {
-      item.config.minChars = 2;
+      itemConfig.minChars = 2;
     }
     if (!Number.isInteger(debounceMs) || debounceMs < 0) {
-      item.config.debounceMs = 250;
+      itemConfig.debounceMs = 250;
     }
     if (!Number.isInteger(maxResults) || maxResults <= 0) {
-      item.config.maxResults = 25;
+      itemConfig.maxResults = 25;
     }
 
-    item.config.requireSelection = Boolean(item.config.requireSelection);
-    item.config.multiSelect = Boolean(item.config.multiSelect);
+    itemConfig.requireSelection = Boolean(itemConfig.requireSelection);
+    itemConfig.multiSelect = Boolean(itemConfig.multiSelect);
+    item.config = itemConfig;
   }
 
   async visitTypeaheadInputFieldModelDefinition(item: TypeaheadInputFieldModelDefinitionOutline): Promise<void> {

--- a/packages/redbox-core/src/visitor/construct.visitor.ts
+++ b/packages/redbox-core/src/visitor/construct.visitor.ts
@@ -1962,6 +1962,8 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
     this.sharedProps.setPropOverride('maxResults', item.config, config);
     this.sharedProps.setPropOverride('requireSelection', item.config, config);
     this.sharedProps.setPropOverride('valueMode', item.config, config);
+    // Required for configured optionObject storage such as dc_title/grant_number.
+    this.sharedProps.setPropOverride('optionObjectFields', item.config, config);
     this.sharedProps.setPropOverride('cacheResults', item.config, config);
     this.sharedProps.setPropOverride('multiSelect', item.config, config);
     this.sharedProps.setPropOverride('placeholder', item.config, config);

--- a/packages/redbox-core/src/visitor/json-type-def.visitor.ts
+++ b/packages/redbox-core/src/visitor/json-type-def.visitor.ts
@@ -175,6 +175,8 @@ export class JsonTypeDefSchemaFormConfigVisitor extends FormConfigVisitor {
   private jsonTypeDefPath: LineagePath;
   private jsonTypeDef: Record<string, unknown>;
   private typeaheadValueModesByJsonPath: Map<string, 'value' | 'optionObject'>;
+  // Typeahead schema needs component config later when the paired model is visited.
+  private typeaheadOptionObjectFieldsByJsonPath: Map<string, Record<string, string>>;
   private formPathHelper: FormPathHelper;
 
   constructor(logger: ILogger) {
@@ -182,6 +184,7 @@ export class JsonTypeDefSchemaFormConfigVisitor extends FormConfigVisitor {
     this.jsonTypeDefPath = [];
     this.jsonTypeDef = {};
     this.typeaheadValueModesByJsonPath = new Map<string, 'value' | 'optionObject'>();
+    this.typeaheadOptionObjectFieldsByJsonPath = new Map<string, Record<string, string>>();
     this.formPathHelper = new FormPathHelper(logger, this);
   }
 
@@ -194,6 +197,7 @@ export class JsonTypeDefSchemaFormConfigVisitor extends FormConfigVisitor {
     this.jsonTypeDefPath = [];
     this.jsonTypeDef = {};
     this.typeaheadValueModesByJsonPath = new Map<string, 'value' | 'optionObject'>();
+    this.typeaheadOptionObjectFieldsByJsonPath = new Map<string, Record<string, string>>();
     this.formPathHelper.reset();
 
     await options.form.accept(this);
@@ -486,17 +490,28 @@ export class JsonTypeDefSchemaFormConfigVisitor extends FormConfigVisitor {
       jsonPathKey,
       item.config?.valueMode === 'optionObject' ? 'optionObject' : 'value'
     );
+    // Store custom object fields by JSON path until the model visitor emits schema.
+    this.typeaheadOptionObjectFieldsByJsonPath.set(jsonPathKey, item.config?.optionObjectFields ?? {});
   }
 
   async visitTypeaheadInputFieldModelDefinition(item: TypeaheadInputFieldModelDefinitionOutline): Promise<void> {
     const jsonPathKey = this.jsonTypeDefPath.join('/');
     const valueMode = this.typeaheadValueModesByJsonPath.get(jsonPathKey) ?? 'value';
     if (valueMode === 'optionObject') {
+      const optionObjectFields = this.typeaheadOptionObjectFieldsByJsonPath.get(jsonPathKey) ?? {};
+      // Custom object mode should describe the configured stored shape, not label/value.
+      const properties = Object.keys(optionObjectFields).length > 0
+        ? Object.keys(optionObjectFields).reduce<Record<string, { type: 'string' }>>((schema, fieldName) => {
+          schema[fieldName] = { type: 'string' };
+          return schema;
+        }, {})
+        : {
+          label: { type: 'string' as const },
+          value: { type: 'string' as const },
+        };
+
       _set(this.jsonTypeDef, this.jsonTypeDefPath, {
-        properties: {
-          label: { type: 'string' },
-          value: { type: 'string' },
-        },
+        properties,
         optionalProperties: {
           sourceType: { type: 'string' },
         },

--- a/packages/redbox-core/src/visitor/json-type-def.visitor.ts
+++ b/packages/redbox-core/src/visitor/json-type-def.visitor.ts
@@ -499,10 +499,10 @@ export class JsonTypeDefSchemaFormConfigVisitor extends FormConfigVisitor {
     const valueMode = this.typeaheadValueModesByJsonPath.get(jsonPathKey) ?? 'value';
     if (valueMode === 'optionObject') {
       const optionObjectFields = this.typeaheadOptionObjectFieldsByJsonPath.get(jsonPathKey) ?? {};
-      // Custom object mode should describe the configured stored shape, not label/value.
       const properties = Object.keys(optionObjectFields).length > 0
-        ? Object.keys(optionObjectFields).reduce<Record<string, { type: 'string' }>>((schema, fieldName) => {
-          schema[fieldName] = { type: 'string' };
+        ? Object.keys(optionObjectFields).reduce<Record<string, Record<string, unknown>>>((schema, fieldName) => {
+          // Configured fields persist raw lookup values; an empty JTD schema accepts any JSON value.
+          schema[fieldName] = {};
           return schema;
         }, {})
         : {

--- a/packages/redbox-core/src/visitor/json-type-def.visitor.ts
+++ b/packages/redbox-core/src/visitor/json-type-def.visitor.ts
@@ -514,6 +514,8 @@ export class JsonTypeDefSchemaFormConfigVisitor extends FormConfigVisitor {
         properties,
         optionalProperties: {
           sourceType: { type: 'string' },
+          // Vocabulary sources persist a historical marker alongside the stored fields.
+          historical: { type: 'boolean' },
         },
       });
       return;

--- a/packages/redbox-core/src/visitor/migrate-config-v4-v5.visitor.ts
+++ b/packages/redbox-core/src/visitor/migrate-config-v4-v5.visitor.ts
@@ -104,6 +104,7 @@ import {
   TypeaheadInputFieldComponentDefinitionOutline,
   TypeaheadInputFieldModelDefinitionOutline,
   TypeaheadInputFormComponentDefinitionOutline,
+  TypeaheadInputPermissiveFieldComponentConfigOutline,
   TypeaheadInputModelName,
 } from '@researchdatabox/sails-ng-common';
 import { TypeaheadInputFieldComponentConfig, TypeaheadInputFieldModelConfig } from '@researchdatabox/sails-ng-common';
@@ -2057,36 +2058,36 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     item: TypeaheadInputFieldComponentDefinitionOutline
   ): Promise<void> {
     const field = this.getV4Data();
-    item.config = new TypeaheadInputFieldComponentConfig();
-    this.sharedPopulateFieldComponentConfig(item.config, field);
+    const itemConfig: TypeaheadInputPermissiveFieldComponentConfigOutline = new TypeaheadInputFieldComponentConfig();
+    this.sharedPopulateFieldComponentConfig(itemConfig, field);
 
     const definition = (field?.definition ?? {}) as Record<string, unknown>;
     const sourceType = this.resolveTypeaheadSourceType(definition);
-    this.sharedProps.setPropOverride('sourceType', item.config, { sourceType });
+    this.sharedProps.setPropOverride('sourceType', itemConfig, { sourceType });
 
     if (sourceType === 'namedQuery') {
       const queryId = String(definition.vocabQueryId ?? definition.queryId ?? '').trim();
       if (queryId) {
-        this.sharedProps.setPropOverride('queryId', item.config, { queryId });
+        this.sharedProps.setPropOverride('queryId', itemConfig, { queryId });
       } else {
         this.logger.warn(
           `${this.logName}: Typeahead migration missing queryId/vocabQueryId at ${JSON.stringify(this.v4FormPath)}.`
         );
       }
       const labelField = this.resolveLegacyLabelField(definition);
-      this.sharedProps.setPropOverride('labelField', item.config, { labelField });
+      this.sharedProps.setPropOverride('labelField', itemConfig, { labelField });
       const valueField = String(definition.valueFieldName ?? definition.valueField ?? 'value').trim() || 'value';
-      this.sharedProps.setPropOverride('valueField', item.config, { valueField });
+      this.sharedProps.setPropOverride('valueField', itemConfig, { valueField });
     } else if (sourceType === 'static') {
       const labelField = this.resolveLegacyLabelField(definition);
       const valueField = String(definition.valueFieldName ?? definition.valueField ?? 'value').trim() || 'value';
       const normalizedOptions = this.normalizeLegacyTypeaheadStaticOptions(definition, labelField, valueField);
-      this.sharedProps.setPropOverride('options', item.config, { options: normalizedOptions });
-      this.sharedProps.setPropOverride('staticOptions', item.config, { staticOptions: normalizedOptions });
+      this.sharedProps.setPropOverride('options', itemConfig, { options: normalizedOptions });
+      this.sharedProps.setPropOverride('staticOptions', itemConfig, { staticOptions: normalizedOptions });
     } else if (sourceType === 'vocabulary') {
       const vocabRef = String(definition.vocabRef ?? definition.vocabId ?? '').trim();
       if (vocabRef) {
-        this.sharedProps.setPropOverride('vocabRef', item.config, { vocabRef });
+        this.sharedProps.setPropOverride('vocabRef', itemConfig, { vocabRef });
       } else {
         this.logger.warn(
           `${this.logName}: Typeahead migration missing vocabRef/vocabId at ${JSON.stringify(this.v4FormPath)}.`
@@ -2095,7 +2096,7 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     } else if (sourceType === 'service') {
       const serviceId = String(definition.serviceId ?? '').trim();
       if (serviceId) {
-        this.sharedProps.setPropOverride('serviceId', item.config, { serviceId });
+        this.sharedProps.setPropOverride('serviceId', itemConfig, { serviceId });
       } else {
         this.logger.warn(
           `${this.logName}: Typeahead migration missing serviceId at ${JSON.stringify(this.v4FormPath)}.`
@@ -2104,7 +2105,7 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
     } else if (sourceType === 'external') {
       const provider = String(definition.provider ?? '').trim();
       if (provider) {
-        this.sharedProps.setPropOverride('provider', item.config, { provider });
+        this.sharedProps.setPropOverride('provider', itemConfig, { provider });
       } else {
         this.logger.warn(
           `${this.logName}: Typeahead migration missing provider at ${JSON.stringify(this.v4FormPath)}.`
@@ -2112,20 +2113,20 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
       }
       const resultArrayProperty = String(definition.resultArrayProperty ?? '').trim();
       if (resultArrayProperty) {
-        this.sharedProps.setPropOverride('resultArrayProperty', item.config, { resultArrayProperty });
+        this.sharedProps.setPropOverride('resultArrayProperty', itemConfig, { resultArrayProperty });
       }
       const labelField = this.resolveLegacyLabelField(definition);
-      this.sharedProps.setPropOverride('labelField', item.config, { labelField });
+      this.sharedProps.setPropOverride('labelField', itemConfig, { labelField });
       const valueField = String(definition.valueFieldName ?? definition.valueField ?? labelField).trim() || labelField;
-      this.sharedProps.setPropOverride('valueField', item.config, { valueField });
+      this.sharedProps.setPropOverride('valueField', itemConfig, { valueField });
     }
 
     const requireSelection = !this.parseLegacyTypeaheadBoolean(definition.freeText, false, 'freeText');
-    this.sharedProps.setPropOverride('requireSelection', item.config, { requireSelection });
+    this.sharedProps.setPropOverride('requireSelection', itemConfig, { requireSelection });
 
     const storeLabelOnly = this.parseLegacyTypeaheadBoolean(definition.storeLabelOnly, true, 'storeLabelOnly');
     const valueMode = storeLabelOnly ? 'value' : 'optionObject';
-    this.sharedProps.setPropOverride('valueMode', item.config, { valueMode });
+    this.sharedProps.setPropOverride('valueMode', itemConfig, { valueMode });
 
     const readOnlyAfterSelect = this.parseLegacyTypeaheadBoolean(
       definition.disableEditAfterSelect,
@@ -2133,9 +2134,10 @@ export class MigrationV4ToV5FormConfigVisitor extends FormConfigVisitor {
       'disableEditAfterSelect'
     );
     if (readOnlyAfterSelect) {
-      this.sharedProps.setPropOverride('readOnlyAfterSelect', item.config, { readOnlyAfterSelect });
+      this.sharedProps.setPropOverride('readOnlyAfterSelect', itemConfig, { readOnlyAfterSelect });
     }
 
+    item.config = itemConfig;
     await this.warnOnDroppedLegacyTypeaheadProperties(definition);
   }
 

--- a/packages/redbox-core/src/visitor/validator.visitor.ts
+++ b/packages/redbox-core/src/visitor/validator.visitor.ts
@@ -69,6 +69,7 @@ import {
   TypeaheadInputFieldComponentDefinitionOutline,
   TypeaheadInputFieldModelDefinitionOutline,
   TypeaheadInputFormComponentDefinitionOutline,
+  TypeaheadInputPermissiveFieldComponentConfigOutline,
   RichTextEditorFieldComponentDefinitionOutline,
   RichTextEditorFieldModelDefinitionOutline,
   RichTextEditorFormComponentDefinitionOutline,
@@ -478,7 +479,7 @@ export class ValidatorFormConfigVisitor extends FormConfigVisitor {
 
     async visitTypeaheadInputFieldComponentDefinition(item: TypeaheadInputFieldComponentDefinitionOutline): Promise<void> {
         const configErrors: FormValidatorSummaryErrors["errors"] = [];
-        const config = item.config;
+        const config = item.config as TypeaheadInputPermissiveFieldComponentConfigOutline | undefined;
         const sourceType = String(config?.sourceType ?? "");
 
         if (!sourceType || !["static", "vocabulary", "namedQuery", "external", "service"].includes(sourceType)) {

--- a/packages/redbox-core/test/unit/construct.visitor.test.ts
+++ b/packages/redbox-core/test/unit/construct.visitor.test.ts
@@ -298,6 +298,43 @@ describe("Construct Visitor", async () => {
             expect(cfg?.cacheResults).to.equal(false);
         });
 
+        it("should preserve typeahead optionObjectFields config", async function () {
+            const visitor = new ConstructFormConfigVisitor(logger);
+            const actual = await visitor.start({
+                formMode: "edit",
+                data: {
+                    name: "test",
+                    componentDefinitions: [
+                        {
+                            name: "research-master-project-id",
+                            component: {
+                                class: "TypeaheadInputComponent",
+                                config: {
+                                    sourceType: "namedQuery",
+                                    queryId: "activity",
+                                    labelField: "dc_title",
+                                    valueField: "grant_number",
+                                    valueMode: "optionObject",
+                                    optionObjectFields: {
+                                        dc_title: "dc_title",
+                                        grant_number: "grant_number"
+                                    }
+                                }
+                            },
+                            model: { class: "TypeaheadInputModel", config: {} }
+                        }
+                    ]
+                }
+            });
+            const cfg = actual.componentDefinitions?.[0]?.component?.config as Record<string, unknown>;
+            expect(cfg?.valueMode).to.equal("optionObject");
+            // The Angular component cannot build custom stored objects if this is dropped.
+            expect(cfg?.optionObjectFields).to.deep.equal({
+                dc_title: "dc_title",
+                grant_number: "grant_number"
+            });
+        });
+
         it("should preserve external typeahead provider config", async function () {
             const visitor = new ConstructFormConfigVisitor(logger);
             const actual = await visitor.start({

--- a/packages/redbox-core/test/unit/json-type-def.visitor.test.ts
+++ b/packages/redbox-core/test/unit/json-type-def.visitor.test.ts
@@ -343,6 +343,46 @@ describe("JSON Type Def Schema Visitor", async () => {
                     }
                 }
             }
+        },
+        {
+            title: "create typeahead schema from configured optionObjectFields",
+            args: {
+                name: "typeahead-form",
+                componentDefinitions: [
+                    {
+                        name: "research-master-project-id",
+                        component: {
+                            class: "TypeaheadInputComponent",
+                            config: {
+                                sourceType: "namedQuery",
+                                queryId: "activity",
+                                labelField: "dc_title",
+                                valueField: "grant_number",
+                                valueMode: "optionObject",
+                                optionObjectFields: {
+                                    dc_title: "dc_title",
+                                    grant_number: "grant_number"
+                                }
+                            }
+                        },
+                        model: {class: "TypeaheadInputModel", config: {}}
+                    }
+                ]
+            },
+            expected: {
+                properties: {
+                    // Schema should match the configured persisted object shape.
+                    "research-master-project-id": {
+                        properties: {
+                            dc_title: {type: "string"},
+                            grant_number: {type: "string"}
+                        },
+                        optionalProperties: {
+                            sourceType: {type: "string"}
+                        }
+                    }
+                }
+            }
         }
     ];
     cases.forEach(({title, args, expected}) => {

--- a/packages/redbox-core/test/unit/json-type-def.visitor.test.ts
+++ b/packages/redbox-core/test/unit/json-type-def.visitor.test.ts
@@ -374,8 +374,8 @@ describe("JSON Type Def Schema Visitor", async () => {
                     // Schema should match the configured persisted object shape.
                     "research-master-project-id": {
                         properties: {
-                            dc_title: {type: "string"},
-                            grant_number: {type: "string"}
+                            dc_title: {},
+                            grant_number: {}
                         },
                         optionalProperties: {
                             sourceType: {type: "string"}

--- a/packages/redbox-core/test/unit/json-type-def.visitor.test.ts
+++ b/packages/redbox-core/test/unit/json-type-def.visitor.test.ts
@@ -338,7 +338,8 @@ describe("JSON Type Def Schema Visitor", async () => {
                             value: {type: "string"}
                         },
                         optionalProperties: {
-                            sourceType: {type: "string"}
+                            sourceType: {type: "string"},
+                            historical: {type: "boolean"}
                         }
                     }
                 }
@@ -378,7 +379,8 @@ describe("JSON Type Def Schema Visitor", async () => {
                             grant_number: {}
                         },
                         optionalProperties: {
-                            sourceType: {type: "string"}
+                            sourceType: {type: "string"},
+                            historical: {type: "boolean"}
                         }
                     }
                 }

--- a/packages/sails-ng-common/src/config/component/typeahead-input.model.ts
+++ b/packages/sails-ng-common/src/config/component/typeahead-input.model.ts
@@ -41,6 +41,8 @@ export class TypeaheadInputFieldComponentConfig extends FieldComponentConfig imp
     maxResults = 25;
     requireSelection = false;
     valueMode: "value" | "optionObject" = "value";
+    // Optional projection used by optionObject mode for non-label/value storage.
+    optionObjectFields?: Record<string, string>;
     cacheResults = true;
     multiSelect = false;
     placeholder?: string;

--- a/packages/sails-ng-common/src/config/component/typeahead-input.model.ts
+++ b/packages/sails-ng-common/src/config/component/typeahead-input.model.ts
@@ -21,13 +21,15 @@ import {
     TypeaheadInputPermissiveFieldComponentConfigOutline,
     TypeaheadInputModelName,
     TypeaheadInputModelValueType,
-    TypeaheadOption
+    TypeaheadOption,
+    TypeaheadSourceType,
+    TypeaheadValueMode
 } from "./typeahead-input.outline";
 
 /* Typeahead Input Component */
 
 export class TypeaheadInputFieldComponentConfig extends FieldComponentConfig implements TypeaheadInputPermissiveFieldComponentConfigOutline {
-    sourceType: "static" | "vocabulary" | "namedQuery" | "external" | "service" = "static";
+    sourceType: TypeaheadSourceType = "static";
     staticOptions: TypeaheadOption[] = [];
     vocabRef?: string;
     queryId?: string;
@@ -41,7 +43,7 @@ export class TypeaheadInputFieldComponentConfig extends FieldComponentConfig imp
     debounceMs = 250;
     maxResults = 25;
     requireSelection = false;
-    valueMode: "value" | "optionObject" = "value";
+    valueMode: TypeaheadValueMode = "value";
     // Optional projection used by optionObject mode when forms need a custom
     // stored object instead of label/value/sourceType.
     optionObjectFields?: Record<string, string>;

--- a/packages/sails-ng-common/src/config/component/typeahead-input.model.ts
+++ b/packages/sails-ng-common/src/config/component/typeahead-input.model.ts
@@ -18,6 +18,7 @@ import {
     TypeaheadInputFieldModelConfigOutline,
     TypeaheadInputFieldModelDefinitionOutline,
     TypeaheadInputFormComponentDefinitionOutline,
+    TypeaheadInputPermissiveFieldComponentConfigOutline,
     TypeaheadInputModelName,
     TypeaheadInputModelValueType,
     TypeaheadOption
@@ -25,7 +26,7 @@ import {
 
 /* Typeahead Input Component */
 
-export class TypeaheadInputFieldComponentConfig extends FieldComponentConfig implements TypeaheadInputFieldComponentConfigOutline {
+export class TypeaheadInputFieldComponentConfig extends FieldComponentConfig implements TypeaheadInputPermissiveFieldComponentConfigOutline {
     sourceType: "static" | "vocabulary" | "namedQuery" | "external" | "service" = "static";
     staticOptions: TypeaheadOption[] = [];
     vocabRef?: string;

--- a/packages/sails-ng-common/src/config/component/typeahead-input.model.ts
+++ b/packages/sails-ng-common/src/config/component/typeahead-input.model.ts
@@ -41,7 +41,8 @@ export class TypeaheadInputFieldComponentConfig extends FieldComponentConfig imp
     maxResults = 25;
     requireSelection = false;
     valueMode: "value" | "optionObject" = "value";
-    // Optional projection used by optionObject mode for non-label/value storage.
+    // Optional projection used by optionObject mode when forms need a custom
+    // stored object instead of label/value/sourceType.
     optionObjectFields?: Record<string, string>;
     cacheResults = true;
     multiSelect = false;

--- a/packages/sails-ng-common/src/config/component/typeahead-input.outline.ts
+++ b/packages/sails-ng-common/src/config/component/typeahead-input.outline.ts
@@ -33,6 +33,11 @@ export type TypeaheadInputComponentNameType = typeof TypeaheadInputComponentName
 export type TypeaheadSourceType = "static" | "vocabulary" | "namedQuery" | "external" | "service";
 export type TypeaheadValueMode = "value" | "optionObject";
 export type TypeaheadStoredSourceType = TypeaheadSourceType | "freeText";
+/**
+ * Maps stored object property names to paths on the selected option/raw result.
+ * When omitted, optionObject mode keeps the legacy label/value/sourceType shape.
+ */
+export type TypeaheadOptionObjectFields = Record<string, string>;
 
 export interface TypeaheadOption {
     label: string;
@@ -68,6 +73,7 @@ export interface TypeaheadInputFieldComponentConfigFrame extends FieldComponentC
     maxResults?: number;
     requireSelection?: boolean;
     valueMode?: TypeaheadValueMode;
+    optionObjectFields?: TypeaheadOptionObjectFields;
     cacheResults?: boolean;
     multiSelect?: boolean;
     placeholder?: string;
@@ -93,9 +99,11 @@ export const TypeaheadInputModelName = "TypeaheadInputModel" as const;
 export type TypeaheadInputModelNameType = typeof TypeaheadInputModelName;
 
 export interface TypeaheadInputModelOptionValue {
-    label: string;
-    value: string;
+    label?: string;
+    value?: string;
     sourceType?: TypeaheadStoredSourceType;
+    /** Allows configured object-mode fields such as dc_title/grant_number. */
+    [key: string]: unknown;
 }
 
 export type TypeaheadInputModelValueType = string | TypeaheadInputModelOptionValue | null;

--- a/packages/sails-ng-common/src/config/component/typeahead-input.outline.ts
+++ b/packages/sails-ng-common/src/config/component/typeahead-input.outline.ts
@@ -59,19 +59,12 @@ export interface TypeaheadOption {
     raw?: unknown;
 }
 
-export interface TypeaheadInputFieldComponentConfigFrame extends FieldComponentConfigFrame {
+export interface TypeaheadInputFieldComponentConfigCommonFrame extends FieldComponentConfigFrame {
     /**
-     * Selects the lookup backend. Each source expects its matching config:
-     * static -> staticOptions, vocabulary -> vocabRef, namedQuery -> queryId,
-     * external -> provider/resultArrayProperty, service -> serviceId.
+     * Static options are required for sourceType: "static"; remote configs may
+     * still carry an empty array from older defaults, so this remains common.
      */
-    sourceType?: TypeaheadSourceType;
     staticOptions?: TypeaheadOption[];
-    vocabRef?: string;
-    queryId?: string;
-    serviceId?: string;
-    provider?: string;
-    resultArrayProperty?: string;
     labelField?: string;
     labelTemplate?: string;
     valueField?: string;
@@ -94,7 +87,62 @@ export interface TypeaheadInputFieldComponentConfigFrame extends FieldComponentC
     historicalVocabMode?: HistoricalVocabMode;
 }
 
-export interface TypeaheadInputFieldComponentConfigOutline extends TypeaheadInputFieldComponentConfigFrame, FieldComponentConfigOutline {
+export interface TypeaheadStaticSourceConfigFrame extends TypeaheadInputFieldComponentConfigCommonFrame {
+    sourceType?: "static";
+}
+
+export interface TypeaheadVocabularySourceConfigFrame extends TypeaheadInputFieldComponentConfigCommonFrame {
+    sourceType: "vocabulary";
+    vocabRef?: string;
+}
+
+export interface TypeaheadNamedQuerySourceConfigFrame extends TypeaheadInputFieldComponentConfigCommonFrame {
+    sourceType: "namedQuery";
+    queryId?: string;
+}
+
+export interface TypeaheadExternalSourceConfigFrame extends TypeaheadInputFieldComponentConfigCommonFrame {
+    sourceType: "external";
+    provider?: string;
+    resultArrayProperty?: string;
+}
+
+export interface TypeaheadServiceSourceConfigFrame extends TypeaheadInputFieldComponentConfigCommonFrame {
+    sourceType: "service";
+    serviceId?: string;
+}
+
+/**
+ * Source-specific config shape for TypeScript-authored forms. The source-specific
+ * IDs remain optional so runtime validator tests can still exercise missing config.
+ */
+export type TypeaheadInputSourceConfigFrame =
+    | TypeaheadStaticSourceConfigFrame
+    | TypeaheadVocabularySourceConfigFrame
+    | TypeaheadNamedQuerySourceConfigFrame
+    | TypeaheadExternalSourceConfigFrame
+    | TypeaheadServiceSourceConfigFrame;
+
+/**
+ * The public config frame uses sourceType as a discriminant while keeping required
+ * source values runtime-validated for JSON, migrated, and intentionally invalid forms.
+ */
+export type TypeaheadInputFieldComponentConfigFrame = TypeaheadInputSourceConfigFrame;
+
+export type TypeaheadInputFieldComponentConfigOutline =
+    TypeaheadInputFieldComponentConfigFrame & FieldComponentConfigOutline;
+
+/**
+ * Runtime defaults stay permissive because the constructed config class has to
+ * carry every possible source property before a concrete sourceType is known.
+ */
+export interface TypeaheadInputPermissiveFieldComponentConfigOutline extends TypeaheadInputFieldComponentConfigCommonFrame, FieldComponentConfigOutline {
+    sourceType?: TypeaheadSourceType;
+    vocabRef?: string;
+    queryId?: string;
+    serviceId?: string;
+    provider?: string;
+    resultArrayProperty?: string;
 }
 
 export interface TypeaheadInputFieldComponentDefinitionFrame extends FieldComponentDefinitionFrame {

--- a/packages/sails-ng-common/src/config/component/typeahead-input.outline.ts
+++ b/packages/sails-ng-common/src/config/component/typeahead-input.outline.ts
@@ -35,6 +35,8 @@ export type TypeaheadValueMode = "value" | "optionObject";
 export type TypeaheadStoredSourceType = TypeaheadSourceType | "freeText";
 /**
  * Maps stored object property names to paths on the selected option/raw result.
+ * Use this only with valueMode: "optionObject" when a form needs a domain-specific
+ * stored object, for example { dc_title: "dc_title", grant_number: "grant_number" }.
  * When omitted, optionObject mode keeps the legacy label/value/sourceType shape.
  */
 export type TypeaheadOptionObjectFields = Record<string, string>;
@@ -58,6 +60,11 @@ export interface TypeaheadOption {
 }
 
 export interface TypeaheadInputFieldComponentConfigFrame extends FieldComponentConfigFrame {
+    /**
+     * Selects the lookup backend. Each source expects its matching config:
+     * static -> staticOptions, vocabulary -> vocabRef, namedQuery -> queryId,
+     * external -> provider/resultArrayProperty, service -> serviceId.
+     */
     sourceType?: TypeaheadSourceType;
     staticOptions?: TypeaheadOption[];
     vocabRef?: string;
@@ -72,6 +79,12 @@ export interface TypeaheadInputFieldComponentConfigFrame extends FieldComponentC
     debounceMs?: number;
     maxResults?: number;
     requireSelection?: boolean;
+    /**
+     * "value" stores the selected option value as a string.
+     * "optionObject" stores an object. Without optionObjectFields that object is
+     * { label, value, sourceType }; with optionObjectFields it uses the configured
+     * persisted property names and source paths.
+     */
     valueMode?: TypeaheadValueMode;
     optionObjectFields?: TypeaheadOptionObjectFields;
     cacheResults?: boolean;
@@ -102,7 +115,10 @@ export interface TypeaheadInputModelOptionValue {
     label?: string;
     value?: string;
     sourceType?: TypeaheadStoredSourceType;
-    /** Allows configured object-mode fields such as dc_title/grant_number. */
+    /**
+     * Allows configured object-mode fields such as dc_title/grant_number while
+     * keeping backwards compatibility with legacy label/value/sourceType objects.
+     */
     [key: string]: unknown;
 }
 

--- a/packages/sails-ng-common/src/config/component/typeahead-input.outline.ts
+++ b/packages/sails-ng-common/src/config/component/typeahead-input.outline.ts
@@ -30,7 +30,8 @@ import type { HistoricalVocabMode } from "./dropdown-input.outline";
 export const TypeaheadInputComponentName = "TypeaheadInputComponent" as const;
 export type TypeaheadInputComponentNameType = typeof TypeaheadInputComponentName;
 
-export type TypeaheadSourceType = "static" | "vocabulary" | "namedQuery" | "external" | "service";
+export const TypeaheadSourceTypes = ["static", "vocabulary", "namedQuery", "external", "service"] as const;
+export type TypeaheadSourceType = typeof TypeaheadSourceTypes[number];
 export type TypeaheadValueMode = "value" | "optionObject";
 export type TypeaheadStoredSourceType = TypeaheadSourceType | "freeText";
 /**

--- a/packages/sails-ng-common/src/config/component/typeahead-input.outline.ts
+++ b/packages/sails-ng-common/src/config/component/typeahead-input.outline.ts
@@ -100,6 +100,13 @@ export interface TypeaheadVocabularySourceConfigFrame extends TypeaheadInputFiel
 export interface TypeaheadNamedQuerySourceConfigFrame extends TypeaheadInputFieldComponentConfigCommonFrame {
     sourceType: "namedQuery";
     queryId?: string;
+    /**
+     * Some existing hooks use vocabRef as the domain identifier for namedQuery
+     * typeaheads, for example ROR-backed lookups. Runtime validation still keys
+     * namedQuery sources from queryId, but the frame accepts vocabRef so those
+     * configs remain type-safe and can be migrated without blocking compilation.
+     */
+    vocabRef?: string;
 }
 
 export interface TypeaheadExternalSourceConfigFrame extends TypeaheadInputFieldComponentConfigCommonFrame {

--- a/packages/sails-ng-common/src/config/form-override.model.ts
+++ b/packages/sails-ng-common/src/config/form-override.model.ts
@@ -74,7 +74,10 @@ import {
   PublishDataLocationSelectorComponentName,
   PublishDataLocationSelectorFormComponentDefinitionOutline,
 } from './component/publish-data-location-selector.outline';
-import { TypeaheadInputModelOptionValue } from './component/typeahead-input.outline';
+import {
+  TypeaheadInputModelOptionValue,
+  TypeaheadInputModelValueType,
+} from './component/typeahead-input.outline';
 import { FormConstraintConfigOutline } from './form-component.outline';
 import { SimpleInputFormComponentDefinitionFrame } from './component/simple-input.outline';
 import { LineagePaths } from './names/naming-helpers';
@@ -812,13 +815,7 @@ export class FormOverride {
       return target;
     }
 
-    const value = source.model.config.value;
-    const displayValue =
-      value && typeof value === 'object' && 'label' in value
-        ? (value as TypeaheadInputModelOptionValue).label
-        : typeof value === 'string'
-          ? value
-          : '';
+    const displayValue = this.resolveTypeaheadContentValue(source.model.config.value, source);
     target.component.config.content = displayValue;
     target.component.config.template = this.resolveReusableViewTemplate(
       this.reusableViewTemplateKeys.leafPlain,
@@ -826,6 +823,107 @@ export class FormOverride {
     );
 
     return target;
+  }
+
+  private resolveTypeaheadContentValue(
+    value: TypeaheadInputModelValueType | undefined,
+    source: TypeaheadInputFormComponentDefinitionOutline
+  ): string {
+    if (typeof value === 'string') {
+      return value;
+    }
+    if (!value || typeof value !== 'object') {
+      return '';
+    }
+
+    const configuredValue = value as TypeaheadInputModelOptionValue;
+    const componentConfig = source.component.config as {
+      labelField?: string;
+      valueField?: string;
+      optionObjectFields?: Record<string, string>;
+    } | undefined;
+
+    const labelField = componentConfig?.labelField?.trim?.() || 'label';
+    const valueField = componentConfig?.valueField?.trim?.() || 'value';
+    const preferredFields = this.getTypeaheadDisplayFields(source);
+    const candidates = [
+      configuredValue.label,
+      this.getConfiguredTypeaheadStoredValue(
+        configuredValue,
+        labelField,
+        source,
+        this.isConfiguredTypeaheadLabelField.bind(this)
+      ),
+      configuredValue[labelField],
+      ...preferredFields.map(field => this.getConfiguredTypeaheadStoredValue(
+        configuredValue,
+        field,
+        source,
+        this.isConfiguredTypeaheadLabelField.bind(this)
+      )),
+      ...preferredFields.map(field => configuredValue[field]),
+      this.getConfiguredTypeaheadStoredValue(
+        configuredValue,
+        valueField,
+        source,
+        this.isConfiguredTypeaheadValueField.bind(this)
+      ),
+      configuredValue[valueField],
+      configuredValue.value,
+    ];
+
+    const resolvedValue = candidates.find(candidate => candidate !== undefined && candidate !== null);
+    return resolvedValue === undefined ? '' : String(resolvedValue);
+  }
+
+  private getConfiguredTypeaheadStoredValue(
+    value: TypeaheadInputModelOptionValue,
+    sourcePath: string,
+    source: TypeaheadInputFormComponentDefinitionOutline,
+    matchesField: (
+      fieldName: string,
+      configuredSourcePath: string,
+      source: TypeaheadInputFormComponentDefinitionOutline
+    ) => boolean
+  ): unknown {
+    const optionObjectFields = this.getTypeaheadOptionObjectFields(source);
+    const directMatch = Object.entries(optionObjectFields).find(([fieldName, configuredSourcePath]) =>
+      configuredSourcePath === sourcePath && value[fieldName] !== undefined
+    );
+    if (directMatch) {
+      return value[directMatch[0]];
+    }
+
+    const semanticMatch = Object.entries(optionObjectFields).find(([fieldName, configuredSourcePath]) =>
+      matchesField(fieldName, configuredSourcePath, source) && value[fieldName] !== undefined
+    );
+    return semanticMatch ? value[semanticMatch[0]] : undefined;
+  }
+
+  private getTypeaheadOptionObjectFields(source: TypeaheadInputFormComponentDefinitionOutline): Record<string, string> {
+    const optionObjectFields = (source.component.config as { optionObjectFields?: unknown } | undefined)?.optionObjectFields;
+    if (!optionObjectFields || typeof optionObjectFields !== 'object' || Array.isArray(optionObjectFields)) {
+      return {};
+    }
+    return optionObjectFields as Record<string, string>;
+  }
+
+  private isConfiguredTypeaheadLabelField(
+    fieldName: string,
+    sourcePath: string,
+    source: TypeaheadInputFormComponentDefinitionOutline
+  ): boolean {
+    const labelField = (source.component.config as { labelField?: string } | undefined)?.labelField ?? 'label';
+    return fieldName === labelField || sourcePath === labelField || fieldName === 'label' || sourcePath === 'label';
+  }
+
+  private isConfiguredTypeaheadValueField(
+    fieldName: string,
+    sourcePath: string,
+    source: TypeaheadInputFormComponentDefinitionOutline
+  ): boolean {
+    const valueField = (source.component.config as { valueField?: string } | undefined)?.valueField ?? 'value';
+    return fieldName === valueField || sourcePath === valueField || fieldName === 'value' || sourcePath === 'value';
   }
 
   private sourceRichTextEditorComponentTargetContentComponent(

--- a/packages/sails-ng-common/test/unit/form-override.test.ts
+++ b/packages/sails-ng-common/test/unit/form-override.test.ts
@@ -233,6 +233,114 @@ describe('FormOverride reusable expansion', () => {
     expect(result).to.not.equal('{{default (get content "fundingSource" "") ""}}');
   });
 
+  it('renders legacy typeahead option objects as content in view mode', () => {
+    const formOverride = new FormOverride(createLogger());
+
+    const transformed = formOverride.applyOverrideTransform(
+      {
+        name: 'fundingSource',
+        component: {
+          class: TypeaheadInputComponentName,
+          config: {
+            valueMode: 'optionObject',
+          },
+        },
+        model: {
+          class: 'TypeaheadInputModel',
+          config: {
+            value: {
+              label: 'Legacy funding source',
+              value: 'legacy-funding-source',
+            },
+          },
+        },
+      } as never,
+      'view',
+      { phase: 'client' }
+    );
+
+    expect(transformed.component.class).to.equal(ContentComponentName);
+    expect((transformed.component.config as { content?: unknown } | undefined)?.content).to.equal(
+      'Legacy funding source'
+    );
+  });
+
+  it('renders configured typeahead option objects as content in view mode', () => {
+    const formOverride = new FormOverride(createLogger());
+
+    const transformed = formOverride.applyOverrideTransform(
+      {
+        name: 'research-master-project-id',
+        component: {
+          class: TypeaheadInputComponentName,
+          config: {
+            labelField: 'dc_title',
+            valueField: 'grant_number',
+            valueMode: 'optionObject',
+            optionObjectFields: {
+              dc_title: 'dc_title',
+              grant_number: 'grant_number',
+            },
+          },
+        },
+        model: {
+          class: 'TypeaheadInputModel',
+          config: {
+            value: {
+              dc_title: 'Improving the transition of agricultural students between vocational and higher education - RSH/4414',
+              grant_number: '0980024219',
+            },
+          },
+        },
+      } as never,
+      'view',
+      { phase: 'client' }
+    );
+
+    expect(transformed.component.class).to.equal(ContentComponentName);
+    expect((transformed.component.config as { content?: unknown } | undefined)?.content).to.equal(
+      'Improving the transition of agricultural students between vocational and higher education - RSH/4414'
+    );
+  });
+
+  it('renders configured typeahead objects when stored keys differ from source paths', () => {
+    const formOverride = new FormOverride(createLogger());
+
+    const transformed = formOverride.applyOverrideTransform(
+      {
+        name: 'research-master-project-id',
+        component: {
+          class: TypeaheadInputComponentName,
+          config: {
+            labelField: 'metadata.dc_title',
+            valueField: 'metadata.grant_number',
+            valueMode: 'optionObject',
+            optionObjectFields: {
+              projectTitle: 'metadata.dc_title',
+              projectGrantNumber: 'metadata.grant_number',
+            },
+          },
+        },
+        model: {
+          class: 'TypeaheadInputModel',
+          config: {
+            value: {
+              projectTitle: 'Mapped project title',
+              projectGrantNumber: 'RSH/4414',
+            },
+          },
+        },
+      } as never,
+      'view',
+      { phase: 'client' }
+    );
+
+    expect(transformed.component.class).to.equal(ContentComponentName);
+    expect((transformed.component.config as { content?: unknown } | undefined)?.content).to.equal(
+      'Mapped project title'
+    );
+  });
+
   it('renders repeatable typeahead objects without stringifying them', () => {
     const formOverride = new FormOverride(createLogger());
 


### PR DESCRIPTION
## Summary

Add configurable object storage support to the Angular typeahead field so forms can persist selected lookup data as a domain-specific object instead of only a scalar value or the legacy `{ label, value, sourceType }` shape.

---

## Context / Motivation

Some institution's records need to retain both the title and a property (e.g. grant number.) The existing typeahead behaviour could display lookup labels and store scalar values, and option-object mode retained only the generic label/value wrapper. That caused form saves to lose the field-specific structure needed for migrated and newly saved records.

---

## Key Features

### Configurable typeahead object storage

- Adds `optionObjectFields` to typeahead configuration so stored object keys can be mapped to selected option or raw lookup result paths.
- Preserves the existing scalar string mode and default label/value/sourceType object behavior when no custom field mapping is configured.
- Supports display of pre-existing configured object values by resolving labels and values from either legacy fields or configured fields.
- Carries vocabulary historical state through configured object storage so historical lookup handling remains consistent.

### Form config and schema propagation

- Passes `optionObjectFields` through the form construction visitor so runtime Angular config receives the mapping.
- Updates JSON Type Definition generation so custom object-mode typeahead fields describe their configured persisted shape.
- Keeps generated schema backward compatible for unconfigured option-object fields by retaining the label/value/sourceType shape.

### Regression coverage

- Adds Angular component coverage for storing configured object fields, displaying pre-populated configured object values, free-text handling, and historical vocabulary behavior.
- Adds core visitor coverage to ensure `optionObjectFields` survives form construction.
- Adds schema visitor coverage for configured object-mode typeahead fields such as `research-master-project-id`.

---

## Testing

- Ran focused Angular typeahead tests: `./node_modules/.bin/ng test @researchdatabox/form --include projects/researchdatabox/form/src/app/component/typeahead-input.component.spec.ts --watch=false --browsers=ChromeHeadless`
- Ran `npm --prefix packages/redbox-core run build`
- Ran `npm --prefix packages/sails-ng-common run compile`
- Verified the rebuilt local portal served the updated Angular bundle.
- Verified a local RDMP save preserves `metadata.research-master-project-id` as `{ dc_title, grant_number }` in `redbox-storage.record`.

---

## Architectural / Operational Impact

### Typeahead model behavior

Typeahead remains string-first by default. Custom object persistence is opt-in through `valueMode: "optionObject"` plus `optionObjectFields`, so existing forms that rely on scalar values or the generic label/value object continue to behave as before.

### Form visitor pipeline

The construction and schema visitors now understand the configured object-field mapping. This ensures the same typeahead storage contract reaches Angular rendering, save behavior, and generated record schema metadata.

---

## Backwards Compatibility

Existing typeahead configurations remain compatible. No migration is required for fields that continue using scalar value mode or default option-object mode. Existing records using `{ label, value, sourceType }` still display correctly.

---

## Deployment Notes

Deployments need the rebuilt Angular form bundle and updated core/common packages so the runtime component, form construction visitor, and schema visitor all share the same typeahead object-field contract.

