### PR TITLE
Bugfix: Keep typeahead search input disabled with its model control

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.spec.ts
@@ -559,6 +559,193 @@ describe("TypeaheadInputComponent", () => {
         expect((formComponent as any).form.get("person_lookup")?.disabled).toBeFalse();
     });
 
+    it("honours a field.disabled gate expression applied on form ready", async () => {
+        const formConfig: FormConfigFrame = {
+            name: "testing",
+            componentDefinitions: [
+                {
+                    name: "dataRecord",
+                    component: { class: "SimpleInputComponent", config: { type: "text" } },
+                    model: { class: "SimpleInputModel", config: { value: "" } }
+                },
+                {
+                    name: "person_lookup",
+                    expressions: [
+                        {
+                            name: "gate-on-data-record",
+                            config: {
+                                conditionKind: "jsonpointer",
+                                condition: "/dataRecord::field.value.changed",
+                                target: "field.disabled",
+                                hasTemplate: true,
+                                template: "event.value ? false : true",
+                                runOnFormReady: true
+                            }
+                        }
+                    ],
+                    component: {
+                        class: "TypeaheadInputComponent",
+                        config: {
+                            sourceType: "static",
+                            staticOptions: [{ label: "Jane Doe", value: "jane" }]
+                        }
+                    },
+                    model: { class: "TypeaheadInputModel", config: {} }
+                },
+                {
+                    name: "gated_text",
+                    expressions: [
+                        {
+                            name: "gate-on-data-record",
+                            config: {
+                                conditionKind: "jsonpointer",
+                                condition: "/dataRecord::field.value.changed",
+                                target: "field.disabled",
+                                hasTemplate: true,
+                                template: "event.value ? false : true",
+                                runOnFormReady: true
+                            }
+                        }
+                    ],
+                    component: { class: "SimpleInputComponent", config: { type: "text" } },
+                    model: { class: "SimpleInputModel", config: { value: "" } }
+                }
+            ]
+        };
+
+        // 'event.value ? false : true' compiled server-side, mocked here.
+        const dynamicAssetOptions: DynamicAssetOptions = {
+            entries: [{
+                urlKeyStart: "http://localhost/default/rdmp/dynamicAsset/formCompiledItems/rdmp",
+                callable: function (keyStr: string, key: (string | number)[], context: any) {
+                    return context?.event?.value ? false : true;
+                }
+            }]
+        };
+
+        const { fixture, formComponent } = await createFormAndWaitForReady(formConfig, undefined, undefined, dynamicAssetOptions);
+        const component = fixture.debugElement.query(By.directive(TypeaheadInputComponent)).componentInstance as TypeaheadInputComponent;
+        const input = fixture.nativeElement.querySelectorAll("input")[1] as HTMLInputElement;
+        const simpleInputs = fixture.debugElement.queryAll(By.directive(SimpleInputComponent));
+        const gated = simpleInputs[simpleInputs.length - 1].componentInstance as SimpleInputComponent;
+
+        // Selecting a data record lifts the gate, clearing it re-applies it.
+        (formComponent as any).form.controls.dataRecord.setValue("record-1");
+        await fixture.whenStable();
+        fixture.detectChanges();
+        expect((gated as any).isDisabled).toBeFalse();
+        expect(component.isDisabled).toBeFalse();
+        expect(component.displayControl.disabled).toBeFalse();
+
+        (formComponent as any).form.controls.dataRecord.setValue("");
+        await fixture.whenStable();
+        fixture.detectChanges();
+        // The typeahead must gate in step with the plain input control field.
+        expect((gated as any).isDisabled).toBeTrue();
+        expect(component.isDisabled).toBeTrue();
+        expect(component.displayControl.disabled).toBeTrue();
+        expect(input.disabled).toBeTrue();
+    });
+
+    it("honours a field.disabled gate expression when nested inside a repeatable", async () => {
+        const formConfig: FormConfigFrame = {
+            name: "testing",
+            componentDefinitions: [
+                {
+                    name: "dataRecord",
+                    component: { class: "SimpleInputComponent", config: { type: "text" } },
+                    model: { class: "SimpleInputModel", config: { value: "" } }
+                },
+                {
+                    name: "grants",
+                    component: {
+                        class: "RepeatableComponent",
+                        config: {
+                            elementTemplate: {
+                                name: "",
+                                component: {
+                                    class: "GroupComponent",
+                                    config: {
+                                        componentDefinitions: [
+                                            {
+                                                name: "grant_lookup",
+                                                expressions: [
+                                                    {
+                                                        name: "gate-on-data-record",
+                                                        config: {
+                                                            conditionKind: "jsonpointer",
+                                                            condition: "/dataRecord::field.value.changed",
+                                                            target: "field.disabled",
+                                                            hasTemplate: true,
+                                                            template: "event.value ? false : true",
+                                                            runOnFormReady: true
+                                                        }
+                                                    }
+                                                ],
+                                                component: {
+                                                    class: "TypeaheadInputComponent",
+                                                    config: {
+                                                        sourceType: "static",
+                                                        staticOptions: [{ label: "Jane Doe", value: "jane" }]
+                                                    }
+                                                },
+                                                model: { class: "TypeaheadInputModel" },
+                                                layout: { class: "InlineLayout", config: {} }
+                                            }
+                                        ]
+                                    }
+                                },
+                                model: { class: "GroupModel" },
+                                layout: { class: "RepeatableElementLayout" }
+                            }
+                        }
+                    },
+                    layout: { class: "DefaultLayout", config: {} },
+                    model: { class: "RepeatableModel", config: { value: [{ grant_lookup: null }] } }
+                }
+            ]
+        };
+
+        const dynamicAssetOptions: DynamicAssetOptions = {
+            entries: [{
+                urlKeyStart: "http://localhost/default/rdmp/dynamicAsset/formCompiledItems/rdmp",
+                callable: function (keyStr: string, key: (string | number)[], context: any) {
+                    // 'event.value ? false : true'
+                    return context?.event?.value ? false : true;
+                }
+            }]
+        };
+
+        const { fixture, formComponent } = await createFormAndWaitForReady(formConfig, undefined, undefined, dynamicAssetOptions);
+        const component = fixture.debugElement.query(By.directive(TypeaheadInputComponent)).componentInstance as TypeaheadInputComponent;
+
+        (formComponent as any).form.controls.dataRecord.setValue("record-1");
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        (formComponent as any).form.controls.dataRecord.setValue("");
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        expect(component.isDisabled).toBeTrue();
+        expect(component.displayControl.disabled).toBeTrue();
+
+        // A row added while the gate is applied must also come up disabled.
+        const repeatable = fixture.debugElement.query(By.directive(RepeatableComponent)).componentInstance as RepeatableComponent;
+        await (repeatable as any).appendNewElement();
+        await fixture.whenStable();
+        fixture.detectChanges();
+        const allTypeaheads = fixture.debugElement.queryAll(By.directive(TypeaheadInputComponent));
+        const added = allTypeaheads[allTypeaheads.length - 1].componentInstance as TypeaheadInputComponent;
+        expect(added.isDisabled).toBeTrue();
+        expect(added.displayControl.disabled).toBeTrue();
+        const addedInput = fixture.nativeElement.querySelectorAll("input")[allTypeaheads.length] as HTMLInputElement;
+        expect(addedInput?.disabled).toBeTrue();
+
+        expect(component.isDisabled).toBeTrue();
+        expect(component.displayControl.disabled).toBeTrue();
+    });
+
     it("shows misconfiguration message when named query source lacks queryId", async () => {
         const formConfig: FormConfigFrame = {
             name: "testing",

--- a/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.ts
@@ -127,6 +127,7 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
   private programmaticDisplayUpdate = false;
   private lastConfirmedDisplayValue = '';
   private modelSubscriptionInitialised = false;
+  private modelDisabledSubscriptionInitialised = false;
   private autoDisplaySyncInFlight: boolean = false;
   private lastAutoDisplaySyncSignature = '';
   private labelTemplate = '';
@@ -189,6 +190,7 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
 
     this.applyInitialDisplayFromModel();
     this.bindModelValueSync();
+    this.bindModelDisabledSync();
     this.displayControl.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(value => {
       if (this.programmaticDisplayUpdate) {
         return;
@@ -441,6 +443,38 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
     this.formControl.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       void this.syncDisplayFromModel();
     });
+  }
+
+  /**
+   * Keep the display control's disabled state in step with the model control.
+   *
+   * setDisabled() only runs when something explicitly toggles this component, but the
+   * model control can also be disabled by its parent: a repeatable row added while a
+   * `field.disabled` gate is applied inherits the disabled state from the parent form
+   * array after this component has initialised. Without this sync the model control is
+   * disabled while the search input stays editable, letting a user type into a gated field.
+   */
+  private bindModelDisabledSync(): void {
+    if (this.modelDisabledSubscriptionInitialised || !this.formControl) {
+      return;
+    }
+    this.modelDisabledSubscriptionInitialised = true;
+    this.syncDisplayControlDisabled();
+    this.formControl.statusChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+      this.syncDisplayControlDisabled();
+    });
+  }
+
+  private syncDisplayControlDisabled(): void {
+    const shouldDisable = this.isDisabled;
+    if (shouldDisable === this.displayControl.disabled) {
+      return;
+    }
+    if (shouldDisable) {
+      this.displayControl.disable({ emitEvent: false, onlySelf: true });
+    } else {
+      this.displayControl.enable({ emitEvent: false, onlySelf: true });
+    }
   }
 
   private async syncDisplayFromModel(): Promise<void> {


### PR DESCRIPTION
## Summary

A `TypeaheadInputComponent` inside a repeatable could report itself as disabled while its search input stayed editable, letting a user type into a field that a `field.disabled` gate had disabled. On the Data Publication form this let contributor names be entered before a Data Record was selected, defeating a data-integrity gate.

## Context / related work

This is stacked on [redbox-mint/redbox-portal#4415](https://github.com/redbox-mint/redbox-portal/pull/4415), which fixed expression-driven value updates in the rich text editor.

## Technical implementation details

- `TypeaheadInputComponent` does honour `field.disabled`: it overrides `setDisabled()` to mirror the state onto its secondary `displayControl`. That path was verified end-to-end, flat and nested in a repeatable, in both directions.
- The gap is a repeatable row created while a gate is already applied. The row is cloned from the pristine element template, so its component config carries no `disabled` flag and init never calls `setDisabled()`. The model control is only disabled afterwards, when it is attached to the already-disabled parent form array, leaving `displayControl` untouched.
- This is specific to this component because it renders its search box against a secondary control. Other input components bind `[formControl]` to the model control, which Angular disables automatically.
- Add `bindModelDisabledSync()` to sync `displayControl` from the model control on init and on subsequent status changes.

## Testing

- `ng test @researchdatabox/form --watch=false --browsers=ChromeHeadless`
- Result: 785 tests passed.
- New specs cover the gate applied by expression, the same gate nested inside a repeatable, and a row added while the gate is applied. The last fails without the fix.

## Future work

A conformance test asserting every input component honours the standard expression targets would catch this class of gap generally. That needs more test infrastructure than this fix and is better scoped separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Typeahead fields now correctly reflect disabled states defined by form rules.
  * Disabled and enabled states stay synchronized with related inputs, including repeated form rows and newly added elements.
  * State changes no longer trigger unintended value updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->