### PR TITLE
bugfix: normalise geojson position from string coordinates to numbers

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
@@ -638,7 +638,8 @@ describe("MapComponent", () => {
       type: "Feature",
       geometry: {
         type: "MultiPoint",
-        coordinates: [[153.02, -27.47], [146.82, -19.25]]
+        // Should allow string coordinates.
+        coordinates: [[153.02, -27.47], ["146.82", "-19.25"]]
       },
       properties: {name: "Queensland sites", mode: "polygon"}
     });
@@ -653,6 +654,7 @@ describe("MapComponent", () => {
     expect((modelValue?.features ?? []).length).toBe(2);
     expect(modelValue.features.map((feature: any) => feature.geometry.type)).toEqual(["Point", "Point"]);
     expect(modelValue.features.every((feature: any) => uuidV4Pattern.test(feature.id) && feature.properties.mode === "point")).toBeTrue();
+    expect(modelValue.features.map((feature: any) => feature.geometry.coordinates)).toEqual([[153.02, -27.47], [146.82, -19.25]]);
   });
 
   it("throws a controlled error when map feature ids cannot be generated", async () => {
@@ -812,8 +814,17 @@ describe("MapComponent", () => {
                 features: [
                   {
                     type: "Feature",
-                    geometry: {type: "Polygon", coordinates: [[144.96, -37.81], ["144.961", "-37.811"], ["144.96", "-37.81"]]},
+                    geometry: {type: "Point", coordinates: [144.96, -37.81]},
                     properties: {name: "Melbourne"}
+                  },
+                  {
+                    type: "Feature",
+                    geometry: {
+                      type: "Point",
+                      // Should allow string coordinates.
+                      coordinates: ["145.935234375", "-22.625184301"]
+                    },
+                    properties: {}
                   }
                 ]
               }
@@ -823,16 +834,27 @@ describe("MapComponent", () => {
       ]
     };
 
-    await createFormAndWaitForReady(formConfig, {editMode: true} as any);
-    expect(fakeDraw.addFeatures).toHaveBeenCalledOnceWith([
+    const {fixture} = await createFormAndWaitForReady(formConfig, {editMode: true} as any);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(fakeDraw.addFeatures).toHaveBeenCalledTimes(1);
+    expect(fakeDraw.addFeatures).toHaveBeenCalledWith([
       jasmine.objectContaining({
         id: jasmine.stringMatching(uuidV4Pattern),
         type: "Feature",
-        geometry: {type: "Polygon", coordinates: [[144.96, -37.81], [144.961, -37.811], [144.96, -37.81]]},
-        properties: jasmine.objectContaining({name: "Melbourne", mode: "polygon"})
+        geometry: {type: "Point", coordinates: [144.96, -37.81]},
+        properties: jasmine.objectContaining({name: "Melbourne", mode: "point"})
+      }),
+      jasmine.objectContaining({
+        id: jasmine.stringMatching(uuidV4Pattern),
+        type: "Feature",
+        geometry: {type: "Point", coordinates: [145.935234375, -22.625184301]},
+        properties: jasmine.objectContaining({mode: "point"})
       })
     ]);
-    expect(drawFeatures.length).toBe(1);
+    expect(drawFeatures.length).toBe(2);
     expect(fakeMap.updateSize).toHaveBeenCalled();
   });
 

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
@@ -817,31 +817,36 @@ describe("MapComponent", () => {
                     geometry: {type: "Point", coordinates: [144.96, -37.81]},
                     properties: {name: "Melbourne"}
                   },
+                  // Should allow string coordinates.
                   {
                     type: "Feature",
-                    geometry: {
-                      type: "Point",
-                      // Should allow string coordinates.
-                      coordinates: ["145.935234375", "-22.625184301"]
-                    },
+                    geometry: {type: "Point", coordinates: ["145.935234375", "-22.625184301"]},
+                    properties: {}
+                  },
+                  // Should only include coordinates that are numbers or non-empty strings.
+                  {
+                    type: "Feature",
+                    geometry: {type: "Point", coordinates: [undefined, -22.62]},
                     properties: {}
                   },
                   {
                     type: "Feature",
-                    geometry: {
-                      type: "Point",
-                      // Should ignore non-string, non-number coordinates.
-                      coordinates: [undefined, null]
-                    },
+                    geometry: {type: "Point", coordinates: [145.93, null]},
                     properties: {}
                   },
                   {
                     type: "Feature",
-                    geometry: {
-                      type: "Point",
-                      // Should ignore non-string, non-number coordinates.
-                      coordinates: [true, {testing: 1}]
-                    },
+                    geometry: {type: "Point", coordinates: [145.93, {}]},
+                    properties: {}
+                  },
+                  {
+                    type: "Feature",
+                    geometry: {type: "Point", coordinates: [145.93, true]},
+                    properties: {}
+                  },
+                  {
+                    type: "Feature",
+                    geometry: {type: "Point", coordinates: ["  \n", -22.62]},
                     properties: {}
                   }
                 ]

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
@@ -825,6 +825,24 @@ describe("MapComponent", () => {
                       coordinates: ["145.935234375", "-22.625184301"]
                     },
                     properties: {}
+                  },
+                  {
+                    type: "Feature",
+                    geometry: {
+                      type: "Point",
+                      // Should ignore non-string, non-number coordinates.
+                      coordinates: [undefined, null]
+                    },
+                    properties: {}
+                  },
+                  {
+                    type: "Feature",
+                    geometry: {
+                      type: "Point",
+                      // Should ignore non-string, non-number coordinates.
+                      coordinates: [true, {testing: 1}]
+                    },
+                    properties: {}
                   }
                 ]
               }

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
@@ -812,7 +812,7 @@ describe("MapComponent", () => {
                 features: [
                   {
                     type: "Feature",
-                    geometry: {type: "Point", coordinates: [144.96, -37.81]},
+                    geometry: {type: "Polygon", coordinates: [[144.96, -37.81], ["144.961", "-37.811"], ["144.96", "-37.81"]]},
                     properties: {name: "Melbourne"}
                   }
                 ]
@@ -828,8 +828,8 @@ describe("MapComponent", () => {
       jasmine.objectContaining({
         id: jasmine.stringMatching(uuidV4Pattern),
         type: "Feature",
-        geometry: {type: "Point", coordinates: [144.96, -37.81]},
-        properties: jasmine.objectContaining({name: "Melbourne", mode: "point"})
+        geometry: {type: "Polygon", coordinates: [[144.96, -37.81], [144.961, -37.811], [144.96, -37.81]]},
+        properties: jasmine.objectContaining({name: "Melbourne", mode: "polygon"})
       })
     ]);
     expect(drawFeatures.length).toBe(1);

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.ts
@@ -1258,15 +1258,15 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
     }
   }
 
-  private normalizePosition(position: GeoJSON.Position): [number, number] | null {
+  private normalizePosition(position: GeoJSON.Position | (string | number)[]): [number, number] | null {
     if (!Array.isArray(position) || position.length < 2) {
       return null;
     }
     let longitude: number | null = null;
     let latitude: number | null = null;
     try {
-      longitude = Number(position[0]);
-      latitude = Number(position[1]);
+      longitude = ["string", "number"].includes(typeof position[0]) ? Number(position[0]) : null;
+      latitude = ["string", "number"].includes(typeof position[1]) ? Number(position[1]) : null;
     } catch (err) {
       this.loggerService.error(`${this.logName}: failed to parse position ${position}`, err);
     }
@@ -1275,7 +1275,7 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
       latitude !== null && Number.isFinite(latitude)) {
       return [longitude, latitude];
     }
-    this.loggerService.warn(`${this.logName}: invalid position ${position}`);
+    this.loggerService.warn(`${this.logName}: invalid position`, position);
     return null;
   }
 

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.ts
@@ -1270,9 +1270,13 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
     } catch (err) {
       this.loggerService.error(`${this.logName}: failed to parse position ${position}`, err);
     }
-    return longitude !== null && Number.isFinite(longitude) &&
-    latitude !== null && Number.isFinite(latitude)
-      ? [longitude, latitude] : null;
+
+    if (longitude !== null && Number.isFinite(longitude) &&
+      latitude !== null && Number.isFinite(latitude)) {
+      return [longitude, latitude];
+    }
+    this.loggerService.warn(`${this.logName}: invalid position ${position}`);
+    return null;
   }
 
   private normalizeLineStringCoordinates(coordinates: GeoJSON.Position[]): [number, number][] {

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.ts
@@ -1262,11 +1262,17 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
     if (!Array.isArray(position) || position.length < 2) {
       return null;
     }
-    const [longitude, latitude] = position;
-    if (typeof longitude !== "number" || typeof latitude !== "number") {
-      return null;
+    let longitude: number | null = null;
+    let latitude: number | null = null;
+    try {
+      longitude = Number(position[0]);
+      latitude = Number(position[1]);
+    } catch (err) {
+      this.loggerService.error(`${this.logName}: failed to parse position ${position}`, err);
     }
-    return [longitude, latitude];
+    return longitude !== null && Number.isFinite(longitude) &&
+    latitude !== null && Number.isFinite(latitude)
+      ? [longitude, latitude] : null;
   }
 
   private normalizeLineStringCoordinates(coordinates: GeoJSON.Position[]): [number, number][] {

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.ts
@@ -1262,20 +1262,33 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
     if (!Array.isArray(position) || position.length < 2) {
       return null;
     }
-    let longitude: number | null = null;
-    let latitude: number | null = null;
-    try {
-      longitude = ["string", "number"].includes(typeof position[0]) ? Number(position[0]) : null;
-      latitude = ["string", "number"].includes(typeof position[1]) ? Number(position[1]) : null;
-    } catch (err) {
-      this.loggerService.error(`${this.logName}: failed to parse position ${position}`, err);
-    }
+
+    const longitude = this.normalizePositionNumber(position[0]);
+    const latitude= this.normalizePositionNumber(position[1]);
 
     if (longitude !== null && Number.isFinite(longitude) &&
       latitude !== null && Number.isFinite(latitude)) {
       return [longitude, latitude];
     }
     this.loggerService.warn(`${this.logName}: invalid position`, position);
+    return null;
+  }
+
+  private normalizePositionNumber(value: unknown): number | null {
+    try {
+      if (typeof value === "number") {
+        return value;
+      }
+      if (typeof value === "string") {
+        const trimmed = value?.trim();
+        if (trimmed.length > 0) {
+          return Number(trimmed);
+        }
+        return null;
+      }
+    } catch (err) {
+      this.loggerService.error(`${this.logName}: failed to parse position value ${value}`, err);
+    }
     return null;
   }
 


### PR DESCRIPTION
## Summary

GeoJSON coordinate arrays can contain strings instead of numbers.
While this does not seem to be strictly allowed, it is common.

Currently string coordinates are silently dropped. Instead, convert them to numbers.

Changes made:

* Be more lenient with geojson format, to allow common data to be imported and loaded.

## Technical implementation details

* Parse coordinates in string format to numbers.

## Testing

* Updated the existing test to ensure string coordinates are correctly parsed and included.
