### PR TITLE
Bugfix: Support callback-style hook initializers

### DIFF
--- a/packages/redbox-core/src/hooks/defineRedboxHook.ts
+++ b/packages/redbox-core/src/hooks/defineRedboxHook.ts
@@ -11,108 +11,7 @@ type HookFactoryResult = {
 export type HookRegistrationMap = Record<string, unknown>;
 
 type HookDone = (error?: Error) => void;
-type PromiseHookInitializer = (sails: Sails.Application) => void | Promise<void>;
-type CallbackHookInitializer = (sails: Sails.Application, done: HookDone) => void | Promise<void>;
-type HookInitializer = PromiseHookInitializer | CallbackHookInitializer;
-
-const FUNCTION_COMMENT_RX = /(\/\/.*$)|(\/\*[\s\S]*?\*\/)/gm;
-
-function getFunctionParameterList(initializer: HookInitializer): string | undefined {
-  const source = Function.prototype.toString.call(initializer).replace(FUNCTION_COMMENT_RX, '');
-  const openingParenthesis = source.indexOf('(');
-  const arrow = source.indexOf('=>');
-
-  if (openingParenthesis === -1 || (arrow !== -1 && arrow < openingParenthesis)) {
-    return undefined;
-  }
-
-  let depth = 0;
-  let quote: string | undefined;
-  let escaped = false;
-
-  for (let index = openingParenthesis; index < source.length; index++) {
-    const character = source[index];
-
-    if (quote) {
-      if (escaped) {
-        escaped = false;
-      } else if (character === '\\') {
-        escaped = true;
-      } else if (character === quote) {
-        quote = undefined;
-      }
-      continue;
-    }
-
-    if (character === '"' || character === "'" || character === '`') {
-      quote = character;
-    } else if (character === '(') {
-      depth++;
-    } else if (character === ')') {
-      depth--;
-      if (depth === 0) {
-        return source.slice(openingParenthesis + 1, index);
-      }
-    }
-  }
-
-  return undefined;
-}
-
-function hasMultipleParameters(parameterList: string): boolean {
-  let depth = 0;
-  let quote: string | undefined;
-  let escaped = false;
-  let parameterCount = 0;
-  let hasParameterText = false;
-
-  for (const character of parameterList) {
-    if (quote) {
-      hasParameterText = true;
-      if (escaped) {
-        escaped = false;
-      } else if (character === '\\') {
-        escaped = true;
-      } else if (character === quote) {
-        quote = undefined;
-      }
-      continue;
-    }
-
-    if (character === '"' || character === "'" || character === '`') {
-      quote = character;
-      hasParameterText = true;
-    } else if (character === '(' || character === '[' || character === '{') {
-      depth++;
-      hasParameterText = true;
-    } else if (character === ')' || character === ']' || character === '}') {
-      depth--;
-      hasParameterText = true;
-    } else if (character === ',' && depth === 0) {
-      if (hasParameterText) {
-        parameterCount++;
-      }
-      hasParameterText = false;
-    } else if (!/\s/.test(character)) {
-      hasParameterText = true;
-    }
-  }
-
-  if (hasParameterText) {
-    parameterCount++;
-  }
-
-  return parameterCount >= 2;
-}
-
-function isCallbackInitializer(initializer: HookInitializer): initializer is CallbackHookInitializer {
-  if (initializer.length >= 2) {
-    return true;
-  }
-
-  const parameterList = getFunctionParameterList(initializer);
-  return parameterList !== undefined && hasMultipleParameters(parameterList);
-}
+type HookInitializer = (sails: Sails.Application, done: HookDone) => void | Promise<void>;
 
 export type DefineRedboxHookOptions = {
   defaults?: Record<string, unknown>;
@@ -157,40 +56,38 @@ export function defineRedboxHook(options: DefineRedboxHookOptions): DefinedRedbo
     const initializer = options.initialize;
     if (initializer) {
       hook.initialize = async (done?: HookDone): Promise<void> => {
-        // Sails supports Promise-returning initializers, but its default
-        // implementation sniffing also supports the older callback form.
-        // Keep accepting both forms while exposing an async hook that also
-        // completes the callback supplied by traditional Sails.
-        try {
-          if (isCallbackInitializer(initializer)) {
-            await new Promise<void>((resolve, reject) => {
-              const initializerDone = (error?: Error): void => {
-                if (error) {
-                  reject(error);
-                } else {
-                  resolve();
-                }
-              };
+        return new Promise<void>((resolve, reject) => {
+          let settled = false;
+          const initializerDone = (error?: unknown): void => {
+            if (settled) {
+              return;
+            }
+            settled = true;
 
-              try {
-                const result = initializer(sails, initializerDone);
-                void Promise.resolve(result).catch(reject);
-              } catch (error) {
-                reject(error);
+            if (error !== undefined) {
+              const normalizedError = error instanceof Error ? error : new Error(String(error));
+              if (done) {
+                done(normalizedError);
+                resolve();
+              } else {
+                reject(normalizedError);
               }
-            });
-          } else {
-            await (initializer as PromiseHookInitializer)(sails);
-          }
-        } catch (error) {
-          if (done) {
-            done(error instanceof Error ? error : new Error(String(error)));
-            return;
-          }
-          throw error;
-        }
+              return;
+            }
 
-        done?.();
+            done?.();
+            resolve();
+          };
+
+          try {
+            const result = initializer(sails, initializerDone);
+            if (result && typeof result.then === 'function') {
+              void Promise.resolve(result).then(() => initializerDone(), initializerDone);
+            }
+          } catch (error) {
+            initializerDone(error);
+          }
+        });
       };
     }
 

--- a/packages/redbox-core/src/hooks/defineRedboxHook.ts
+++ b/packages/redbox-core/src/hooks/defineRedboxHook.ts
@@ -5,16 +5,21 @@ type HookFactoryResult = {
   defaults?: Record<string, unknown>;
   routes?: unknown;
   configure?: () => void;
-  initialize?: (done: () => void) => void;
+  initialize?: () => Promise<void>;
 };
 
 export type HookRegistrationMap = Record<string, unknown>;
+
+type HookInitializer = {
+  (sails: Sails.Application): void | Promise<void>;
+  (sails: Sails.Application, done: (error?: Error) => void): void;
+};
 
 export type DefineRedboxHookOptions = {
   defaults?: Record<string, unknown>;
   routes?: ((sails: Sails.Application) => unknown) | unknown;
   configure?: (sails: Sails.Application) => void;
-  initialize?: (sails: Sails.Application, done: () => void) => void;
+  initialize?: HookInitializer;
   registerRedboxConfig?: () => HookRegistrationMap;
   registerHookApiRoutes?: () => readonly ApiRouteDefinition[];
   registerRedboxControllers?: () => HookRegistrationMap;
@@ -53,8 +58,33 @@ export function defineRedboxHook(options: DefineRedboxHookOptions): DefinedRedbo
     }
 
     if (options.initialize) {
-      hook.initialize = (done: () => void): void => {
-        options.initialize?.(sails, done);
+      hook.initialize = async (): Promise<void> => {
+        const initializer = options.initialize as HookInitializer;
+
+        // Sails supports Promise-returning initializers, but its default
+        // implementation sniffing also supports the older callback form.
+        // Keep accepting both forms while always exposing a zero-argument
+        // Promise-returning hook to Sails.
+        if (initializer.length >= 2) {
+          await new Promise<void>((resolve, reject) => {
+            const done = (error?: Error): void => {
+              if (error) {
+                reject(error);
+              } else {
+                resolve();
+              }
+            };
+
+            try {
+              initializer(sails, done);
+            } catch (error) {
+              reject(error);
+            }
+          });
+          return;
+        }
+
+        await initializer(sails);
       };
     }
 

--- a/packages/redbox-core/src/hooks/defineRedboxHook.ts
+++ b/packages/redbox-core/src/hooks/defineRedboxHook.ts
@@ -5,15 +5,114 @@ type HookFactoryResult = {
   defaults?: Record<string, unknown>;
   routes?: unknown;
   configure?: () => void;
-  initialize?: () => Promise<void>;
+  initialize?: (done?: (error?: Error) => void) => Promise<void>;
 };
 
 export type HookRegistrationMap = Record<string, unknown>;
 
-type HookInitializer = {
-  (sails: Sails.Application): void | Promise<void>;
-  (sails: Sails.Application, done: (error?: Error) => void): void;
-};
+type HookDone = (error?: Error) => void;
+type PromiseHookInitializer = (sails: Sails.Application) => void | Promise<void>;
+type CallbackHookInitializer = (sails: Sails.Application, done: HookDone) => void | Promise<void>;
+type HookInitializer = PromiseHookInitializer | CallbackHookInitializer;
+
+const FUNCTION_COMMENT_RX = /(\/\/.*$)|(\/\*[\s\S]*?\*\/)/gm;
+
+function getFunctionParameterList(initializer: HookInitializer): string | undefined {
+  const source = Function.prototype.toString.call(initializer).replace(FUNCTION_COMMENT_RX, '');
+  const openingParenthesis = source.indexOf('(');
+  const arrow = source.indexOf('=>');
+
+  if (openingParenthesis === -1 || (arrow !== -1 && arrow < openingParenthesis)) {
+    return undefined;
+  }
+
+  let depth = 0;
+  let quote: string | undefined;
+  let escaped = false;
+
+  for (let index = openingParenthesis; index < source.length; index++) {
+    const character = source[index];
+
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === '\\') {
+        escaped = true;
+      } else if (character === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+
+    if (character === '"' || character === "'" || character === '`') {
+      quote = character;
+    } else if (character === '(') {
+      depth++;
+    } else if (character === ')') {
+      depth--;
+      if (depth === 0) {
+        return source.slice(openingParenthesis + 1, index);
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function hasMultipleParameters(parameterList: string): boolean {
+  let depth = 0;
+  let quote: string | undefined;
+  let escaped = false;
+  let parameterCount = 0;
+  let hasParameterText = false;
+
+  for (const character of parameterList) {
+    if (quote) {
+      hasParameterText = true;
+      if (escaped) {
+        escaped = false;
+      } else if (character === '\\') {
+        escaped = true;
+      } else if (character === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+
+    if (character === '"' || character === "'" || character === '`') {
+      quote = character;
+      hasParameterText = true;
+    } else if (character === '(' || character === '[' || character === '{') {
+      depth++;
+      hasParameterText = true;
+    } else if (character === ')' || character === ']' || character === '}') {
+      depth--;
+      hasParameterText = true;
+    } else if (character === ',' && depth === 0) {
+      if (hasParameterText) {
+        parameterCount++;
+      }
+      hasParameterText = false;
+    } else if (!/\s/.test(character)) {
+      hasParameterText = true;
+    }
+  }
+
+  if (hasParameterText) {
+    parameterCount++;
+  }
+
+  return parameterCount >= 2;
+}
+
+function isCallbackInitializer(initializer: HookInitializer): initializer is CallbackHookInitializer {
+  if (initializer.length >= 2) {
+    return true;
+  }
+
+  const parameterList = getFunctionParameterList(initializer);
+  return parameterList !== undefined && hasMultipleParameters(parameterList);
+}
 
 export type DefineRedboxHookOptions = {
   defaults?: Record<string, unknown>;
@@ -46,9 +145,7 @@ export function defineRedboxHook(options: DefineRedboxHookOptions): DefinedRedbo
     };
 
     if (options.routes) {
-      hook.routes = typeof options.routes === 'function'
-        ? options.routes(sails)
-        : options.routes;
+      hook.routes = typeof options.routes === 'function' ? options.routes(sails) : options.routes;
     }
 
     if (options.configure) {
@@ -57,34 +154,43 @@ export function defineRedboxHook(options: DefineRedboxHookOptions): DefinedRedbo
       };
     }
 
-    if (options.initialize) {
-      hook.initialize = async (): Promise<void> => {
-        const initializer = options.initialize as HookInitializer;
-
+    const initializer = options.initialize;
+    if (initializer) {
+      hook.initialize = async (done?: HookDone): Promise<void> => {
         // Sails supports Promise-returning initializers, but its default
         // implementation sniffing also supports the older callback form.
-        // Keep accepting both forms while always exposing a zero-argument
-        // Promise-returning hook to Sails.
-        if (initializer.length >= 2) {
-          await new Promise<void>((resolve, reject) => {
-            const done = (error?: Error): void => {
-              if (error) {
-                reject(error);
-              } else {
-                resolve();
-              }
-            };
+        // Keep accepting both forms while exposing an async hook that also
+        // completes the callback supplied by traditional Sails.
+        try {
+          if (isCallbackInitializer(initializer)) {
+            await new Promise<void>((resolve, reject) => {
+              const initializerDone = (error?: Error): void => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve();
+                }
+              };
 
-            try {
-              initializer(sails, done);
-            } catch (error) {
-              reject(error);
-            }
-          });
-          return;
+              try {
+                const result = initializer(sails, initializerDone);
+                void Promise.resolve(result).catch(reject);
+              } catch (error) {
+                reject(error);
+              }
+            });
+          } else {
+            await (initializer as PromiseHookInitializer)(sails);
+          }
+        } catch (error) {
+          if (done) {
+            done(error instanceof Error ? error : new Error(String(error)));
+            return;
+          }
+          throw error;
         }
 
-        await initializer(sails);
+        done?.();
       };
     }
 

--- a/packages/redbox-core/test/hooks/defineRedboxHook.test.ts
+++ b/packages/redbox-core/test/hooks/defineRedboxHook.test.ts
@@ -1,8 +1,40 @@
+/**
+ * Tests for `defineRedboxHook`, the helper that wraps a ReDBox hook definition into the
+ * shape Sails expects from a hook factory.
+ *
+ * The behaviour under test is the `initialize` bridge. ReDBox hooks are written in two
+ * different styles and both have to keep working:
+ *
+ *   - callback style:  `initialize(sails, done) { ...; done(); }`
+ *   - promise style:   `async initialize(sails) { await ... }`
+ *
+ * Sails itself also decides how to drive a hook's `initialize` by inspecting the function's
+ * arity (`initialize.length`): an arity of at least 1 means "I will call you with a `done`
+ * callback". So the wrapper has to satisfy both directions at once — accept either author
+ * style underneath, while always presenting a single-argument, promise-returning function
+ * outward.
+ *
+ * An earlier implementation sniffed the author's function arity to guess which style was in
+ * use. That is unreliable, because JavaScript's `Function.length` ignores parameters with
+ * default values and rest parameters — `(sails, done = () => {})` and `(sails, ...rest)` both
+ * report a length of 1 and were therefore misread as promise-style initializers, which meant
+ * the hook resolved before the author's callback ever fired. The tests below pin down the
+ * arity-free behaviour that replaced the sniffing.
+ */
 import { defineRedboxHook } from '../../src/hooks/defineRedboxHook';
 
+// Chai is ESM-only, so `expect` is populated by the dynamic import in `before()` below.
 let expect: Chai.ExpectStatic;
+
+// A stand-in Sails app. Nothing under test reads from it; the tests only need a stable
+// reference to assert that this exact object is threaded through to the hook callbacks.
 const testSails = {} as Sails.Application;
 
+/**
+ * Builds a hook from `options`, runs the factory with the fake Sails app, and returns its
+ * `initialize` — i.e. the wrapper that the tests exercise, not the initializer that was
+ * passed in. Throws rather than returning `undefined` so each test can assume it exists.
+ */
 function getInitialize(
   options: Parameters<typeof defineRedboxHook>[0]
 ): (done?: (error?: Error) => void) => Promise<void> {
@@ -20,6 +52,8 @@ describe('defineRedboxHook', function () {
   });
 
   it('evaluates functional routes with the Sails application', function () {
+    // `routes` may be a plain object or a factory function. When it is a function it must be
+    // invoked once, with the Sails app, and its return value used verbatim as `hook.routes`.
     const routes = {};
     const hook = defineRedboxHook({
       routes: (sails: Sails.Application) => {
@@ -28,10 +62,15 @@ describe('defineRedboxHook', function () {
       },
     })(testSails);
 
+    // Identity check, not a deep equal: the exact object returned by the factory is passed
+    // straight through without being copied or merged.
     expect(hook.routes).to.equal(routes);
   });
 
   it('accepts and waits for callback-style initializers', async function () {
+    // Baseline callback case: the initializer finishes asynchronously (`setImmediate`) and
+    // signals completion via `done()`. The wrapper's promise must not resolve until then, so
+    // awaiting it is enough to guarantee `initialized` has been set.
     let initialized = false;
     const initialize = getInitialize({
       initialize(_sails, done) {
@@ -48,24 +87,37 @@ describe('defineRedboxHook', function () {
   });
 
   it('waits for callback initializers with a default parameter', async function () {
+    // Regression case #1 for the removed arity sniffing: a default value on `done` makes
+    // `initialize.length === 1`, which the old implementation read as "promise style".
     let complete: ((error?: Error) => void) | undefined;
     let receivedArgumentCount = 0;
     const initialize = getInitialize({
       initialize(_sails: Sails.Application, done: (error?: Error) => void = () => {}) {
+        // `arguments.length` reports what the wrapper actually passed, as opposed to the
+        // declared arity — this is what proves the default value was never used.
         // eslint-disable-next-line prefer-rest-params
         receivedArgumentCount = arguments.length;
+        // Deliberately do not complete yet; the test drives completion by hand below.
         complete = done;
       },
     });
 
+    // Drive it the way Sails would, passing an outer `done` callback.
     let doneCallCount = 0;
     const initialization = initialize(() => {
       doneCallCount++;
     });
+    // Yield one microtask so the wrapper has synchronously called the initializer and any
+    // promise plumbing inside it has had a chance to run.
     await Promise.resolve();
 
+    // The wrapper always supplies its own callback, so the default is shadowed.
     expect(receivedArgumentCount).to.equal(2);
     expect(complete).to.be.a('function');
+
+    // The returned promise must still be pending: the initializer has not called back yet.
+    // `settled` is sampled after a microtask turn, which is enough to catch a wrapper that
+    // resolved eagerly instead of waiting for the callback.
     let settled = false;
     void initialization.then(() => {
       settled = true;
@@ -73,13 +125,20 @@ describe('defineRedboxHook', function () {
     await Promise.resolve();
     expect(settled).to.equal(false);
 
+    // Completing the callback resolves the wrapper's promise and notifies the outer `done`.
     complete?.();
     await initialization;
+
+    // Completion is latched: a second call — even one reporting an error — is ignored, so a
+    // sloppy initializer cannot re-enter Sails' callback or reject an already-settled hook.
     complete?.(new Error('ignored completion'));
     expect(doneCallCount).to.equal(1);
   });
 
   it('waits for callback initializers with a rest parameter', async function () {
+    // Regression case #2 for the removed arity sniffing: rest parameters are also excluded
+    // from `Function.length`, so this initializer likewise reports an arity of 1 despite
+    // being callback style. The callback must still arrive, as `rest[0]`.
     let complete: (() => void) | undefined;
     const initialize = getInitialize({
       initialize(_sails: Sails.Application, ...rest: [(error?: Error) => void]) {
@@ -87,22 +146,33 @@ describe('defineRedboxHook', function () {
       },
     });
 
+    // Note: no outer `done` here — the wrapper must supply its callback regardless of how it
+    // was itself invoked.
     const initialization = initialize();
     await Promise.resolve();
 
     expect(complete).to.be.a('function');
     complete?.();
+    // Awaiting would hang if the callback had not been wired through, so reaching the end of
+    // the test is the assertion.
     await initialization;
   });
 
   it('completes Sails callback consumers for Promise initializers', async function () {
+    // The other direction: a promise-style initializer that never touches `done`. The
+    // wrapper still has to call Sails' callback once the promise settles.
     const initialize = getInitialize({
       initialize: async function initializePromise() {
         await Promise.resolve();
       },
     });
 
+    // The exposed wrapper must declare exactly one parameter. Sails checks this arity to
+    // decide whether to hand the hook a `done` callback, so an arity of 0 would silently
+    // change how Sails drives initialization.
     expect(initialize.length).to.equal(1);
+
+    // Consume it purely through the callback contract — the promise result is ignored here.
     await new Promise<void>((resolve, reject) => {
       initialize(error => {
         if (error) {
@@ -115,6 +185,8 @@ describe('defineRedboxHook', function () {
   });
 
   it('passes initializer errors to Sails callback consumers', async function () {
+    // A rejected initializer must surface as the callback's error argument, preserving the
+    // original Error instance rather than wrapping or stringifying it.
     const error = new Error('initialization failed');
     const initialize = getInitialize({
       initialize: async function initializePromise() {
@@ -122,6 +194,10 @@ describe('defineRedboxHook', function () {
       },
     });
 
+    // Using `resolve` directly as the Sails callback captures whatever error it is handed.
+    // The wrapper's own promise is deliberately ignored (`void`): when a callback is present
+    // the failure is reported through it, and the promise resolves instead of rejecting so
+    // there is no unhandled rejection.
     const receivedError = await new Promise<Error | undefined>(resolve => {
       void initialize(resolve);
     });
@@ -130,6 +206,8 @@ describe('defineRedboxHook', function () {
   });
 
   it('rejects when a Promise initializer fails without a Sails callback', async function () {
+    // Same failure, but invoked without a callback — the error then has nowhere to go except
+    // the returned promise, which must reject with the original Error.
     const error = new Error('initialization failed');
     const initialize = getInitialize({
       initialize: async function initializePromise() {
@@ -148,6 +226,9 @@ describe('defineRedboxHook', function () {
   });
 
   it('normalizes synchronous initializer errors for Sails callback consumers', async function () {
+    // Two things at once: a throw from the *synchronous* body of an initializer is caught
+    // (rather than escaping the wrapper), and a non-Error throwable is normalized into an
+    // Error so downstream Sails code can rely on `.message`.
     const initialize = getInitialize({
       initialize() {
         throw 'initialization failed';

--- a/packages/redbox-core/test/hooks/defineRedboxHook.test.ts
+++ b/packages/redbox-core/test/hooks/defineRedboxHook.test.ts
@@ -55,25 +55,35 @@ describe('defineRedboxHook', function () {
     // `routes` may be a plain object or a factory function. When it is a function it must be
     // invoked once, with the Sails app, and its return value used verbatim as `hook.routes`.
     const routes = {};
+    let routesCallCount = 0;
+    let receivedSails: Sails.Application | undefined;
     const hook = defineRedboxHook({
       routes: (sails: Sails.Application) => {
-        expect(sails).to.equal(testSails);
+        routesCallCount++;
+        receivedSails = sails;
         return routes;
       },
     })(testSails);
 
+    // Evaluated exactly once, with the Sails app the hook factory was called with.
+    expect(routesCallCount).to.equal(1);
+    expect(receivedSails).to.equal(testSails);
     // Identity check, not a deep equal: the exact object returned by the factory is passed
     // straight through without being copied or merged.
     expect(hook.routes).to.equal(routes);
+    // Hooks always get a `defaults` object, even when the definition omits one.
+    expect(hook.defaults).to.deep.equal({});
   });
 
   it('accepts and waits for callback-style initializers', async function () {
-    // Baseline callback case: the initializer finishes asynchronously (`setImmediate`) and
-    // signals completion via `done()`. The wrapper's promise must not resolve until then, so
-    // awaiting it is enough to guarantee `initialized` has been set.
+    // Baseline callback case: the initializer finishes asynchronously (`setImmediate` defers
+    // to a later event-loop tick) and signals completion via `done()`. The wrapper's promise
+    // must not resolve until then, so awaiting it is enough to guarantee `initialized` is set.
     let initialized = false;
+    let receivedSails: Sails.Application | undefined;
     const initialize = getInitialize({
-      initialize(_sails, done) {
+      initialize(sails, done) {
+        receivedSails = sails;
         setImmediate(() => {
           initialized = true;
           done();
@@ -81,7 +91,14 @@ describe('defineRedboxHook', function () {
       },
     });
 
-    await initialize();
+    const initialization = initialize();
+
+    // The initializer has started - and been handed the Sails app - but its deferred body has
+    // not run yet, so this is the "still in flight" state the wrapper has to wait out.
+    expect(receivedSails).to.equal(testSails);
+    expect(initialized).to.equal(false);
+
+    await initialization;
 
     expect(initialized).to.equal(true);
   });
@@ -102,22 +119,37 @@ describe('defineRedboxHook', function () {
       },
     });
 
-    // Drive it the way Sails would, passing an outer `done` callback.
+    // Nothing has run yet: the initializer is only invoked when `initialize` is called, so a
+    // `complete` that is already set would mean the helper above, not this call, ran it.
+    expect(complete).to.equal(undefined);
+
+    // Drive it the way Sails would, by passing an outer `done` callback.
     let doneCallCount = 0;
     const initialization = initialize(() => {
       doneCallCount++;
     });
-    // Yield one microtask so the wrapper has synchronously called the initializer and any
-    // promise plumbing inside it has had a chance to run.
+
+    // Yield one turn of the microtask queue. The wrapper calls the initializer synchronously,
+    // so `complete` is already assigned by this point; the yield matters because it also lets
+    // the wrapper's promise branch run. Had the wrapper misread this initializer as
+    // promise-style, it would have settled during this turn - so anything still pending after
+    // the yield is pending because the wrapper is genuinely waiting on the callback.
     await Promise.resolve();
 
-    // The wrapper always supplies its own callback, so the default is shadowed.
+    // The wrapper always supplies its own callback, so the declared default is shadowed. This
+    // is the assertion that separates the two branches: on the promise branch the initializer
+    // would have been called with one argument and `done` would be the local `() => {}`, which
+    // is still "a function" - so the argument count, not `complete`, is what proves the fix.
     expect(receivedArgumentCount).to.equal(2);
     expect(complete).to.be.a('function');
 
-    // The returned promise must still be pending: the initializer has not called back yet.
-    // `settled` is sampled after a microtask turn, which is enough to catch a wrapper that
-    // resolved eagerly instead of waiting for the callback.
+    // Nothing has completed yet, so Sails' callback must not have fired.
+    expect(doneCallCount).to.equal(0);
+
+    // The returned promise must still be pending. `.then()` callbacks are themselves queued as
+    // microtasks, so `settled` cannot be read on the same turn it is registered - the second
+    // yield below is what gives an already-resolved promise the chance to set it. Without that
+    // yield the assertion would pass trivially and catch nothing.
     let settled = false;
     void initialization.then(() => {
       settled = true;
@@ -128,8 +160,9 @@ describe('defineRedboxHook', function () {
     // Completing the callback resolves the wrapper's promise and notifies the outer `done`.
     complete?.();
     await initialization;
+    expect(doneCallCount).to.equal(1);
 
-    // Completion is latched: a second call — even one reporting an error — is ignored, so a
+    // Completion is latched: a second call - even one reporting an error - is ignored, so a
     // sloppy initializer cannot re-enter Sails' callback or reject an already-settled hook.
     complete?.(new Error('ignored completion'));
     expect(doneCallCount).to.equal(1);
@@ -138,32 +171,55 @@ describe('defineRedboxHook', function () {
   it('waits for callback initializers with a rest parameter', async function () {
     // Regression case #2 for the removed arity sniffing: rest parameters are also excluded
     // from `Function.length`, so this initializer likewise reports an arity of 1 despite
-    // being callback style. The callback must still arrive, as `rest[0]`.
+    // being callback style.
+    //
+    // Where `rest[0]` comes from: the wrapper always calls the initializer as
+    // `initializer(sails, initializerDone)`. A rest parameter collects every argument after
+    // the declared ones into an array, so `sails` binds to `_sails` and everything after it -
+    // here just the wrapper's own callback - lands in `rest`. `rest[0]` is therefore the same
+    // `done` that the previous test received as a named parameter; the tuple type
+    // `[(error?: Error) => void]` is what tells TypeScript to expect exactly that one entry.
     let complete: (() => void) | undefined;
+    let receivedRestLength = -1;
     const initialize = getInitialize({
       initialize(_sails: Sails.Application, ...rest: [(error?: Error) => void]) {
+        receivedRestLength = rest.length;
         complete = rest[0];
       },
     });
 
-    // Note: no outer `done` here — the wrapper must supply its callback regardless of how it
-    // was itself invoked.
+    // Not yet run, so the assignment below can only come from the call that follows.
+    expect(complete).to.equal(undefined);
+
+    // Note: no outer `done` here - the wrapper must supply its callback to the initializer
+    // regardless of how the wrapper itself was invoked.
     const initialization = initialize();
+
+    // As in the previous test, one microtask turn. The initializer runs synchronously, but
+    // yielding here lets the wrapper's promise branch settle if it took it by mistake, so the
+    // state observed below is the state the wrapper really intends.
     await Promise.resolve();
 
+    // Exactly one trailing argument, and it is the completion callback - a promise-style
+    // invocation would have passed none and left `rest` empty.
+    expect(receivedRestLength).to.equal(1);
     expect(complete).to.be.a('function');
+
+    // Completing through `rest[0]` must settle the wrapper's promise. If the callback had not
+    // been wired through, this await would never resolve and mocha would time out - so
+    // reaching the end of the test is itself the assertion.
     complete?.();
-    // Awaiting would hang if the callback had not been wired through, so reaching the end of
-    // the test is the assertion.
     await initialization;
   });
 
   it('completes Sails callback consumers for Promise initializers', async function () {
     // The other direction: a promise-style initializer that never touches `done`. The
     // wrapper still has to call Sails' callback once the promise settles.
+    let initializerRan = false;
     const initialize = getInitialize({
       initialize: async function initializePromise() {
         await Promise.resolve();
+        initializerRan = true;
       },
     });
 
@@ -172,9 +228,12 @@ describe('defineRedboxHook', function () {
     // change how Sails drives initialization.
     expect(initialize.length).to.equal(1);
 
-    // Consume it purely through the callback contract — the promise result is ignored here.
+    // Consume it purely through the callback contract - the returned promise is ignored, the
+    // way a callback-based Sails consumer would.
+    let doneCallCount = 0;
     await new Promise<void>((resolve, reject) => {
       initialize(error => {
+        doneCallCount++;
         if (error) {
           reject(error);
         } else {
@@ -182,6 +241,10 @@ describe('defineRedboxHook', function () {
         }
       });
     });
+
+    // The callback fired after the initializer finished, exactly once and without an error.
+    expect(initializerRan).to.equal(true);
+    expect(doneCallCount).to.equal(1);
   });
 
   it('passes initializer errors to Sails callback consumers', async function () {

--- a/packages/redbox-core/test/hooks/defineRedboxHook.test.ts
+++ b/packages/redbox-core/test/hooks/defineRedboxHook.test.ts
@@ -1,0 +1,111 @@
+import { defineRedboxHook } from '../../src/hooks/defineRedboxHook';
+
+let expect: Chai.ExpectStatic;
+const testSails = {} as Sails.Application;
+
+function getInitialize(
+  options: Parameters<typeof defineRedboxHook>[0]
+): (done?: (error?: Error) => void) => Promise<void> {
+  const hook = defineRedboxHook(options)(testSails);
+  if (!hook.initialize) {
+    throw new Error('Expected hook initializer to be defined.');
+  }
+  return hook.initialize;
+}
+
+describe('defineRedboxHook', function () {
+  before(async function () {
+    const chai = await import('chai');
+    expect = chai.expect;
+  });
+
+  it('accepts and waits for callback-style initializers', async function () {
+    let initialized = false;
+    const initialize = getInitialize({
+      initialize(_sails, done) {
+        setImmediate(() => {
+          initialized = true;
+          done();
+        });
+      },
+    });
+
+    await initialize();
+
+    expect(initialized).to.equal(true);
+  });
+
+  it('waits for callback initializers with a default parameter', async function () {
+    let complete: (() => void) | undefined;
+    const initialize = getInitialize({
+      initialize(_sails: Sails.Application, done: (error?: Error) => void = () => {}) {
+        complete = done;
+      },
+    });
+
+    const initialization = initialize();
+    await Promise.resolve();
+
+    expect(complete).to.be.a('function');
+    let settled = false;
+    void initialization.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).to.equal(false);
+
+    complete?.();
+    await initialization;
+  });
+
+  it('waits for callback initializers with a rest parameter', async function () {
+    let complete: (() => void) | undefined;
+    const initialize = getInitialize({
+      initialize(_sails: Sails.Application, ...rest: [(error?: Error) => void]) {
+        complete = rest[0];
+      },
+    });
+
+    const initialization = initialize();
+    await Promise.resolve();
+
+    expect(complete).to.be.a('function');
+    complete?.();
+    await initialization;
+  });
+
+  it('completes Sails callback consumers for Promise initializers', async function () {
+    const initialize = getInitialize({
+      initialize: async function initializePromise() {
+        await Promise.resolve();
+      },
+    });
+
+    expect(initialize.length).to.equal(1);
+    await new Promise<void>((resolve, reject) => {
+      initialize(error => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  });
+
+  it('passes initializer errors to Sails callback consumers', async function () {
+    const error = new Error('initialization failed');
+    const initialize = getInitialize({
+      initialize: async function initializePromise() {
+        throw error;
+      },
+    });
+
+    await new Promise<void>(resolve => {
+      initialize(receivedError => {
+        expect(receivedError).to.equal(error);
+        resolve();
+      });
+    });
+  });
+});

--- a/packages/redbox-core/test/hooks/defineRedboxHook.test.ts
+++ b/packages/redbox-core/test/hooks/defineRedboxHook.test.ts
@@ -19,6 +19,18 @@ describe('defineRedboxHook', function () {
     expect = chai.expect;
   });
 
+  it('evaluates functional routes with the Sails application', function () {
+    const routes = {};
+    const hook = defineRedboxHook({
+      routes: (sails: Sails.Application) => {
+        expect(sails).to.equal(testSails);
+        return routes;
+      },
+    })(testSails);
+
+    expect(hook.routes).to.equal(routes);
+  });
+
   it('accepts and waits for callback-style initializers', async function () {
     let initialized = false;
     const initialize = getInitialize({
@@ -36,16 +48,23 @@ describe('defineRedboxHook', function () {
   });
 
   it('waits for callback initializers with a default parameter', async function () {
-    let complete: (() => void) | undefined;
+    let complete: ((error?: Error) => void) | undefined;
+    let receivedArgumentCount = 0;
     const initialize = getInitialize({
       initialize(_sails: Sails.Application, done: (error?: Error) => void = () => {}) {
+        // eslint-disable-next-line prefer-rest-params
+        receivedArgumentCount = arguments.length;
         complete = done;
       },
     });
 
-    const initialization = initialize();
+    let doneCallCount = 0;
+    const initialization = initialize(() => {
+      doneCallCount++;
+    });
     await Promise.resolve();
 
+    expect(receivedArgumentCount).to.equal(2);
     expect(complete).to.be.a('function');
     let settled = false;
     void initialization.then(() => {
@@ -56,6 +75,8 @@ describe('defineRedboxHook', function () {
 
     complete?.();
     await initialization;
+    complete?.(new Error('ignored completion'));
+    expect(doneCallCount).to.equal(1);
   });
 
   it('waits for callback initializers with a rest parameter', async function () {
@@ -101,11 +122,43 @@ describe('defineRedboxHook', function () {
       },
     });
 
-    await new Promise<void>(resolve => {
-      initialize(receivedError => {
-        expect(receivedError).to.equal(error);
-        resolve();
-      });
+    const receivedError = await new Promise<Error | undefined>(resolve => {
+      void initialize(resolve);
     });
+
+    expect(receivedError).to.equal(error);
+  });
+
+  it('rejects when a Promise initializer fails without a Sails callback', async function () {
+    const error = new Error('initialization failed');
+    const initialize = getInitialize({
+      initialize: async function initializePromise() {
+        throw error;
+      },
+    });
+
+    let receivedError: unknown;
+    try {
+      await initialize();
+    } catch (error) {
+      receivedError = error;
+    }
+
+    expect(receivedError).to.equal(error);
+  });
+
+  it('normalizes synchronous initializer errors for Sails callback consumers', async function () {
+    const initialize = getInitialize({
+      initialize() {
+        throw 'initialization failed';
+      },
+    });
+
+    const receivedError = await new Promise<Error | undefined>(resolve => {
+      void initialize(resolve);
+    });
+
+    expect(receivedError).to.be.instanceOf(Error);
+    expect(receivedError?.message).to.equal('initialization failed');
   });
 });


### PR DESCRIPTION
## Summary

Fixes modern async hook initialization in `redbox-core` so Sails loads hooks correctly whether the initializer uses the modern promise form or the traditional callback form.

Changes made:

* Hook initializers with callback signatures (including those using default or rest parameters) are now detected reliably and awaited until the `done` callback is invoked.
* The exposed `initialize` stays async while also completing the callback that Sails' callback-based consumers expect.
* Errors from both promise- and callback-style initializers are forwarded to Sails callback consumers.

## Context / related work

* The previous detection relied on `fn.length`, which reports a shorter parameter count for initializers that use default or rest parameters. Such initializers were misclassified as promise-based and never received the `done` callback, causing hooks to hang or never report completion.
* This builds on the modern async hook initialization added in an earlier commit on this branch.

## Technical implementation details

* `defineRedboxHook.ts` now sniffs the initializer's source parameter list (stripping comments and handling quoted strings/nested delimiters) to detect multi-parameter callback signatures when `fn.length` is ambiguous.
* The exposed hook wraps both forms: callback initializers run inside a promise that resolves on `done()` and rejects on error; promise initializers are awaited directly.
* Added test coverage for callback initializers, default/rest parameter detection, promise consumer completion, and error propagation.

## Testing

* Added `packages/redbox-core/test/hooks/defineRedboxHook.test.ts` with unit tests covering callback-style, default-parameter, rest-parameter, promise-consumer, and error-propagation cases.
* Existing `redbox-core` test suite should continue to pass.

## Future work

* None identified; the hook now supports both initialization conventions.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hook initialization now supports both Promise-based and callback-based workflows.
  * Initialization can optionally signal completion through a callback.
  * Initialization errors are consistently reported and propagated, including rejected Promises and synchronous failures.
  * Completion handling prevents duplicate callback notifications.

* **Tests**
  * Added comprehensive coverage for asynchronous initialization, callback handling, completion callbacks, route evaluation, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->