### PR TITLE
Fix: Make option input config properties reactive to updates

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/checkbox-input.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/checkbox-input.component.spec.ts
@@ -151,6 +151,49 @@ describe('CheckboxInputComponent', () => {
     expect(checkbox?.checked).toBeTrue();
   });
 
+  it('should render the legacy toggle when booleanMode changes after initialisation', async () => {
+    const formConfig: FormConfigFrame = {
+      name: 'testing_checkbox_dynamic_boolean_mode',
+      debugValue: false,
+      defaultComponentConfig: {
+        defaultComponentCssClasses: 'row',
+      },
+      editCssClasses: 'redbox-form form',
+      componentDefinitions: [
+        {
+          name: 'checkbox_dynamic_boolean_mode',
+          model: {
+            class: 'CheckboxInputModel',
+            config: {
+              value: false,
+            },
+          },
+          component: {
+            class: 'CheckboxInputComponent',
+            config: {
+              booleanMode: false,
+              options: [],
+            },
+          },
+        },
+      ],
+    };
+
+    const { fixture } = await createFormAndWaitForReady(formConfig);
+    const component = fixture.debugElement.query(By.directive(CheckboxInputComponent))
+      .componentInstance as CheckboxInputComponent;
+
+    expect(fixture.nativeElement.querySelector('input[type="checkbox"]')).toBeNull();
+
+    component.setProperty('booleanMode', true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const checkbox = (fixture.nativeElement as HTMLElement).querySelector<HTMLInputElement>('input[type="checkbox"]');
+    expect(checkbox).not.toBeNull();
+    expect(checkbox?.id).toEqual('checkbox_dynamic_boolean_mode-true');
+  });
+
   it('should resolve language-map labels for options', async () => {
     translationService.translationMap = translationService.translationMap || {};
     translationService.translationMap['@checkbox-language-label'] = 'English Label';

--- a/angular/projects/researchdatabox/form/src/app/component/checkbox-input.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/checkbox-input.component.spec.ts
@@ -323,5 +323,52 @@ describe('CheckboxInputComponent', () => {
     expect(legacyInput?.checked).toBeFalse();
   });
 
+  it('should render options and tooltip changed after initialisation', async () => {
+    const formConfig: FormConfigFrame = {
+      name: 'testing_checkbox_dynamic_options',
+      debugValue: false,
+      defaultComponentConfig: {
+        defaultComponentCssClasses: 'row',
+      },
+      editCssClasses: 'redbox-form form',
+      componentDefinitions: [
+        {
+          name: 'checkbox_dynamic_options',
+          model: {
+            class: 'CheckboxInputModel',
+            config: {
+              validators: [],
+            },
+          },
+          component: {
+            class: 'CheckboxInputComponent',
+            config: {
+              options: [],
+              tooltip: 'original tooltip',
+            },
+          },
+        },
+      ],
+    };
+
+    const { fixture } = await createFormAndWaitForReady(formConfig);
+    const component = fixture.debugElement.query(By.directive(CheckboxInputComponent)).componentInstance as CheckboxInputComponent;
+
+    component.setProperty('options', [
+      { label: 'Alpha', value: 'a' },
+      { label: 'Bravo', value: 'b' },
+    ]);
+    component.setProperty('tooltip', 'updated tooltip');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const checkboxInputs = compiled.querySelectorAll<HTMLInputElement>('input[type="checkbox"]');
+    expect(Array.from(checkboxInputs).map(input => input.id)).toEqual([
+      'checkbox_dynamic_options-a',
+      'checkbox_dynamic_options-b',
+    ]);
+    expect(checkboxInputs[0].title).toEqual('updated tooltip');
+  });
 
 });

--- a/angular/projects/researchdatabox/form/src/app/component/checkbox-input.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/checkbox-input.component.ts
@@ -54,9 +54,14 @@ export class CheckboxInputComponent extends OptionInputBaseComponent<
   CheckboxInputFieldComponentDefinitionFrame
 > {
   protected override logName = CheckboxInputComponentName;
-  public placeholder: string | undefined = '';
-  public multipleValues: boolean = true;
-  public booleanMode: boolean = false;
+
+  public get multipleValues(): boolean {
+    return this.getBooleanProperty('multipleValues', true);
+  }
+
+  public get booleanMode(): boolean {
+    return this.getBooleanProperty('booleanMode', false);
+  }
 
   /**
    * The model associated with this component.
@@ -64,15 +69,11 @@ export class CheckboxInputComponent extends OptionInputBaseComponent<
   @Input() public override model?: CheckboxInputModel;
 
   protected override async initData(): Promise<void> {
-    const config = this.getOptionInputConfig(CheckboxInputComponentName);
-    this.setSharedOptionConfig(config);
-    this.placeholder = config?.placeholder ?? "";
-    this.multipleValues = config?.multipleValues ?? true;
-    this.booleanMode = config?.booleanMode ?? false;
+    // Validate the component definition; the remaining properties are read from the config on demand.
+    this.getOptionInputConfig(CheckboxInputComponentName);
     if (this.booleanMode && this.options.length === 0) {
       this.options = [{ label: '', value: 'true' }];
     }
-
   }
 
   /**

--- a/angular/projects/researchdatabox/form/src/app/component/checkbox-input.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/checkbox-input.component.ts
@@ -63,6 +63,17 @@ export class CheckboxInputComponent extends OptionInputBaseComponent<
     return this.getBooleanProperty('booleanMode', false);
   }
 
+  public override get options(): CheckboxOption[] {
+    const options = super.options;
+    return this.booleanMode && options.length === 0
+      ? [{ label: '', value: 'true' }]
+      : options;
+  }
+
+  public override set options(value: CheckboxOption[]) {
+    super.options = value;
+  }
+
   /**
    * The model associated with this component.
    */
@@ -71,9 +82,6 @@ export class CheckboxInputComponent extends OptionInputBaseComponent<
   protected override async initData(): Promise<void> {
     // Validate the component definition; the remaining properties are read from the config on demand.
     this.getOptionInputConfig(CheckboxInputComponentName);
-    if (this.booleanMode && this.options.length === 0) {
-      this.options = [{ label: '', value: 'true' }];
-    }
   }
 
   /**

--- a/angular/projects/researchdatabox/form/src/app/component/dropdown-input.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/dropdown-input.component.spec.ts
@@ -3,6 +3,7 @@ import { DropdownInputComponent } from './dropdown-input.component';
 import { createFormAndWaitForReady, createTestbedModule } from '../helpers.spec';
 import { TestBed } from '@angular/core/testing';
 import i18next from 'i18next';
+import { By } from '@angular/platform-browser';
 
 describe('DropdownInputComponent', () => {
   let translationService: any;
@@ -195,5 +196,51 @@ describe('DropdownInputComponent', () => {
     expect(selectEl.selectedIndex).toBe(0);
     expect(selectEl.value).toBe('');
     expect(formComponent.form?.get('dropdown_existing_empty')?.value).toBe('');
+  });
+
+  it('should render options added after initialisation', async () => {
+    const formConfig: FormConfigFrame = {
+      name: 'testing_dropdown_dynamic_options',
+      debugValue: false,
+      defaultComponentConfig: {
+        defaultComponentCssClasses: 'row',
+      },
+      editCssClasses: 'redbox-form form',
+      componentDefinitions: [
+        {
+          name: 'dropdown_dynamic_options',
+          model: {
+            class: 'DropdownInputModel',
+            config: {
+              validators: [],
+            },
+          },
+          component: {
+            class: 'DropdownInputComponent',
+            config: {
+              options: [],
+            },
+          },
+        },
+      ],
+    };
+
+    const { fixture } = await createFormAndWaitForReady(formConfig);
+    const component = fixture.debugElement.query(By.directive(DropdownInputComponent)).componentInstance as DropdownInputComponent;
+
+    component.setProperty('options', [
+      { label: 'Chief investigator', value: 'Chief investigator' },
+      { label: 'Supervisor', value: 'Supervisor' },
+    ]);
+    component.setProperty('tooltip', 'updated tooltip');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const selectEl = fixture.nativeElement.querySelector('select') as HTMLSelectElement;
+    expect(Array.from(selectEl.options).map(option => option.text)).toEqual([
+      'Chief investigator',
+      'Supervisor',
+    ]);
+    expect(selectEl.title).toEqual('updated tooltip');
   });
 });

--- a/angular/projects/researchdatabox/form/src/app/component/dropdown-input.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/dropdown-input.component.ts
@@ -1,13 +1,14 @@
 import { Component, Input } from '@angular/core';
-import { FormFieldBaseComponent, FormFieldCompMapEntry, FormFieldModel } from '@researchdatabox/portal-ng-common';
+import { FormFieldModel } from '@researchdatabox/portal-ng-common';
 import {
   DropdownInputComponentName,
-  DropdownInputFieldComponentConfig,
+  DropdownInputFieldComponentDefinitionFrame,
   DropdownInputModelName,
   DropdownInputModelValueType,
   DropdownOption,
 } from '@researchdatabox/sails-ng-common';
-import { isEmpty as _isEmpty, isUndefined as _isUndefined } from 'lodash-es';
+import { isUndefined as _isUndefined } from 'lodash-es';
+import { OptionInputBaseComponent } from './option-input-base.component';
 
 export class DropdownInputModel extends FormFieldModel<DropdownInputModelValueType> {
   protected override logName = DropdownInputModelName;
@@ -37,31 +38,17 @@ export class DropdownInputModel extends FormFieldModel<DropdownInputModelValueTy
   `,
   standalone: false,
 })
-export class DropdownInputComponent extends FormFieldBaseComponent<DropdownInputModelValueType> {
+export class DropdownInputComponent extends OptionInputBaseComponent<
+  DropdownInputModelValueType,
+  DropdownOption,
+  DropdownInputFieldComponentDefinitionFrame['config'],
+  DropdownInputFieldComponentDefinitionFrame
+> {
   protected override logName = DropdownInputComponentName;
-  public tooltip: string = '';
-  public placeholder: string | undefined = undefined;
-  public options: DropdownOption[] = [];
 
-  /**
-   * Override to set additional properties required by the wrapper component.
-   *
-   * @param formFieldCompMapEntry
-   */
-  protected override setPropertiesFromComponentMapEntry(formFieldCompMapEntry: FormFieldCompMapEntry): void {
-    super.setPropertiesFromComponentMapEntry(formFieldCompMapEntry);
-    this.tooltip = this.getStringProperty('tooltip');
-    this.placeholder = this.getStringProperty('placeholder');
-    const dropdownInputConfig = this.componentDefinition?.config as DropdownInputFieldComponentConfig | undefined;
-    const defaultConfig = new DropdownInputFieldComponentConfig();
-    const cfg =
-      _isUndefined(dropdownInputConfig) || _isEmpty(dropdownInputConfig) ? defaultConfig : dropdownInputConfig;
-    const cfgOptions: DropdownOption[] = cfg.options;
-    if (!_isUndefined(cfgOptions) && !_isEmpty(cfgOptions)) {
-      this.options = cfgOptions;
-    } else {
-      this.options = defaultConfig.options;
-    }
+  protected override async initData(): Promise<void> {
+    // Validate the component definition; options, tooltip and placeholder are read from the config on demand.
+    this.getOptionInputConfig(DropdownInputComponentName);
     this.setDefaultSelection();
   }
 

--- a/angular/projects/researchdatabox/form/src/app/component/option-input-base.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/option-input-base.component.ts
@@ -1,9 +1,11 @@
 import { FormFieldBaseComponent } from '@researchdatabox/portal-ng-common';
 import { FieldDefinitionFrame, isTypeFieldDefinitionName } from '@researchdatabox/sails-ng-common';
+import { get as _get } from 'lodash-es';
 
 type OptionInputConfig<TOption extends { value: string; disabled?: boolean }> = {
     options?: TOption[];
     tooltip?: string;
+    placeholder?: string;
 };
 
 export abstract class OptionInputBaseComponent<
@@ -12,8 +14,35 @@ export abstract class OptionInputBaseComponent<
     TConfig extends OptionInputConfig<TOption> | undefined,
     TFieldComponent extends FieldDefinitionFrame & { config?: TConfig }
 > extends FormFieldBaseComponent<TValue> {
-    public tooltip: string = '';
-    public options: TOption[] = [];
+    /**
+     * The config is the single source of truth for these properties, so that changes
+     * applied via `setProperty` (e.g. from a form expression) are picked up by the
+     * template without each component having to keep a copy in sync.
+     */
+    public get options(): TOption[] {
+        const configOptions: unknown = _get(this.componentDefinition?.config, 'options');
+        return Array.isArray(configOptions) ? configOptions as TOption[] : [];
+    }
+
+    public set options(value: TOption[]) {
+        this.setProperty('options', value);
+    }
+
+    public get tooltip(): string {
+        return this.getStringProperty('tooltip');
+    }
+
+    public set tooltip(value: string) {
+        this.setProperty('tooltip', value);
+    }
+
+    public get placeholder(): string {
+        return this.getStringProperty('placeholder');
+    }
+
+    public set placeholder(value: string) {
+        this.setProperty('placeholder', value);
+    }
 
     protected getOptionInputConfig(expectedComponentName: string): TConfig | undefined {
         const formComponentFrame = this.componentDefinition;
@@ -21,11 +50,6 @@ export abstract class OptionInputBaseComponent<
             throw new Error(`${this.logName}: Expected ${expectedComponentName} but got ${JSON.stringify(formComponentFrame)}`);
         }
         return formComponentFrame.config;
-    }
-
-    protected setSharedOptionConfig(config: OptionInputConfig<TOption> | undefined): void {
-        this.options = config?.options ?? [];
-        this.tooltip = config?.tooltip ?? '';
     }
 
     protected setControlValue(value: TValue): void {

--- a/angular/projects/researchdatabox/form/src/app/component/radio-input.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/radio-input.component.spec.ts
@@ -254,4 +254,53 @@ describe('RadioInputComponent', () => {
     expect(activeInput?.checked).toBeFalse();
     expect(legacyInput?.checked).toBeFalse();
   });
+
+  it('should render options and tooltip changed after initialisation', async () => {
+    const formConfig: FormConfigFrame = {
+      name: 'testing_radio_dynamic_options',
+      debugValue: false,
+      defaultComponentConfig: {
+        defaultComponentCssClasses: 'row',
+      },
+      editCssClasses: 'redbox-form form',
+      componentDefinitions: [
+        {
+          name: 'radio_dynamic_options',
+          model: {
+            class: 'RadioInputModel',
+            config: {
+              validators: []
+            }
+          },
+          component: {
+            class: 'RadioInputComponent',
+            config: {
+              options: [],
+              tooltip: 'original tooltip'
+            }
+          }
+        }
+      ]
+    };
+
+    const { fixture } = await createFormAndWaitForReady(formConfig);
+    const component = fixture.debugElement.query(By.directive(RadioInputComponent)).componentInstance as RadioInputComponent;
+
+    component.setProperty('options', [
+      { label: 'Chief investigator', value: 'Chief investigator' },
+      { label: 'Supervisor', value: 'Supervisor' },
+    ]);
+    component.setProperty('tooltip', 'updated tooltip');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const labels = compiled.querySelectorAll<HTMLLabelElement>('label');
+    expect(Array.from(labels).map(label => label.textContent?.trim())).toEqual([
+      'Chief investigator',
+      'Supervisor',
+    ]);
+    const radioInputs = compiled.querySelectorAll<HTMLInputElement>('input[type="radio"]');
+    expect(radioInputs[0].title).toEqual('updated tooltip');
+  });
 });

--- a/angular/projects/researchdatabox/form/src/app/component/radio-input.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/radio-input.component.ts
@@ -61,8 +61,8 @@ export class RadioInputComponent extends OptionInputBaseComponent<
   @Input() public override model?: RadioInputModel;
 
   protected override async initData(): Promise<void> {
-    const config = this.getOptionInputConfig(RadioInputComponentName);
-    this.setSharedOptionConfig(config);
+    // Validate the component definition; options and tooltip are read from the config on demand.
+    this.getOptionInputConfig(RadioInputComponentName);
   }
 
   public isOptionSelected(optionValue: string): boolean {


### PR DESCRIPTION
## Summary

Make option-input configuration properties reactive after component initialisation, so form-expression updates are reflected in rendered Checkbox, Dropdown, and Radio controls.

## Context / related work

This is stacked on [redbox-mint/redbox-portal#4385](https://github.com/redbox-mint/redbox-portal/pull/4385), which introduced the post-save form synchronisation flow.

## Technical implementation details

- Move shared option, tooltip, and placeholder access to getters backed by the component definition config.
- Reuse `OptionInputBaseComponent` for dropdown inputs and retain dynamic boolean behavior for checkboxes.
- Add regression coverage for options and tooltips changed through `setProperty` after initialisation.

## Testing

- `ng t --browsers=ChromeHeadless --project=@researchdatabox/form --no-watch --no-progress`
- Result: 780 tests passed.

## Future work

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Form option controls now reflect updated options, tooltips, and placeholders after initialization.
  * Checkbox, dropdown, and radio inputs provide more consistent configuration-driven behavior.

* **Bug Fixes**
  * Updated option and tooltip values now appear correctly in rendered form fields.

* **Tests**
  * Added coverage for dynamic updates to checkbox, dropdown, and radio inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->