### PR TITLE
Feature: Add configurable favicons per branding

### DIFF
--- a/angular/projects/researchdatabox/branding/src/app/branding-admin.component.html
+++ b/angular/projects/researchdatabox/branding/src/app/branding-admin.component.html
@@ -58,6 +58,16 @@
                 <input type="file" class="form-control" id="logoUpload" (change)="uploadLogo($event)" accept="image/*" />
               </div>
             </div>
+            <div class="col-md-6 mt-3">
+              <div class="mb-3">
+                <label for="faviconUpload" class="form-label">
+                  <i class="fas fa-star me-2"></i>
+                  {{ 'branding-favicon-upload-label' | i18next }}
+                </label>
+                <input type="file" class="form-control" id="faviconUpload" (change)="uploadFavicon($event)" accept="image/png,image/svg+xml,image/x-icon,.ico" />
+                <div class="form-text">{{ 'branding-favicon-upload-help' | i18next }}</div>
+              </div>
+            </div>
           </div>
 
           <div class="row mt-3 border-top pt-3">

--- a/angular/projects/researchdatabox/branding/src/app/branding-admin.component.ts
+++ b/angular/projects/researchdatabox/branding/src/app/branding-admin.component.ts
@@ -49,6 +49,7 @@ export class BrandingAdminComponent extends BaseComponent {
   previewCssUrl?: string;
   previewBaseCssUrl?: string;
   logoUrl?: string;
+  faviconUrl?: string;
 
   // Track component initialization state without casting
   private componentReady: boolean = false;
@@ -66,6 +67,7 @@ export class BrandingAdminComponent extends BaseComponent {
   publishing = false;
   generatingPreview = false;
   logoUploading = false;
+  faviconUploading = false;
   message?: string;
   error?: string;
   // Variables sourced exclusively from assets/styles/custom-variables.scss
@@ -88,6 +90,7 @@ export class BrandingAdminComponent extends BaseComponent {
     // Set logo URL
     const base = this.brandingService.getBrandingAndPortalUrl();
     this.logoUrl = `${base}/images/logo`;
+    this.faviconUrl = `${base}/images/favicon`;
     // Initialize Bootstrap tooltips for all elements with data-bs-toggle="tooltip"
     setTimeout(() => {
       const tooltipTriggerList = Array.from(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
@@ -298,6 +301,21 @@ export class BrandingAdminComponent extends BaseComponent {
       this.error = `Failed to upload logo: ${e?.message || e}`;
       this.logger.error(this.error);
     } finally { this.logoUploading = false; }
+  }
+
+  async uploadFavicon(event: any) {
+    const file: File | undefined = event?.target?.files?.[0];
+    if (!file) { return; }
+    this.faviconUploading = true; this.message = this.error = undefined;
+    try {
+      const formData = new FormData();
+      formData.append('favicon', file);
+      await this.brandingService.uploadFavicon(formData);
+      this.message = 'Favicon uploaded';
+    } catch (e: any) {
+      this.error = `Failed to upload favicon: ${e?.message || e}`;
+      this.logger.error(this.error);
+    } finally { this.faviconUploading = false; }
   }
 
   copyToClipboard(text: string) {

--- a/angular/projects/researchdatabox/branding/src/app/branding-admin.service.ts
+++ b/angular/projects/researchdatabox/branding/src/app/branding-admin.service.ts
@@ -93,4 +93,23 @@ export class BrandingAdminService extends HttpClientService {
     const result$ = this.http.post(url, formData, uploadOptions);
     return await firstValueFrom(result$);
   }
+
+  /**
+   * Upload favicon file
+   */
+  public async uploadFavicon(formData: FormData): Promise<any> {
+    const url = `${this.brandingAndPortalUrl}/app/branding/favicon`;
+
+    // Create HttpContext for FormData uploads - include CSRF but skip JSON content-type
+    const fileUploadContext = new HttpContext();
+    fileUploadContext.set(RB_HTTP_INTERCEPTOR_AUTH_CSRF, this.config.csrfToken);
+    fileUploadContext.set(RB_HTTP_INTERCEPTOR_SKIP_JSON_CONTENT_TYPE, true);
+
+    const uploadOptions = {
+      context: fileUploadContext
+    };
+
+    const result$ = this.http.post(url, formData, uploadOptions);
+    return await firstValueFrom(result$);
+  }
 }

--- a/language-defaults/en/translation.json
+++ b/language-defaults/en/translation.json
@@ -1354,6 +1354,8 @@
   "branding-light-label": "Light",
   "branding-links-help": "Controls link colours for normal, hover, and focus states.",
   "branding-links-name": "Links",
+  "branding-favicon-upload-help": "PNG, SVG or ICO. Displayed as the browser tab icon. Max 256 KB.",
+  "branding-favicon-upload-label": "Upload Favicon",
   "branding-logo-upload-label": "Upload Logo",
   "branding-main-menu-active-dropdown-item-background-color-help": "Sets the background colour for active dropdown items in the main menu.",
   "branding-main-menu-active-dropdown-item-background-color-hover-help": "Sets the background colour for active dropdown items in the main menu on hover.",

--- a/packages/redbox-core/src/api-routes/groups/branding.ts
+++ b/packages/redbox-core/src/api-routes/groups/branding.ts
@@ -10,6 +10,7 @@ import {
   brandingDraftBody,
   brandingPublishBody,
   logoUploadBody,
+  faviconUploadBody,
   objectField,
   responseField,
   stringField,
@@ -97,6 +98,30 @@ export const brandingLogoRoute = apiRoute(
   }
 );
 
+export const brandingFaviconRoute = apiRoute(
+  'post',
+  '/:branding/:portal/api/branding/favicon',
+  'webservice/BrandingController',
+  'favicon',
+  {
+    body: { content: { 'multipart/form-data': { schema: faviconUploadBody } } },
+    files: {
+      favicon: {
+        required: true,
+        multiple: false,
+        maxBytes: 256 * 1024,
+        mimeTypes: ['image/png', 'image/svg+xml', 'image/x-icon', 'image/vnd.microsoft.icon'],
+        description: 'Branding favicon upload',
+      },
+    },
+  },
+  {
+    tags: ['Branding'],
+    summary: 'Upload branding favicon',
+    responses: { 200: responseField(brandingLogoResponseSchema, 'Branding favicon uploaded') },
+  }
+);
+
 export const brandingHistoryRoute = apiRoute(
   'get',
   '/:branding/:portal/api/branding/history',
@@ -116,5 +141,6 @@ export const brandingApiRoutes = [
   brandingPublishRoute,
   brandingRollbackRoute,
   brandingLogoRoute,
+  brandingFaviconRoute,
   brandingHistoryRoute,
 ];

--- a/packages/redbox-core/src/api-routes/schemas/common.ts
+++ b/packages/redbox-core/src/api-routes/schemas/common.ts
@@ -165,6 +165,8 @@ export const brandingPublishBody = objectField({
 
 export const logoUploadBody = objectField({}, [], 'Multipart logo upload body', true);
 
+export const faviconUploadBody = objectField({}, [], 'Multipart favicon upload body', true);
+
 export const datastreamUploadBody = objectField({}, [], 'Multipart datastream upload body', true);
 
 export const notificationBody = objectField(

--- a/packages/redbox-core/src/config/routes.config.ts
+++ b/packages/redbox-core/src/config/routes.config.ts
@@ -81,6 +81,10 @@ export const routes: RoutesConfig = {
         controller: 'BrandingController',
         action: 'renderImage'
     },
+    '/:branding/:portal/images/favicon': {
+        controller: 'BrandingController',
+        action: 'renderFavicon'
+    },
 
     // Admin routes
     '/:branding/:portal/admin': {
@@ -193,6 +197,7 @@ export const routes: RoutesConfig = {
     'post /:branding/:portal/app/branding/preview': { controller: 'BrandingAppController', action: 'preview' },
     'post /:branding/:portal/app/branding/publish': { controller: 'BrandingAppController', action: 'publish' },
     'post /:branding/:portal/app/branding/logo': { controller: 'BrandingAppController', action: 'logo' },
+    'post /:branding/:portal/app/branding/favicon': { controller: 'BrandingAppController', action: 'favicon' },
 
     // Admin user management routes
     'get /:branding/:portal/admin/users/get': 'AdminController.getUsers',

--- a/packages/redbox-core/src/config/static_assets.config.ts
+++ b/packages/redbox-core/src/config/static_assets.config.ts
@@ -6,9 +6,13 @@
 export interface StaticAssetsConfig {
     logoName: string;
     imageType: string;
+    faviconName: string;
+    faviconType: string;
 }
 
 export const static_assets: StaticAssetsConfig = {
     logoName: 'logo.png',
-    imageType: 'image/png'
+    imageType: 'image/png',
+    faviconName: 'favicon-32x32.png',
+    faviconType: 'image/png'
 };

--- a/packages/redbox-core/src/controllers/BrandingAppController.ts
+++ b/packages/redbox-core/src/controllers/BrandingAppController.ts
@@ -20,12 +20,13 @@ function mapError(e: Error): { status: number; body: unknown } {
   if (msg === 'history-not-found') return { status: 404, body: { error: 'history-not-found' } };
   if (msg === 'publish-conflict') return { status: 409, body: { error: 'publish-conflict' } };
   if (msg.startsWith('logo-invalid')) return { status: 400, body: { error: 'logo-invalid', detail: msg } };
+  if (msg.startsWith('favicon-invalid')) return { status: 400, body: { error: 'favicon-invalid', detail: msg } };
   return { status: 500, body: { error: 'server-error', detail: msg } };
 }
 
 export namespace Controllers {
   export class BrandingApp extends controllers.Core.Controller {
-    protected override _exportedMethods: string[] = ['config', 'draft', 'preview', 'publish', 'logo'];
+    protected override _exportedMethods: string[] = ['config', 'draft', 'preview', 'publish', 'logo', 'favicon'];
 
     /** 9.1 Return current draft/active branding config + logo meta */
     async config(req: Sails.Req, res: Sails.Res) {
@@ -119,6 +120,35 @@ export namespace Controllers {
         const buf = await fs.readFile(f.fd);
         try {
           const { hash } = await BrandingLogoService.putLogo({ branding, portal, fileBuffer: buf, contentType: f.type as string });
+          await fs.unlink(f.fd);
+          return res.ok({ hash });
+        } catch (e) {
+          await fs.unlink(f.fd);
+          throw e;
+        }
+      } catch (e: unknown) {
+        const { status, body } = mapError(e as Error);
+        return res.status(status).json(body);
+      }
+    }
+
+    /** 9.6 Upload favicon */
+    async favicon(req: Sails.Req, res: Sails.Res) {
+      const branding = getRouteParam(req, 'branding');
+      const portal = getRouteParam(req, 'portal');
+      try {
+        if (!(req._fileparser && typeof (req as globalThis.Record<string, unknown>).file === 'function')) {
+          return res.badRequest({ error: 'no-file' });
+        }
+        const files = await new Promise<globalThis.Record<string, unknown>[]>((resolve, reject) => {
+          try { ((req as globalThis.Record<string, unknown>).file as (name: string) => { upload: (cb: (err: unknown, uploaded: globalThis.Record<string, unknown>[]) => void) => void })('favicon').upload((err: unknown, uploaded: globalThis.Record<string, unknown>[]) => err ? reject(err) : resolve(uploaded)); } catch (_e) { resolve([]); }
+        });
+        if (!files || !files.length) return res.badRequest({ error: 'no-file' });
+        const f = files[0];
+        const fs = require('fs').promises;
+        const buf = await fs.readFile(f.fd);
+        try {
+          const { hash } = await BrandingLogoService.putFavicon({ branding, portal, fileBuffer: buf, contentType: f.type as string });
           await fs.unlink(f.fd);
           return res.ok({ hash });
         } catch (e) {

--- a/packages/redbox-core/src/controllers/BrandingController.ts
+++ b/packages/redbox-core/src/controllers/BrandingController.ts
@@ -93,6 +93,7 @@ export namespace Controllers {
       'init',
       'renderCss',
       'renderImage',
+      'renderFavicon',
       'renderApiB',
       'renderSwaggerJSON',
       'renderSwaggerYAML',
@@ -319,6 +320,48 @@ export namespace Controllers {
       } catch (_e) {
         res.contentType(sails.config.static_assets.imageType);
         return res.sendFile(sails.config.appPath + `/assets/images/${sails.config.static_assets.logoName}`);
+      }
+    }
+
+    /**
+     * Serves the per-brand favicon from storage, falling back to the static
+     * default favicon when no custom favicon has been configured.
+     *
+     * @param req
+     * @param res
+     */
+    public async renderFavicon(req: Sails.Req, res: Sails.Res) {
+      const sendDefault = () => {
+        res.contentType('image/png');
+        return res.sendFile(`${sails.config.appPath}/assets/favicon-32x32.png`);
+      };
+      try {
+        const branding = req.param('branding');
+        const brand = await BrandingConfig.findOne({ name: branding });
+        const favicon = brand?.favicon as Record<string, unknown> | undefined;
+        const storageId = typeof favicon?.storageKey === 'string'
+          ? favicon.storageKey
+          : typeof favicon?.gridFsId === 'string'
+            ? favicon.gridFsId
+            : null;
+        if (!brand || !favicon || !storageId) {
+          return sendDefault();
+        }
+        const buf = await BrandingLogoService.getBinaryAsync(storageId);
+        if (!buf) {
+          return sendDefault();
+        }
+        res.contentType((favicon.contentType as string) || 'image/png');
+        const etagSeed = typeof favicon.sha256 === 'string'
+          ? favicon.sha256
+          : crypto.createHash('sha256').update(buf).digest('hex');
+        const etag = this.generateETag(etagSeed, 'favicon-');
+        res.set('ETag', etag);
+        if (req.headers['if-none-match'] === etag) return res.status(304).end();
+        res.set('Cache-Control', 'public, max-age=3600');
+        return res.send(buf);
+      } catch (_e) {
+        return sendDefault();
       }
     }
   }

--- a/packages/redbox-core/src/controllers/BrandingController.ts
+++ b/packages/redbox-core/src/controllers/BrandingController.ts
@@ -332,8 +332,8 @@ export namespace Controllers {
      */
     public async renderFavicon(req: Sails.Req, res: Sails.Res) {
       const sendDefault = () => {
-        res.contentType('image/png');
-        return res.sendFile(`${sails.config.appPath}/assets/favicon-32x32.png`);
+        res.contentType(sails.config.static_assets.faviconType);
+        return res.sendFile(`${sails.config.appPath}/assets/${sails.config.static_assets.faviconName}`);
       };
       try {
         const branding = req.param('branding');

--- a/packages/redbox-core/src/controllers/webservice/BrandingController.ts
+++ b/packages/redbox-core/src/controllers/webservice/BrandingController.ts
@@ -7,6 +7,7 @@ import {
   brandingPublishRoute,
   brandingRollbackRoute,
   brandingLogoRoute,
+  brandingFaviconRoute,
   brandingHistoryRoute,
 } from '../../index';
 
@@ -19,6 +20,7 @@ function mapError(e: unknown): { status: number; displayErrors: Array<{ code?: s
   if (msg === 'history-not-found') return { status: 404, displayErrors: [{ code: 'history-not-found' }] };
   if (msg === 'publish-conflict') return { status: 409, displayErrors: [{ code: 'publish-conflict' }] };
   if (msg.startsWith('logo-invalid')) return { status: 400, displayErrors: [{ code: 'logo-invalid', detail: msg }] };
+  if (msg.startsWith('favicon-invalid')) return { status: 400, displayErrors: [{ code: 'favicon-invalid', detail: msg }] };
   return { status: 500, displayErrors: [{ code: 'server-error', detail: msg }] };
 }
 
@@ -28,7 +30,7 @@ function toValidationDisplayErrors(issues: Array<{ path: string; message: string
 
 export namespace Controllers {
   export class Branding extends controllers.Core.Controller {
-    protected override _exportedMethods: string[] = ['draft', 'preview', 'publish', 'rollback', 'logo', 'history'];
+    protected override _exportedMethods: string[] = ['draft', 'preview', 'publish', 'rollback', 'logo', 'favicon', 'history'];
 
     async draft(req: Sails.Req, res: Sails.Res) {
       const validated = getValidatedApiRequest(req);
@@ -163,6 +165,53 @@ export namespace Controllers {
         const fs = require('fs').promises;
         const buf = await fs.readFile(f.fd);
         const { hash } = await BrandingLogoService.putLogo({ branding, portal, fileBuffer: buf, contentType: f.type });
+        return this.apiRespond(req, res, { hash }, 200);
+      } catch (e: unknown) {
+        const { status, displayErrors } = mapError(e);
+        return this.sendResp(req, res, {
+          status,
+          displayErrors,
+          headers: this.getNoCacheHeaders(),
+        });
+      }
+    }
+    async favicon(req: Sails.Req, res: Sails.Res) {
+      const validated = getValidatedApiRequest(req);
+      const { params } = validated;
+      const branding = params.branding as string;
+      const portal = params.portal as string;
+      try {
+        const reqObj = req as unknown as globalThis.Record<string, unknown>;
+        if (!(reqObj._fileparser && typeof reqObj.file === 'function')) {
+          return this.sendResp(req, res, {
+            status: 400,
+            displayErrors: [{ code: 'no-file' }],
+            headers: this.getNoCacheHeaders(),
+          });
+        }
+        const fileFn = reqObj.file as (name: string) => {
+          upload: (cb: (err: unknown, uploaded: Array<{ fd: string; type: string }>) => void) => void;
+        };
+        const files = await new Promise<Array<{ fd: string; type: string }>>((resolve, reject) => {
+          try {
+            fileFn('favicon').upload((err: unknown, uploaded) => (err ? reject(err) : resolve(uploaded)));
+          } catch (_e) {
+            resolve([]);
+          }
+        });
+        const fileValidation = validateApiRouteFiles(brandingFaviconRoute, { favicon: files });
+        if (!fileValidation.valid) {
+          return this.sendResp(req, res, {
+            status: 400,
+            displayErrors: toValidationDisplayErrors(fileValidation.issues),
+            headers: this.getNoCacheHeaders(),
+          });
+        }
+        req.apiRequest = { ...validated, files: { favicon: files } };
+        const f = files[0];
+        const fs = require('fs').promises;
+        const buf = await fs.readFile(f.fd);
+        const { hash } = await BrandingLogoService.putFavicon({ branding, portal, fileBuffer: buf, contentType: f.type });
         return this.apiRespond(req, res, { hash }, 200);
       } catch (e: unknown) {
         const { status, displayErrors } = mapError(e);

--- a/packages/redbox-core/src/controllers/webservice/BrandingController.ts
+++ b/packages/redbox-core/src/controllers/webservice/BrandingController.ts
@@ -152,20 +152,24 @@ export namespace Controllers {
             resolve([]);
           }
         });
-        const fileValidation = validateApiRouteFiles(brandingLogoRoute, { logo: files });
-        if (!fileValidation.valid) {
-          return this.sendResp(req, res, {
-            status: 400,
-            displayErrors: toValidationDisplayErrors(fileValidation.issues),
-            headers: this.getNoCacheHeaders(),
-          });
-        }
-        req.apiRequest = { ...validated, files: { logo: files } };
-        const f = files[0];
         const fs = require('fs').promises;
-        const buf = await fs.readFile(f.fd);
-        const { hash } = await BrandingLogoService.putLogo({ branding, portal, fileBuffer: buf, contentType: f.type });
-        return this.apiRespond(req, res, { hash }, 200);
+        try {
+          const fileValidation = validateApiRouteFiles(brandingLogoRoute, { logo: files });
+          if (!fileValidation.valid) {
+            return this.sendResp(req, res, {
+              status: 400,
+              displayErrors: toValidationDisplayErrors(fileValidation.issues),
+              headers: this.getNoCacheHeaders(),
+            });
+          }
+          req.apiRequest = { ...validated, files: { logo: files } };
+          const f = files[0];
+          const buf = await fs.readFile(f.fd);
+          const { hash } = await BrandingLogoService.putLogo({ branding, portal, fileBuffer: buf, contentType: f.type });
+          return this.apiRespond(req, res, { hash }, 200);
+        } finally {
+          await Promise.all(files.map(file => fs.unlink(file.fd).catch(() => undefined)));
+        }
       } catch (e: unknown) {
         const { status, displayErrors } = mapError(e);
         return this.sendResp(req, res, {
@@ -199,20 +203,24 @@ export namespace Controllers {
             resolve([]);
           }
         });
-        const fileValidation = validateApiRouteFiles(brandingFaviconRoute, { favicon: files });
-        if (!fileValidation.valid) {
-          return this.sendResp(req, res, {
-            status: 400,
-            displayErrors: toValidationDisplayErrors(fileValidation.issues),
-            headers: this.getNoCacheHeaders(),
-          });
-        }
-        req.apiRequest = { ...validated, files: { favicon: files } };
-        const f = files[0];
         const fs = require('fs').promises;
-        const buf = await fs.readFile(f.fd);
-        const { hash } = await BrandingLogoService.putFavicon({ branding, portal, fileBuffer: buf, contentType: f.type });
-        return this.apiRespond(req, res, { hash }, 200);
+        try {
+          const fileValidation = validateApiRouteFiles(brandingFaviconRoute, { favicon: files });
+          if (!fileValidation.valid) {
+            return this.sendResp(req, res, {
+              status: 400,
+              displayErrors: toValidationDisplayErrors(fileValidation.issues),
+              headers: this.getNoCacheHeaders(),
+            });
+          }
+          req.apiRequest = { ...validated, files: { favicon: files } };
+          const f = files[0];
+          const buf = await fs.readFile(f.fd);
+          const { hash } = await BrandingLogoService.putFavicon({ branding, portal, fileBuffer: buf, contentType: f.type });
+          return this.apiRespond(req, res, { hash }, 200);
+        } finally {
+          await Promise.all(files.map(file => fs.unlink(file.fd).catch(() => undefined)));
+        }
       } catch (e: unknown) {
         const { status, displayErrors } = mapError(e);
         return this.sendResp(req, res, {

--- a/packages/redbox-core/src/model/storage/BrandingModel.ts
+++ b/packages/redbox-core/src/model/storage/BrandingModel.ts
@@ -4,5 +4,7 @@ export class BrandingModel {
     id: string = '';
     name: string = '';
     css: string = '';
+    logo?: Record<string, unknown>;
+    favicon?: Record<string, unknown>;
     roles: RoleModel[] = [];
 }

--- a/packages/redbox-core/src/services/BrandingLogoService.ts
+++ b/packages/redbox-core/src/services/BrandingLogoService.ts
@@ -66,19 +66,46 @@ export namespace Services {
       return /^[0-9a-fA-F]{24}$/.test(id);
     }
 
+    private extForContentType(contentType: string): string {
+      switch (contentType) {
+        case 'image/png': return 'png';
+        case 'image/jpeg': return 'jpg';
+        case 'image/svg+xml': return 'svg';
+        case 'image/x-icon':
+        case 'image/vnd.microsoft.icon': return 'ico';
+        default: return 'png';
+      }
+    }
+
     private logoStorageKey(branding: string, portal: string, contentType: string): string {
-      const ext = contentType === 'image/png' ? 'png' : contentType === 'image/jpeg' ? 'jpg' : 'svg';
+      const ext = this.extForContentType(contentType);
       return `${branding}/${portal}/images/logo.${ext}`;
+    }
+
+    private faviconStorageKey(branding: string, portal: string, contentType: string): string {
+      const ext = this.extForContentType(contentType);
+      return `${branding}/${portal}/images/favicon.${ext}`;
     }
 
     getMaxBytes(): number {
       return _.get(sails, 'config.branding.logoMaxBytes', 512 * 1024);
     }
 
+    getFaviconMaxBytes(): number {
+      return _.get(sails, 'config.branding.faviconMaxBytes', 256 * 1024);
+    }
+
     allowedContentTypes = new Set([
       'image/png',
       'image/jpeg',
       'image/svg+xml'
+    ]);
+
+    faviconAllowedContentTypes = new Set([
+      'image/png',
+      'image/svg+xml',
+      'image/x-icon',
+      'image/vnd.microsoft.icon'
     ]);
 
     /** Basic SVG detection */
@@ -88,9 +115,11 @@ export namespace Services {
       return /<svg[\s>]/.test(str);
     }
 
-    async sanitizeAndValidate(fileBuf: Buffer, contentType: string): Promise<{ ok: boolean; sha256?: string; sanitizedBuffer?: Buffer; errors?: string[]; warnings?: string[]; finalContentType?: string; }> {
+    async sanitizeAndValidate(fileBuf: Buffer, contentType: string, opts?: { allowed?: Set<string>; maxBytes?: number }): Promise<{ ok: boolean; sha256?: string; sanitizedBuffer?: Buffer; errors?: string[]; warnings?: string[]; finalContentType?: string; }> {
       const errors: string[] = [];
       const warnings: string[] = [];
+      const allowed = opts?.allowed ?? this.allowedContentTypes;
+      const max = opts?.maxBytes ?? this.getMaxBytes();
 
       if (!fileBuf || !Buffer.isBuffer(fileBuf)) {
         errors.push('empty');
@@ -102,10 +131,9 @@ export namespace Services {
         return { ok: false, errors, warnings };
       }
 
-      if (!this.allowedContentTypes.has(contentType)) {
+      if (!allowed.has(contentType)) {
         errors.push('unsupported-type');
       }
-      const max = this.getMaxBytes();
       if (fileBuf.length > max) {
         errors.push('too-large');
       }
@@ -160,6 +188,40 @@ export namespace Services {
         updatedAt: new Date().toISOString(),
       };
       await BrandingConfig.update({ id: brand.id }, { logo: meta });
+      return { hash: sha256!, gridFsId: storageKey, storageKey, contentType: resolvedContentType, updatedAt: meta.updatedAt };
+    }
+
+    async putFavicon(opts: { branding: string; portal: string; fileBuffer: Buffer; contentType: string; }): Promise<{
+      hash: string;
+      gridFsId: string;
+      storageKey: string;
+      contentType: string;
+      updatedAt: string;
+    }> {
+      const brand = await BrandingConfig.findOne({ name: opts.branding });
+      if (!brand) throw new Error('branding-not-found');
+      const { ok, sha256, sanitizedBuffer, errors, finalContentType } = await this.sanitizeAndValidate(
+        opts.fileBuffer,
+        opts.contentType,
+        { allowed: this.faviconAllowedContentTypes, maxBytes: this.getFaviconMaxBytes() }
+      );
+      const errorList = errors ?? [];
+      if (!ok) throw new Error('favicon-invalid: ' + errorList.join(','));
+
+      const resolvedContentType = finalContentType ?? opts.contentType;
+      const storageKey = this.faviconStorageKey(opts.branding, opts.portal, resolvedContentType);
+
+      await StorageManagerService.primaryDisk().put(storageKey, sanitizedBuffer!, { contentType: resolvedContentType });
+
+      this.setCache(storageKey, sanitizedBuffer!);
+      const meta = {
+        gridFsId: storageKey,
+        storageKey,
+        sha256,
+        contentType: resolvedContentType,
+        updatedAt: new Date().toISOString(),
+      };
+      await BrandingConfig.update({ id: brand.id }, { favicon: meta });
       return { hash: sha256!, gridFsId: storageKey, storageKey, contentType: resolvedContentType, updatedAt: meta.updatedAt };
     }
 

--- a/packages/redbox-core/src/waterline-models/BrandingConfig.ts
+++ b/packages/redbox-core/src/waterline-models/BrandingConfig.ts
@@ -95,6 +95,9 @@ export class BrandingConfigClass {
   @Attr({ type: 'json' })
   public logo?: Record<string, unknown>;
 
+  @Attr({ type: 'json' })
+  public favicon?: Record<string, unknown>;
+
   @HasMany('role', 'branding')
   public roles?: unknown[];
 }
@@ -107,6 +110,7 @@ export interface BrandingConfigAttributes extends Sails.WaterlineAttributes {
   css?: string;
   hash?: string;
   logo?: Record<string, unknown>;
+  favicon?: Record<string, unknown>;
   name?: string;
   roles?: unknown[];
   variables?: Record<string, string>;

--- a/packages/redbox-core/test/services/BrandingLogoService.test.ts
+++ b/packages/redbox-core/test/services/BrandingLogoService.test.ts
@@ -113,4 +113,66 @@ describe('BrandingLogoService', function() {
       expect(mockPrimaryDisk.getBytes.calledOnce).to.be.true;
     });
   });
+
+  describe('putFavicon', function() {
+    it('should throw if brand not found', async function() {
+      (global as any).BrandingConfig.findOne.resolves(null);
+      try {
+        await service.putFavicon({ branding: 'brand', portal: 'portal', fileBuffer: Buffer.from('data'), contentType: 'image/png' });
+        expect.fail('Should have thrown');
+      } catch (e: unknown) {
+        expect(e instanceof Error ? e.message : String(e)).to.equal('branding-not-found');
+      }
+    });
+
+    it('should store a PNG favicon and update config', async function() {
+      const brand = { id: 'brand1' };
+      (global as any).BrandingConfig.findOne.resolves(brand);
+      (global as any).BrandingConfig.update.resolves([]);
+
+      const result = await service.putFavicon({ branding: 'brand', portal: 'portal', fileBuffer: Buffer.from('data'), contentType: 'image/png' });
+
+      expect(result.contentType).to.equal('image/png');
+      expect(result.storageKey).to.equal('brand/portal/images/favicon.png');
+      expect(mockPrimaryDisk.put.firstCall.args[0]).to.equal('brand/portal/images/favicon.png');
+      expect((global as any).BrandingConfig.update.firstCall.args[1].favicon).to.include({
+        storageKey: 'brand/portal/images/favicon.png',
+        contentType: 'image/png',
+      });
+    });
+
+    it('should accept an ICO favicon', async function() {
+      const brand = { id: 'brand1' };
+      (global as any).BrandingConfig.findOne.resolves(brand);
+      (global as any).BrandingConfig.update.resolves([]);
+
+      const result = await service.putFavicon({ branding: 'brand', portal: 'portal', fileBuffer: Buffer.from('icodata'), contentType: 'image/x-icon' });
+
+      expect(result.contentType).to.equal('image/x-icon');
+      expect(result.storageKey).to.equal('brand/portal/images/favicon.ico');
+    });
+
+    it('should reject an unsupported favicon content type', async function() {
+      const brand = { id: 'brand1' };
+      (global as any).BrandingConfig.findOne.resolves(brand);
+      try {
+        await service.putFavicon({ branding: 'brand', portal: 'portal', fileBuffer: Buffer.from('data'), contentType: 'image/jpeg' });
+        expect.fail('Should have thrown');
+      } catch (e: unknown) {
+        expect(e instanceof Error ? e.message : String(e)).to.match(/favicon-invalid: .*unsupported-type/);
+      }
+    });
+
+    it('should reject an oversized favicon', async function() {
+      const brand = { id: 'brand1' };
+      (global as any).BrandingConfig.findOne.resolves(brand);
+      mockSails.config.branding = { faviconMaxBytes: 10 };
+      try {
+        await service.putFavicon({ branding: 'brand', portal: 'portal', fileBuffer: Buffer.alloc(20, 0), contentType: 'image/png' });
+        expect.fail('Should have thrown');
+      } catch (e: unknown) {
+        expect(e instanceof Error ? e.message : String(e)).to.match(/favicon-invalid: .*too-large/);
+      }
+    });
+  });
 });

--- a/test/integration/services/BrandingFaviconService.test.ts
+++ b/test/integration/services/BrandingFaviconService.test.ts
@@ -1,0 +1,57 @@
+/* eslint-disable no-unused-expressions */
+const { expect } = require('chai');
+const { createHash } = require('node:crypto');
+
+describe('BrandingLogoService favicon', () => {
+
+  it('accepts and stores a PNG favicon', async () => {
+    const pngBuf = Buffer.from('89504e470d0a1a0a0000000d4948445200000001000000010802000000907753de0000000a49444154789c636000000200015c0d0a2db40000000049454e44ae426082', 'hex');
+    const expectedHash = createHash('sha256').update(pngBuf).digest('hex');
+    const res = await BrandingLogoService.putFavicon({ branding: 'default', portal: 'default', fileBuffer: pngBuf, contentType: 'image/png' });
+    expect(res.hash).to.match(/^[0-9a-f]{64}$/);
+    expect(res.hash).to.equal(expectedHash);
+    expect(res.storageKey).to.equal('default/default/images/favicon.png');
+    const brand = await BrandingConfig.findOne({ name: 'default' });
+    expect(brand.favicon).to.have.property('sha256', res.hash);
+  });
+
+  it('accepts an ICO favicon', async () => {
+    const icoBuf = Buffer.from('00000100010010101000010004002806000016000000', 'hex');
+    const res = await BrandingLogoService.putFavicon({ branding: 'default', portal: 'default', fileBuffer: icoBuf, contentType: 'image/x-icon' });
+    expect(res.contentType).to.equal('image/x-icon');
+    expect(res.storageKey).to.equal('default/default/images/favicon.ico');
+  });
+
+  it('rejects unsupported content type', async () => {
+    let err; try { await BrandingLogoService.putFavicon({ branding: 'default', portal: 'default', fileBuffer: Buffer.from('test'), contentType: 'image/jpeg' }); } catch (e) { err = e; }
+    expect(err).to.exist;
+    expect(err.message).to.match(/favicon-invalid: .*unsupported-type/);
+  });
+
+  it('rejects oversized file', async () => {
+    const originalLimit = sails.config.branding.faviconMaxBytes;
+    sails.config.branding.faviconMaxBytes = 100;
+    const big = Buffer.alloc(110, 0);
+    let err; try { await BrandingLogoService.putFavicon({ branding: 'default', portal: 'default', fileBuffer: big, contentType: 'image/png' }); } catch (e) { err = e; }
+    sails.config.branding.faviconMaxBytes = originalLimit;
+    expect(err).to.exist;
+    expect(err.message).to.match(/favicon-invalid: .*too-large/);
+  });
+
+  it('sanitizes unsafe SVG', async () => {
+    const unsafe = Buffer.from('<svg><script>alert(1)</script></svg>');
+    let err; try { await BrandingLogoService.putFavicon({ branding: 'default', portal: 'default', fileBuffer: unsafe, contentType: 'image/svg+xml' }); } catch (e) { err = e; }
+    expect(err).to.exist;
+    expect(err.message).to.match(/svg-script-element/);
+  });
+
+  it('accepts safe minimal SVG', async () => {
+    const safe = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10" fill="#000"/></svg>');
+    const res = await BrandingLogoService.putFavicon({ branding: 'default', portal: 'default', fileBuffer: safe, contentType: 'image/svg+xml' });
+    expect(res.hash).to.match(/^[0-9a-f]{64}$/);
+    expect(res.contentType).to.equal('image/svg+xml');
+    expect(res.storageKey).to.equal('default/default/images/favicon.svg');
+    const stored = await BrandingLogoService.getBinaryAsync(res.gridFsId);
+    expect(stored).to.be.instanceOf(Buffer);
+  });
+});

--- a/views/default/default/layout.ejs
+++ b/views/default/default/layout.ejs
@@ -8,7 +8,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="<%= typeof description == 'undefined' ? 'ReDBox research data management portal' : description %>">
-  <link rel="icon" href="<%= BrandingService.getBrandAndPortalPath(req) %>/images/favicon">
+  <link rel="apple-touch-icon" sizes="180x180" href="<%= BrandingService.getRootContext() %>/apple-touch-icon.png">
+  <link rel="icon" href="<%= BrandingService.getBrandAndPortalPath(req) %>/images/favicon" type="image/png">
 
   <title>
     <%=typeof title == 'undefined' ? TranslationService.t('default-title') : title%>

--- a/views/default/default/layout.ejs
+++ b/views/default/default/layout.ejs
@@ -8,9 +8,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="<%= typeof description == 'undefined' ? 'ReDBox research data management portal' : description %>">
-  <link rel="apple-touch-icon" sizes="180x180" href="<%= BrandingService.getRootContext() %>/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="<%= BrandingService.getRootContext() %>/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="<%= BrandingService.getRootContext() %>/favicon-16x16.png">
+  <link rel="icon" href="<%= BrandingService.getBrandAndPortalPath(req) %>/images/favicon">
 
   <title>
     <%=typeof title == 'undefined' ? TranslationService.t('default-title') : title%>


### PR DESCRIPTION
## Summary

Adds configurable favicons to the branding administration workflow. Administrators can upload a PNG, SVG, or ICO favicon for a brand, and portal pages serve it from the brand-specific favicon route with a default fallback.

---

## Context / Motivation

Portal branding already supports custom logos, but browser favicons remained fixed static assets. This change brings favicon management into the existing branding storage and administration flow so each brand can present its own browser tab icon.

---

## Key Features

### Branding administration

- Adds a favicon upload control to the branding admin interface.
- Accepts PNG, SVG, and ICO files up to 256 KB.
- Adds translated upload label and help text.

### Upload and storage

- Adds authenticated application and webservice upload endpoints.
- Reuses the branding image validation and SVG sanitisation pipeline with favicon-specific file types and size limits.
- Stores the favicon under a brand- and portal-specific key and records its metadata on `BrandingConfig`.

### Favicon delivery

- Adds a brand-aware `/images/favicon` route and updates the default layout to use it.
- Serves the configured favicon with its stored content type, ETag support, and cache headers.
- Falls back to the default favicon when no custom favicon is configured or the stored asset cannot be loaded.

---

## Testing

- Adds unit coverage for missing brands, PNG and ICO storage, unsupported content types, and oversized uploads.
- Adds integration coverage for PNG, ICO, and SVG uploads, including unsafe SVG rejection and persisted asset retrieval.

---

## Architectural / Operational Impact

### Data model and storage

`BrandingConfig` gains optional favicon metadata. Favicon binaries use the existing branding storage abstraction, so no new storage service or dependency is introduced.

### API and routing

The branding API exposes a multipart favicon upload endpoint alongside the existing logo endpoint. The server-rendered layout now resolves its favicon through the brand and portal path.

---

## Backwards Compatibility

Existing branding configurations remain valid because favicon metadata is optional. Portals without a configured favicon continue to receive the default PNG favicon.

---

## Deployment Notes

No manual migration or new dependency is required. Existing deployments should ensure their configured branding storage is writable for favicon uploads.

---

## Impact

Each configured brand can now manage and serve its own validated favicon through the existing branding system.
