### PR TITLE
fix: add href to facet filter links

### DIFF
--- a/angular/projects/researchdatabox/record-search/src/app/record-search-refiner/record-search-refiner.component.html
+++ b/angular/projects/researchdatabox/record-search/src/app/record-search-refiner/record-search-refiner.component.html
@@ -24,11 +24,11 @@
       </div>
     }
     @if (refinerConfig.type === 'facet') {
-      <div class="input-group">
+      <div class="facet-list">
         @for (facetValue of refinerConfig.value; track facetValue.value) {
           @if (facetValue.count > 0 && facetValue.value) {
             <div>
-              <a (click)="applyFilter($event, facetValue.value)"
+              <a href="#" (click)="applyFilter($event, facetValue.value)"
                 >{{ facetValue.value }} ({{ facetValue.count }})</a
               >
             </div>


### PR DESCRIPTION
## Summary
- Adds `href="#"` to facet filter links in the record search refiner component
- Changes the container class from `input-group` to `facet-list` for proper styling

## Changes
- `record-search-refiner.component.html`: Added href attribute to anchor tags and updated container class

## Testing
- Verified facet filter links are clickable and properly styled
