### PR TITLE
Feature: improve cli sync-translations 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
             - docker-images/redbox-portal-runtime-pdfgen-test.tar
   test-bruno-general:
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2404:current
     resource_class: large
     environment:
       RBPORTAL_IMAGE: redbox-portal:test
@@ -199,7 +199,7 @@ jobs:
             - ~/.npm
   test-bruno-oidc:
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2404:current
     resource_class: large
     environment:
       RBPORTAL_IMAGE: redbox-portal:test
@@ -252,7 +252,7 @@ jobs:
             - ~/.npm
   test-bruno-s3:
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2404:current
     resource_class: large
     environment:
       RBPORTAL_IMAGE: redbox-portal:test
@@ -305,7 +305,7 @@ jobs:
             - ~/.npm
   test-playwright:
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2404:current
     resource_class: large
     environment:
       RBPORTAL_IMAGE: redbox-portal:test
@@ -352,7 +352,7 @@ jobs:
             - ~/.npm
   test-mocha:
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2404:current
     resource_class: large
     environment:
       RBPORTAL_IMAGE: redbox-portal:test
@@ -408,7 +408,7 @@ jobs:
       angular_app:
         type: string
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2404:current
     resource_class: large
     steps:
       - checkout
@@ -447,7 +447,7 @@ jobs:
             - ~/.npm
   test-sails-ng-common:
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2404:current
     resource_class: large
     steps:
       - checkout
@@ -482,7 +482,7 @@ jobs:
           path: packages/sails-ng-common/support/junit
   test-redbox-core:
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2404:current
     resource_class: large
     steps:
       - checkout
@@ -544,7 +544,7 @@ jobs:
             - ~/.npm
   test-redbox-dev-tools-cli:
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2404:current
     resource_class: medium
     steps:
       - checkout
@@ -664,7 +664,7 @@ jobs:
             npm run lint
   # test-sails-hook-redbox-storage-mongo:
   #   machine:
-  #     image: ubuntu-2204:current
+  #     image: ubuntu-2404:current
   #   resource_class: medium
   #   environment:
   #     BUILDKIT_PROGRESS: 'plain'
@@ -798,7 +798,7 @@ jobs:
           command: chmod +x support/build/docker-publish-amd64-variant.sh && support/build/docker-publish-amd64-variant.sh runtime ""
   publish-runtime-arm64:
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2404:current
     resource_class: arm.medium
     steps:
       - checkout
@@ -819,7 +819,7 @@ jobs:
           command: chmod +x support/build/docker-publish-amd64-variant.sh && support/build/docker-publish-amd64-variant.sh runtime_pdfgen "-pdfgen"
   publish-runtime-pdfgen-arm64:
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2404:current
     resource_class: arm.medium
     steps:
       - checkout
@@ -855,7 +855,7 @@ jobs:
             docker push "${REPO}:${DEPLOY_TAG}-pdfgen-amd64"
   deploy-arm64:
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2404:current
     resource_class: arm.medium
     steps:
       - checkout
@@ -865,7 +865,7 @@ jobs:
           command: chmod +x support/build/docker-publish-arm64-variant.sh && support/build/docker-publish-arm64-variant.sh runtime ""
   deploy-runtime-pdfgen-arm64:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2404:current
     resource_class: arm.medium
     steps:
       - checkout
@@ -893,7 +893,7 @@ jobs:
           command: chmod +x support/build/docker-publish-manifest.sh && support/build/docker-publish-manifest.sh "-pdfgen"
   generate-docs:
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2404:current
     steps:
       - add_ssh_keys:
           fingerprints:

--- a/packages/redbox-dev-tools/src/commands/sync-translation.ts
+++ b/packages/redbox-dev-tools/src/commands/sync-translation.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 import path from "node:path";
 
 type MetaEntryKey = string;
-const contentFormats = ["plain", "html"];
+const contentFormats = ["plain", "html"] as const;
 type ContentFormats = typeof contentFormats[number];
 type MetaEntryValue = {
   category?: string,
@@ -12,7 +12,7 @@ type MetaEntryValue = {
 };
 export type MetaEntries = Record<MetaEntryKey, MetaEntryValue>;
 
-function isContentFormat(value: string | undefined): value is ContentFormats | undefined {
+function isContentFormat(value: string | undefined): value is (ContentFormats | undefined) {
   return contentFormats.some(contentFormat => contentFormat === value);
 }
 
@@ -94,7 +94,16 @@ export function registerSyncTranslationCommand(program: Command): void {
             throw new Error(`Duplicate locale ${locale}`);
           }
           const translationDataFromUrl = translationData.find(i => i.locale === locale) ?? {locale, data: {}};
-          const newData = {...data, ...translationDataFromUrl.data};
+          const dataOnlyStrings: Record<string, string> = {};
+          for (const [key, value] of Object.entries(translationDataFromUrl.data)) {
+            if (typeof value === 'string') {
+              dataOnlyStrings[key] = value;
+            } else {
+              console.log(`Dropped key '${key}' with non-string value ${JSON.stringify(value)}`);
+            }
+          }
+
+          const newData = {...data, ...dataOnlyStrings};
           if (globalOptions.dryRun) {
             const changes = Object.entries(newData)
               .filter(([key, value]) => data[key] !== value)
@@ -125,17 +134,27 @@ export function registerSyncTranslationCommand(program: Command): void {
           for (const key of Object.keys(localeTranslation)) {
             const entriesItems = entriesLocale.filter(e => e.key === key);
             const entriesItem = entriesItems.length > 0 ? entriesItems[0] : undefined;
-            const translationItem = localeTranslation[key];
+            const translationItem = localeTranslation[key] ?? "";
             const metaItem = langDefaultsMetaData[key];
 
-            const newItem = {
-              category: firstNonEmptyString(entriesItem?.category, metaItem?.category),
-              description: firstNonEmptyString(entriesItem?.description, metaItem?.description),
-              contentFormat: firstNonEmptyString(entriesItem?.contentFormat, metaItem?.contentFormat),
-            };
-            if (!isContentFormat(newItem.contentFormat)) {
-              newItem.contentFormat = undefined;
+            // Populate the meta data.
+            const contentFormatRaw = firstNonEmptyString(entriesItem?.contentFormat, metaItem?.contentFormat);
+            let contentFormat: ContentFormats | undefined = isContentFormat(contentFormatRaw) ? contentFormatRaw : undefined;
+            if (
+              !contentFormat && (typeof translationItem === 'string' && (
+              translationItem?.includes('<') &&
+              translationItem?.includes('</') &&
+              translationItem?.includes('>')))
+            ) {
+              contentFormat = "html";
             }
+
+            const description = firstNonEmptyString(entriesItem?.description, metaItem?.description) ?? `Translation for ${key}`;
+
+            const keySplit = key.split(/[_\-:.@]+/).filter(i => !!i);
+            const category = firstNonEmptyString(entriesItem?.category, metaItem?.category) ?? (keySplit.length > 0 ? keySplit[0] : undefined);
+
+            const newItem: MetaEntryValue = {category, description, contentFormat};
 
             if (globalOptions.dryRun && JSON.stringify(metaItem) !== JSON.stringify(newItem)) {
               console.log({key, metaItem, translationItem, entriesItem, newItem});

--- a/packages/redbox-dev-tools/src/commands/sync-translation.ts
+++ b/packages/redbox-dev-tools/src/commands/sync-translation.ts
@@ -88,6 +88,7 @@ export function registerSyncTranslationCommand(program: Command): void {
         }
 
         // Merge locale data
+        // Maintain _meta in translation.json file, but don't update it from remote meta.
         const translationMerged: Record<string, Record<string, string>> = {};
         for (const {locale, data} of langDefaultsLocaleTranslationData) {
           if (locale in translationMerged) {
@@ -127,32 +128,40 @@ export function registerSyncTranslationCommand(program: Command): void {
           }
         }
 
-        // Merge meta
+        // Merge meta, in highest to lowest priority order:
+        // remote meta, _meta key from the translation, existing meta entry.
+        // Use a calculated value for description and category if they are not provided.
         const metaMerged: MetaEntries = {};
         for (const [locale, localeTranslation] of Object.entries(translationMerged)) {
           const entriesLocale = entriesData.filter(e => e.locale === locale);
           for (const key of Object.keys(localeTranslation)) {
+            if (key === '_meta' || key.startsWith('_meta.')) {
+              continue;
+            }
             const entriesItems = entriesLocale.filter(e => e.key === key);
             const entriesItem = entriesItems.length > 0 ? entriesItems[0] : undefined;
             const translationItem = localeTranslation[key] ?? "";
+            const translationMetaItem = ('_meta' in localeTranslation && localeTranslation['_meta'] !== null && typeof localeTranslation['_meta'] === 'object') ? (localeTranslation['_meta'] as Record<string, Record<string, unknown>>)[key] : undefined;
             const metaItem = langDefaultsMetaData[key];
 
             // Populate the meta data.
-            const contentFormatRaw = firstNonEmptyString(entriesItem?.contentFormat, metaItem?.contentFormat);
+            const contentFormatRaw = firstNonEmptyString(
+              entriesItem?.contentFormat, translationMetaItem?.contentFormat, metaItem?.contentFormat
+            );
             let contentFormat: ContentFormats | undefined = isContentFormat(contentFormatRaw) ? contentFormatRaw : undefined;
-            if (
-              !contentFormat && (typeof translationItem === 'string' && (
-              translationItem?.includes('<') &&
-              translationItem?.includes('</') &&
-              translationItem?.includes('>')))
-            ) {
-              contentFormat = "html";
-            }
 
-            const description = firstNonEmptyString(entriesItem?.description, metaItem?.description) ?? `Translation for ${key}`;
+            // Don't guess whether the translation value is html or plain, leave it as-is.
+
+            const description = firstNonEmptyString(
+              entriesItem?.description, translationMetaItem?.description, metaItem?.description,
+              `Translation for ${key}`
+            );
 
             const keySplit = key.split(/[_\-:.@]+/).filter(i => !!i);
-            const category = firstNonEmptyString(entriesItem?.category, metaItem?.category) ?? (keySplit.length > 0 ? keySplit[0] : undefined);
+            const category = firstNonEmptyString(
+              entriesItem?.category, translationMetaItem?.category, metaItem?.category,
+              keySplit.length > 0 ? keySplit[0] : undefined
+            );
 
             const newItem: MetaEntryValue = {category, description, contentFormat};
 

--- a/packages/redbox-dev-tools/test/commands/sync-translation.test.ts
+++ b/packages/redbox-dev-tools/test/commands/sync-translation.test.ts
@@ -120,7 +120,7 @@ describe('sync-translation command', () => {
     expect(targetMeta).to.eql(tempMetaData);
 
     expect(Object.keys(tempEnTranslationData)).to.have.length(3);
-    expect(tempEnTranslationData["@name-test1"]).to.eql("Name 1");
+    expect(tempEnTranslationData["@name-test1"]).to.eql("Name 1 <a href=\"https://qcif.edu.au\">link</a>");
     expect(tempEnTranslationData["@name-test2"]).to.eql("Name 2");
     expect(tempEnTranslationData["@name-test3"]).to.eql("Name 3");
 
@@ -128,7 +128,7 @@ describe('sync-translation command', () => {
     expect(tempMetaData["@name-test1"]).to.eql({
       "category": "name",
       "description": "Name for test 1.",
-      "contentFormat": "plain"
+      "contentFormat": "html"
     });
     expect(tempMetaData["@name-test2"]).to.eql({
       "category": "name",
@@ -136,6 +136,7 @@ describe('sync-translation command', () => {
       "contentFormat": "plain"
     });
     expect(tempMetaData["@name-test3"]).to.eql({
+      "category": "name",
       "description": "Name for test 3."
     });
 
@@ -199,8 +200,7 @@ describe('sync-translation command', () => {
     expect(Object.keys(tempMetaData)).to.have.length(2);
     expect(tempMetaData["@name-test1"]).to.eql({
       "category": "name",
-      "description": "Name for test 1.",
-      "contentFormat": "plain"
+      "description": "Name for test 1."
     });
     expect(tempMetaData["@name-test3"]).to.eql({
       "description": "Name for test 3."

--- a/packages/redbox-dev-tools/test/commands/sync-translation.test.ts
+++ b/packages/redbox-dev-tools/test/commands/sync-translation.test.ts
@@ -116,19 +116,26 @@ describe('sync-translation command', () => {
     const tempEnTranslationData = readJsonFile(tempEnTranslationFile) as Record<string, unknown>;
     const tempMetaData = readJsonFile(tempMetaFile) as Record<string, unknown>;
 
-    expect(targetTranslation).to.eql(tempEnTranslationData);
-    expect(targetMeta).to.eql(tempMetaData);
+    expect(tempEnTranslationData).to.eql(targetTranslation);
+    expect(tempMetaData).to.eql(targetMeta);
 
-    expect(Object.keys(tempEnTranslationData)).to.have.length(3);
+    expect(Object.keys(tempEnTranslationData)).to.have.length(4);
+    expect(tempEnTranslationData["_meta"]).to.eql({
+      "@name-test1": {
+        "category": "naming"
+      },
+      "@name-test2": {
+        "category": "naming"
+      }
+    });
     expect(tempEnTranslationData["@name-test1"]).to.eql("Name 1 <a href=\"https://qcif.edu.au\">link</a>");
     expect(tempEnTranslationData["@name-test2"]).to.eql("Name 2");
     expect(tempEnTranslationData["@name-test3"]).to.eql("Name 3");
 
     expect(Object.keys(tempMetaData)).to.have.length(3);
     expect(tempMetaData["@name-test1"]).to.eql({
-      "category": "name",
-      "description": "Name for test 1.",
-      "contentFormat": "html"
+      "category": "naming",
+      "description": "Name for test 1."
     });
     expect(tempMetaData["@name-test2"]).to.eql({
       "category": "name",
@@ -193,13 +200,20 @@ describe('sync-translation command', () => {
     expect(originalEnTranslationData).to.eql(tempEnTranslationData);
     expect(originalMetaData).to.eql(tempMetaData);
 
-    expect(Object.keys(tempEnTranslationData)).to.have.length(2);
+    expect(Object.keys(tempEnTranslationData)).to.have.length(3);
+    expect(tempEnTranslationData["_meta"]).to.eql({
+      "@name-test1": {
+        "category": "naming"
+      },
+      "@name-test2": {
+        "category": "naming"
+      }
+    });
     expect(tempEnTranslationData["@name-test1"]).to.eql("");
     expect(tempEnTranslationData["@name-test3"]).to.eql("Name 3");
 
     expect(Object.keys(tempMetaData)).to.have.length(2);
     expect(tempMetaData["@name-test1"]).to.eql({
-      "category": "name",
       "description": "Name for test 1."
     });
     expect(tempMetaData["@name-test3"]).to.eql({

--- a/packages/redbox-dev-tools/test/resources/sync-translation/original/en/translation.json
+++ b/packages/redbox-dev-tools/test/resources/sync-translation/original/en/translation.json
@@ -1,4 +1,12 @@
 {
+  "_meta": {
+    "@name-test1": {
+      "category": "naming"
+    },
+    "@name-test2": {
+      "category": "naming"
+    }
+  },
   "@name-test1": "",
   "@name-test3": "Name 3"
 }

--- a/packages/redbox-dev-tools/test/resources/sync-translation/original/http-entries.json
+++ b/packages/redbox-dev-tools/test/resources/sync-translation/original/http-entries.json
@@ -2,7 +2,6 @@
   {
     "locale": "en",
     "key": "@name-test1",
-    "category": "name",
     "description": "Name for test 1."
   },
   {

--- a/packages/redbox-dev-tools/test/resources/sync-translation/original/http-entries.json
+++ b/packages/redbox-dev-tools/test/resources/sync-translation/original/http-entries.json
@@ -3,9 +3,7 @@
     "locale": "en",
     "key": "@name-test1",
     "category": "name",
-    "description": "Name for test 1.",
-    "contentFormat": "plain"
-
+    "description": "Name for test 1."
   },
   {
     "locale": "en",

--- a/packages/redbox-dev-tools/test/resources/sync-translation/original/http-translation.json
+++ b/packages/redbox-dev-tools/test/resources/sync-translation/original/http-translation.json
@@ -1,4 +1,4 @@
 {
-  "@name-test1": "Name 1",
+  "@name-test1": "Name 1 <a href=\"https://qcif.edu.au\">link</a>",
   "@name-test2": "Name 2"
 }

--- a/packages/redbox-dev-tools/test/resources/sync-translation/original/meta.json
+++ b/packages/redbox-dev-tools/test/resources/sync-translation/original/meta.json
@@ -1,8 +1,7 @@
 {
   "@name-test1": {
     "category": "name",
-    "description": "Name for test 1.",
-    "contentFormat": "plain"
+    "description": "Name for test 1."
   },
   "@name-test3": {
     "description": "Name for test 3."

--- a/packages/redbox-dev-tools/test/resources/sync-translation/original/meta.json
+++ b/packages/redbox-dev-tools/test/resources/sync-translation/original/meta.json
@@ -1,6 +1,5 @@
 {
   "@name-test1": {
-    "category": "name",
     "description": "Name for test 1."
   },
   "@name-test3": {

--- a/packages/redbox-dev-tools/test/resources/sync-translation/target/en/translation.json
+++ b/packages/redbox-dev-tools/test/resources/sync-translation/target/en/translation.json
@@ -1,5 +1,5 @@
 {
-  "@name-test1": "Name 1",
+  "@name-test1": "Name 1 <a href=\"https://qcif.edu.au\">link</a>",
   "@name-test2": "Name 2",
   "@name-test3": "Name 3"
 }

--- a/packages/redbox-dev-tools/test/resources/sync-translation/target/en/translation.json
+++ b/packages/redbox-dev-tools/test/resources/sync-translation/target/en/translation.json
@@ -1,4 +1,12 @@
 {
+  "_meta": {
+    "@name-test1": {
+      "category": "naming"
+    },
+    "@name-test2": {
+      "category": "naming"
+    }
+  },
   "@name-test1": "Name 1 <a href=\"https://qcif.edu.au\">link</a>",
   "@name-test2": "Name 2",
   "@name-test3": "Name 3"

--- a/packages/redbox-dev-tools/test/resources/sync-translation/target/meta.json
+++ b/packages/redbox-dev-tools/test/resources/sync-translation/target/meta.json
@@ -1,8 +1,7 @@
 {
   "@name-test1": {
-    "category": "name",
-    "description": "Name for test 1.",
-    "contentFormat": "html"
+    "category": "naming",
+    "description": "Name for test 1."
   },
   "@name-test2": {
     "category": "name",

--- a/packages/redbox-dev-tools/test/resources/sync-translation/target/meta.json
+++ b/packages/redbox-dev-tools/test/resources/sync-translation/target/meta.json
@@ -2,7 +2,7 @@
   "@name-test1": {
     "category": "name",
     "description": "Name for test 1.",
-    "contentFormat": "plain"
+    "contentFormat": "html"
   },
   "@name-test2": {
     "category": "name",
@@ -10,6 +10,7 @@
     "contentFormat": "plain"
   },
   "@name-test3": {
+    "category": "name",
     "description": "Name for test 3."
   }
 }


### PR DESCRIPTION
## Summary

Improve the sync-translation dev cli command to also populate meta data for each translation string.

Changes made:

* This helps keep the translation strings in a current redbox site up to date with the translation strings in the source language files.

## Context / related work

It is easy to miss adding both translation strings and the meta entry.
This change allows syncing those from a running site and ensures the meta and translation files match.

## Technical implementation details

* at one point, this change tried to guess content format from translation string, but does not do that now
* include meta entries for all translation strings
* add good enough meta category from first segment of translation string

## Testing

* update tests to match
