### PR TITLE
Bugfix: cap and stabilise saved-feature map fitting

### DIFF
--- a/angular/projects/researchdatabox/form/karma.conf.js
+++ b/angular/projects/researchdatabox/form/karma.conf.js
@@ -20,6 +20,9 @@ module.exports = function (config) {
         // the possible options are listed at https://jasmine.github.io/api/edge/Configuration.html
         // for example, you can disable the random execution with `random: false`
         // or set a specific seed with `seed: 4321`
+        // Keep CI ordering deterministic so leaked browser activity cannot make the suite
+        // intermittently stall after all specs have reported success.
+        random: !isCI,
       },
       clearContext: false // leave Jasmine Spec Runner output visible in browser
     },

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
@@ -918,7 +918,7 @@ describe("MapComponent", () => {
     expect(fakeView.fit).toHaveBeenCalledWith([0, 0, 1, 1], {padding: [24, 24, 24, 24], maxZoom: 18});
   });
 
-  it("loads pre-existing features into draw state and invalidates map size", async () => {
+  it("rounds pre-existing coordinates to the configured draw precision", async () => {
     const formConfig: FormConfigFrame = {
       name: "testing",
       componentDefinitions: [
@@ -927,7 +927,8 @@ describe("MapComponent", () => {
           component: {
             class: "MapComponent",
             config: {
-              enableImport: true
+              enableImport: true,
+              coordinatePrecision: 9
             }
           },
           model: {
@@ -938,13 +939,13 @@ describe("MapComponent", () => {
                 features: [
                   {
                     type: "Feature",
-                    geometry: {type: "Point", coordinates: [144.96, -37.81]},
+                    geometry: {type: "Point", coordinates: [144.9600000004, -37.8100000004]},
                     properties: {name: "Melbourne"}
                   },
                   // Should allow string coordinates.
                   {
                     type: "Feature",
-                    geometry: {type: "Point", coordinates: ["145.935234375", "-22.625184301"]},
+                    geometry: {type: "Point", coordinates: ["145.9352343759", "-22.6251843014"]},
                     properties: {}
                   },
                   // Should only include coordinates that are numbers or non-empty strings.
@@ -997,7 +998,7 @@ describe("MapComponent", () => {
       jasmine.objectContaining({
         id: jasmine.stringMatching(uuidV4Pattern),
         type: "Feature",
-        geometry: {type: "Point", coordinates: [145.935234375, -22.625184301]},
+        geometry: {type: "Point", coordinates: [145.935234376, -22.625184301]},
         properties: jasmine.objectContaining({mode: "point"})
       })
     ]);

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
@@ -825,7 +825,7 @@ describe("MapComponent", () => {
       ]
     };
 
-    const {formComponent} = await createFormAndWaitForReady(formConfig, {editMode: false} as any);
+    const {fixture, formComponent} = await createFormAndWaitForReady(formConfig, {editMode: false} as any);
     const mapComponent = formComponent.getComponentDefByName("map_coverage")?.component as MapComponent;
     fakeView.fit.calls.reset();
     (mapComponent as any).pendingFitSize = undefined;
@@ -842,6 +842,7 @@ describe("MapComponent", () => {
       expect(fakeView.fit).toHaveBeenCalledWith([0, 0, 1, 1], {padding: [12, 12, 12, 12], maxZoom: 18});
     } finally {
       jasmine.clock().uninstall();
+      fixture.destroy();
     }
   });
 
@@ -937,13 +938,17 @@ describe("MapComponent", () => {
       ]
     };
 
-    const {formComponent} = await createFormAndWaitForReady(formConfig, {editMode: false} as any);
+    const {fixture, formComponent} = await createFormAndWaitForReady(formConfig, {editMode: false} as any);
     const mapComponent = formComponent.getComponentDefByName("map_coverage")?.component as MapComponent;
     fakeView.fit.and.throwError("fit failed");
 
-    expect(() => (mapComponent as any).fitToLayerBounds()).not.toThrow();
-    expect((mapComponent as any).fitToLayerBounds()).toBeTrue();
-    expect(mapComponent.mapError).toContain("Saved map features could not be displayed.");
+    try {
+      expect(() => (mapComponent as any).fitToLayerBounds()).not.toThrow();
+      expect((mapComponent as any).fitToLayerBounds()).toBeTrue();
+      expect(mapComponent.mapError).toContain("Saved map features could not be displayed.");
+    } finally {
+      fixture.destroy();
+    }
   });
 
   it("defers collection fitting until the map surface has a size", async () => {

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
@@ -874,6 +874,50 @@ describe("MapComponent", () => {
     expect(fakeView.fit).toHaveBeenCalledWith([0, 0, 1, 1], {padding: [24, 24, 24, 24], maxZoom: 18});
   });
 
+  it("re-arms fitting after a retry budget exhausted during a nonzero resize", async () => {
+    const formConfig: FormConfigFrame = {
+      name: "testing",
+      componentDefinitions: [
+        {
+          name: "map_coverage",
+          component: {
+            class: "MapComponent",
+            config: {}
+          },
+          model: {
+            class: "MapModel",
+            config: {
+              defaultValue: {type: "FeatureCollection", features: []}
+            }
+          }
+        }
+      ]
+    };
+
+    const {fixture, formComponent} = await createFormAndWaitForReady(formConfig, {editMode: true} as any);
+    const mapComponent = formComponent.getComponentDefByName("map_coverage")?.component as MapComponent;
+    const mapSurface = fixture.nativeElement.querySelector(".rb-map-surface") as HTMLElement;
+    (mapComponent as any).pendingFeatureCollectionFit = {
+      type: "FeatureCollection",
+      features: [{type: "Feature", geometry: {type: "Point", coordinates: [144.96, -37.81]}, properties: {}}]
+    };
+    (mapComponent as any).pendingFitRetryCount = (mapComponent as any).maxPendingFitRetries;
+    (mapComponent as any).pendingFitSize = [729, 450];
+    Object.defineProperty(mapSurface, "clientWidth", {configurable: true, value: 800});
+    Object.defineProperty(mapSurface, "clientHeight", {configurable: true, value: 450});
+    fakeView.fit.calls.reset();
+
+    (mapComponent as any).rearmPendingFitRetryForLayoutChange();
+
+    expect((mapComponent as any).pendingFitRetryCount).toBe(0);
+    (mapComponent as any).fitPendingFeatureCollectionBounds();
+    expect(fakeView.fit).not.toHaveBeenCalled();
+    (mapComponent as any).pendingFitStableSince = Date.now() - 100;
+    (mapComponent as any).fitPendingFeatureCollectionBounds();
+
+    expect(fakeView.fit).toHaveBeenCalledWith([0, 0, 1, 1], {padding: [24, 24, 24, 24], maxZoom: 18});
+  });
+
   it("loads pre-existing features into draw state and invalidates map size", async () => {
     const formConfig: FormConfigFrame = {
       name: "testing",

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
@@ -1495,6 +1495,9 @@ describe("MapComponent", () => {
     fixture.detectChanges();
 
     expect(fakeAdapterCtor).toHaveBeenCalled();
+    expect(fakeAdapterCtor).toHaveBeenCalledWith(jasmine.objectContaining({
+      coordinatePrecision: 15
+    }));
     expect(fakeDraw.start).toHaveBeenCalled();
   });
 
@@ -1530,6 +1533,35 @@ describe("MapComponent", () => {
     expect(fakeMapTarget?.querySelector("canvas")).not.toBeNull();
     expect(fakeAdapterCtor).toHaveBeenCalled();
     expect(fakeDraw.start).toHaveBeenCalled();
+  });
+
+  it("uses configured coordinate precision for draw tooling", async () => {
+    const formConfig: FormConfigFrame = {
+      name: "testing",
+      componentDefinitions: [
+        {
+          name: "map_coverage",
+          component: {
+            class: "MapComponent",
+            config: {
+              coordinatePrecision: 12
+            }
+          },
+          model: {
+            class: "MapModel",
+            config: {
+              defaultValue: {type: "FeatureCollection", features: []}
+            }
+          }
+        }
+      ]
+    };
+
+    await createFormAndWaitForReady(formConfig, {editMode: true} as any);
+
+    expect(fakeAdapterCtor).toHaveBeenCalledWith(jasmine.objectContaining({
+      coordinatePrecision: 12
+    }));
   });
 
   it("creates map with fromLonLat for configured center", async () => {

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
@@ -825,9 +825,125 @@ describe("MapComponent", () => {
       ]
     };
 
-    await createFormAndWaitForReady(formConfig, {editMode: false} as any);
+    const {formComponent} = await createFormAndWaitForReady(formConfig, {editMode: false} as any);
+    const mapComponent = formComponent.getComponentDefByName("map_coverage")?.component as MapComponent;
+    fakeView.fit.calls.reset();
+    (mapComponent as any).pendingFitSize = undefined;
+    (mapComponent as any).pendingFitStableSince = 0;
+    (mapComponent as any).vectorLayerFitPending = true;
+    (mapComponent as any).pendingFitRetryCount = (mapComponent as any).maxPendingFitRetries;
+    jasmine.clock().install();
+    try {
+      jasmine.clock().mockDate(new Date());
+      (mapComponent as any).runPendingFitPass();
+      jasmine.clock().tick(100);
+      (mapComponent as any).runPendingFitPass();
 
-    expect(fakeView.fit).toHaveBeenCalledWith([0, 0, 1, 1], {padding: [12, 12, 12, 12], maxZoom: 18});
+      expect(fakeView.fit).toHaveBeenCalledWith([0, 0, 1, 1], {padding: [12, 12, 12, 12], maxZoom: 18});
+    } finally {
+      jasmine.clock().uninstall();
+    }
+  });
+
+  it("does not initialise or respond to layout changes after destruction", async () => {
+    const formConfig: FormConfigFrame = {
+      name: "testing",
+      componentDefinitions: [
+        {
+          name: "map_coverage",
+          component: {
+            class: "MapComponent",
+            config: {}
+          },
+          model: {
+            class: "MapModel",
+            config: {
+              defaultValue: {type: "FeatureCollection", features: []}
+            }
+          }
+        }
+      ]
+    };
+
+    const {fixture, formComponent} = await createFormAndWaitForReady(formConfig, {editMode: true} as any);
+    const mapComponent = formComponent.getComponentDefByName("map_coverage")?.component as MapComponent;
+
+    fixture.destroy();
+    (mapComponent as any).initialiseMap();
+    (mapComponent as any).handleMapLayoutChange();
+
+    expect((mapComponent as any).map).toBeUndefined();
+  });
+
+  it("resets fit stability when the map target changes", async () => {
+    const formConfig: FormConfigFrame = {
+      name: "testing",
+      componentDefinitions: [
+        {
+          name: "map_coverage",
+          component: {
+            class: "MapComponent",
+            config: {}
+          },
+          model: {
+            class: "MapModel",
+            config: {
+              defaultValue: {type: "FeatureCollection", features: []}
+            }
+          }
+        }
+      ]
+    };
+
+    const {fixture, formComponent} = await createFormAndWaitForReady(formConfig, {editMode: true} as any);
+    const mapComponent = formComponent.getComponentDefByName("map_coverage")?.component as MapComponent;
+    (mapComponent as any).pendingFitSize = [729, 450];
+    (mapComponent as any).pendingFitStableSince = 123;
+    spyOn(mapComponent as any, "invalidateMap");
+
+    (mapComponent as any).handleMapLayoutChange();
+
+    expect((mapComponent as any).pendingFitSize).toBeUndefined();
+    expect((mapComponent as any).pendingFitStableSince).toBe(0);
+    fixture.destroy();
+  });
+
+  it("handles errors when fitting saved layer bounds", async () => {
+    const formConfig: FormConfigFrame = {
+      name: "testing",
+      componentDefinitions: [
+        {
+          name: "map_coverage",
+          component: {
+            class: "MapComponent",
+            config: {}
+          },
+          model: {
+            class: "MapModel",
+            config: {
+              value: {
+                type: "FeatureCollection",
+                features: [
+                  {
+                    type: "Feature",
+                    geometry: {type: "Point", coordinates: [144.96, -37.81]},
+                    properties: {}
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    };
+
+    const {formComponent} = await createFormAndWaitForReady(formConfig, {editMode: false} as any);
+    const mapComponent = formComponent.getComponentDefByName("map_coverage")?.component as MapComponent;
+    fakeView.fit.and.throwError("fit failed");
+
+    expect(() => (mapComponent as any).fitToLayerBounds()).not.toThrow();
+    expect((mapComponent as any).fitToLayerBounds()).toBeTrue();
+    expect(mapComponent.mapError).toContain("Saved map features could not be displayed.");
   });
 
   it("defers collection fitting until the map surface has a size", async () => {

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.spec.ts
@@ -41,6 +41,8 @@ describe("MapComponent", () => {
   // OpenLayers-style fake constructors
   function FakeMapCtor(this: any, opts: any) {
     this.target = opts.target;
+    Object.defineProperty(this.target, "clientWidth", {configurable: true, value: 729});
+    Object.defineProperty(this.target, "clientHeight", {configurable: true, value: 450});
     fakeMapTarget = opts.target;
     this.layers = opts.layers;
     this.view = opts.view;
@@ -607,7 +609,7 @@ describe("MapComponent", () => {
     expect(modelValue.features.every((feature: any) => uuidV4Pattern.test(feature.id))).toBeTrue();
     expect(modelValue.features[0].geometry.coordinates).toEqual([-122.681944, 45.52]);
     expect(modelValue.features[4].geometry.coordinates[0][0]).toEqual([-122.681944, 45.52]);
-    expect(fakeView.fit).toHaveBeenCalledWith([0, 0, 1, 1], { padding: [24, 24, 24, 24] });
+    expect(fakeView.fit).toHaveBeenCalledWith([0, 0, 1, 1], { padding: [24, 24, 24, 24], maxZoom: 18 });
   });
 
   it("expands GeoJSON multi-geometries into draw-compatible features", async () => {
@@ -794,6 +796,84 @@ describe("MapComponent", () => {
     expect(fixture.nativeElement.querySelector("textarea")).toBeNull();
   });
 
+  it("caps saved feature fitting in view mode", async () => {
+    const formConfig: FormConfigFrame = {
+      name: "testing",
+      componentDefinitions: [
+        {
+          name: "map_coverage",
+          component: {
+            class: "MapComponent",
+            config: {}
+          },
+          model: {
+            class: "MapModel",
+            config: {
+              value: {
+                type: "FeatureCollection",
+                features: [
+                  {
+                    type: "Feature",
+                    geometry: {type: "Point", coordinates: [144.96, -37.81]},
+                    properties: {}
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    };
+
+    await createFormAndWaitForReady(formConfig, {editMode: false} as any);
+
+    expect(fakeView.fit).toHaveBeenCalledWith([0, 0, 1, 1], {padding: [12, 12, 12, 12], maxZoom: 18});
+  });
+
+  it("defers collection fitting until the map surface has a size", async () => {
+    const formConfig: FormConfigFrame = {
+      name: "testing",
+      componentDefinitions: [
+        {
+          name: "map_coverage",
+          component: {
+            class: "MapComponent",
+            config: {}
+          },
+          model: {
+            class: "MapModel",
+            config: {
+              defaultValue: {type: "FeatureCollection", features: []}
+            }
+          }
+        }
+      ]
+    };
+
+    const {fixture, formComponent} = await createFormAndWaitForReady(formConfig, {editMode: true} as any);
+    const mapComponent = formComponent.getComponentDefByName("map_coverage")?.component as MapComponent;
+    const mapSurface = fixture.nativeElement.querySelector(".rb-map-surface") as HTMLElement;
+    Object.defineProperty(mapSurface, "clientWidth", {configurable: true, value: 0});
+    Object.defineProperty(mapSurface, "clientHeight", {configurable: true, value: 0});
+    (mapComponent as any).pendingFeatureCollectionFit = {
+      type: "FeatureCollection",
+      features: [{type: "Feature", geometry: {type: "Point", coordinates: [144.96, -37.81]}, properties: {}}]
+    };
+    fakeView.fit.calls.reset();
+
+    (mapComponent as any).fitPendingFeatureCollectionBounds();
+
+    expect(fakeView.fit).not.toHaveBeenCalled();
+
+    Object.defineProperty(mapSurface, "clientWidth", {configurable: true, value: 729});
+    Object.defineProperty(mapSurface, "clientHeight", {configurable: true, value: 450});
+    (mapComponent as any).pendingFitSize = [729, 450];
+    (mapComponent as any).pendingFitStableSince = Date.now() - 100;
+    (mapComponent as any).fitPendingFeatureCollectionBounds();
+
+    expect(fakeView.fit).toHaveBeenCalledWith([0, 0, 1, 1], {padding: [24, 24, 24, 24], maxZoom: 18});
+  });
+
   it("loads pre-existing features into draw state and invalidates map size", async () => {
     const formConfig: FormConfigFrame = {
       name: "testing",
@@ -879,6 +959,7 @@ describe("MapComponent", () => {
     ]);
     expect(drawFeatures.length).toBe(2);
     expect(fakeMap.updateSize).toHaveBeenCalled();
+    expect(fakeView.fit).toHaveBeenCalledWith([0, 0, 1, 1], {padding: [24, 24, 24, 24], maxZoom: 18});
   });
 
   it("shows saved features read-only when edit draw ids cannot be generated", async () => {

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.ts
@@ -484,7 +484,9 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
   private zoom = 4;
   // Prevent very small or zero-size feature extents from using OpenLayers' default zoom of 28.
   private readonly defaultFeatureFitMaxZoom = 18;
-  private drawCoordinatePrecision = 15;
+  private readonly defaultDrawCoordinatePrecision = 15;
+  private readonly maxDrawCoordinatePrecision = 15;
+  private drawCoordinatePrecision = this.defaultDrawCoordinatePrecision;
   private tileLayers: MapTileLayerConfig[] = [];
   private enabledModes: MapDrawingMode[] = ["point", "polygon", "linestring", "rectangle", "circle", "select"];
   public toolbarModes: MapDrawingMode[] = [];
@@ -542,9 +544,10 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
     this.center = Array.isArray(cfg.center) && cfg.center.length === 2 ? cfg.center : [-24.67, 134.07];
     this.zoom = Number.isFinite(cfg.zoom) ? Number(cfg.zoom) : 4;
     this.mapHeight = String(cfg.mapHeight ?? "450px");
-    this.drawCoordinatePrecision = Number.isInteger(cfg.coordinatePrecision) && Number(cfg.coordinatePrecision) >= 0
+    this.drawCoordinatePrecision = Number.isInteger(cfg.coordinatePrecision) && Number(cfg.coordinatePrecision) >= 0 &&
+      Number(cfg.coordinatePrecision) <= this.maxDrawCoordinatePrecision
       ? Number(cfg.coordinatePrecision)
-      : 15;
+      : this.defaultDrawCoordinatePrecision;
     this.tileLayers = Array.isArray(cfg.tileLayers) ? cfg.tileLayers : [];
     this.enabledModes = Array.isArray(cfg.enabledModes) && cfg.enabledModes.length > 0
       ? cfg.enabledModes
@@ -1350,16 +1353,22 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
 
   private normalizePositionNumber(value: unknown): number | null {
     try {
+      let coordinate: number;
       if (typeof value === "number") {
-        return value;
-      }
-      if (typeof value === "string") {
+        coordinate = value;
+      } else if (typeof value === "string") {
         const trimmed = value?.trim();
         if (trimmed.length > 0) {
-          return Number(trimmed);
+          coordinate = Number(trimmed);
+        } else {
+          return null;
         }
+      } else {
         return null;
       }
+      return Number.isFinite(coordinate)
+        ? Number(coordinate.toFixed(this.drawCoordinatePrecision))
+        : coordinate;
     } catch (err) {
       this.loggerService.error(`${this.logName}: failed to parse position value ${value}`, err);
     }

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.ts
@@ -701,6 +701,9 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
   }
 
   private initialiseMap(): void {
+    if (this._destroyed) {
+      return;
+    }
     if (!this.mapHost?.nativeElement || this.map || !this.mapDeps) {
       if (!this.map && this.mapDeps) {
         this.scheduleMapInitialisationRetry();
@@ -1505,6 +1508,9 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
   }
 
   private handleMapLayoutChange(): void {
+    if (this._destroyed) {
+      return;
+    }
     if (!this.map && this.mapDeps && this.mapHost?.nativeElement) {
       this.initialiseMap();
       return;
@@ -1513,6 +1519,8 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
       const targetChanged = this.attachMapToCurrentHost();
       if (targetChanged) {
         this.pendingFitRetryCount = 0;
+        this.pendingFitSize = undefined;
+        this.pendingFitStableSince = 0;
       } else {
         this.rearmPendingFitRetryForLayoutChange();
       }
@@ -1568,22 +1576,17 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
     if (!this.map) {
       return;
     }
-    globalThis.requestAnimationFrame?.(() => {
-      this.map?.updateSize();
-      if (this.vectorSource && this.vectorLayerFitPending && this.hasStableMapSizeForFit()) {
-        this.vectorLayerFitPending = !this.fitToLayerBounds();
-      }
-      this.fitPendingFeatureCollectionBounds();
-      this.schedulePendingFitRetry();
-    });
-    globalThis.setTimeout(() => {
-      this.map?.updateSize();
-      if (this.vectorSource && this.vectorLayerFitPending && this.hasStableMapSizeForFit()) {
-        this.vectorLayerFitPending = !this.fitToLayerBounds();
-      }
-      this.fitPendingFeatureCollectionBounds();
-      this.schedulePendingFitRetry();
-    }, 0);
+    globalThis.requestAnimationFrame?.(() => this.runPendingFitPass());
+    globalThis.setTimeout(() => this.runPendingFitPass(), 0);
+  }
+
+  private runPendingFitPass(): void {
+    this.map?.updateSize();
+    if (this.vectorSource && this.vectorLayerFitPending && this.hasStableMapSizeForFit()) {
+      this.vectorLayerFitPending = !this.fitToLayerBounds();
+    }
+    this.fitPendingFeatureCollectionBounds();
+    this.schedulePendingFitRetry();
   }
 
   private hasStableMapSizeForFit(): boolean {
@@ -1642,12 +1645,17 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
     if (!this.map || !this.mapDeps || !source || !this.hasLayerExtent()) {
       return false;
     }
-    const extent = source.getExtent();
-    if (extent != null && !this.mapDeps.extentIsEmpty(extent)) {
+    try {
+      const extent = source.getExtent();
+      if (extent == null) {
+        return false;
+      }
       this.map.getView().fit(extent, {padding: [12, 12, 12, 12], maxZoom: this.getFeatureFitMaxZoom()});
-      return true;
+    } catch (error) {
+      this.mapError ||= this.translateText("@map-feature-fit-error", "Saved map features could not be displayed.");
+      this.loggerService.warn(`${this.logName}: failed to fit map layer bounds.`, error);
     }
-    return false;
+    return true;
   }
 
   private scheduleFitToFeatureCollectionBounds(value: MapModelValueType): void {

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.ts
@@ -1525,9 +1525,9 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
       return;
     }
     const currentSize: [number, number] = [mapElement.clientWidth, mapElement.clientHeight];
-    const hadRenderableSize = this.pendingFitSize != null && this.pendingFitSize[0] > 0 && this.pendingFitSize[1] > 0;
     const hasRenderableSize = currentSize[0] > 0 && currentSize[1] > 0;
-    if (hasRenderableSize && !hadRenderableSize) {
+    const dimensionsChanged = !this.pendingFitSize || this.pendingFitSize[0] !== currentSize[0] || this.pendingFitSize[1] !== currentSize[1];
+    if (hasRenderableSize && dimensionsChanged) {
       this.pendingFitRetryCount = 0;
     }
   }

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ElementRef, InjectionToken, Input, OnDestroy, ViewChild, inject } from "@angular/core";
+import { AfterViewInit, Component, ElementRef, InjectionToken, Input, NgZone, OnDestroy, ViewChild, inject } from "@angular/core";
 import { FormFieldBaseComponent, FormFieldCompMapEntry, FormFieldModel, ModifyOptions, TranslationService } from "@researchdatabox/portal-ng-common";
 import {
   MapComponentName,
@@ -309,6 +309,10 @@ function expandTileUrl(url: string, subdomains?: unknown): string | string[] {
     }
   `,
   styles: [`
+    :host {
+      display: block;
+    }
+
     .rb-map-wrapper {
       width: 100%;
     }
@@ -440,6 +444,8 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
   private readonly loadMapDependencies = inject(MAP_DEPENDENCIES_LOADER);
   private readonly translationService = inject(TranslationService);
   private readonly confirmationDialogService = inject(ConfirmationDialogService);
+  private readonly ngZone = inject(NgZone);
+  private readonly hostElement = inject(ElementRef<HTMLElement>);
 
   @Input() public override model?: MapModel;
   @ViewChild("mapHost", { static: false }) private mapHost?: ElementRef<HTMLDivElement>;
@@ -456,6 +462,18 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
   private draw?: any;
   private featureLayer?: OLVectorLayer<OLVectorSource>;
   private vectorSource?: OLVectorSource;
+  private vectorLayerFitPending = false;
+  private pendingFeatureCollectionFit?: MapModelValueType;
+  private pendingFitSize?: [number, number];
+  private pendingFitStableSince = 0;
+  private readonly mapFitStabilityDelayMs = 50;
+  private layoutObserver?: ResizeObserver;
+  private pendingFitRetryTimer?: number;
+  private pendingFitRetryCount = 0;
+  private readonly maxPendingFitRetries = 20;
+  private mapInitialisationRetryTimer?: number;
+  private mapInitialisationRetryCount = 0;
+  private readonly maxMapInitialisationRetries = 20;
   private mapDeps?: MapDependencies;
   private mapInteractionStates = new Map<OLInteraction, boolean>();
   private _destroyed = false;
@@ -464,6 +482,8 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
   private visibilityObserver?: IntersectionObserver;
   private center: [number, number] = [-24.67, 134.07];
   private zoom = 4;
+  // Prevent very small or zero-size feature extents from using OpenLayers' default zoom of 28.
+  private readonly defaultFeatureFitMaxZoom = 18;
   private tileLayers: MapTileLayerConfig[] = [];
   private enabledModes: MapDrawingMode[] = ["point", "polygon", "linestring", "rectangle", "circle", "select"];
   public toolbarModes: MapDrawingMode[] = [];
@@ -559,6 +579,7 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
 
   override ngAfterViewInit(): void {
     super.ngAfterViewInit();
+    this.installVisibilityObserver();
     void this.loadMapDependencies()
       .then((deps) => {
         if (this._destroyed) {
@@ -579,6 +600,16 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
     this._destroyed = true;
     this.visibilityObserver?.disconnect();
     this.visibilityObserver = undefined;
+    this.layoutObserver?.disconnect();
+    this.layoutObserver = undefined;
+    if (this.pendingFitRetryTimer != null) {
+      globalThis.clearTimeout(this.pendingFitRetryTimer);
+      this.pendingFitRetryTimer = undefined;
+    }
+    if (this.mapInitialisationRetryTimer != null) {
+      globalThis.clearTimeout(this.mapInitialisationRetryTimer);
+      this.mapInitialisationRetryTimer = undefined;
+    }
     this.drawReadyObserver?.disconnect();
     this.drawReadyObserver = undefined;
     try {
@@ -594,6 +625,7 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
     }
     this.featureLayer = undefined;
     this.vectorSource = undefined;
+    this.pendingFeatureCollectionFit = undefined;
     this.selectedFeatureIds.clear();
   }
 
@@ -602,6 +634,7 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
     if (!importedValue) {
       return;
     }
+    this.clearPendingFeatureCollectionFit();
     this.importError = "";
     this.importDataString = "";
     const merged = this.mergeCollections(this.currentModelValue(), importedValue);
@@ -614,7 +647,9 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
       this.renderValue(merged, true);
     }
     this.invalidateMap();
-    this.scheduleFitToFeatureCollectionBounds(valueToFit);
+    if (this.isEditMode()) {
+      this.scheduleFitToFeatureCollectionBounds(valueToFit);
+    }
   }
 
   public async onClearAllClicked(): Promise<void> {
@@ -631,6 +666,7 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
     if (!confirmed) {
       return;
     }
+    this.clearPendingFeatureCollectionFit();
     const emptyValue = emptyFeatureCollection();
     try {
       this.draw?.clear?.();
@@ -659,7 +695,15 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
 
   private initialiseMap(): void {
     if (!this.mapHost?.nativeElement || this.map || !this.mapDeps) {
+      if (!this.map && this.mapDeps) {
+        this.scheduleMapInitialisationRetry();
+      }
       return;
+    }
+    this.mapInitialisationRetryCount = 0;
+    if (this.mapInitialisationRetryTimer != null) {
+      globalThis.clearTimeout(this.mapInitialisationRetryTimer);
+      this.mapInitialisationRetryTimer = undefined;
     }
     const deps = this.mapDeps;
 
@@ -718,7 +762,6 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
       this.renderReadonlyLayer(this.currentReadonlyValue());
     }
 
-    this.installVisibilityObserver();
     this.invalidateMap();
   }
 
@@ -738,6 +781,7 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
       const startingValue = this.currentModelValue();
       if (startingValue.features.length > 0) {
         this.pushFeaturesToDraw(startingValue.features);
+        this.scheduleFitToFeatureCollectionBounds(startingValue);
       }
       this.mapError = "";
     } catch (error) {
@@ -998,8 +1042,12 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
     this.featureLayer = new this.mapDeps.VectorLayer({
       source: this.vectorSource
     });
+    this.vectorLayerFitPending = value.features.length > 0 && this.hasLayerExtent();
+    if (this.vectorLayerFitPending) {
+      this.pendingFitRetryCount = 0;
+    }
     this.map.addLayer(this.featureLayer);
-    this.fitToLayerBounds();
+    this.schedulePendingFitRetry();
   }
 
   private removeFeatureLayer(): void {
@@ -1008,9 +1056,12 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
     }
     this.featureLayer = undefined;
     this.vectorSource = undefined;
+    this.vectorLayerFitPending = false;
+    this.clearPendingFeatureCollectionFit();
   }
 
   private renderValue(value: MapModelValueType, updateModel: boolean): void {
+    this.clearPendingFeatureCollectionFit();
     if (this.isEditMode()) {
       this.pushFeaturesToDraw(value.features);
       if (updateModel) {
@@ -1419,15 +1470,81 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
   }
 
   private installVisibilityObserver(): void {
-    if (!this.mapHost?.nativeElement || typeof IntersectionObserver === "undefined") {
+    const hostElement = this.hostElement.nativeElement;
+    if (typeof IntersectionObserver !== "undefined") {
+      this.visibilityObserver = new IntersectionObserver((entries) => {
+        if (entries[0]?.isIntersecting) {
+          this.ngZone.run(() => this.handleMapLayoutChange());
+        }
+      }, { threshold: 0.1 });
+      this.visibilityObserver.observe(hostElement);
+    }
+    if (typeof ResizeObserver !== "undefined") {
+      this.layoutObserver = new ResizeObserver(() => {
+        this.ngZone.run(() => this.handleMapLayoutChange());
+      });
+      this.layoutObserver.observe(hostElement);
+    }
+  }
+
+  private handleMapLayoutChange(): void {
+    if (!this.map && this.mapDeps && this.mapHost?.nativeElement) {
+      this.initialiseMap();
       return;
     }
-    this.visibilityObserver = new IntersectionObserver((entries) => {
-      if (entries[0]?.isIntersecting) {
-        this.invalidateMap();
+    if (this.map) {
+      const targetChanged = this.attachMapToCurrentHost();
+      if (targetChanged) {
+        this.pendingFitRetryCount = 0;
+      } else {
+        this.rearmPendingFitRetryForLayoutChange();
       }
-    }, { threshold: 0.1 });
-    this.visibilityObserver.observe(this.mapHost.nativeElement);
+      this.invalidateMap();
+    }
+  }
+
+  private attachMapToCurrentHost(): boolean {
+    const mapHost = this.mapHost?.nativeElement;
+    if (!this.map || !mapHost) {
+      return false;
+    }
+    const currentTarget = (this.map as any).getTargetElement?.() as HTMLElement | undefined;
+    const targetChanged = currentTarget !== mapHost;
+    if (targetChanged) {
+      this.map.setTarget(mapHost);
+    }
+    return targetChanged;
+  }
+
+  private rearmPendingFitRetryForLayoutChange(): void {
+    if (!this.hasPendingMapFit() || this.pendingFitRetryCount < this.maxPendingFitRetries) {
+      return;
+    }
+    const mapElement = this.mapHost?.nativeElement;
+    if (!mapElement) {
+      return;
+    }
+    const currentSize: [number, number] = [mapElement.clientWidth, mapElement.clientHeight];
+    const hadRenderableSize = this.pendingFitSize != null && this.pendingFitSize[0] > 0 && this.pendingFitSize[1] > 0;
+    const hasRenderableSize = currentSize[0] > 0 && currentSize[1] > 0;
+    if (hasRenderableSize && !hadRenderableSize) {
+      this.pendingFitRetryCount = 0;
+    }
+  }
+
+  private scheduleMapInitialisationRetry(): void {
+    if (this.map || !this.mapDeps || this.mapInitialisationRetryTimer != null ||
+      this.mapInitialisationRetryCount >= this.maxMapInitialisationRetries) {
+      return;
+    }
+    this.mapInitialisationRetryTimer = globalThis.setTimeout(() => {
+      this.mapInitialisationRetryTimer = undefined;
+      if (this.map || !this.mapDeps) {
+        return;
+      }
+      this.mapInitialisationRetryCount += 1;
+      this.initialiseMap();
+    }, 100);
   }
 
   private invalidateMap(): void {
@@ -1436,45 +1553,137 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
     }
     globalThis.requestAnimationFrame?.(() => {
       this.map?.updateSize();
-      if (this.vectorSource) {
-        this.fitToLayerBounds();
+      if (this.vectorSource && this.vectorLayerFitPending && this.hasStableMapSizeForFit()) {
+        this.vectorLayerFitPending = !this.fitToLayerBounds();
       }
+      this.fitPendingFeatureCollectionBounds();
+      this.schedulePendingFitRetry();
     });
     globalThis.setTimeout(() => {
       this.map?.updateSize();
-      if (this.vectorSource) {
-        this.fitToLayerBounds();
+      if (this.vectorSource && this.vectorLayerFitPending && this.hasStableMapSizeForFit()) {
+        this.vectorLayerFitPending = !this.fitToLayerBounds();
       }
+      this.fitPendingFeatureCollectionBounds();
+      this.schedulePendingFitRetry();
     }, 0);
   }
 
-  private fitToLayerBounds(): void {
-    if (!this.map || !this.vectorSource || !this.mapDeps) {
+  private hasStableMapSizeForFit(): boolean {
+    const mapElement = this.mapHost?.nativeElement;
+    if (!mapElement) {
+      this.pendingFitSize = undefined;
+      this.pendingFitStableSince = 0;
+      return false;
+    }
+    const currentSize: [number, number] = [mapElement.clientWidth, mapElement.clientHeight];
+    if (!this.pendingFitSize || this.pendingFitSize[0] !== currentSize[0] || this.pendingFitSize[1] !== currentSize[1]) {
+      this.pendingFitSize = currentSize;
+      const hasRenderableSize = currentSize[0] > 0 && currentSize[1] > 0;
+      this.pendingFitStableSince = hasRenderableSize ? Date.now() : 0;
+      return false;
+    }
+    if (currentSize[0] <= 0 || currentSize[1] <= 0) {
+      return false;
+    }
+    return Date.now() - this.pendingFitStableSince >= this.mapFitStabilityDelayMs;
+  }
+
+  private hasPendingMapFit(): boolean {
+    return this.vectorLayerFitPending || this.pendingFeatureCollectionFit != null;
+  }
+
+  private clearPendingFeatureCollectionFit(): void {
+    this.pendingFeatureCollectionFit = undefined;
+  }
+
+  private schedulePendingFitRetry(): void {
+    if (!this.hasPendingMapFit() || this.pendingFitRetryTimer != null ||
+      this.pendingFitRetryCount >= this.maxPendingFitRetries) {
       return;
     }
-    const extent = this.vectorSource.getExtent();
-    if (extent != null && !this.mapDeps.extentIsEmpty(extent)) {
-      this.map.getView().fit(extent, { padding: [12, 12, 12, 12] });
+    this.pendingFitRetryTimer = globalThis.setTimeout(() => {
+      this.pendingFitRetryTimer = undefined;
+      if (!this.hasPendingMapFit()) {
+        return;
+      }
+      this.pendingFitRetryCount += 1;
+      this.invalidateMap();
+    }, 100);
+  }
+
+  private hasLayerExtent(): boolean {
+    if (!this.vectorSource || !this.mapDeps) {
+      return false;
     }
+    const extent = this.vectorSource.getExtent();
+    return extent != null && !this.mapDeps.extentIsEmpty(extent);
+  }
+
+  private fitToLayerBounds(): boolean {
+    const source = this.vectorSource;
+    if (!this.map || !this.mapDeps || !source || !this.hasLayerExtent()) {
+      return false;
+    }
+    const extent = source.getExtent();
+    if (extent != null && !this.mapDeps.extentIsEmpty(extent)) {
+      this.map.getView().fit(extent, {padding: [12, 12, 12, 12], maxZoom: this.getFeatureFitMaxZoom()});
+      return true;
+    }
+    return false;
   }
 
   private scheduleFitToFeatureCollectionBounds(value: MapModelValueType): void {
     if (!this.map || !this.mapDeps || value.features.length === 0) {
       return;
     }
-    globalThis.requestAnimationFrame?.(() => this.fitToFeatureCollectionBounds(value));
-    globalThis.setTimeout(() => this.fitToFeatureCollectionBounds(value), 0);
+    this.pendingFeatureCollectionFit = value;
+    this.pendingFitRetryCount = 0;
+    globalThis.requestAnimationFrame?.(() => this.fitPendingFeatureCollectionBounds());
+    globalThis.setTimeout(() => this.fitPendingFeatureCollectionBounds(), 0);
   }
 
-  private fitToFeatureCollectionBounds(value: MapModelValueType): void {
-    if (!this.map || !this.mapDeps || value.features.length === 0) {
+  private fitPendingFeatureCollectionBounds(): void {
+    if (!this.pendingFeatureCollectionFit || !this.hasStableMapSizeForFit()) {
       return;
     }
-    const { source } = this.createVectorSourceFromFeatureCollection(value);
-    const extent = source.getExtent();
-    if (extent != null && !this.mapDeps.extentIsEmpty(extent)) {
-      this.map.getView().fit(extent, { padding: [24, 24, 24, 24] });
+    const value = this.pendingFeatureCollectionFit;
+    if (this.fitToFeatureCollectionBounds(value)) {
+      this.pendingFeatureCollectionFit = undefined;
+      this.pendingFitRetryCount = 0;
     }
+    this.schedulePendingFitRetry();
+  }
+
+  private fitToFeatureCollectionBounds(value: MapModelValueType): boolean {
+    if (!this.map || !this.mapDeps || value.features.length === 0) {
+      return false;
+    }
+    try {
+      const { source } = this.createVectorSourceFromFeatureCollection(value);
+      const extent = source.getExtent();
+      if (extent != null && !this.mapDeps.extentIsEmpty(extent)) {
+        this.map.getView().fit(extent, {padding: [24, 24, 24, 24], maxZoom: this.getFeatureFitMaxZoom()});
+      }
+    } catch (error) {
+      this.mapError ||= this.translateText("@map-feature-fit-error", "Saved map features could not be displayed.");
+      this.loggerService.warn(`${this.logName}: failed to fit map feature collection bounds.`, error);
+    }
+    // Empty or invalid feature collections are handled without retrying indefinitely.
+    return true;
+  }
+
+  private getFeatureFitMaxZoom(): number {
+    const rawConfiguredMaxZoom = this.tileLayers[0]?.options?.["maxZoom"];
+    const configuredMaxZoom = typeof rawConfiguredMaxZoom === "number"
+      ? rawConfiguredMaxZoom
+      : typeof rawConfiguredMaxZoom === "string" && rawConfiguredMaxZoom.trim().length > 0
+        ? Number(rawConfiguredMaxZoom)
+        : NaN;
+    if (Number.isFinite(configuredMaxZoom)) {
+      return Math.min(this.defaultFeatureFitMaxZoom, Math.max(0, configuredMaxZoom));
+    }
+    return this.defaultFeatureFitMaxZoom;
   }
 
   public isEditMode(): boolean {

--- a/angular/projects/researchdatabox/form/src/app/component/map.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/map.component.ts
@@ -484,6 +484,7 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
   private zoom = 4;
   // Prevent very small or zero-size feature extents from using OpenLayers' default zoom of 28.
   private readonly defaultFeatureFitMaxZoom = 18;
+  private drawCoordinatePrecision = 15;
   private tileLayers: MapTileLayerConfig[] = [];
   private enabledModes: MapDrawingMode[] = ["point", "polygon", "linestring", "rectangle", "circle", "select"];
   public toolbarModes: MapDrawingMode[] = [];
@@ -541,6 +542,9 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
     this.center = Array.isArray(cfg.center) && cfg.center.length === 2 ? cfg.center : [-24.67, 134.07];
     this.zoom = Number.isFinite(cfg.zoom) ? Number(cfg.zoom) : 4;
     this.mapHeight = String(cfg.mapHeight ?? "450px");
+    this.drawCoordinatePrecision = Number.isInteger(cfg.coordinatePrecision) && Number(cfg.coordinatePrecision) >= 0
+      ? Number(cfg.coordinatePrecision)
+      : 15;
     this.tileLayers = Array.isArray(cfg.tileLayers) ? cfg.tileLayers : [];
     this.enabledModes = Array.isArray(cfg.enabledModes) && cfg.enabledModes.length > 0
       ? cfg.enabledModes
@@ -873,7 +877,11 @@ export class MapComponent extends FormFieldBaseComponent<MapModelValueType> impl
         toLonLat: this.mapDeps.toLonLat,
       };
 
-      const adapter = new AdapterCtor({ map: this.map, lib: openLayersLib });
+      const adapter = new AdapterCtor({
+        map: this.map,
+        lib: openLayersLib,
+        coordinatePrecision: this.drawCoordinatePrecision
+      });
       const modes: unknown[] = [];
       if (this.enabledModes.includes("point") && PointMode) {
         modes.push(new PointMode());

--- a/packages/redbox-core/src/visitor/construct.visitor.ts
+++ b/packages/redbox-core/src/visitor/construct.visitor.ts
@@ -1397,6 +1397,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
     this.sharedProps.setPropOverride('enabledModes', item.config, config);
     this.sharedProps.setPropOverride('enableImport', item.config, config);
     this.sharedProps.setPropOverride('coordinatesHelp', item.config, config);
+    this.sharedProps.setPropOverride('coordinatePrecision', item.config, config);
 
     item.config.enabledModes = this.sanitizeMapEnabledModes(item.config.enabledModes, 'construct');
   }

--- a/packages/redbox-core/test/unit/construct.visitor.test.ts
+++ b/packages/redbox-core/test/unit/construct.visitor.test.ts
@@ -446,7 +446,8 @@ describe("Construct Visitor", async () => {
                             component: {
                                 class: "MapComponent",
                                 config: {
-                                    enabledModes: ["point", "polygon", "bad-mode" as any, "rectangle"]
+                                    enabledModes: ["point", "polygon", "bad-mode" as any, "rectangle"],
+                                    coordinatePrecision: 12
                                 }
                             },
                             model: {
@@ -461,6 +462,7 @@ describe("Construct Visitor", async () => {
             const mapConfig = actual.componentDefinitions?.[0]?.component?.config as Record<string, unknown>;
             const enabledModes = mapConfig?.enabledModes as string[];
             expect(enabledModes).to.deep.equal(["point", "polygon", "rectangle"]);
+            expect(mapConfig.coordinatePrecision).to.equal(12);
             expect(warnings.some((msg) => msg.includes("Map construct dropped unsupported enabledModes"))).to.equal(true);
         });
 

--- a/packages/redbox-core/test/unit/migrate-config-v4-v5.visitor.test.ts
+++ b/packages/redbox-core/test/unit/migrate-config-v4-v5.visitor.test.ts
@@ -1214,6 +1214,7 @@ describe('Migrate v4 to v5 Visitor', async () => {
     const componentConfig = migratedField.component.config as Record<string, unknown>;
     expect(componentConfig.center).to.deep.equal([-24.67, 134.07]);
     expect(componentConfig.zoom).to.equal(5);
+    expect(componentConfig.coordinatePrecision).to.equal(15);
     expect(componentConfig.enabledModes).to.deep.equal(['point', 'polygon', 'rectangle', 'circle', 'select']);
     const modelConfig = migratedField.model?.config as Record<string, unknown>;
     expect(modelConfig.defaultValue).to.deep.equal({

--- a/packages/sails-ng-common/src/config/component/map.model.ts
+++ b/packages/sails-ng-common/src/config/component/map.model.ts
@@ -37,6 +37,7 @@ export class MapFieldComponentConfig extends FieldComponentConfig implements Map
     enabledModes: MapDrawingMode[] = ["point", "polygon", "linestring", "rectangle", "circle", "select"];
     enableImport = true;
     coordinatesHelp?: string;
+    coordinatePrecision = 15;
 
     constructor() {
         super();

--- a/packages/sails-ng-common/src/config/component/map.outline.ts
+++ b/packages/sails-ng-common/src/config/component/map.outline.ts
@@ -57,6 +57,7 @@ export interface MapFieldComponentConfigFrame extends FieldComponentConfigFrame 
     enabledModes?: MapDrawingMode[];
     enableImport?: boolean;
     coordinatesHelp?: string;
+    coordinatePrecision?: number;
 }
 
 export interface MapFieldComponentConfigOutline extends MapFieldComponentConfigFrame, FieldComponentConfigOutline {

--- a/packages/sails-ng-common/src/config/component/map.outline.ts
+++ b/packages/sails-ng-common/src/config/component/map.outline.ts
@@ -57,6 +57,7 @@ export interface MapFieldComponentConfigFrame extends FieldComponentConfigFrame 
     enabledModes?: MapDrawingMode[];
     enableImport?: boolean;
     coordinatesHelp?: string;
+    /** Maximum coordinate decimal places retained for TerraDraw. Integer from 0 to 15; defaults to 15. */
     coordinatePrecision?: number;
 }
 


### PR DESCRIPTION
## Summary

Improves saved-feature handling in the form map component. Map fitting now waits for a usable rendered size, retries when layout or initialisation is delayed, and applies a bounded zoom. Map drawing also supports configurable coordinate precision and normalises pre-existing coordinates consistently.

---

## Context / Motivation

Saved feature collections could be fitted before the map host had a measurable size, causing the fit to be ineffective or lost. Very small or empty extents could also select OpenLayers' default zoom of 28. In addition, drawn coordinates and coordinates loaded from existing values did not share an explicit precision policy.

---

## Key Features

### Reliable saved-feature fitting

- Defers layer and feature-collection fitting until the map host has a stable, non-zero size.
- Retries pending fits and map initialisation when the host is delayed, hidden, resized, or reattached.
- Caps feature-fit zoom at 18, or the configured tile-layer maximum when lower.
- Re-arms fitting when map dimensions change and cleans up timers, observers, and pending state during teardown or value replacement.

### Coordinate precision

- Adds the map `coordinatePrecision` configuration option, accepting integer values from 0 through 15 and defaulting to 15.
- Passes the configured precision to the drawing adapter and applies the same rounding to pre-existing coordinates.

---

## Testing

- Added and updated map component tests for bounded zoom, delayed fitting, layout changes, saved-feature fitting, and coordinate rounding.
- Updated visitor and form configuration tests to cover propagation of `coordinatePrecision`.
- Tests were not run as part of this PR metadata update.

---

## Architectural / Operational Impact

### Map lifecycle

Map fitting is managed through explicit pending state, bounded retry counters, and host-level `IntersectionObserver`/`ResizeObserver` callbacks. Observers and timers are disconnected on destruction to avoid stale work.

### Configuration and data output

`coordinatePrecision` extends the map form configuration and is forwarded to the drawing integration. The default preserves the previous high-precision behaviour while ensuring newly drawn and loaded coordinates are treated consistently.

---

## Backwards Compatibility

Existing map configurations remain valid. The new precision option is optional and defaults to 15 decimal places. Maps with ordinary feature extents retain their existing fitting behaviour, subject to the new maximum zoom safeguard.

---

## Deployment Notes

No migration or dependency changes are required. Deploy the portal and its updated form packages together so the configuration type, visitor, and map component remain aligned.

---

## Impact

Saved map features now fit reliably across delayed and changing layouts, while map coordinate output has a documented, configurable precision policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable coordinate precision for map data, defaulting to 15 decimal places.
  * Map views now wait for stable dimensions before fitting and automatically retry after layout changes.
  * Added safer map and feature fitting with valid bounds and a maximum zoom level of 18.

* **Bug Fixes**
  * Improved map behavior when components become visible, resize, or are reinitialized.
  * Prevented stale fitting operations after map data is replaced or removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->