### PR TITLE
Bugfix: Redact secrets from OIDC and audit logging and fix Okta state parameter

### DIFF
--- a/packages/redbox-core/src/controllers/UserController.ts
+++ b/packages/redbox-core/src/controllers/UserController.ts
@@ -24,6 +24,7 @@ import {
   Controllers as controllers,
   RequestDetails,
 } from '../index';
+import { redactObject } from '../utilities/RedactionUtils';
 
 type AnyRecord = globalThis.Record<string, unknown>;
 
@@ -376,7 +377,7 @@ export namespace Controllers {
     private decodeErrorMappings(options: unknown, errorMessage: string) {
 
       sails.log.verbose('decodeErrorMappings - errorMessage: ' + errorMessage);
-      sails.log.verbose('decodeErrorMappings - options: ' + JSON.stringify(options));
+      sails.log.verbose('decodeErrorMappings - options: ' + JSON.stringify(redactObject(options)));
       let errorMessageDecoded: unknown = 'oidc-default-unknown-error';
       const errorMappingList = _.get(options, 'errorMappings', []);
 

--- a/packages/redbox-core/src/services/IntegrationAuditService.ts
+++ b/packages/redbox-core/src/services/IntegrationAuditService.ts
@@ -10,7 +10,7 @@ import {
   IntegrationAuditStatus,
 } from '../model/storage/IntegrationAuditModel';
 import { StorageServiceResponse } from '../StorageServiceResponse';
-import { redactObject } from './figshare-v2/observability';
+import { redactObject } from '../utilities/RedactionUtils';
 import { StorageService } from '../StorageService';
 
 type AnyRecord = Record<string, unknown>;

--- a/packages/redbox-core/src/services/UsersService.ts
+++ b/packages/redbox-core/src/services/UsersService.ts
@@ -31,6 +31,7 @@ import { SearchService } from '../SearchService';
 import { UserModel } from '../model/storage/UserModel';
 import { UserAttributes } from '../waterline-models/User';
 import { Services as services } from '../CoreService';
+import { redactObject } from '../utilities/RedactionUtils';
 
 import * as crypto from 'crypto';
 
@@ -1354,18 +1355,20 @@ export namespace Services {
                 }
                 const strategy = new Strategy(strategyOptions, verifyCallbackFn);
                 const additionalAuthParams = _.omit(authParams, ['scope']);
-                if (!_.isEmpty(additionalAuthParams)) {
-                  strategy.authorizationRequestParams = () => {
-                    const params = new URLSearchParams();
-                    for (const [key, value] of Object.entries(additionalAuthParams)) {
-                      if (_.isNil(value)) {
-                        continue;
-                      }
-                      params.set(key, _.isString(value) ? value : JSON.stringify(value));
+                const defaultAuthorizationRequestParams = strategy.authorizationRequestParams.bind(strategy);
+                strategy.authorizationRequestParams = (req: unknown, options?: AnyRecord) => {
+                  const params = defaultAuthorizationRequestParams(req, options);
+                  for (const [key, value] of Object.entries(additionalAuthParams)) {
+                    if (_.isNil(value)) {
+                      continue;
                     }
-                    return params;
-                  };
-                }
+                    params.set(key, _.isString(value) ? value : JSON.stringify(value));
+                  }
+                  // Okta requires state even when PKCE is used. openid-client only adds
+                  // it automatically when the authorization server does not support PKCE.
+                  params.set('state', openIdClient.randomState());
+                  return params;
+                };
                 (sails.config.passport as PassportLike).use(passportIdentifier, strategy);
                 sails.log.info(`OIDC is active, client ${passportIdentifier} configured and ready.`);
 
@@ -1410,13 +1413,13 @@ export namespace Services {
       }
 
       sails.log.verbose(`OIDC login success, tokenset: `);
-      sails.log.verbose(JSON.stringify(tokenSet));
+      sails.log.verbose(JSON.stringify(redactObject(tokenSet)));
       sails.log.verbose(`Claims:`);
       const tokenClaims = typeof tokenSet.claims === 'function' ? tokenSet.claims() : {};
-      sails.log.verbose(JSON.stringify(tokenClaims));
+      sails.log.verbose(JSON.stringify(redactObject(tokenClaims)));
       if (!_.isUndefined(userinfo)) {
         sails.log.verbose(`Userinfo:`);
-        sails.log.verbose(JSON.stringify(userinfo));
+        sails.log.verbose(JSON.stringify(redactObject(userinfo)));
       } else {
         userinfo = tokenClaims as AnyRecord;
       }
@@ -1463,7 +1466,7 @@ export namespace Services {
         username: userName
       }, function (err: unknown, user: unknown) {
         sails.log.verbose("At OIDC Strategy verify, payload:");
-        sails.log.verbose(userinfo);
+        sails.log.verbose(redactObject(userinfo));
         sails.log.verbose("User:");
         sails.log.verbose(user);
         sails.log.verbose("Error:");

--- a/packages/redbox-core/src/services/figshare-v2/http.ts
+++ b/packages/redbox-core/src/services/figshare-v2/http.ts
@@ -15,7 +15,8 @@ import {
   FigshareCreateFilePayload,
   FigshareEmbargoPayload,
 } from './types';
-import { logEvent, redactObject, withSpan } from './observability';
+import { logEvent, withSpan } from './observability';
+import { redactObject } from '../../utilities/RedactionUtils';
 
 export class FigshareHttpError extends Error {
   statusCode?: number;

--- a/packages/redbox-core/src/services/figshare-v2/observability.ts
+++ b/packages/redbox-core/src/services/figshare-v2/observability.ts
@@ -1,53 +1,8 @@
 import { trace, SpanStatusCode, type Attributes } from '@opentelemetry/api';
 import { FigshareRunContext } from './types';
+import { redactObject } from '../../utilities/RedactionUtils';
 
-const JWT_PATTERN = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
-const API_KEY_PATTERN = /^(sk_live_|sk_test_)[A-Za-z0-9]+$/;
-const URI_CREDENTIAL_PATTERN = /\/\/[^:\s]+:[^@\s]+@/;
-
-export function redactSecret(value: unknown): unknown {
-  if (typeof value !== 'string') {
-    return value;
-  }
-
-  const trimmed = value.trim();
-  if (
-    /^Bearer\s+/i.test(trimmed) ||
-    JWT_PATTERN.test(trimmed) ||
-    API_KEY_PATTERN.test(trimmed) ||
-    URI_CREDENTIAL_PATTERN.test(trimmed)
-  ) {
-    return 'REDACTED';
-  }
-  return value;
-}
-
-export function redactObject(value: unknown, visited: WeakSet<object> = new WeakSet<object>()): unknown {
-  if (Array.isArray(value)) {
-    if (visited.has(value)) {
-      return '[Circular]';
-    }
-    visited.add(value);
-    return value.map((entry) => redactObject(entry, visited));
-  }
-  if (value != null && typeof value === 'object' && !Array.isArray(value)) {
-    if (visited.has(value)) {
-      return '[Circular]';
-    }
-    visited.add(value);
-    const obj = value as Record<string, unknown>;
-    const result: Record<string, unknown> = {};
-    for (const [key, entry] of Object.entries(obj)) {
-      if (key.toLowerCase().includes('token') || key.toLowerCase().includes('authorization') || key.toLowerCase().includes('secret')) {
-        result[key] = 'REDACTED';
-      } else {
-        result[key] = redactObject(entry, visited);
-      }
-    }
-    return result;
-  }
-  return redactSecret(value);
-}
+export { redactObject, redactSecret } from '../../utilities/RedactionUtils';
 
 export function withSpan<T>(name: string, runContext: FigshareRunContext, attributes: Attributes, fn: () => Promise<T>): Promise<T> {
   const tracer = trace.getTracer('redbox.figshare-v2');

--- a/packages/redbox-core/src/utilities/RedactionUtils.ts
+++ b/packages/redbox-core/src/utilities/RedactionUtils.ts
@@ -1,0 +1,48 @@
+const JWT_PATTERN = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+const API_KEY_PATTERN = /^(sk_live_|sk_test_)[A-Za-z0-9]+$/;
+const URI_CREDENTIAL_PATTERN = /\/\/[^:\s]+:[^@\s]+@/;
+
+export function redactSecret(value: unknown): unknown {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  const trimmed = value.trim();
+  if (
+    /^Bearer\s+/i.test(trimmed) ||
+    JWT_PATTERN.test(trimmed) ||
+    API_KEY_PATTERN.test(trimmed) ||
+    URI_CREDENTIAL_PATTERN.test(trimmed)
+  ) {
+    return 'REDACTED';
+  }
+  return value;
+}
+
+export function redactObject(value: unknown, visited: WeakSet<object> = new WeakSet<object>()): unknown {
+  if (Array.isArray(value)) {
+    if (visited.has(value)) {
+      return '[Circular]';
+    }
+    visited.add(value);
+    return value.map((entry) => redactObject(entry, visited));
+  }
+  if (value != null && typeof value === 'object') {
+    if (visited.has(value)) {
+      return '[Circular]';
+    }
+    visited.add(value);
+    const obj = value as Record<string, unknown>;
+    const result: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(obj)) {
+      const normalizedKey = key.toLowerCase();
+      if (normalizedKey.includes('token') || normalizedKey.includes('authorization') || normalizedKey.includes('secret')) {
+        result[key] = 'REDACTED';
+      } else {
+        result[key] = redactObject(entry, visited);
+      }
+    }
+    return result;
+  }
+  return redactSecret(value);
+}

--- a/packages/redbox-core/src/utilities/RedactionUtils.ts
+++ b/packages/redbox-core/src/utilities/RedactionUtils.ts
@@ -36,7 +36,15 @@ export function redactObject(value: unknown, visited: WeakSet<object> = new Weak
     const result: Record<string, unknown> = {};
     for (const [key, entry] of Object.entries(obj)) {
       const normalizedKey = key.toLowerCase();
-      if (normalizedKey.includes('token') || normalizedKey.includes('authorization') || normalizedKey.includes('secret')) {
+      if (
+        normalizedKey.includes('token') ||
+        normalizedKey.includes('authorization') ||
+        normalizedKey.includes('secret') ||
+        normalizedKey.includes('apikey') ||
+        normalizedKey.includes('api_key') ||
+        normalizedKey.includes('password') ||
+        normalizedKey.includes('credential')
+      ) {
         result[key] = 'REDACTED';
       } else {
         result[key] = redactObject(entry, visited);

--- a/packages/redbox-core/test/controllers/UserController.test.ts
+++ b/packages/redbox-core/test/controllers/UserController.test.ts
@@ -106,4 +106,29 @@ describe('UserController', () => {
             }))).to.be.true;
         });
     });
+
+    describe('OIDC error logging', () => {
+        it('should redact secrets and tokens from the logged configuration', () => {
+            const oidcConfig = {
+                opts: {
+                    client: {
+                        client_id: 'safe-client-id',
+                        client_secret: 'do-not-log-this'
+                    },
+                    access_token: 'do-not-log-this-token'
+                }
+            };
+
+            (controller as any).decodeErrorMappings(oidcConfig, 'OIDC failed');
+
+            const optionsLog = mockSails.log.verbose.args
+                .map((args: unknown[]) => String(args[0]))
+                .find((message: string) => message.startsWith('decodeErrorMappings - options:'));
+
+            expect(optionsLog).to.include('safe-client-id');
+            expect(optionsLog).to.include('REDACTED');
+            expect(optionsLog).to.not.include('do-not-log-this');
+            expect(optionsLog).to.not.include('do-not-log-this-token');
+        });
+    });
 });

--- a/packages/redbox-core/test/services/UsersService.test.ts
+++ b/packages/redbox-core/test/services/UsersService.test.ts
@@ -321,6 +321,62 @@ describe('UsersService', function () {
     });
   });
 
+  describe('OIDC authorization request parameters', function () {
+    it('should generate a unique state while preserving default and configured parameters', async function () {
+      const passportUse = sinon.stub();
+      mockSails.config.passport = {
+        use: passportUse
+      };
+      (global as any).ConfigService.getBrand.returns({
+        active: ['oidc'],
+        oidc: {
+          discoverAttemptsMax: 1,
+          opts: {
+            issuer: {
+              issuer: 'https://example.okta.com/oauth2/default',
+              authorization_endpoint: 'https://example.okta.com/oauth2/default/v1/authorize',
+              token_endpoint: 'https://example.okta.com/oauth2/default/v1/token',
+              jwks_uri: 'https://example.okta.com/oauth2/default/v1/keys',
+              code_challenge_methods_supported: ['S256']
+            },
+            client: {
+              client_id: 'test-client',
+              client_secret: 'test-secret',
+              redirect_uris: ['https://portal.example.com/user/login_oidc']
+            },
+            params: {
+              scope: 'openid profile email',
+              claims: {
+                userinfo: {
+                  email: { essential: true }
+                }
+              }
+            }
+          }
+        }
+      });
+
+      (UsersService as any).openIdConnectAuth();
+      expect(mockSails.on.calledOnceWith('ready')).to.be.true;
+      await mockSails.on.firstCall.args[1]();
+
+      expect(passportUse.calledOnce).to.be.true;
+      const strategy = passportUse.firstCall.args[1];
+      const firstParams = strategy.authorizationRequestParams({}, { prompt: 'login' });
+      const secondParams = strategy.authorizationRequestParams({}, { prompt: 'login' });
+
+      expect(firstParams.get('state')).to.be.a('string').and.not.be.empty;
+      expect(secondParams.get('state')).to.be.a('string').and.not.be.empty;
+      expect(firstParams.get('state')).to.not.equal(secondParams.get('state'));
+      expect(firstParams.get('prompt')).to.equal('login');
+      expect(firstParams.get('claims')).to.equal(JSON.stringify({
+        userinfo: {
+          email: { essential: true }
+        }
+      }));
+    });
+  });
+
   describe('addUserAuditEvent', function () {
     it('should return null when no user provided', async function () {
       const result = await UsersService.addUserAuditEvent(null, 'login', {});

--- a/packages/redbox-core/test/utilities/RedactionUtils.test.ts
+++ b/packages/redbox-core/test/utilities/RedactionUtils.test.ts
@@ -1,0 +1,43 @@
+import { expect } from 'chai';
+import { redactObject, redactSecret } from '../../src/utilities/RedactionUtils';
+
+describe('RedactionUtils', function () {
+  it('redacts sensitive keys recursively without modifying the source object', function () {
+    const source = {
+      client_id: 'diagnostic-client-id',
+      client_secret: 'secret-value',
+      nested: {
+        access_token: 'access-token-value',
+        authorization: 'Bearer credential'
+      }
+    };
+
+    expect(redactObject(source)).to.deep.equal({
+      client_id: 'diagnostic-client-id',
+      client_secret: 'REDACTED',
+      nested: {
+        access_token: 'REDACTED',
+        authorization: 'REDACTED'
+      }
+    });
+    expect(source.client_secret).to.equal('secret-value');
+    expect(source.nested.access_token).to.equal('access-token-value');
+  });
+
+  it('redacts credential-shaped string values', function () {
+    expect(redactSecret('Bearer abc123')).to.equal('REDACTED');
+    expect(redactSecret('header.payload.signature')).to.equal('REDACTED');
+    expect(redactSecret('https://user:password@example.com/path')).to.equal('REDACTED');
+    expect(redactSecret('ordinary diagnostic text')).to.equal('ordinary diagnostic text');
+  });
+
+  it('handles arrays and circular references', function () {
+    const source: Record<string, unknown> = { values: [{ refresh_token: 'token-value' }] };
+    source.self = source;
+
+    expect(redactObject(source)).to.deep.equal({
+      values: [{ refresh_token: 'REDACTED' }],
+      self: '[Circular]'
+    });
+  });
+});

--- a/packages/redbox-core/test/utilities/RedactionUtils.test.ts
+++ b/packages/redbox-core/test/utilities/RedactionUtils.test.ts
@@ -8,7 +8,11 @@ describe('RedactionUtils', function () {
       client_secret: 'secret-value',
       nested: {
         access_token: 'access-token-value',
-        authorization: 'Bearer credential'
+        authorization: 'Bearer credential',
+        apiKey: 'opaque-api-key',
+        api_key: 'another-opaque-api-key',
+        password: 'opaque-password',
+        credential: 'opaque-credential'
       }
     };
 
@@ -17,7 +21,11 @@ describe('RedactionUtils', function () {
       client_secret: 'REDACTED',
       nested: {
         access_token: 'REDACTED',
-        authorization: 'REDACTED'
+        authorization: 'REDACTED',
+        apiKey: 'REDACTED',
+        api_key: 'REDACTED',
+        password: 'REDACTED',
+        credential: 'REDACTED'
       }
     });
     expect(source.client_secret).to.equal('secret-value');


### PR DESCRIPTION
## Summary

Redact sensitive credentials (tokens, secrets, API keys) from OIDC and integration audit logs, extract redaction utilities into a shared module, and fix Okta OIDC login by ensuring a unique `state` parameter is included in every authorization request.

---

## Context / Motivation

OIDC token sets, claims, userinfo payloads, and client secrets were being written to application logs in plaintext during both successful logins and error-path diagnostics. The existing `redactObject` helper lived exclusively inside the Figshare observability module, making it unavailable to other services. Additionally, Okta requires an explicit `state` parameter even when PKCE is enabled, causing Okta-backed OIDC logins to fail intermittently.

---

## Key Features

### Shared redaction utilities

- `RedactionUtils.ts` extracted from `figshare-v2/observability.ts` into `packages/redbox-core/src/utilities/RedactionUtils.ts`
- `redactObject` and `redactSecret` are now importable project-wide
- Handles JWTs, Bearer tokens, API keys (`sk_live_*`, `sk_test_*`), and URI credentials
- Circular reference safe via `WeakSet` tracking

### OIDC log redaction

- `UsersService`: tokenSet, tokenClaims, and userinfo are now passed through `redactObject` before logging on successful OIDC login
- `UserController`: OIDC error configuration (`decodeErrorMappings`) is redacted before logging
- Figshare HTTP service continues to use the shared utility via re-export

### Okta OIDC state parameter fix

- `authorizationRequestParams` is now wrapped as a pass-through that decorates the strategy's defaults rather than replacing them entirely
- A unique `state` value (`openIdClient.randomState()`) is appended to every authorization request, satisfying Okta's requirements when PKCE is active
- Configured `additionalAuthParams` are preserved and merged correctly

---

## Testing

- `RedactionUtils.test.ts` (new): covers recursive key redaction, sensitive string patterns, arrays, and circular references
- `UsersService.test.ts`: verifies `authorizationRequestParams` generates unique state values across calls while preserving prompt and claims
- `UserController.test.ts`: verifies `decodeErrorMappings` redacts secrets and tokens from logged OIDC configuration

---

## Architectural / Operational Impact

### Security

OIDC client secrets, access tokens, refresh tokens, and bearer credentials no longer appear in application logs. This reduces the blast radius of log exfiltration or log-forwarding misconfigurations.

### Observability

Diagnostic log output for OIDC failures remains useful: safe fields (e.g. `client_id`, issuer URL, error messages) are preserved while sensitive fields are replaced with `REDACTED`.

---

## Backwards Compatibility

Fully backwards compatible. The redaction functions are pure transforms applied only at log output boundaries. No API, configuration, or storage changes are introduced.

---

## Deployment Notes

No migrations or configuration changes required. Existing OIDC configurations continue to work unchanged. Okta integrations that previously failed due to missing `state` will begin working immediately after upgrade.

---

## Impact

Hardens sensitive credential handling across the portal's OIDC and integration logging, extracts a reusable redaction utility, and resolves Okta login failures caused by the missing authorization `state` parameter.
