### PR TITLE
Bugfix: Render expression-driven value updates in rich text editor

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/rich-text-editor.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/rich-text-editor.component.spec.ts
@@ -222,6 +222,87 @@ describe("RichTextEditorComponent", () => {
     expect(richTextComponent.editor?.getHTML()).toContain("<p>Updated by formControl</p>");
   });
 
+  it("syncs the editor when an expression updates model.value with emitEvent false", async () => {
+    const formConfig: FormConfigFrame = {
+      name: "testing",
+      componentDefinitions: [{
+        name: "editableField",
+        component: { class: "RichTextEditorComponent" },
+        model: { class: "RichTextEditorModel", config: { value: "" } }
+      }]
+    };
+
+    const { fixture, formComponent } = await createFormAndWaitForReady(formConfig, editModeProps);
+    const richTextComponent = fixture.debugElement.query(By.directive(RichTextEditorComponent)).componentInstance as RichTextEditorComponent;
+    const control = formComponent.form?.controls["editableField"];
+    expect(control).toBeDefined();
+    if (!control) {
+      return;
+    }
+
+    // Expression-driven updates bypass valueChanges, then the framework calls syncDisplayFromModel.
+    control.setValue("<p>Archival data record created for v5 verification.</p>", { emitEvent: false });
+    await richTextComponent.syncDisplayFromModel();
+    await fixture.whenStable();
+
+    expect(richTextComponent.editor?.getHTML()).toContain("Archival data record created for v5 verification.");
+  });
+
+  it("does not write back to the formControl when syncing display from the model", async () => {
+    const formConfig: FormConfigFrame = {
+      name: "testing",
+      componentDefinitions: [{
+        name: "editableField",
+        component: { class: "RichTextEditorComponent" },
+        model: { class: "RichTextEditorModel", config: { value: "<p>Before</p>" } }
+      }]
+    };
+
+    const { fixture, formComponent } = await createFormAndWaitForReady(formConfig, editModeProps);
+    const richTextComponent = fixture.debugElement.query(By.directive(RichTextEditorComponent)).componentInstance as RichTextEditorComponent;
+    const control = formComponent.form?.controls["editableField"];
+    expect(control).toBeDefined();
+    if (!control) {
+      return;
+    }
+    control.setValue("<p>Set by expression</p>", { emitEvent: false });
+    const setValueSpy = spyOn(control, "setValue").and.callThrough();
+
+    await richTextComponent.syncDisplayFromModel();
+    await fixture.whenStable();
+
+    expect(setValueSpy.calls.count()).toBe(0);
+    expect(control.value).toContain("<p>Set by expression</p>");
+  });
+
+  it("syncs the readonly view when an expression updates model.value with emitEvent false", async () => {
+    const formConfig: FormConfigFrame = {
+      name: "testing",
+      componentDefinitions: [{
+        name: "syncField",
+        component: {
+          class: "RichTextEditorComponent",
+          config: {
+            readonly: true,
+            outputFormat: "html"
+          }
+        },
+        model: { class: "RichTextEditorModel", config: { value: "<p>Before</p>" } }
+      }]
+    };
+
+    const { fixture, formComponent } = await createFormAndWaitForReady(formConfig);
+    const richTextComponent = fixture.debugElement.query(By.directive(RichTextEditorComponent)).componentInstance as RichTextEditorComponent;
+    (formComponent as any).form.controls.syncField.setValue("<p>Set by expression</p>", { emitEvent: false });
+    await richTextComponent.syncDisplayFromModel();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const content = (compiled.querySelector(".redbox-rich-text-view") as HTMLElement)?.innerHTML ?? "";
+    expect(content).toContain("<p>Set by expression</p>");
+  });
+
   it("prevents value sync loops between editor and formControl", async () => {
     const formConfig: FormConfigFrame = {
       name: "testing",

--- a/angular/projects/researchdatabox/form/src/app/component/rich-text-editor.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/rich-text-editor.component.ts
@@ -197,21 +197,48 @@ export class RichTextEditorComponent extends FormFieldBaseComponent<string> impl
     this.valueSyncSub?.unsubscribe();
     this.valueSyncSub = this.formControl.valueChanges.subscribe((value) => {
       const nextValue = value ?? "";
-      this.sourceValue = nextValue;
-      this.renderedViewHtml = this.toViewHtml(nextValue);
-      if (!this.editor) {
-        return;
-      }
+      this.applyViewValue(nextValue);
       if (this.skipNextSync) {
+        // This change originated from the editor itself, so pushing it back would loop.
         this.skipNextSync = false;
         return;
       }
-      if (nextValue === this.getEditorValue(this.editor)) {
-        return;
-      }
-      this.skipNextSync = true;
-      this.setEditorValue(nextValue);
+      this.applyEditorValue(nextValue);
     });
+  }
+
+  /**
+   * Invoked by the framework after expression-driven `model.value` updates,
+   * which use emitEvent:false and therefore bypass the valueChanges subscription.
+   *
+   * Without this, a "populate from related record" expression updates the model
+   * but leaves the editor rendering its stale (usually empty) document.
+   */
+  public async syncDisplayFromModel(): Promise<void> {
+    const control = this.model?.formControl;
+    if (!control) {
+      return;
+    }
+    const nextValue = control.value ?? "";
+    this.applyViewValue(nextValue);
+    this.applyEditorValue(nextValue);
+  }
+
+  private applyViewValue(value: string): void {
+    this.sourceValue = value;
+    this.renderedViewHtml = this.toViewHtml(value);
+  }
+
+  private applyEditorValue(value: string): void {
+    if (!this.editor) {
+      return;
+    }
+    if (value === this.getEditorValue(this.editor)) {
+      return;
+    }
+    // Guard the onUpdate handler that setContent triggers from writing back to the control.
+    this.skipNextSync = true;
+    this.setEditorValue(value);
   }
 
   public override setDisabled(disabled: boolean, opts?: ModifyOptions): void {


### PR DESCRIPTION
## Summary

`RichTextEditorComponent` did not react to `model.value` updates applied by form expressions. On the Data Publication form, selecting a related Data Record populated the description in the model and saved it correctly, but the editor kept rendering an empty document, so the user saw a blank required field holding inherited text.

## Context / related work

This is stacked on [redbox-mint/redbox-portal#4391](https://github.com/redbox-mint/redbox-portal/pull/4391), which made option input config properties reactive to updates.

## Technical implementation details

- The component already subscribed to `formControl.valueChanges`, but expression targets of `model.value` are applied with `emitEvent: false` and instead rely on the framework calling `syncDisplayFromModel()`, which the component did not implement. `SimpleInputComponent` and `DropdownInputComponent` are unaffected because they are ControlValueAccessors, so Angular still calls `writeValue()` under `emitEvent: false`.
- Implement `syncDisplayFromModel()` so the component participates in the existing custom display sync contract, alongside `CheckboxTreeComponent` and `TypeaheadInputComponent`.
- Factor value application into `applyViewValue()` and `applyEditorValue()`, shared with the `valueChanges` subscription, so both entry points behave identically and the existing `setContent` to `onUpdate` write-back guard still prevents feedback loops.
- The readonly view and the raw source textarea had the same gap and are covered by the same change.

## Testing

- `ng test @researchdatabox/form --watch=false --browsers=ChromeHeadless`
- Result: 783 tests passed.
- Verified the new specs fail without the fix, reproducing the reported symptom (`Expected '<p></p>' to contain 'Archival data record created for v5 verification.'`).

## Future work

None.
