### PR TITLE
Bugfix: Preserve owner permissions without contributors

### DIFF
--- a/test/unit/services/RDMPService.test.js
+++ b/test/unit/services/RDMPService.test.js
@@ -39,7 +39,9 @@ describe('The RDMPService', function () {
         it('assignPermissions with no viewers or editors', function (done) {
             const oid = "assignPermissions-no-viewers-no-editors";
             const record = {
-                metaMetadata: {},
+                metaMetadata: {
+                    createdBy: userAdminDefault.name
+                },
                 workflow: {},
                 authorization: {
                     edit: [],
@@ -72,8 +74,8 @@ describe('The RDMPService', function () {
                 "recordCreatorPermissions": "view&edit"
             };
             RDMPService.assignPermissions(oid, record, options).subscribe(function (record) {
-                expect(record.authorization.edit).to.be.empty;
-                expect(record.authorization.view).to.be.empty;
+                expect(record.authorization.edit).eql([userAdminDefault.name]);
+                expect(record.authorization.view).eql([userAdminDefault.name]);
                 expect(record.authorization.editPending).to.be.empty;
                 expect(record.authorization.viewPending).to.be.empty;
                 User.count().then(function (count) {

--- a/typescript/api/services/RDMPService.ts
+++ b/typescript/api/services/RDMPService.ts
@@ -533,6 +533,14 @@ export module Services {
       }
       // when both are empty, simpy return the record
       if (_.isEmpty(editContributorEmails) && _.isEmpty(viewContributorEmails)) {
+        if (recordCreatorPermissions == "edit" || recordCreatorPermissions == "view&edit") {
+          record.authorization.edit = [record.metaMetadata.createdBy];
+          record.authorization.editPending = [];
+        }
+        if (recordCreatorPermissions == "view" || recordCreatorPermissions == "view&edit") {
+          record.authorization.view = [record.metaMetadata.createdBy];
+          record.authorization.viewPending = [];
+        }
         return Observable.of(record);
       }
       _.each(editContributorEmails, editorEmail => {


### PR DESCRIPTION

## Summary

Ensure record owners receive their configured permissions when no editor or viewer contributors are present.

---

## Context / Motivation

`assignPermissions` returned early when both contributor lists were empty, preventing `recordCreatorPermissions` from being applied. This left the record owner without an entry in the edit or view authorization lists.

---

## Key Features

### Owner permission assignment

- Applies the owner to the edit authorization list for `edit` or `view&edit` permissions.
- Applies the owner to the view authorization list for `view` or `view&edit` permissions.
- Maintains empty pending lists when no contributors are supplied.

### Regression coverage

- Updates the empty-contributor service test to verify the owner receives both permissions.

---

## Testing

- `git diff --check` passes.
- Docker-backed Mocha tests were attempted but could not start because the Docker host ran out of storage while pulling test images.

---

## Architectural / Operational Impact

### Authorization behavior

Records configured with owner permissions no longer leave the owner without access when contributor fields are empty.

### Operational impact

No schema, migration, dependency, or deployment changes are required.

---

## Backwards Compatibility

Existing contributor-based permission assignment is unchanged. The change only affects records with no editor or viewer contributors and a configured `recordCreatorPermissions` value.

---

## Deployment Notes

Deploy the service and test updates through the normal portal release process. No migration is required.

---

## Impact

Record owners consistently retain the configured access level, including when no additional contributors are defined.
