### PR TITLE
Bugfix: Resolve translation codes in form config default values

### DIFF
--- a/packages/redbox-core/src/services/FormsService.ts
+++ b/packages/redbox-core/src/services/FormsService.ts
@@ -594,6 +594,29 @@ export namespace Services {
     }
 
     /**
+     * Build the translation lookup used to resolve form config default values.
+     *
+     * Returns undefined when the translation service is not available, so the form
+     * config values are left as they are rather than failing to build the form.
+     *
+     * @param branding The branding name.
+     */
+    private buildFormConfigTranslator(branding?: string): ((key: string) => string) | undefined {
+      if (typeof TranslationService === 'undefined' || typeof TranslationService?.t !== 'function') {
+        return undefined;
+      }
+      const brandingName = branding || 'default';
+      return (key: string): string => {
+        try {
+          return String(TranslationService.t(key, undefined, 'en', brandingName) ?? key);
+        } catch (error) {
+          this.logger.warn(`Failed to translate form config value '${key}': ${(error as Error)?.message}`);
+          return key;
+        }
+      };
+    }
+
+    /**
      * Convert a server-side form config to a client-side form config.
      *
      * @param item The source item.
@@ -613,7 +636,10 @@ export namespace Services {
       recordAccessContext?: RecordAccessContext
     ): Promise<FormConfigOutline> {
       const constructor = new ConstructFormConfigVisitor(this.logger);
-      const constructed = await constructor.start({ data: item, reusableFormDefs, formMode, record: recordMetadata });
+      const constructed = await constructor.start({
+        data: item, reusableFormDefs, formMode, record: recordMetadata,
+        translate: this.buildFormConfigTranslator(branding),
+      });
       const vocabVisitor = new VocabInlineFormConfigVisitor(this.logger);
       await vocabVisitor.resolveVocabs(constructed, branding, {
         includeHistoricalValues: recordMetadata !== null && recordMetadata !== undefined

--- a/packages/redbox-core/src/visitor/construct.visitor.ts
+++ b/packages/redbox-core/src/visitor/construct.visitor.ts
@@ -1,5 +1,5 @@
 import { cloneDeep as _cloneDeep, get as _get, mergeWith as _mergeWith, set as _set } from 'lodash';
-import { FormConfig, ValidatorsSupport } from '@researchdatabox/sails-ng-common';
+import { FormConfig, isLikelyNaturalLanguage, ValidatorsSupport } from '@researchdatabox/sails-ng-common';
 
 import { FormConfigVisitor } from '@researchdatabox/sails-ng-common';
 import { FormConfigFrame, FormConfigOutline } from '@researchdatabox/sails-ng-common';
@@ -391,6 +391,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
   private recordValues: Record<string, unknown> | null;
   private removeOverrides: boolean;
   private extractedDefaultValues: Record<string, unknown>;
+  private translate?: (key: string) => string;
 
   private mostRecentRepeatableElementTemplatePath: LineagePath | null;
 
@@ -435,6 +436,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
    * @param options.formMode The currently active form mode. Defaults to 'view'.
    * @param options.record The record metadata values. Set to undefined or null to use the form default values.
    * @param options.removeOverrides True to remove all overrides, false to retain the overrides that the client visitor might use.
+   * @param options.translate Resolve a translation code to text, used for form config default values.
    */
   async start(options: {
     data: FormConfigFrame;
@@ -442,10 +444,12 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
     formMode?: FormModesConfig;
     record?: Record<string, unknown> | null;
     removeOverrides?: boolean;
+    translate?: (key: string) => string;
   }): Promise<FormConfigOutline> {
     this.data = _cloneDeep(options.data);
     this.reusableFormDefs = options.reusableFormDefs ?? {};
     this.formMode = options.formMode ?? 'view';
+    this.translate = options.translate;
 
     // When options.record is null or undefined, use the form defaults. Otherwise, use recordValues only.
     // This allows for specifying an empty record '{}' and using that instead of the defaults.
@@ -2408,7 +2412,9 @@ this.mostRecentRepeatableElementTemplatePath !== null ||
 
     // Set the model.config.value or new item value
     if (isElementTemplate) {
-      item.config.newEntryValue = config?.newEntryValue;
+      // newEntryValue is the elementTemplate's equivalent of defaultValue, so it is
+      // authored in the form config and needs the same translation code resolution.
+      item.config.newEntryValue = this.translateConfigDefault(config?.newEntryValue);
     } else if (!isElementTemplateDescendant) {
       // NOTE: It is useless to set the model.config.value on an elementTemplate or a descendant component.
       // The top-most repeatable must have either:
@@ -2448,7 +2454,40 @@ this.mostRecentRepeatableElementTemplatePath !== null ||
    */
   protected currentDefaultValue(itemDefaultValue?: unknown) {
     const dataModelPath = this.formPathHelper.formPath.dataModel;
-    return _cloneDeep(_get(this.extractedDefaultValues, dataModelPath, itemDefaultValue));
+    const value = _cloneDeep(_get(this.extractedDefaultValues, dataModelPath, itemDefaultValue));
+    return this.translateConfigDefault(value);
+  }
+
+  /**
+   * Resolve translation codes in a form config default value.
+   *
+   * Default values are authored in the form config, so a value such as
+   * '@dataPublication-citation-publisher-default' is a translation code rather than
+   * literal text. Labels are resolved by the client i18next pipe, but a default value
+   * becomes record metadata, so leaving it unresolved persists the raw code. Strings
+   * that look like natural language are left untouched, and an unknown code resolves
+   * to itself, so this is a no-op unless the value really is a translation code.
+   *
+   * @param value The default value from the form config.
+   * @protected
+   */
+  protected translateConfigDefault(value: unknown): unknown {
+    if (!this.translate) {
+      return value;
+    }
+    if (typeof value === 'string') {
+      return isLikelyNaturalLanguage(value) ? value : this.translate(value);
+    }
+    if (Array.isArray(value)) {
+      return value.map(entry => this.translateConfigDefault(entry));
+    }
+    // Only walk plain objects, so class instances and dates are left as they are.
+    if (value !== null && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype) {
+      return Object.fromEntries(
+        Object.entries(value as Record<string, unknown>).map(([key, entry]) => [key, this.translateConfigDefault(entry)])
+      );
+    }
+    return value;
   }
 
   /**

--- a/packages/redbox-core/test/visitor/construct-default-value-translation.test.ts
+++ b/packages/redbox-core/test/visitor/construct-default-value-translation.test.ts
@@ -1,0 +1,155 @@
+let expect: Chai.ExpectStatic;
+import('chai').then(mod => expect = mod.expect);
+import { FormConfigFrame } from '@researchdatabox/sails-ng-common';
+import type { ILogger } from '../../src/Logger';
+import { ConstructFormConfigVisitor } from '../../src/visitor/construct.visitor';
+
+describe('ConstructFormConfigVisitor default value translation', () => {
+  const logger: ILogger = {
+    silly: () => undefined,
+    verbose: () => undefined,
+    trace: () => undefined,
+    debug: () => undefined,
+    log: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    crit: () => undefined,
+    fatal: () => undefined,
+    silent: () => undefined,
+    blank: () => undefined,
+  };
+
+  const translations: Record<string, string> = {
+    '@dataPublication-citation-publisher-default': 'Western Sydney University',
+    '@dataPublication-accessRights-prefLabel-default': 'Copyright Western Sydney University',
+    '@grant-name-default': 'Default grant name',
+  };
+  // i18next returns the key itself when the key is unknown.
+  const translate = (key: string): string => translations[key] ?? key;
+
+  function buildForm(): FormConfigFrame {
+    return {
+      name: 'test',
+      componentDefinitions: [
+        {
+          name: 'publisher',
+          component: { class: 'SimpleInputComponent', config: {} },
+          model: {
+            class: 'SimpleInputModel',
+            config: { defaultValue: '@dataPublication-citation-publisher-default' }
+          }
+        },
+        {
+          name: 'accessRights',
+          component: { class: 'TextAreaComponent', config: { rows: 3, cols: 40 } },
+          model: {
+            class: 'TextAreaModel',
+            config: { defaultValue: '@dataPublication-accessRights-prefLabel-default' }
+          }
+        },
+        {
+          name: 'naturalLanguageDefault',
+          component: { class: 'SimpleInputComponent', config: {} },
+          model: {
+            class: 'SimpleInputModel',
+            config: { defaultValue: 'Some literal default text' }
+          }
+        },
+        {
+          name: 'unknownCodeDefault',
+          component: { class: 'SimpleInputComponent', config: {} },
+          model: {
+            class: 'SimpleInputModel',
+            config: { defaultValue: '@no-such-translation-key' }
+          }
+        },
+        {
+          name: 'objectDefault',
+          component: { class: 'GroupComponent', config: { componentDefinitions: [] } },
+          model: {
+            class: 'GroupModel',
+            config: {
+              defaultValue: {
+                publisher: '@dataPublication-citation-publisher-default',
+                nested: { rights: '@dataPublication-accessRights-prefLabel-default' }
+              }
+            }
+          }
+        }
+      ]
+    };
+  }
+
+  it('resolves translation codes used as model default values', async () => {
+    const constructor = new ConstructFormConfigVisitor(logger as any);
+    const constructed = await constructor.start({ data: buildForm(), formMode: 'edit', translate });
+
+    const valueAt = (index: number) =>
+      (constructed.componentDefinitions?.[index] as { model?: { config?: { value?: unknown } } })?.model?.config?.value;
+
+    expect(valueAt(0)).to.equal('Western Sydney University');
+    expect(valueAt(1)).to.equal('Copyright Western Sydney University');
+    // Natural language defaults must be left exactly as authored.
+    expect(valueAt(2)).to.equal('Some literal default text');
+    // An unknown code resolves to itself rather than becoming empty.
+    expect(valueAt(3)).to.equal('@no-such-translation-key');
+    expect(valueAt(4)).to.deep.equal({
+      publisher: 'Western Sydney University',
+      nested: { rights: 'Copyright Western Sydney University' }
+    });
+  });
+
+  it('leaves default values untouched when no translator is supplied', async () => {
+    const constructor = new ConstructFormConfigVisitor(logger as any);
+    const constructed = await constructor.start({ data: buildForm(), formMode: 'edit' });
+
+    const publisher = (constructed.componentDefinitions?.[0] as { model?: { config?: { value?: unknown } } })?.model?.config?.value;
+    expect(publisher).to.equal('@dataPublication-citation-publisher-default');
+  });
+
+  it('does not translate record values, only form config defaults', async () => {
+    const constructor = new ConstructFormConfigVisitor(logger as any);
+    const constructed = await constructor.start({
+      data: buildForm(),
+      formMode: 'edit',
+      // A record holding text that looks like a code must be preserved verbatim.
+      record: { publisher: '@dataPublication-citation-publisher-default' },
+      translate,
+    });
+
+    const publisher = (constructed.componentDefinitions?.[0] as { model?: { config?: { value?: unknown } } })?.model?.config?.value;
+    expect(publisher).to.equal('@dataPublication-citation-publisher-default');
+  });
+
+  it('resolves translation codes in a repeatable elementTemplate newEntryValue', async () => {
+    const input: FormConfigFrame = {
+      name: 'test',
+      componentDefinitions: [
+        {
+          name: 'grants',
+          component: {
+            class: 'RepeatableComponent',
+            config: {
+              elementTemplate: {
+                name: '',
+                component: { class: 'SimpleInputComponent', config: {} },
+                model: { class: 'SimpleInputModel', config: { newEntryValue: '@grant-name-default' } },
+                layout: { class: 'RepeatableElementLayout' }
+              }
+            }
+          },
+          model: { class: 'RepeatableModel', config: {} }
+        }
+      ]
+    };
+
+    const constructor = new ConstructFormConfigVisitor(logger as any);
+    const constructed = await constructor.start({ data: input, formMode: 'edit', translate });
+
+    const repeatable = constructed.componentDefinitions?.[0] as {
+      component?: { config?: { elementTemplate?: { model?: { config?: { newEntryValue?: unknown } } } } };
+    };
+    expect(repeatable.component?.config?.elementTemplate?.model?.config?.newEntryValue).to.equal('Default grant name');
+  });
+});


### PR DESCRIPTION
## Summary

A model `defaultValue` such as `@dataPublication-citation-publisher-default` was copied verbatim into `model.config.value`, so the form opened with the raw translation code shown as the field value and saving persisted that code as record metadata. On the Data Publication form this affected two required fields on the primary publication workflow.

## Context / related work

This is stacked on [redbox-mint/redbox-portal#4416](https://github.com/redbox-mint/redbox-portal/pull/4416), which fixed the typeahead search input disabled state.

## Technical implementation details

- Labels avoid this because the client i18next pipe resolves them at render time. A default value is data rather than a label, so it is never piped.
- The fix cannot go client-side: the construct visitor merges `defaultValue` into `value` and deletes it, so by the time the client sees the config a default is indistinguishable from record data.
- Apply resolution in `currentDefaultValue()`, the single accessor for defaults and the last point where that distinction still exists, gated on the existing `isLikelyNaturalLanguage()` helper.
- Inject the translator from `FormsService`, branding-aware, and leave it undefined when the translation service is unavailable so form building never fails on it. Because i18next returns the key for unknown keys, this is a no-op unless the value really is a translation code.
- Record values are untouched, and this is covered by a test.
- Repeatable elementTemplate `newEntryValue` gets the same treatment, being the elementTemplate equivalent of `defaultValue` and having the identical failure mode.

## Testing

- `npm test` in `packages/redbox-core`
- Result: 1757 tests passed, 14 pending.
- Verified both behaviour specs fail without the fix, resolving to the raw code rather than the translated text.

## Future work

Server-side translation uses `en`, matching every other server-side `TranslationService.t` call. No request language is plumbed through `buildClientFormConfig`; adding that would be a separate change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Form default values can now be translated based on the selected branding and English locale.
  - Translation support includes nested values, repeatable entries, and unknown keys with graceful fallbacks.
  - Literal text and values without translation support remain unchanged.

- **Bug Fixes**
  - Improved handling of translated defaults when translations are unavailable or incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->