### PR TITLE
Bugfix: Improve dynamic form validation state handling

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/validation-summary.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/validation-summary.component.spec.ts
@@ -35,6 +35,24 @@ describe('ValidationSummaryFieldComponent', () => {
     expect(component).toBeDefined();
   });
 
+  it('should reveal tabs implemented by a dynamically loaded component instance', () => {
+    const fixture = TestBed.createComponent(ValidationSummaryFieldComponent);
+    const component = fixture.componentInstance as any;
+    const selectTab = jasmine.createSpy('selectTab');
+    spyOn(component, 'findComponentEntryByName').and.callFake((name: string) =>
+      name === 'mainTab'
+        ? {
+            compConfigJson: { component: { class: 'TabComponent' } },
+            component: { selectTab },
+          }
+        : undefined,
+    );
+
+    component.revealTabParents(['mainTab', 'storage', 'field']);
+
+    expect(selectTab).toHaveBeenCalledOnceWith('storage');
+  });
+
   it('should cancel a deferred validation refresh when destroyed', fakeAsync(() => {
     const fixture = TestBed.createComponent(ValidationSummaryFieldComponent);
     const component = fixture.componentInstance as any;

--- a/angular/projects/researchdatabox/form/src/app/component/validation-summary.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/validation-summary.component.ts
@@ -10,6 +10,7 @@ import {
   GroupFieldModelName,
   isTypeFieldDefinitionName,
   RepeatableComponentName,
+  TabComponentName,
   TabContentComponentName,
   TabContentLayoutName,
   ValidationSummaryComponentName,
@@ -281,8 +282,12 @@ export class ValidationSummaryFieldComponent extends FormFieldBaseComponent<stri
       const containerName = String(angularPath[index]);
       const targetTabId = String(angularPath[index + 1]);
       const candidate = this.findComponentEntryByName(containerName);
-      if (candidate?.component instanceof TabComponent) {
-        candidate.component.selectTab(targetTabId);
+      const tabComponent = candidate?.component as Pick<TabComponent, 'selectTab'> | undefined;
+      if (
+        candidate?.compConfigJson?.component?.class === TabComponentName &&
+        typeof tabComponent?.selectTab === 'function'
+      ) {
+        tabComponent.selectTab(targetTabId);
       }
     }
   }

--- a/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
@@ -232,6 +232,49 @@ describe('FormComponent', () => {
     }
   });
 
+  it('broadcasts the settled result of form-level async validation without restarting it', async () => {
+    const formConfig: FormConfigFrame = {
+      name: 'async-form-validator-status-broadcast',
+      debugValue: false,
+      defaultComponentConfig: { defaultComponentCssClasses: 'row' },
+      editCssClasses: 'redbox-form form',
+      componentDefinitions: [
+        {
+          name: 'async_field',
+          model: { class: 'SimpleInputModel', config: { value: 'ready' } },
+          component: { class: 'SimpleInputComponent' },
+        },
+      ],
+    };
+    const { fixture, formComponent } = await createFormAndWaitForReady(formConfig);
+    const bus = TestBed.inject(FormComponentEventBus);
+    const broadcasts: FormValidationBroadcastEvent[] = [];
+    const sub = bus.select$(FormComponentEventType.FORM_VALIDATION_BROADCAST)
+      .subscribe(event => broadcasts.push(event));
+    let validatorCalls = 0;
+
+    try {
+      formComponent.form!.setAsyncValidators([
+        async () => {
+          validatorCalls += 1;
+          await Promise.resolve();
+          return null;
+        },
+      ]);
+      formComponent.form!.updateValueAndValidity();
+      await fixture.whenStable();
+
+      expect(validatorCalls).toBe(1);
+      expect(formComponent.form!.status).toBe('VALID');
+      expect(broadcasts.length).toBeGreaterThan(0);
+      const settledBroadcast = broadcasts[broadcasts.length - 1];
+      expect(settledBroadcast?.status?.pending).toBeFalse();
+      expect(settledBroadcast?.isValid).toBeTrue();
+    } finally {
+      sub.unsubscribe();
+    }
+  });
+
   it('broadcastFormStatus is a no-op when the form has not been created yet', () => {
     const fixture = TestBed.createComponent(FormComponent);
     const formComponent = fixture.componentInstance;
@@ -548,9 +591,10 @@ describe('FormComponent', () => {
 
       // The formGroupChangesSub subscription must have fired broadcastFormStatus
       // at least once between releasing the barrier and the save completing.
-      // That call publishes a FORM_VALIDATION_BROADCAST and re-runs validators
-      // synchronously; if any of that interfered with the save resumption we
-      // would either see no update call or a FORM_SAVE_FAILURE.
+      // That call publishes a FORM_VALIDATION_BROADCAST with the already-settled
+      // status (it does not re-run validators on this path); if publishing that
+      // broadcast interfered with the save resumption we would either see no
+      // update call or a FORM_SAVE_FAILURE.
       expect(broadcastSpy.calls.count()).toBeGreaterThan(broadcastCallsBeforeResolve);
       expect(validationBroadcasts.length).toBeGreaterThan(broadcastEventsBeforeResolve);
       expect(updateSpy).toHaveBeenCalledTimes(1);

--- a/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
@@ -653,6 +653,79 @@ describe('FormComponent', () => {
     expect(formComponent.form?.valid).toBeTrue();
   });
 
+  it('restores nested group validity after temporary save validation', async () => {
+    const formConfig: FormConfigFrame = {
+      name: 'nested-grouped-save-validation',
+      debugValue: false,
+      enabledValidationGroups: ['none'],
+      validationGroups: {
+        none: {
+          description: 'Allow incomplete draft saves.',
+          initialMembership: 'none',
+        },
+        activation: {
+          description: 'Validate fields required for activation.',
+          initialMembership: 'all',
+        },
+      },
+      componentDefinitions: [
+        {
+          name: 'description',
+          model: {
+            class: 'SimpleInputModel',
+            config: { value: 'Original description' },
+          },
+          component: { class: 'SimpleInputComponent' },
+        },
+        {
+          name: 'contributor_ci',
+          model: { class: 'GroupModel' },
+          component: {
+            class: 'GroupComponent',
+            config: {
+              componentDefinitions: [
+                {
+                  name: 'name',
+                  model: {
+                    class: 'SimpleInputModel',
+                    config: {
+                      value: '',
+                      validators: [{ class: 'required' }],
+                    },
+                  },
+                  component: { class: 'SimpleInputComponent' },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    };
+
+    const { fixture, formComponent } = await createFormAndWaitForReady(formConfig);
+    const updateSpy = spyOn(formComponent.recordService, 'update').and.resolveTo({ success: true } as any);
+
+    expect(formComponent.form?.valid).toBeTrue();
+
+    await formComponent.saveForm({
+      force: true,
+      targetStep: 'active',
+      enabledValidationGroups: ['activation'],
+    });
+
+    expect(formComponent.form?.valid).toBeFalse();
+    expect(formComponent.form?.get('contributor_ci')?.valid).toBeFalse();
+    expect(updateSpy).not.toHaveBeenCalled();
+
+    formComponent.form?.get('description')?.setValue('Changed description');
+    await fixture.whenStable();
+
+    expect(formComponent.enabledValidationGroups).toEqual(['none']);
+    expect(formComponent.form?.get('contributor_ci.name')?.hasError('required')).toBeFalse();
+    expect(formComponent.form?.get('contributor_ci')?.valid).toBeTrue();
+    expect(formComponent.form?.valid).toBeTrue();
+  });
+
   it('compares validation groups independent of order', () => {
     const fixture = TestBed.createComponent(FormComponent);
     const formComponent = fixture.componentInstance as unknown as {

--- a/angular/projects/researchdatabox/form/src/app/form.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.ts
@@ -675,7 +675,10 @@ export class FormComponent extends BaseComponent implements OnDestroy {
       this.subMaps['formGroupChangesSub'] = this.form.events.subscribe(
         (formGroupEvent: StatusChangeEvent | PristineChangeEvent | ValueChangeEvent<unknown> | unknown) => {
           if (formGroupEvent instanceof StatusChangeEvent || formGroupEvent instanceof PristineChangeEvent) {
-            this.broadcastFormStatus();
+            // Angular has already recalculated the form for these events. Re-running
+            // validation here restarts form-level async validators and can leave
+            // consumers permanently observing PENDING instead of the settled status.
+            this.broadcastFormStatus(false);
           }
         }
       );
@@ -713,12 +716,17 @@ export class FormComponent extends BaseComponent implements OnDestroy {
    * — e.g. expression-driven model updates — so consumers like the Save button
    * effect can re-evaluate. Without this, silent updates can leave the UI's idea
    * of validity out of sync with the FormGroup's actual state.
+   *
+   * Pass `false` when Angular has already recalculated validation for the event
+   * being broadcast, particularly for settled async-validation status changes.
    */
-  public broadcastFormStatus(): void {
+  public broadcastFormStatus(revalidate = true): void {
     if (!this.form) {
       return;
     }
-    this.form.updateValueAndValidity({ emitEvent: false });
+    if (revalidate) {
+      this.form.updateValueAndValidity({ emitEvent: false });
+    }
     this.formGroupStatus.set(this.dataStatus);
     this.eventBus.publish(
       createFormValidationBroadcastEvent({

--- a/angular/projects/researchdatabox/form/src/app/form.service.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.service.ts
@@ -825,17 +825,18 @@ export class FormService extends HttpClientService {
   public updateValidators(
     mapEntry: FormFieldCompMapEntry, enabledValidationGroups?: string[] | null, validationGroups?: FormValidationGroups | null
   ): void {
+    // Update descendants first so container controls recalculate their aggregate
+    // status from the refreshed child validation state.
+    for (const childMapEntry of mapEntry?.component?.formFieldCompMapEntries ?? []) {
+      this.updateValidators(childMapEntry, enabledValidationGroups, validationGroups)
+    }
+
     // Set the validators for the form control.
     if (mapEntry?.model?.formControl) {
       const formControl = mapEntry?.model?.formControl;
       const validators = mapEntry?.model?.validators;
       const updateValueAndValidityOpts = { doUpdate: true, onlySelf: true, emitEvent: false };
       this.setValidators(formControl, validators, enabledValidationGroups, validationGroups, updateValueAndValidityOpts, mapEntry);
-    }
-
-    // Set the validators for any child controls.
-    for (const childMapEntry of mapEntry?.component?.formFieldCompMapEntries ?? []) {
-      this.updateValidators(childMapEntry, enabledValidationGroups, validationGroups)
     }
   }
 


### PR DESCRIPTION
## Summary

Improves form validation state handling across nested forms, dynamic tabs, and asynchronous validators.

---

## Context / Motivation

Validation state could become stale after transition checks, validation summaries could fail to focus fields in dynamic tabs, and settled async validation events could unnecessarily restart validators.

---

## Key Features

### Validation state propagation

- Refreshes nested validation state after transition checks.
- Keeps validation summaries and focused fields aligned across dynamically rendered tabs.

### Async validation stability

- Prevents settled validation broadcasts from restarting asynchronous validators.
- Adds regression coverage for the affected form workflows.

---

## Testing

- Updated Angular form component and validation summary unit tests.
- Added regression coverage for nested state refresh, dynamic-tab focus, and settled async validation.

---

## Architectural / Operational Impact

### Form workflow behaviour

Validation state is propagated more consistently through the existing form service and component lifecycle without changing the public form configuration model.

### User experience

Users receive more reliable validation feedback and are taken to the relevant invalid fields when validation spans dynamic tabs.

---

## Backwards Compatibility

Existing form configurations remain compatible. The changes correct validation lifecycle behaviour for existing forms.

---

## Deployment Notes

No migration or additional deployment configuration is required.

---

## Impact

Improves reliability and usability of validation in complex forms while avoiding unnecessary asynchronous validation work.
