### PR TITLE
Bugfix: Preserve v5 owner permissions without contributors

### DIFF
--- a/packages/redbox-core/src/services/RDMPService.ts
+++ b/packages/redbox-core/src/services/RDMPService.ts
@@ -577,6 +577,14 @@ export namespace Services {
       }
       // when both are empty, simpy return the record
       if (_.isEmpty(editContributorEmails) && _.isEmpty(viewContributorEmails)) {
+        if (recordCreatorPermissions == "edit" || recordCreatorPermissions == "view&edit") {
+          auth.edit = createdBy ? [createdBy] : [];
+          auth.editPending = [];
+        }
+        if (recordCreatorPermissions == "view" || recordCreatorPermissions == "view&edit") {
+          auth.view = createdBy ? [createdBy] : [];
+          auth.viewPending = [];
+        }
         return of(record);
       }
       _.each(editContributorEmails, (editorEmail: string) => {

--- a/packages/redbox-core/test/services/RDMPService.test.ts
+++ b/packages/redbox-core/test/services/RDMPService.test.ts
@@ -792,6 +792,42 @@ describe('RDMPService', function () {
       expect(result).to.deep.equal(record);
     });
 
+    it('should assign both owner permissions when there are no contributors', async function () {
+      const record: any = {
+        metaMetadata: { createdBy: 'creator' },
+        metadata: {},
+        authorization: {}
+      };
+      const options = {
+        recordCreatorPermissions: 'view&edit'
+      };
+
+      const result: any = await firstValueFrom(RDMPService.assignPermissions('oid-1', record, options));
+
+      expect(result.authorization.edit).to.deep.equal(['creator']);
+      expect(result.authorization.view).to.deep.equal(['creator']);
+      expect(result.authorization.editPending).to.deep.equal([]);
+      expect(result.authorization.viewPending).to.deep.equal([]);
+      expect(mockUser.findOne.called).to.be.false;
+    });
+
+    it('should assign only the configured owner permission when there are no contributors', async function () {
+      const record: any = {
+        metaMetadata: { createdBy: 'creator' },
+        metadata: {},
+        authorization: {}
+      };
+      const options = {
+        recordCreatorPermissions: 'view'
+      };
+
+      const result: any = await firstValueFrom(RDMPService.assignPermissions('oid-1', record, options));
+
+      expect(result.authorization.edit).to.be.undefined;
+      expect(result.authorization.view).to.deep.equal(['creator']);
+      expect(result.authorization.viewPending).to.deep.equal([]);
+    });
+
     it('should assign permissions based on contributor properties', async function () {
       const record = {
         metadata: {


### PR DESCRIPTION

## Summary

Ensure v5 record owners receive their configured permissions when no editor or viewer contributors are present.

---

## Context / Motivation

The v5 `RDMPService` returned early when both contributor lists were empty. As a result, `recordCreatorPermissions` was not applied and the record owner could be left without edit or view access.

---

## Key Features

### Owner permission assignment

- Assigns the owner to edit permissions for `edit` and `view&edit` configurations.
- Assigns the owner to view permissions for `view` and `view&edit` configurations.
- Preserves v5’s existing creator fallback to the supplied user username.
- Initializes pending contributor lists as empty when no contributors exist.

### Unit test coverage

- Verifies both permissions are assigned for `view&edit`.
- Verifies only the configured permission is assigned for `view`.
- Verifies no user lookup is performed when contributor lists are empty.

---

## Testing

- Added focused unit tests in `packages/redbox-core/test/services/RDMPService.test.ts`.
- `git diff --check` passes.
- Unit tests were not executed because the package Mocha dependencies are not installed in the workspace.

---

## Architectural / Operational Impact

### Authorization behavior

Records with no additional contributors now consistently retain the configured owner access level.

### Operational impact

No schema, migration, dependency, or deployment changes are required.

---

## Backwards Compatibility

Contributor-based permission assignment remains unchanged. The change affects only records with no editor or viewer contributors and configured owner permissions.

---

## Deployment Notes

Deploy through the normal v5 release process. No migration is required.

---

## Impact

Record owners will not lose configured access solely because contributor fields are empty.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected permission assignment when no additional contributors are provided.
  * Record creators now receive the configured view and/or edit permissions automatically.
  * Cleared pending permission requests when creator permissions are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->