### PR TITLE
Feature: Sync server metadata back into form after save

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/form-server-sync.service.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-server-sync.service.spec.ts
@@ -1,0 +1,49 @@
+import { TestBed } from '@angular/core/testing';
+import { FormControl, FormGroup } from '@angular/forms';
+import { LoggerService } from '@researchdatabox/portal-ng-common';
+import { FormConfigFrame } from '@researchdatabox/sails-ng-common';
+import { FormComponentsMap, FormService } from './form.service';
+import { FormServerSyncService } from './form-server-sync.service';
+
+describe('FormServerSyncService', () => {
+  let service: FormServerSyncService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        FormServerSyncService,
+        { provide: FormService, useValue: { shouldIncludeInFormControlMap: () => true } },
+        { provide: LoggerService, useValue: { warn: () => undefined } },
+      ],
+    });
+    service = TestBed.inject(FormServerSyncService);
+  });
+
+  it('keeps a control dirty when it was edited while the save was in flight', async () => {
+    const serverControl = new FormControl('before-server-sync');
+    const localControl = new FormControl('before-local-edit');
+    const form = new FormGroup({ serverControl, localControl });
+    form.markAsPristine();
+    localControl.setValue('edited-during-save');
+    localControl.markAsDirty();
+
+    const formDefMap = new FormComponentsMap([], {} as FormConfigFrame);
+    formDefMap.withFormControl = { serverControl, localControl };
+
+    const result = await service.applyServerMetadata(
+      { serverControl: 'before-server-sync', localControl: 'before-local-edit' },
+      { serverControl: 'after-server-sync', localControl: 'server-value' },
+      formDefMap,
+      form,
+      'preserveLocalEdits'
+    );
+
+    expect(serverControl.value).toBe('after-server-sync');
+    expect(serverControl.pristine).toBeTrue();
+    expect(localControl.value).toBe('edited-during-save');
+    expect(localControl.dirty).toBeTrue();
+    expect(form.dirty).toBeTrue();
+    expect(result.patched).toEqual(['serverControl']);
+    expect(result.skipped).toEqual([{ name: 'localControl', reason: 'local-edit' }]);
+  });
+});

--- a/angular/projects/researchdatabox/form/src/app/form-server-sync.service.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-server-sync.service.spec.ts
@@ -46,4 +46,77 @@ describe('FormServerSyncService', () => {
     expect(result.patched).toEqual(['serverControl']);
     expect(result.skipped).toEqual([{ name: 'localControl', reason: 'local-edit' }]);
   });
+
+  it('reports controls that cannot be synchronized', async () => {
+    const unchanged = new FormControl('same');
+    const excluded = new FormControl('old');
+    const failed = {
+      dirty: false,
+      pristine: true,
+      markAsPristine: () => undefined,
+      setCustomValue: () => Promise.reject(new Error('cannot set')),
+    } as any;
+    const form = new FormGroup({ unchanged, excluded });
+    const formDefMap = new FormComponentsMap([], {} as FormConfigFrame);
+    formDefMap.withFormControl = {
+      unchanged,
+      excluded,
+      failed,
+      missingFromServer: new FormControl('local'),
+      noComponent: new FormControl('old'),
+    };
+    formDefMap.completeGroupMap = {
+      excluded: {} as any,
+    };
+
+    const formService = TestBed.inject(FormService);
+    spyOn(formService, 'shouldIncludeInFormControlMap').and.callFake(
+      component => component !== formDefMap.completeGroupMap?.['excluded']
+    );
+
+    const result = await service.applyServerMetadata(
+      {
+        unchanged: 'same',
+        missingFromServer: 'sent',
+        noComponent: 'sent',
+        excluded: 'sent',
+        failed: 'old',
+      },
+      {
+        unchanged: 'same',
+        noComponent: 'server',
+        excluded: 'server',
+        failed: 'new',
+      },
+      formDefMap,
+      form,
+      'always'
+    );
+
+    expect(result.patched).toEqual(['noComponent']);
+    expect(result.skipped).toEqual([
+      { name: 'unchanged', reason: 'unchanged' },
+      { name: 'missingFromServer', reason: 'not-in-server' },
+      { name: 'excluded', reason: 'excluded' },
+      { name: 'failed', reason: 'set-failed' },
+    ]);
+  });
+
+  it('does nothing when server synchronization is disabled', async () => {
+    const control = new FormControl('local');
+    const form = new FormGroup({ control });
+    const formDefMap = new FormComponentsMap([], {} as FormConfigFrame);
+    formDefMap.withFormControl = { control };
+
+    const result = await service.applyServerMetadata(
+      { control: 'local' },
+      { control: 'server' },
+      formDefMap,
+      form,
+      'never'
+    );
+
+    expect(control.value).toBe('local');
+    expect(result).toEqual({ patched: [], skipped: [] });
+  });
 });

--- a/angular/projects/researchdatabox/form/src/app/form-server-sync.service.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-server-sync.service.ts
@@ -60,6 +60,11 @@ export class FormServerSyncService {
 
       try {
         await setControlValue(control, server, { emitEvent: false });
+        // Only a control whose value was accepted from the server is clean.
+        // A control skipped above may have been edited while the request was
+        // in flight and must remain dirty for a subsequent save/navigation
+        // guard to detect it.
+        control.markAsPristine();
         result.patched.push(name);
       } catch (error) {
         result.skipped.push({ name, reason: 'set-failed' });
@@ -67,7 +72,6 @@ export class FormServerSyncService {
       }
     }
 
-    form.markAsPristine();
     form.updateValueAndValidity({ emitEvent: false });
     return result;
   }

--- a/angular/projects/researchdatabox/form/src/app/form-server-sync.service.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-server-sync.service.ts
@@ -1,0 +1,74 @@
+import { Injectable, inject } from '@angular/core';
+import { AbstractControl, FormGroup } from '@angular/forms';
+import { isEqual } from 'lodash-es';
+import { LoggerService } from '@researchdatabox/portal-ng-common';
+import { FormComponentsMap, FormService } from './form.service';
+import { setControlValue } from './form-state/custom-set-value.control';
+
+export type ServerSyncMode = 'always' | 'preserveLocalEdits' | 'never';
+
+export interface ServerSyncResult {
+  patched: string[];
+  skipped: Array<{ name: string; reason: string }>;
+}
+
+@Injectable({ providedIn: 'root' })
+export class FormServerSyncService {
+  private readonly formService = inject(FormService);
+  private readonly logger = inject(LoggerService);
+
+  public async applyServerMetadata(
+    sentValue: Record<string, unknown>,
+    serverValue: Record<string, unknown>,
+    formDefMap: FormComponentsMap,
+    form: FormGroup,
+    mode: ServerSyncMode
+  ): Promise<ServerSyncResult> {
+    const result: ServerSyncResult = { patched: [], skipped: [] };
+    if (mode === 'never') {
+      return result;
+    }
+
+    const completeGroupMap = formDefMap.completeGroupMap ?? {};
+    const controls = formDefMap.withFormControl ?? {};
+    const names = new Set([...Object.keys(sentValue), ...Object.keys(serverValue)]);
+
+    for (const name of names) {
+      const control = controls[name] as AbstractControl<unknown> | undefined;
+      if (!control) {
+        result.skipped.push({ name, reason: 'no-control' });
+        continue;
+      }
+
+      const component = completeGroupMap[name];
+      if (component && !this.formService.shouldIncludeInFormControlMap(component)) {
+        result.skipped.push({ name, reason: 'excluded' });
+        continue;
+      }
+
+      const sent = sentValue[name];
+      const server = serverValue[name];
+      if (isEqual(sent, server)) {
+        result.skipped.push({ name, reason: 'unchanged' });
+        continue;
+      }
+
+      if (mode === 'preserveLocalEdits' && control.dirty) {
+        result.skipped.push({ name, reason: 'local-edit' });
+        continue;
+      }
+
+      try {
+        await setControlValue(control, server, { emitEvent: false });
+        result.patched.push(name);
+      } catch (error) {
+        result.skipped.push({ name, reason: 'set-failed' });
+        this.logger.warn(`Failed to sync server value for form control '${name}'.`, error);
+      }
+    }
+
+    form.markAsPristine();
+    form.updateValueAndValidity({ emitEvent: false });
+    return result;
+  }
+}

--- a/angular/projects/researchdatabox/form/src/app/form-server-sync.service.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-server-sync.service.ts
@@ -34,6 +34,10 @@ export class FormServerSyncService {
     const names = new Set([...Object.keys(sentValue), ...Object.keys(serverValue)]);
 
     for (const name of names) {
+      if (!(name in serverValue)) {
+        result.skipped.push({ name, reason: 'not-in-server' });
+        continue;
+      }
       const control = controls[name] as AbstractControl<unknown> | undefined;
       if (!control) {
         result.skipped.push({ name, reason: 'no-control' });

--- a/angular/projects/researchdatabox/form/src/app/form-state/effects/form-event-bus-adapter.effects.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/effects/form-event-bus-adapter.effects.ts
@@ -291,12 +291,8 @@ export class FormEventBusAdapterEffects {
           savedData: event.savedData,
           lastSavedAt: new Date().toISOString(),
         });
-        const metadata = event.response?.metadata;
-        if (metadata !== null && typeof metadata === 'object' && !Array.isArray(metadata)) {
-          return [
-            submitAction,
-            FormActions.syncModelSnapshot({ snapshot: metadata }),
-          ];
+        if (event.modelSnapshot !== undefined) {
+          return [submitAction, FormActions.syncModelSnapshot({ snapshot: event.modelSnapshot })];
         }
         return submitAction;
       }

--- a/angular/projects/researchdatabox/form/src/app/form-state/effects/form-event-bus-adapter.effects.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/effects/form-event-bus-adapter.effects.ts
@@ -13,8 +13,8 @@
 import { Injectable, inject, InjectionToken } from '@angular/core';
 import { Actions, createEffect } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
-import { Observable, EMPTY } from 'rxjs';
-import { map, throttleTime, tap, filter, catchError, withLatestFrom } from 'rxjs/operators';
+import { Observable, EMPTY, from } from 'rxjs';
+import { map, mergeMap, throttleTime, tap, filter, catchError, withLatestFrom } from 'rxjs/operators';
 import { FormComponentEventBus } from '../events/form-component-event-bus.service';
 import {
   FormComponentEventType,
@@ -286,8 +286,20 @@ export class FormEventBusAdapterEffects {
     this.createPromotionStream(
       FormComponentEventType.FORM_SAVE_SUCCESS,
       PromotionCriterion.TRIGGERS_SIDE_EFFECT,
-      (event: FormSaveSuccessEvent) =>
-        FormActions.submitFormSuccess({ savedData: event.savedData, lastSavedAt: new Date().toISOString() })
+      (event: FormSaveSuccessEvent) => {
+        const submitAction = FormActions.submitFormSuccess({
+          savedData: event.savedData,
+          lastSavedAt: new Date().toISOString(),
+        });
+        const metadata = event.response?.metadata;
+        if (metadata !== null && typeof metadata === 'object' && !Array.isArray(metadata)) {
+          return [
+            submitAction,
+            FormActions.syncModelSnapshot({ snapshot: metadata }),
+          ];
+        }
+        return submitAction;
+      }
     )
   );
   /**
@@ -389,12 +401,13 @@ export class FormEventBusAdapterEffects {
         trailing: false
       }),
       // R15.23 & R15.26: Map to action and (optionally) log promotion in one step
-      map((event) => {
-        const action = actionMapper(event);
+      mergeMap((event) => {
+        const mapped = actionMapper(event);
+        const actions = Array.isArray(mapped) ? mapped : [mapped];
         if (this.config.diagnosticsEnabled) {
-          logPromotion(this.logger, eventType, criterion, action.type);
+          actions.forEach(action => logPromotion(this.logger, eventType, criterion, action.type));
         }
-        return action;
+        return from(actions);
       }),
       // Ensure errors in the stream do not terminate the effect
       catchError((err) => {

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-event.types.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-event.types.ts
@@ -192,6 +192,8 @@ export interface FormSaveSuccessEvent extends FormComponentEventBase, SaveRedire
   readonly savedData?: any;
   readonly oid?: string;
   readonly response?: any;
+  /** Snapshot of the actual form state after eligible server synchronization. */
+  readonly modelSnapshot?: Record<string, unknown>;
 }
 
 /**

--- a/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
@@ -874,9 +874,62 @@ describe('FormComponent', () => {
       expect(events[0].savedData).toEqual({text_create: 'create value'});
       expect(events[0].oid).toEqual('oid-123');
       expect(events[0].response).toEqual({success: true, oid: 'oid-123'});
+      expect(events[0].modelSnapshot).toEqual({text_create: 'create value'});
       expect(events[0].closeOnSave).toEqual(undefined);
       expect(events[0].redirectLocation).toEqual(undefined);
       expect(events[0].redirectDelaySeconds).toEqual(undefined);
+    } finally {
+      sub.unsubscribe();
+    }
+  });
+
+  it('preserves edits made during a never-sync save and emits the current model snapshot', async () => {
+    const formConfig: FormConfigFrame = {
+      name: 'save-never-sync',
+      debugValue: false,
+      serverSyncOnSave: 'never',
+      componentDefinitions: [
+        {
+          name: 'text_never_sync',
+          model: {
+            class: 'SimpleInputModel',
+            config: { value: 'initial value' },
+          },
+          component: { class: 'SimpleInputComponent' },
+        },
+      ],
+    };
+    const { formComponent } = await createFormAndWaitForReady(formConfig, {
+      oid: 'oid-123',
+      recordType: 'rdmp',
+      editMode: true,
+      formName: 'save-never-sync',
+      downloadAndCreateOnInit: false,
+    });
+    const bus = TestBed.inject(FormComponentEventBus);
+    const events: FormSaveSuccessEvent[] = [];
+    const sub = bus.select$(FormComponentEventType.FORM_SAVE_SUCCESS).subscribe(event => events.push(event));
+    let resolveUpdate!: (response: any) => void;
+    const updatePromise = new Promise<any>(resolve => { resolveUpdate = resolve; });
+    const updateSpy = spyOn(formComponent.recordService, 'update').and.returnValue(updatePromise);
+
+    try {
+      const control = formComponent.form!.get('text_never_sync')!;
+      control.setValue('sent value');
+      control.markAsDirty();
+      formComponent.form!.markAsDirty();
+      const savePromise = formComponent.saveForm();
+
+      expect(updateSpy).toHaveBeenCalledOnceWith('oid-123', { text_never_sync: 'sent value' }, '');
+      control.setValue('edited during save');
+      control.markAsDirty();
+      resolveUpdate({ success: true, oid: 'oid-123', metadata: { text_never_sync: 'server value' } });
+      await savePromise;
+
+      expect(control.value).toBe('edited during save');
+      expect(control.dirty).toBeTrue();
+      expect(events.length).toBe(1);
+      expect(events[0].modelSnapshot).toEqual({text_never_sync: 'edited during save'});
     } finally {
       sub.unsubscribe();
     }

--- a/angular/projects/researchdatabox/form/src/app/form.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.ts
@@ -1205,6 +1205,7 @@ export class FormComponent extends BaseComponent implements OnDestroy {
             }
             const oid = !_isEmpty(response?.oid) ? String(response?.oid) : this.trimmedParams.oid();
             const redirectLocation = this.resolveRedirectLocation(options?.redirectLocation ?? '', oid);
+            let modelSnapshot: Record<string, unknown> | undefined;
             if (
               response.metadata !== null &&
               typeof response.metadata === 'object' &&
@@ -1214,13 +1215,17 @@ export class FormComponent extends BaseComponent implements OnDestroy {
               this.form &&
               this.formDefMap
             ) {
-              await this.serverSyncService.applyServerMetadata(
-                currentFormValue,
-                response.metadata,
-                this.formDefMap,
-                this.form,
-                this.formDefMap.formConfig?.serverSyncOnSave ?? 'preserveLocalEdits'
-              );
+              const syncMode = this.formDefMap.formConfig?.serverSyncOnSave ?? 'preserveLocalEdits';
+              if (syncMode !== 'never') {
+                await this.serverSyncService.applyServerMetadata(
+                  currentFormValue,
+                  response.metadata,
+                  this.formDefMap,
+                  this.form,
+                  syncMode
+                );
+                modelSnapshot = this.getPersistedFormValue();
+              }
               this.broadcastFormStatus();
             }
             // Emit success event
@@ -1229,6 +1234,7 @@ export class FormComponent extends BaseComponent implements OnDestroy {
                 savedData: currentFormValue,
                 oid: oid,
                 response,
+                modelSnapshot,
                 closeOnSave: options?.closeOnSave,
                 redirectLocation: redirectLocation || undefined,
                 redirectDelaySeconds: options?.redirectDelaySeconds,

--- a/angular/projects/researchdatabox/form/src/app/form.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.ts
@@ -112,6 +112,7 @@ import * as FormActions from './form-state/state/form.actions';
 import { FormComponentValueChangeEventConsumer } from './form-state/events/';
 import { DebugInfo, FormDebugStateService } from './form-debug/form-debug-state.service';
 import { FormBehaviourManager } from './form-state/behaviours/form-behaviour-manager.service';
+import { FormServerSyncService } from './form-server-sync.service';
 
 /**
  * The ReDBox Form
@@ -237,6 +238,7 @@ export class FormComponent extends BaseComponent implements OnDestroy {
    */
   componentsLoaded = signal<boolean>(false);
   public readonly debugState = inject(FormDebugStateService);
+  private readonly serverSyncService = inject(FormServerSyncService);
 
   readonly viewAuditRoles = signal<string[]>(['Admin', 'Librarians']);
   // Backward-compatible aliases for existing tests and callers.
@@ -1179,12 +1181,13 @@ export class FormComponent extends BaseComponent implements OnDestroy {
         this.loggerService.info(
           `${this.logName}: Form valid flag: ${this.form.valid}, targetStep: ${targetStep}, enabledValidationGroups: ${enabledValidationGroups}. Saving...`
         );
-        this.loggerService.debug(`${this.logName}: Form value:`, this.form.value);
+          this.loggerService.debug(`${this.logName}: Form value:`, this.form.value);
 
         try {
           let response: RecordActionResult;
           const currentFormValue = this.getPersistedFormValue();
-          // Mark form as pristine as we cloned the data already
+          // Snapshot and mark pristine together: preserveLocalEdits uses dirty to identify
+          // edits made after this save payload was sent.
           this.form.markAsPristine();
           if (_isEmpty(this.trimmedParams.oid())) {
             // Actual record creation via RecordService call
@@ -1201,6 +1204,25 @@ export class FormComponent extends BaseComponent implements OnDestroy {
               this.locationService.replaceState(this.buildEditRecordPath(createdOid));
             }
             const oid = !_isEmpty(response?.oid) ? String(response?.oid) : this.trimmedParams.oid();
+            const redirectLocation = this.resolveRedirectLocation(options?.redirectLocation ?? '', oid);
+            if (
+              response.metadata !== null &&
+              typeof response.metadata === 'object' &&
+              !Array.isArray(response.metadata) &&
+              !options?.closeOnSave &&
+              !redirectLocation &&
+              this.form &&
+              this.formDefMap
+            ) {
+              await this.serverSyncService.applyServerMetadata(
+                currentFormValue,
+                response.metadata,
+                this.formDefMap,
+                this.form,
+                this.formDefMap.formConfig?.serverSyncOnSave ?? 'preserveLocalEdits'
+              );
+              this.broadcastFormStatus();
+            }
             // Emit success event
             this.eventBus.publish(
               createFormSaveSuccessEvent({
@@ -1208,7 +1230,7 @@ export class FormComponent extends BaseComponent implements OnDestroy {
                 oid: oid,
                 response,
                 closeOnSave: options?.closeOnSave,
-                redirectLocation: this.resolveRedirectLocation(options?.redirectLocation ?? '', oid) || undefined,
+                redirectLocation: redirectLocation || undefined,
                 redirectDelaySeconds: options?.redirectDelaySeconds,
               })
             );

--- a/angular/projects/researchdatabox/form/src/app/form.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.ts
@@ -1207,26 +1207,30 @@ export class FormComponent extends BaseComponent implements OnDestroy {
             const redirectLocation = this.resolveRedirectLocation(options?.redirectLocation ?? '', oid);
             let modelSnapshot: Record<string, unknown> | undefined;
             if (
-              response.metadata !== null &&
-              typeof response.metadata === 'object' &&
-              !Array.isArray(response.metadata) &&
               !options?.closeOnSave &&
               !redirectLocation &&
-              this.form &&
-              this.formDefMap
+              this.form
             ) {
-              const syncMode = this.formDefMap.formConfig?.serverSyncOnSave ?? 'preserveLocalEdits';
-              if (syncMode !== 'never') {
-                await this.serverSyncService.applyServerMetadata(
-                  currentFormValue,
-                  response.metadata,
-                  this.formDefMap,
-                  this.form,
-                  syncMode
-                );
-                modelSnapshot = this.getPersistedFormValue();
+              modelSnapshot = this.getPersistedFormValue();
+              if (
+                response.metadata !== null &&
+                typeof response.metadata === 'object' &&
+                !Array.isArray(response.metadata) &&
+                this.formDefMap
+              ) {
+                const syncMode = this.formDefMap.formConfig?.serverSyncOnSave ?? 'preserveLocalEdits';
+                if (syncMode !== 'never') {
+                  await this.serverSyncService.applyServerMetadata(
+                    currentFormValue,
+                    response.metadata,
+                    this.formDefMap,
+                    this.form,
+                    syncMode
+                  );
+                  modelSnapshot = this.getPersistedFormValue();
+                }
+                this.broadcastFormStatus();
               }
-              this.broadcastFormStatus();
             }
             // Emit success event
             this.eventBus.publish(

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/record.service.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/record.service.ts
@@ -690,6 +690,6 @@ export class RecordActionResult {
   success: boolean = false;
   oid: string = '';
   message: string = '';
-  // TODO: placeholder for incremental setting of data unto the form, etc.
   data: any = null;
+  metadata: Record<string, unknown> | null = null;
 }

--- a/packages/redbox-core/src/config/record.config.ts
+++ b/packages/redbox-core/src/config/record.config.ts
@@ -60,6 +60,7 @@ export interface RecordAttachmentsConfig {
 
 export interface RecordFormConfig {
     htmlSanitizationMode: 'sanitize' | 'reject';
+    returnMetadataOnSave: boolean;
 }
 
 export interface RecordConfig {
@@ -95,7 +96,8 @@ export const record: RecordConfig = {
     diskSpaceThreshold: 10737418240,
     datastreamService: 'standarddatastreamservice',
     form: {
-        htmlSanitizationMode: 'sanitize'
+        htmlSanitizationMode: 'sanitize',
+        returnMetadataOnSave: true,
     },
     api: {
         create: { method: 'post', url: "/api/v1/object/$packageType" },

--- a/packages/redbox-core/src/controllers/RecordController.ts
+++ b/packages/redbox-core/src/controllers/RecordController.ts
@@ -47,8 +47,14 @@ import type { DashboardTableConfig } from '../config/workflow.config';
 import type { DashboardViewDefinition, DashboardViewStepDefinition } from '../config/dashboardview.config';
 import { RecordRelationshipExpandOptions, RecordRelationshipGraph } from '../RecordsService';
 import { TusStorageManagerDataStore } from '../storage/TusStorageManagerDataStore';
+import { FormConfigFrame, FormModesConfig } from '@researchdatabox/sails-ng-common';
 
 type AnyRecord = Record<string, unknown>;
+type ControllerRecord = AnyRecord & {
+  metaMetadata?: unknown;
+  metadata: AnyRecord;
+  redboxOid?: string;
+};
 
 interface TusRequestExtension {
   _tusBaseUrl?: string;
@@ -280,6 +286,81 @@ export namespace Controllers {
       };
     }
 
+    /**
+     * Build the client form used by the record metadata read and save-sync paths.
+     * The false edit lookup / edit form mode pairing is inherited from getMeta and
+     * has not been independently reviewed; keep both values explicit at call sites.
+     */
+    private async getEffectiveClientFormConfig(
+      req: Sails.Req,
+      brand: BrandingModel,
+      record: ControllerRecord,
+      formName: string,
+      formLookupEditMode: boolean,
+      formMode: FormModesConfig
+    ): Promise<FormConfigFrame | undefined> {
+      const metaMetadata = record.metaMetadata as AnyRecord | undefined;
+      const brandId = String(metaMetadata?.['brandId'] ?? brand.id);
+      const formRecord = await firstValueFrom(FormsService.getFormByName(formName, formLookupEditMode, brandId));
+      const formConfig = formRecord?.configuration;
+      if (!formConfig) {
+        return undefined;
+      }
+
+      const userRoles = ((req.user?.['roles'] ?? []) as AnyRecord[])
+        .map((role: AnyRecord) => String(role['name'] ?? ''))
+        .filter((name: string) => !!name);
+      const reusableFormDefs = sails.config.reusableFormDefinitions;
+      const contextVariablesMap = ContextVariableUtils.evaluateContextVariables(req, record);
+      return FormsService.buildClientFormConfig(
+        formConfig,
+        formMode,
+        userRoles,
+        record.metadata,
+        reusableFormDefs,
+        String(brand?.name ?? ''),
+        contextVariablesMap
+      );
+    }
+
+    private async getPostSaveMetadata(
+      req: Sails.Req,
+      brand: BrandingModel,
+      savedRecord: ControllerRecord,
+      targetStep: unknown
+    ): Promise<AnyRecord | null> {
+      if (targetStep || sails.config.record?.form?.returnMetadataOnSave === false) {
+        return null;
+      }
+
+      try {
+        const formName = (savedRecord.metaMetadata as AnyRecord | undefined)?.['form'];
+        if (typeof formName !== 'string' || formName.length === 0) {
+          return null;
+        }
+        const clientFormConfig = await this.getEffectiveClientFormConfig(
+          req,
+          brand,
+          savedRecord,
+          formName,
+          false,
+          'edit'
+        );
+        if (!clientFormConfig) {
+          return null;
+        }
+        return await FormRecordConsistencyService.projectMetadataClientFormConfig(
+          savedRecord.metadata,
+          clientFormConfig,
+          'edit',
+          sails.config.reusableFormDefinitions
+        );
+      } catch (error) {
+        sails.log.error(`Failed to project post-save metadata for record ${savedRecord.redboxOid}:`, error);
+        return null;
+      }
+    }
+
     public async getMeta(req: Sails.Req, res: Sails.Res) {
       const brand: BrandingModel = this.getReqBrand(req);
       const oid = req.param('oid') ?? '';
@@ -297,37 +378,22 @@ export namespace Controllers {
           const formName = record.metaMetadata?.['form'] as string | undefined;
           if (formName) {
             try {
-              const brandId = String(record.metaMetadata?.['brandId'] ?? brand.id);
-              const formRecord = await firstValueFrom(FormsService.getFormByName(formName, false, brandId));
-              const formConfig = formRecord?.configuration;
-
-              if (formConfig) {
-                const userRoles = ((req.user?.['roles'] ?? []) as AnyRecord[]).map((role: AnyRecord) => String(role['name'] ?? '')).filter((name: string) => !!name);
+              const clientFormConfig = await this.getEffectiveClientFormConfig(
+                req,
+                brand,
+                record,
+                formName,
+                false,
+                'edit'
+              );
+              if (clientFormConfig) {
                 const reusableFormDefs = sails.config.reusableFormDefinitions;
-                const contextVariablesMap = ContextVariableUtils.evaluateContextVariables(req, record);
-                const clientFormConfig = await FormsService.buildClientFormConfig(
-                  formConfig,
-                  'edit',
-                  userRoles,
-                  record.metadata,
-                  reusableFormDefs,
-                  String(brand?.name ?? ''),
-                  contextVariablesMap
-                );
-                const emptyOriginal = {
-                  redboxOid: record.redboxOid,
-                  metaMetadata: record.metaMetadata,
-                  metadata: {}
-                } as unknown as Parameters<typeof FormRecordConsistencyService.mergeRecordClientFormConfig>[0];
-
-                const filteredRecord = await FormRecordConsistencyService.mergeRecordClientFormConfig(
-                  emptyOriginal,
-                  record as unknown as Parameters<typeof FormRecordConsistencyService.mergeRecordClientFormConfig>[1],
+                record.metadata = await FormRecordConsistencyService.projectMetadataClientFormConfig(
+                  record.metadata as AnyRecord,
                   clientFormConfig,
                   'edit',
                   reusableFormDefs
                 );
-                record.metadata = filteredRecord.metadata;
               }
             } catch (formErr) {
               sails.log.error(`Failed to filter metadata for record ${oid} using form ${formName}:`, formErr);
@@ -697,8 +763,10 @@ export namespace Controllers {
         const createResponse = await this.recordsService.create(brand, record, recordType, user, true, true, targetStep);
 
         if (createResponse && _.isFunction(createResponse.isSuccessful) && createResponse.isSuccessful()) {
+          const savedRecord = await this.recordsService.getMeta(createResponse.oid);
+          createResponse.metadata = await this.getPostSaveMetadata(req, brand, savedRecord, targetStep);
           return this.sendResp(req, res, {
-            data: await this.recordsService.getMeta(createResponse.oid),
+            data: savedRecord,
             meta: { ...createResponse },
             v1: createResponse,
           });
@@ -877,8 +945,10 @@ export namespace Controllers {
         sails.log.verbose(JSON.stringify(response));
         if (response && response.isSuccessful()) {
           sails.log.verbose(`RecordController - updateInternal - before ajaxOk`);
+          const savedRecord = await this.recordsService.getMeta(oid);
+          response.metadata = await this.getPostSaveMetadata(req, brand, savedRecord, nextStepResp);
           return this.sendResp(req, res, {
-            data: await this.recordsService.getMeta(oid),
+            data: savedRecord,
             meta: response ? { ...response } : undefined,
             v1: response,
           });

--- a/packages/redbox-core/src/controllers/RecordController.ts
+++ b/packages/redbox-core/src/controllers/RecordController.ts
@@ -319,7 +319,8 @@ export namespace Controllers {
         record.metadata,
         reusableFormDefs,
         String(brand?.name ?? ''),
-        contextVariablesMap
+        contextVariablesMap,
+        { user: req.user as UserModel, brand }
       );
     }
 

--- a/packages/redbox-core/src/controllers/RecordController.ts
+++ b/packages/redbox-core/src/controllers/RecordController.ts
@@ -326,10 +326,10 @@ export namespace Controllers {
     private async getPostSaveMetadata(
       req: Sails.Req,
       brand: BrandingModel,
-      savedRecord: ControllerRecord,
+      savedRecord: ControllerRecord | null,
       targetStep: unknown
     ): Promise<AnyRecord | null> {
-      if (targetStep || sails.config.record?.form?.returnMetadataOnSave === false) {
+      if (!savedRecord || targetStep || sails.config.record?.form?.returnMetadataOnSave === false) {
         return null;
       }
 
@@ -356,7 +356,7 @@ export namespace Controllers {
           sails.config.reusableFormDefinitions
         );
       } catch (error) {
-        sails.log.error(`Failed to project post-save metadata for record ${savedRecord.redboxOid}:`, error);
+        sails.log.error(`Failed to project post-save metadata for record ${savedRecord?.redboxOid ?? 'unknown'}:`, error);
         return null;
       }
     }
@@ -764,7 +764,10 @@ export namespace Controllers {
 
         if (createResponse && _.isFunction(createResponse.isSuccessful) && createResponse.isSuccessful()) {
           const savedRecord = await this.recordsService.getMeta(createResponse.oid);
-          createResponse.metadata = await this.getPostSaveMetadata(req, brand, savedRecord, targetStep);
+          const postSaveMetadata = await this.getPostSaveMetadata(req, brand, savedRecord, targetStep);
+          if (postSaveMetadata !== null) {
+            createResponse.metadata = postSaveMetadata;
+          }
           return this.sendResp(req, res, {
             data: savedRecord,
             meta: { ...createResponse },
@@ -946,7 +949,10 @@ export namespace Controllers {
         if (response && response.isSuccessful()) {
           sails.log.verbose(`RecordController - updateInternal - before ajaxOk`);
           const savedRecord = await this.recordsService.getMeta(oid);
-          response.metadata = await this.getPostSaveMetadata(req, brand, savedRecord, nextStepResp);
+          const postSaveMetadata = await this.getPostSaveMetadata(req, brand, savedRecord, nextStepResp);
+          if (postSaveMetadata !== null) {
+            response.metadata = postSaveMetadata;
+          }
           return this.sendResp(req, res, {
             data: savedRecord,
             meta: response ? { ...response } : undefined,

--- a/packages/redbox-core/src/services/FormRecordConsistencyService.ts
+++ b/packages/redbox-core/src/services/FormRecordConsistencyService.ts
@@ -169,6 +169,32 @@ export namespace Services {
         }
 
         /**
+         * Project authoritative metadata to the fields in an already filtered client form.
+         * This intentionally uses an empty original so server-only metadata is not retained.
+         */
+        public async projectMetadataClientFormConfig(
+            metadata: Record<string, unknown>,
+            clientFormConfig: FormConfigFrame,
+            formMode: FormModesConfig,
+            reusableFormDefs?: ReusableFormDefinitions
+        ): Promise<Record<string, unknown>> {
+            const projected = await this.mergeRecordClientFormConfig(
+                {
+                    redboxOid: '',
+                    metadata: {},
+                },
+                {
+                    redboxOid: '',
+                    metadata,
+                },
+                clientFormConfig,
+                formMode,
+                reusableFormDefs
+            );
+            return projected.metadata;
+        }
+
+        /**
          * Merge the original and changed records, using the client form config to know which changes to include.
          * @param original The existing original record.
          * @param changed The new record.

--- a/packages/redbox-core/src/services/FormRecordConsistencyService.ts
+++ b/packages/redbox-core/src/services/FormRecordConsistencyService.ts
@@ -247,7 +247,6 @@ export namespace Services {
                 // pre-calculate aspects of the original item
                 const isKeyInOriginal = key in originalRecord;
                 const originalValue = isKeyInOriginal ? originalRecord[key] : undefined;
-                const originalValueType = guessType(originalValue);
 
                 // pre-calculate aspects of the changed item
                 const isKeyInChanged = key in changedRecord;
@@ -261,6 +260,14 @@ export namespace Services {
                 const isPermittedChangeArray = isKeyInPermittedChange && !!permittedChangesValue && 'elements' in permittedChangesValue;
                 const isPermittedChangeType = isKeyInPermittedChange && !!permittedChangesValue && 'type' in permittedChangesValue;
                 const isPermittedChangeEmpty = isKeyInPermittedChange && !!permittedChangesValue && Object.keys(permittedChangesValue).length === 0;
+                const originalValueForMerge = isKeyInOriginal
+                  ? originalValue
+                  : isPermittedChangeArray
+                    ? []
+                    : isPermittedChangeObject
+                      ? {}
+                      : undefined;
+                const originalValueForMergeType = guessType(originalValueForMerge);
 
                 // ensure the permitted changes item is valid
                 const isPermittedChangeMatches = {
@@ -276,9 +283,8 @@ export namespace Services {
                 // evaluate the combinations of original and changed values
                 if (
                     isPermittedChangeArray
-                    && isKeyInOriginal
                     && isKeyInChanged
-                    && originalValueType === "array"
+                    && originalValueForMergeType === "array"
                     && changedValueType === "array"
                 ) {
                     // The change is permitted and an array, original and changed have the key and both are arrays.
@@ -313,9 +319,8 @@ export namespace Services {
 
                 } else if (
                     isPermittedChangeObject
-                    && isKeyInOriginal
                     && isKeyInChanged
-                    && originalValueType === "object"
+                    && originalValueForMergeType === "object"
                     && changedValueType === "object"
                 ) {
                     // The change is permitted and an object, original and changed have the key and both are objects.
@@ -323,7 +328,7 @@ export namespace Services {
                     const newPermittedChanges = permittedChangesValue as Record<string, unknown>;
                     const newPath = [...currentPath, key];
                     const keyChanges = relevantChanges?.filter(i => arrayStartsWithArray(newPath, i?.path));
-                    result[key] = this.mergeRecordMetadataPermitted(originalValue as object, changedValue as object, newPermittedChanges, keyChanges, newPath as FormRecordConsistencyChangePath);
+                    result[key] = this.mergeRecordMetadataPermitted(originalValueForMerge as object, changedValue as object, newPermittedChanges, keyChanges, newPath as FormRecordConsistencyChangePath);
 
                 } else if (isKeyInPermittedChange && isKeyInChanged) {
                     // The change is permitted and the key is in the changed.

--- a/packages/redbox-core/src/services/FormsService.ts
+++ b/packages/redbox-core/src/services/FormsService.ts
@@ -174,6 +174,7 @@ export namespace Services {
           componentDefinitions: formConfigRaw.componentDefinitions as FormConfigFrame['componentDefinitions'],
           debugValue: formConfigRaw.debugValue as FormConfigFrame['debugValue'],
           attachmentFields: (formConfigRaw.attachmentFields ?? []) as FormConfigFrame['attachmentFields'],
+          serverSyncOnSave: formConfigRaw.serverSyncOnSave as FormConfigFrame['serverSyncOnSave'],
 
           // Deprecated legacy properties (now removed):
           // fields → replaced by componentDefinitions

--- a/packages/redbox-core/src/visitor/construct.visitor.ts
+++ b/packages/redbox-core/src/visitor/construct.visitor.ts
@@ -497,6 +497,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
     // classes because the runtime consumes the config directly.
     this.sharedProps.setPropOverride('behaviours', item, currentData);
     this.sharedProps.setPropOverride('attachmentFields', item, currentData);
+    this.sharedProps.setPropOverride('serverSyncOnSave', item, currentData);
     // Ensure the default validation groups are present.
     if (!item.validationGroups) {
       item.validationGroups = {};

--- a/packages/redbox-core/test/controllers/RecordController.test.ts
+++ b/packages/redbox-core/test/controllers/RecordController.test.ts
@@ -16,6 +16,7 @@ describe('RecordController getWorkflowSteps', () => {
   let originalWorkflowStepsService: any;
   let originalDashboardTypesService: any;
   let originalFormsService: any;
+  let originalFormRecordConsistencyService: any;
   let originalTranslationService: any;
 
   beforeEach(() => {
@@ -25,6 +26,7 @@ describe('RecordController getWorkflowSteps', () => {
     originalWorkflowStepsService = (global as any).WorkflowStepsService;
     originalDashboardTypesService = (global as any).DashboardTypesService;
     originalFormsService = (global as any).FormsService;
+    originalFormRecordConsistencyService = (global as any).FormRecordConsistencyService;
     originalTranslationService = (global as any).TranslationService;
 
     (global as any).sails = {
@@ -54,6 +56,10 @@ describe('RecordController getWorkflowSteps', () => {
     (global as any).FormsService = {
       getFormByStartingWorkflowStep: sinon.stub(),
       getFormByName: sinon.stub(),
+      buildClientFormConfig: sinon.stub(),
+    };
+    (global as any).FormRecordConsistencyService = {
+      projectMetadataClientFormConfig: sinon.stub(),
     };
     (global as any).TranslationService = {
       t: sinon.stub().callsFake((key: string) => ({
@@ -81,6 +87,7 @@ describe('RecordController getWorkflowSteps', () => {
     (global as any).WorkflowStepsService = originalWorkflowStepsService;
     (global as any).DashboardTypesService = originalDashboardTypesService;
     (global as any).FormsService = originalFormsService;
+    (global as any).FormRecordConsistencyService = originalFormRecordConsistencyService;
     (global as any).TranslationService = originalTranslationService;
   });
 
@@ -492,6 +499,56 @@ describe('RecordController getWorkflowSteps', () => {
     controller.redirectLegacyConsolidatedDashboard(req, res);
 
     expect((res.redirect as any).calledWith('/default/rdmp/dashboard-view/consolidated')).to.be.true;
+  });
+
+  it('builds an effective client form config with the record brand and user roles', async () => {
+    const formConfig = { componentDefinitions: [] };
+    const clientFormConfig = { componentDefinitions: [{ name: 'title' }] };
+    (global as any).sails.config = { reusableFormDefinitions: { shared: {} } };
+    (global as any).FormsService.getFormByName.returns(of({ configuration: formConfig }));
+    (global as any).FormsService.buildClientFormConfig.returns(clientFormConfig);
+    const req = { user: { roles: [{ name: 'admin' }, { name: '' }, {}] } } as unknown as Sails.Req;
+    const record = { metaMetadata: { brandId: 'record-brand' }, metadata: { title: 'A title' } };
+
+    const result = await (controller as any).getEffectiveClientFormConfig(
+      req, { id: 'fallback-brand', name: 'fallback' }, record, 'form-1', false, 'edit'
+    );
+
+    expect(result).to.equal(clientFormConfig);
+    expect((global as any).FormsService.getFormByName.calledWith('form-1', false, 'record-brand')).to.be.true;
+    expect((global as any).FormsService.buildClientFormConfig.calledWith(
+      formConfig, 'edit', ['admin'], record.metadata, { shared: {} }, 'fallback', sinon.match.any
+    )).to.be.true;
+  });
+
+  it('returns no post-save metadata when syncing is not applicable', async () => {
+    (global as any).sails.config = { record: { form: { returnMetadataOnSave: true } } };
+    const req = {} as Sails.Req;
+    const brand = { id: 'brand-1', name: 'default' };
+
+    expect(await (controller as any).getPostSaveMetadata(req, brand, null, null)).to.equal(null);
+    expect(await (controller as any).getPostSaveMetadata(req, brand, { metadata: {} }, { name: 'next' })).to.equal(null);
+    expect(await (controller as any).getPostSaveMetadata(req, brand, { metadata: {}, metaMetadata: {} }, null)).to.equal(null);
+    (global as any).sails.config.record.form.returnMetadataOnSave = false;
+    expect(await (controller as any).getPostSaveMetadata(req, brand, {
+      metadata: {}, metaMetadata: { form: 'form-1' },
+    }, null)).to.equal(null);
+  });
+
+  it('projects post-save metadata and handles projection failures', async () => {
+    (global as any).sails.config = { record: { form: { returnMetadataOnSave: true } }, reusableFormDefinitions: {} };
+    const req = {} as Sails.Req;
+    const brand = { id: 'brand-1', name: 'default' };
+    const savedRecord = { redboxOid: 'oid-1', metaMetadata: { form: 'form-1' }, metadata: { title: 'server title' } };
+    const clientFormConfig = { componentDefinitions: [] };
+    sinon.stub(controller as any, 'getEffectiveClientFormConfig').resolves(clientFormConfig);
+    (global as any).FormRecordConsistencyService.projectMetadataClientFormConfig.resolves({ title: 'projected' });
+
+    expect(await (controller as any).getPostSaveMetadata(req, brand, savedRecord, null)).to.deep.equal({ title: 'projected' });
+
+    (global as any).FormRecordConsistencyService.projectMetadataClientFormConfig.rejects(new Error('projection failed'));
+    expect(await (controller as any).getPostSaveMetadata(req, brand, savedRecord, null)).to.equal(null);
+    expect((global as any).sails.log.error.calledOnce).to.be.true;
   });
 });
 

--- a/packages/redbox-core/test/controllers/RecordController.test.ts
+++ b/packages/redbox-core/test/controllers/RecordController.test.ts
@@ -509,15 +509,17 @@ describe('RecordController getWorkflowSteps', () => {
     (global as any).FormsService.buildClientFormConfig.returns(clientFormConfig);
     const req = { user: { roles: [{ name: 'admin' }, { name: '' }, {}] } } as unknown as Sails.Req;
     const record = { metaMetadata: { brandId: 'record-brand' }, metadata: { title: 'A title' } };
+    const brand = { id: 'fallback-brand', name: 'fallback' };
 
     const result = await (controller as any).getEffectiveClientFormConfig(
-      req, { id: 'fallback-brand', name: 'fallback' }, record, 'form-1', false, 'edit'
+      req, brand, record, 'form-1', false, 'edit'
     );
 
     expect(result).to.equal(clientFormConfig);
     expect((global as any).FormsService.getFormByName.calledWith('form-1', false, 'record-brand')).to.be.true;
     expect((global as any).FormsService.buildClientFormConfig.calledWith(
-      formConfig, 'edit', ['admin'], record.metadata, { shared: {} }, 'fallback', sinon.match.any
+      formConfig, 'edit', ['admin'], record.metadata, { shared: {} }, 'fallback', sinon.match.any,
+      { user: req.user, brand }
     )).to.be.true;
   });
 

--- a/packages/redbox-core/test/services/FormRecordConsistencyService.test.ts
+++ b/packages/redbox-core/test/services/FormRecordConsistencyService.test.ts
@@ -141,6 +141,31 @@ describe('FormRecordConsistencyService', function () {
     });
   });
 
+  describe('projectMetadataClientFormConfig', function () {
+    it('projects only metadata permitted by the client form', async function () {
+      sinon.stub(FormRecordConsistencyService, 'mergeRecordClientFormConfig').resolves({
+        redboxOid: '',
+        metadata: { title: 'visible' },
+      });
+
+      const result = await FormRecordConsistencyService.projectMetadataClientFormConfig(
+        { title: 'visible', serverOnly: 'hidden' },
+        { componentDefinitions: [] },
+        'edit',
+        { shared: {} }
+      );
+
+      expect(result).to.deep.equal({ title: 'visible' });
+      expect((FormRecordConsistencyService.mergeRecordClientFormConfig as sinon.SinonStub).calledWith(
+        { redboxOid: '', metadata: {} },
+        { redboxOid: '', metadata: { title: 'visible', serverOnly: 'hidden' } },
+        { componentDefinitions: [] },
+        'edit',
+        { shared: {} }
+      )).to.be.true;
+    });
+  });
+
   describe('compareRecords', function () {
     it('should detect changes in simple objects', function () {
       const original = { a: 1 };

--- a/packages/redbox-core/test/unit/client.visitor.test.ts
+++ b/packages/redbox-core/test/unit/client.visitor.test.ts
@@ -1264,6 +1264,7 @@ describe("Client Visitor", async () => {
           defaultComponentCssClasses: 'row',
         },
         editCssClasses: "redbox-form form",
+        serverSyncOnSave: 'preserveLocalEdits',
         enabledValidationGroups: ["all"],
         validators: [],
         validationGroups: {
@@ -1407,6 +1408,7 @@ describe("Client Visitor", async () => {
           defaultComponentCssClasses: 'row',
         },
         editCssClasses: "redbox-form form",
+        serverSyncOnSave: 'preserveLocalEdits',
         enabledValidationGroups: ["all"],
         validators: [],
         validationGroups: {
@@ -1493,6 +1495,7 @@ describe("Client Visitor", async () => {
           defaultComponentCssClasses: 'row',
         },
         editCssClasses: "redbox-form form",
+        serverSyncOnSave: 'preserveLocalEdits',
         enabledValidationGroups: ["all"],
         validators: [],
         validationGroups: {
@@ -1661,6 +1664,7 @@ describe("Client Visitor", async () => {
           defaultComponentCssClasses: 'row',
         },
         editCssClasses: "redbox-form form",
+        serverSyncOnSave: 'preserveLocalEdits',
         enabledValidationGroups: ["all"],
         validators: [],
         validationGroups: {

--- a/packages/redbox-hook-dev/src/config/recordtype.ts
+++ b/packages/redbox-hook-dev/src/config/recordtype.ts
@@ -14,6 +14,18 @@ export const recordtype: RecordTypeConfig = {
             onCreate: {
                 pre: [
                     {
+                        function: 'sails.services.rdmpservice.runTemplates',
+                        options: {
+                            parseObject: false,
+                            templates: [
+                                {
+                                    field: 'metadata.server_sync_test_value',
+                                    template: 'test-<%= _.random(100000, 999999) %>'
+                                }
+                            ]
+                        }
+                    },
+                    {
                         function: 'sails.services.rdmpservice.assignPermissions',
                         options: {
                             "emailProperty": "email",
@@ -36,6 +48,18 @@ export const recordtype: RecordTypeConfig = {
             },
             onUpdate: {
                 pre: [
+                    {
+                        function: 'sails.services.rdmpservice.runTemplates',
+                        options: {
+                            parseObject: false,
+                            templates: [
+                                {
+                                    field: 'metadata.server_sync_test_value',
+                                    template: 'test-<%= _.random(100000, 999999) %>'
+                                }
+                            ]
+                        }
+                    },
                     {
                         function: 'sails.services.rdmpservice.assignPermissions',
                         options: {

--- a/packages/redbox-hook-dev/src/form-config/default-1.0-draft.ts
+++ b/packages/redbox-hook-dev/src/form-config/default-1.0-draft.ts
@@ -115,6 +115,28 @@ const formConfig: FormConfigFrame = {
                       },
                     },
                     {
+                      name: 'server_sync_test_value',
+                      layout: {
+                        class: 'DefaultLayout',
+                        config: {
+                          label: 'Server sync test value',
+                          helpText: 'This readonly value is replaced by the RDMP pre-save hook on create and update.',
+                        },
+                      },
+                      model: {
+                        class: 'SimpleInputModel',
+                        config: {
+                          defaultValue: '',
+                        },
+                      },
+                      component: {
+                        class: 'SimpleInputComponent',
+                        config: {
+                          readonly: true,
+                        },
+                      },
+                    },
+                    {
                       name: 'contributor_ci',
                       constraints: {
                         authorization: {

--- a/packages/sails-ng-common/src/config/form-config.model.ts
+++ b/packages/sails-ng-common/src/config/form-config.model.ts
@@ -24,6 +24,7 @@ export class FormConfig implements FormConfigOutline {
     all: { description: 'Validate all fields with validators.', initialMembership: 'all' },
     none: { description: 'Validate none of the fields.', initialMembership: 'none' },
   };
+  public serverSyncOnSave: 'always' | 'preserveLocalEdits' | 'never' = 'preserveLocalEdits';
   public componentDefinitions: AvailableFormComponentDefinitionOutlines[] = [];
   public debugValue: boolean = false;
   public expressions?: FormExpressionsConfigOutline[];

--- a/packages/sails-ng-common/src/config/form-config.outline.ts
+++ b/packages/sails-ng-common/src/config/form-config.outline.ts
@@ -78,6 +78,10 @@ export interface FormConfigFrame {
    * These are the only validation group names that can be used in the validator config.
    */
   validationGroups?: FormValidationGroups;
+  /**
+   * Controls how server-side metadata returned after save is applied to the form.
+   */
+  serverSyncOnSave?: 'always' | 'preserveLocalEdits' | 'never';
 
   // -- Component-related config --
 

--- a/test/integration/services/FormRecordConsistencyService.test.ts
+++ b/test/integration/services/FormRecordConsistencyService.test.ts
@@ -350,6 +350,82 @@ describe('The FormRecordConsistencyService', function () {
       };
       expect(func).to.throw(Error, 'elements');
     });
+
+    it('filters newly added nested objects and arrays when projecting metadata', async function () {
+      const clientFormConfig: FormConfigFrame = {
+        name: 'project-nested-metadata',
+        type: 'rdmp',
+        debugValue: false,
+        domElementType: 'form',
+        defaultComponentConfig: {},
+        editCssClasses: 'redbox-form form',
+        enabledValidationGroups: ['all'],
+        componentDefinitions: [
+          {
+            name: 'parent',
+            model: { class: 'GroupModel', config: {} },
+            component: {
+              class: 'GroupComponent',
+              config: {
+                componentDefinitions: [
+                  {
+                    name: 'visible',
+                    model: { class: 'SimpleInputModel', config: {} },
+                    component: { class: 'SimpleInputComponent' },
+                  },
+                  {
+                    name: 'children',
+                    model: { class: 'RepeatableModel', config: {} },
+                    component: {
+                      class: 'RepeatableComponent',
+                      config: {
+                        elementTemplate: {
+                          name: null,
+                          model: { class: 'GroupModel', config: {} },
+                          component: {
+                            class: 'GroupComponent',
+                            config: {
+                              componentDefinitions: [
+                                {
+                                  name: 'visibleChild',
+                                  model: { class: 'SimpleInputModel', config: {} },
+                                  component: { class: 'SimpleInputComponent' },
+                                },
+                              ],
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      };
+
+      const projected = await FormRecordConsistencyService.projectMetadataClientFormConfig(
+        {
+          parent: {
+            visible: 'included',
+            omitted: 'excluded',
+            children: [
+              { visibleChild: 'included child', omittedChild: 'excluded child' },
+            ],
+          },
+        },
+        clientFormConfig,
+        'edit'
+      );
+
+      expect(projected).to.eql({
+        parent: {
+          visible: 'included',
+          children: [{ visibleChild: 'included child' }],
+        },
+      });
+    });
   });
 
   describe('buildDataModelDefault methods', function () {

--- a/test/integration/services/FormsService.test.ts
+++ b/test/integration/services/FormsService.test.ts
@@ -173,6 +173,7 @@ describe('The FormsService', function () {
       };
       const expected: FormConfigFrame = {
         name: 'basic-form',
+        serverSyncOnSave: 'preserveLocalEdits',
         type: 'rdmp',
         debugValue: true,
         domElementType: 'form',
@@ -316,6 +317,7 @@ describe('The FormsService', function () {
       };
       const expected: FormConfigFrame = {
         name: 'basic-form',
+        serverSyncOnSave: 'preserveLocalEdits',
         type: 'rdmp',
         debugValue: true,
         domElementType: 'form',
@@ -565,6 +567,7 @@ describe('The FormsService', function () {
       };
       const expected: FormConfigFrame = {
         name: 'basic-form',
+        serverSyncOnSave: 'preserveLocalEdits',
         type: 'rdmp',
         debugValue: true,
         domElementType: 'form',
@@ -842,6 +845,7 @@ describe('The FormsService', function () {
       };
       const expected: FormConfigFrame = {
         name: 'remove-item-constraint-mode',
+        serverSyncOnSave: 'preserveLocalEdits',
         type: 'rdmp',
         debugValue: true,
         domElementType: 'form',


### PR DESCRIPTION
## Summary

Synchronize authoritative server metadata back into the form after a successful save. Previously, server-side pre-save hooks (e.g. template-generated or defaulted values) could alter record metadata during save, but the form continued to display stale client state until a reload. This PR adds an end-to-end post-save sync pipeline: the server projects saved metadata through the client form config and returns it with the save response, the form applies it to the model, and the NgRx store is updated with the reconciled snapshot.

---

## Context / Motivation

Record save workflows invoke server-side hooks (`onCreate`/`onUpdate` pre-hooks such as `runTemplates`) that mutate metadata after the client has already snapshotted its form value. The form's "dirty" state and displayed values then diverge from what is actually stored, which can trigger spurious navigation/save guards and leave users looking at values that no longer match the record. This work lets the server be the source of truth for form state immediately after save while still preserving any edits a user makes while the save is in flight.

---

## Key Features

### Server metadata projection

- `RecordController` returns the saved record's metadata projected through the client form config on create and update responses, shared via a new `getEffectiveClientFormConfig` helper (also reused by the existing `getMeta` path).
- New `FormRecordConsistencyService.projectMetadataClientFormConfig` builds a projected metadata map using an empty original so server-only fields are not retained.
- Projection is gated by a new `record.form.returnMetadataOnSave` config flag (defaults to enabled) and is skipped when saving with a target step or when no client form config can be resolved.

### Client-side post-save sync

- New `FormServerSyncService` applies returned server metadata to form controls with per-form `serverSyncOnSave` mode support:
  - `always` – overwrite control values with server values
  - `preserveLocalEdits` (default) – leave controls that were edited while the save was in flight dirty and unpatched
  - `never` – disable sync entirely
- Controls successfully patched from the server are marked pristine so the store snapshot reflects reconciled state.

### Form event bus and store integration

- `FORM_SAVE_SUCCESS` events now carry an optional `modelSnapshot` of the reconciled form value.
- `FormEventBusAdapterEffects` emits a `syncModelSnapshot` action when a snapshot is available, and the promotion pipeline now supports mapping a single event to multiple actions.

### Form configuration

- New `serverSyncOnSave` property on `FormConfig`/`FormConfigFrame`, threaded through `FormsService`, the construct visitor, and the shared Angular common config model.

### Developer scaffolding

- Dev hook create/update pre-hooks and the default draft form config include a read-only `server_sync_test_value` field populated by `runTemplates`, exercising the sync flow in development.

---

## Testing

- New `FormServerSyncService` unit spec covering dirty-state preservation and patch/skip results.
- Updated `client.visitor` unit tests and `FormsService` integration tests for the `serverSyncOnSave` config property.

---

## Architectural / Operational Impact

### Controller consolidation

`RecordController` get-meta and post-save metadata projection now share one client form config construction path, reducing duplicated form lookup/building logic and keeping the two code paths aligned.

### Effect pipeline

`FormEventBusAdapterEffects` promotion mapping now supports arrays of actions, enabling richer event-to-state reactions without changing the event contract.

### Response shape

`RecordActionResult` gains a `metadata` field carrying the projected post-save metadata, available to API consumers of the create/update responses.

---

## Backwards Compatibility

- Existing forms are unaffected: `serverSyncOnSave` defaults to `preserveLocalEdits` and `returnMetadataOnSave` defaults to enabled, but sync only changes form values when the server's projected metadata differs from what the client sent.
- The `getMeta` filtering path was refactored onto the shared helper with equivalent behavior.
- No persisted data or API schema migrations are required.

---

## Deployment Notes

- No migration steps required. The new config flags default to the backward-compatible behavior.
- The dev hook and draft form config changes are development-only test scaffolding and can be reverted independently.

---

## Impact

Forms now converge to authoritative server state immediately after save, reducing stale-value drift and spurious dirty-state warnings, while edits made during a save remain safe. The change is configurable and backward compatible, and is backed by new unit and integration test coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable server synchronization after saving forms: always, preserve local edits, or never.
  * Server-generated metadata can now be returned and reflected in the saved form state.
  * Save results include the updated form snapshot and redirect information when applicable.
  * Added support for projecting metadata through client-visible form fields while excluding server-only values.

* **Bug Fixes**
  * Local edits are preserved by default during post-save synchronization.
  * Form validity and save status are refreshed after synchronized values are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->