### PR TITLE
Restore Handlebars dashboard rule rendering

### DIFF
--- a/angular/projects/researchdatabox/dashboard/src/app/dashboard.component.spec.ts
+++ b/angular/projects/researchdatabox/dashboard/src/app/dashboard.component.spec.ts
@@ -342,6 +342,11 @@ describe('DashboardComponent standard', () => {
     const secondRowRules = [{ ruleSetName: 'second-row-rules' }];
     const secondGroupRowConfig = [{ variable: 'second-group-column' }];
     const secondGroupRowRules = [{ ruleSetName: 'second-group-rules' }];
+    const dashboardFormatRules = recordDataStandard.dashboardType.formatRules;
+    const firstFormatRules = {
+      ...dashboardFormatRules,
+      groupBy: 'groupedByRelationships',
+    };
     const renderedRuleConfigs: any[] = [];
 
     dashboardComponent.dashboardView = 'multi-step-dashboard';
@@ -357,6 +362,7 @@ describe('DashboardComponent standard', () => {
             rowRulesConfig: firstRowRules,
             groupRowConfig: firstGroupRowConfig,
             groupRowRulesConfig: firstGroupRowRules,
+            formatRules: firstFormatRules,
           },
         },
         {
@@ -378,6 +384,7 @@ describe('DashboardComponent standard', () => {
         rowLevelRules: dashboardComponent.rowLevelRules,
         groupRowConfig: dashboardComponent.groupRowConfig,
         groupRowRules: dashboardComponent.groupRowRules,
+        formatRules: dashboardComponent.formatRules,
       });
     });
 
@@ -390,18 +397,21 @@ describe('DashboardComponent standard', () => {
         rowLevelRules: firstRowRules,
         groupRowConfig: firstGroupRowConfig,
         groupRowRules: firstGroupRowRules,
+        formatRules: firstFormatRules,
       },
       {
         evaluateStepName: 'second-step',
         rowLevelRules: secondRowRules,
         groupRowConfig: secondGroupRowConfig,
         groupRowRules: secondGroupRowRules,
+        formatRules: dashboardFormatRules,
       },
       {
         evaluateStepName: 'first-step',
         rowLevelRules: firstRowRules,
         groupRowConfig: firstGroupRowConfig,
         groupRowRules: firstGroupRowRules,
+        formatRules: firstFormatRules,
       },
     ]);
   });

--- a/angular/projects/researchdatabox/dashboard/src/app/dashboard.component.spec.ts
+++ b/angular/projects/researchdatabox/dashboard/src/app/dashboard.component.spec.ts
@@ -332,6 +332,80 @@ describe('DashboardComponent standard', () => {
     expect(dashboardComponent.initStep).toHaveBeenCalledWith('draft', 'draft', 'rdmp', '', 1, jasmine.any(Object));
   });
 
+  it('restores dashboard view rule configuration for the step being rendered', async () => {
+    const fixture = TestBed.createComponent(DashboardComponent);
+    const dashboardComponent = fixture.componentInstance;
+    const recordService = TestBed.inject(RecordService);
+    const firstRowRules = [{ ruleSetName: 'first-row-rules' }];
+    const firstGroupRowConfig = [{ variable: 'first-group-column' }];
+    const firstGroupRowRules = [{ ruleSetName: 'first-group-rules' }];
+    const secondRowRules = [{ ruleSetName: 'second-row-rules' }];
+    const secondGroupRowConfig = [{ variable: 'second-group-column' }];
+    const secondGroupRowRules = [{ ruleSetName: 'second-group-rules' }];
+    const renderedRuleConfigs: any[] = [];
+
+    dashboardComponent.dashboardView = 'multi-step-dashboard';
+    spyOn(recordService, 'getDashboardView').and.returnValue(Promise.resolve({
+      sourceRecordType: 'rdmp',
+      dashboardType: 'consolidated',
+      steps: [
+        {
+          name: 'first-step',
+          sourceRecordType: 'rdmp',
+          fetchMode: 'allForRecordType',
+          dashboardTable: {
+            rowRulesConfig: firstRowRules,
+            groupRowConfig: firstGroupRowConfig,
+            groupRowRulesConfig: firstGroupRowRules,
+          },
+        },
+        {
+          name: 'second-step',
+          sourceRecordType: 'rdmp',
+          fetchMode: 'allForRecordType',
+          dashboardTable: {
+            rowRulesConfig: secondRowRules,
+            groupRowConfig: secondGroupRowConfig,
+            groupRowRulesConfig: secondGroupRowRules,
+          },
+        },
+      ],
+    } as any));
+    spyOn(recordService, 'getDashboardType').and.returnValue(Promise.resolve(recordDataStandard.dashboardType as any));
+    spyOn(dashboardComponent, 'initStep').and.callFake(async (_stepName, evaluateStepName) => {
+      renderedRuleConfigs.push({
+        evaluateStepName,
+        rowLevelRules: dashboardComponent.rowLevelRules,
+        groupRowConfig: dashboardComponent.groupRowConfig,
+        groupRowRules: dashboardComponent.groupRowRules,
+      });
+    });
+
+    await dashboardComponent.initDashboardView('multi-step-dashboard');
+    await dashboardComponent.pageChanged({ page: 2 } as any, 'first-step');
+
+    expect(renderedRuleConfigs).toEqual([
+      {
+        evaluateStepName: 'first-step',
+        rowLevelRules: firstRowRules,
+        groupRowConfig: firstGroupRowConfig,
+        groupRowRules: firstGroupRowRules,
+      },
+      {
+        evaluateStepName: 'second-step',
+        rowLevelRules: secondRowRules,
+        groupRowConfig: secondGroupRowConfig,
+        groupRowRules: secondGroupRowRules,
+      },
+      {
+        evaluateStepName: 'first-step',
+        rowLevelRules: firstRowRules,
+        groupRowConfig: firstGroupRowConfig,
+        groupRowRules: firstGroupRowRules,
+      },
+    ]);
+  });
+
   it('initializes through initComponent when a dashboard view is configured', async () => {
     const fixture = TestBed.createComponent(DashboardComponent);
     const dashboardComponent = fixture.componentInstance;

--- a/angular/projects/researchdatabox/dashboard/src/app/dashboard.component.spec.ts
+++ b/angular/projects/researchdatabox/dashboard/src/app/dashboard.component.spec.ts
@@ -18,6 +18,7 @@ import {
   getStubRecordService,
   getStubUserService,
 } from '@researchdatabox/portal-ng-common';
+import { handlebarsCompile } from '@researchdatabox/sails-ng-common';
 
 const username = 'testUser';
 const password = 'some-password';
@@ -1137,6 +1138,64 @@ describe('DashboardComponent consolidated group by record type', () => {
     );
     expect(dashboardComponent.records['consolidated'].currentPage).toEqual(1);
     expect(dashboardComponent.records['consolidated'].items.length).toBeGreaterThan(0);
+  });
+
+  it('renders row and group rules through the Handlebars template context', () => {
+    const fixture = TestBed.createComponent(DashboardComponent);
+    const dashboardComponent = fixture.componentInstance;
+    const handlebarsTemplateService = TestBed.inject(HandlebarsTemplateService) as jasmine.SpyObj<HandlebarsTemplateService>;
+
+    handlebarsTemplateService.compileAndRunTemplate.and.callFake((template: string, context: any) => handlebarsCompile(template)(context));
+
+    dashboardComponent.tableConfig = {
+      consolidated: [
+        {
+          variable: 'actions',
+          template: '{{evaluateRowLevelRules rulesConfig metadata metaMetadata workflow oid "dashboardActionsPerRow"}}',
+        },
+      ],
+    };
+
+    const rowRules = [
+      {
+        ruleSetName: 'dashboardActionsPerRow',
+        rules: [
+          {
+            evaluateRulesTemplate: 'true',
+            renderItemTemplate: '<a href="/record/edit/{{oid}}">Edit</a>',
+          },
+        ],
+      },
+    ];
+    const groupRowConfig = [
+      {
+        variable: 'actions',
+        template: '{{evaluateGroupRowRules groupRulesConfig groupedItems "dashboardActionsPerGroupRow"}}',
+      },
+    ];
+    const groupRules = [
+      {
+        ruleSetName: 'dashboardActionsPerGroupRow',
+        rules: [
+          {
+            evaluateRulesTemplate: 'true',
+            renderItemTemplate: '<button type="button">Send for Conferral</button>',
+          },
+        ],
+      },
+    ];
+
+    const planTable = dashboardComponent.evaluatePlanTableColumns(
+      groupRowConfig,
+      groupRules,
+      rowRules,
+      'consolidated',
+      recordDataConsolidated.groupedRecords,
+      'rdmp'
+    );
+
+    expect(planTable.items[0].actions).toBe('<a href="/record/edit/1234567890">Edit</a>');
+    expect(planTable.items[1].actions).toBe('<button type="button">Send for Conferral</button>');
   });
 });
 

--- a/angular/projects/researchdatabox/dashboard/src/app/dashboard.component.ts
+++ b/angular/projects/researchdatabox/dashboard/src/app/dashboard.component.ts
@@ -1,6 +1,7 @@
 import { Component, Inject, ElementRef } from '@angular/core';
 import { PageChangedEvent } from 'ngx-bootstrap/pagination';
 import { BaseComponent, UtilityService, LoggerService, TranslationService, RecordService, PlanTable, UserService, ConfigService, FormatRules, SortGroupBy, QueryFilter, FilterField, HandlebarsTemplateService, DashboardViewDefinitionResponse, DashboardViewStepDefinitionResponse } from '@researchdatabox/portal-ng-common';
+import { handlebarsInstance } from '@researchdatabox/sails-ng-common';
 import { get as _get, set as _set, isEmpty as _isEmpty, isUndefined as _isUndefined, trim as _trim, isNull as _isNull, orderBy as _orderBy, map as _map, find as _find, indexOf as _indexOf, isArray as _isArray, forEach as _forEach, join as _join, first as _first, has as _has, unset as _unset } from 'lodash-es';
 
 @Component({
@@ -538,6 +539,7 @@ export class DashboardComponent extends BaseComponent {
     if (isGrouped && !_isUndefined(allGroupedItems) && !_isEmpty(allGroupedItems)) {
 
       const imports: any = {};
+      this.setRuleEvaluationContext(imports, recordType, stepName);
       for (let groupedRecords of allGroupedItems) {
 
         let groupedItems = _get(groupedRecords, 'items');
@@ -603,6 +605,7 @@ export class DashboardComponent extends BaseComponent {
         for (let stagedRecord of stagedOrGroupedRecordItems) {
 
           const imports: any = {};
+          this.setRuleEvaluationContext(imports, recordType, stepName);
 
           _forEach(columnMappings, (value, key) => {
             _set(imports, key, _get(stagedRecord, value));
@@ -612,6 +615,7 @@ export class DashboardComponent extends BaseComponent {
           _set(imports, 'rootContext', this.rootContext);
           _set(imports, 'portal', this.portal);
           _set(imports, 'translationService', this.translationService);
+          _set(imports, 'rulesConfig', rowLevelRulesConfig);
 
           let record: any = {};
           let stepRowConfig = this.tableConfig[stepName];
@@ -634,6 +638,19 @@ export class DashboardComponent extends BaseComponent {
     planTable.items = recordRows;
 
     return planTable;
+  }
+
+  private setRuleEvaluationContext(imports: any, recordType: string, stepName: string): void {
+    const handlebars = handlebarsInstance();
+
+    _set(imports, 'evaluateRowLevelRules', (rulesConfig: any, metadata: any, metaMetadata: any, workflow: any, oid: string, ruleSetName: string) => {
+      const result = this.evaluateRowLevelRules(rulesConfig, metadata, metaMetadata, workflow, oid, ruleSetName, recordType, stepName);
+      return new handlebars.SafeString(result ?? '');
+    });
+    _set(imports, 'evaluateGroupRowRules', (groupRulesConfig: any, groupedItems: any, ruleSetName: string) => {
+      const result = this.evaluateGroupRowRules(groupRulesConfig, groupedItems, ruleSetName, recordType, stepName);
+      return new handlebars.SafeString(result ?? '');
+    });
   }
 
   private getRuleSetConfig(rulesConfig: any, ruleSetName: string) {

--- a/angular/projects/researchdatabox/dashboard/src/app/dashboard.component.ts
+++ b/angular/projects/researchdatabox/dashboard/src/app/dashboard.component.ts
@@ -137,6 +137,11 @@ export class DashboardComponent extends BaseComponent {
   //Per each row rules show/hide fields or buttons/activities(links) that apply to one row
   defaultRowLevelRules: any = {};
   rowLevelRules: any = {};
+  private dashboardViewRuleConfigByStep: Record<string, {
+    rowLevelRules: any;
+    groupRowConfig: any;
+    groupRowRules: any;
+  }> = {};
 
   constructor(
     @Inject(LoggerService) private loggerService: LoggerService,
@@ -281,6 +286,7 @@ export class DashboardComponent extends BaseComponent {
     this.records = {};
     this.tableConfig = {};
     this.sortMap = {};
+    this.dashboardViewRuleConfigByStep = {};
     this.hideWorkflowStepTitle = false;
 
     const dashboardViewConfig = await this.recordService.getDashboardView(dashboardView);
@@ -299,7 +305,14 @@ export class DashboardComponent extends BaseComponent {
     const steps = (dashboardViewConfig.steps || []).map((step) => this.normalizeDashboardViewStep(step));
     for (const step of steps) {
       const stepKey = this.getStepKey(step);
+      const dashboardTable = _get(step, 'config.dashboard.table', {});
+      this.dashboardViewRuleConfigByStep[stepKey] = {
+        rowLevelRules: _get(dashboardTable, 'rowRulesConfig', this.defaultRowLevelRules),
+        groupRowConfig: _get(dashboardTable, 'groupRowConfig', this.defaultGroupRowConfig),
+        groupRowRules: _get(dashboardTable, 'groupRowRulesConfig', this.defaultGroupRowRules)
+      };
       this.initStepTableConfig(this.dashboardView || this.recordType, step);
+      this.restoreDashboardViewRuleConfig(stepKey);
       const defaultSortObject = this.initSortMap(step);
       this.workflowSteps.push(step);
       await this.handlebarsTemplateService.loadDashboardViewTemplates(this.branding, this.portal, dashboardView, stepKey, this.dashboardTypeSelected);
@@ -309,6 +322,17 @@ export class DashboardComponent extends BaseComponent {
       const stepRecordType = dashboardStep.sourceRecordType || this.recordType;
       await this.initStep(stepName, stepKey, stepRecordType, '', 1, defaultSortObject);
     }
+  }
+
+  private restoreDashboardViewRuleConfig(stepName: string) {
+    const ruleConfig = this.dashboardViewRuleConfigByStep[stepName];
+    if (_isUndefined(ruleConfig)) {
+      return;
+    }
+
+    this.rowLevelRules = ruleConfig.rowLevelRules;
+    this.groupRowConfig = ruleConfig.groupRowConfig;
+    this.groupRowRules = ruleConfig.groupRowRules;
   }
 
   private async initWorkflowSteps(recordType: string) {
@@ -900,6 +924,7 @@ export class DashboardComponent extends BaseComponent {
       const stepName = dashboardViewStep.fetchMode == 'workflowStage'
         ? (dashboardViewStep.sourceWorkflowStage || evaluateStepName)
         : '';
+      this.restoreDashboardViewRuleConfig(evaluateStepName);
       await this.initStep(stepName, evaluateStepName, recordType, '', event.page, {});
       this.isProcessingPageChange = false;
     }

--- a/angular/projects/researchdatabox/dashboard/src/app/dashboard.component.ts
+++ b/angular/projects/researchdatabox/dashboard/src/app/dashboard.component.ts
@@ -137,10 +137,11 @@ export class DashboardComponent extends BaseComponent {
   //Per each row rules show/hide fields or buttons/activities(links) that apply to one row
   defaultRowLevelRules: any = {};
   rowLevelRules: any = {};
-  private dashboardViewRuleConfigByStep: Record<string, {
+  private dashboardViewStepConfigByStep: Record<string, {
     rowLevelRules: any;
     groupRowConfig: any;
     groupRowRules: any;
+    formatRules: FormatRules;
   }> = {};
 
   constructor(
@@ -286,7 +287,7 @@ export class DashboardComponent extends BaseComponent {
     this.records = {};
     this.tableConfig = {};
     this.sortMap = {};
-    this.dashboardViewRuleConfigByStep = {};
+    this.dashboardViewStepConfigByStep = {};
     this.hideWorkflowStepTitle = false;
 
     const dashboardViewConfig = await this.recordService.getDashboardView(dashboardView);
@@ -302,17 +303,19 @@ export class DashboardComponent extends BaseComponent {
     this.groupRowConfig = this.defaultGroupRowConfig;
     this.groupRowRules = this.defaultGroupRowRules;
 
+    const dashboardFormatRules = this.formatRules;
     const steps = (dashboardViewConfig.steps || []).map((step) => this.normalizeDashboardViewStep(step));
     for (const step of steps) {
       const stepKey = this.getStepKey(step);
-      const dashboardTable = _get(step, 'config.dashboard.table', {});
-      this.dashboardViewRuleConfigByStep[stepKey] = {
+      const dashboardTable: any = _get(step, 'config.dashboard.table', {});
+      this.dashboardViewStepConfigByStep[stepKey] = {
         rowLevelRules: _get(dashboardTable, 'rowRulesConfig', this.defaultRowLevelRules),
         groupRowConfig: _get(dashboardTable, 'groupRowConfig', this.defaultGroupRowConfig),
-        groupRowRules: _get(dashboardTable, 'groupRowRulesConfig', this.defaultGroupRowRules)
+        groupRowRules: _get(dashboardTable, 'groupRowRulesConfig', this.defaultGroupRowRules),
+        formatRules: _get(dashboardTable, 'formatRules', dashboardFormatRules)
       };
       this.initStepTableConfig(this.dashboardView || this.recordType, step);
-      this.restoreDashboardViewRuleConfig(stepKey);
+      this.restoreDashboardViewStepConfig(stepKey);
       const defaultSortObject = this.initSortMap(step);
       this.workflowSteps.push(step);
       await this.handlebarsTemplateService.loadDashboardViewTemplates(this.branding, this.portal, dashboardView, stepKey, this.dashboardTypeSelected);
@@ -324,15 +327,16 @@ export class DashboardComponent extends BaseComponent {
     }
   }
 
-  private restoreDashboardViewRuleConfig(stepName: string) {
-    const ruleConfig = this.dashboardViewRuleConfigByStep[stepName];
-    if (_isUndefined(ruleConfig)) {
+  private restoreDashboardViewStepConfig(stepName: string) {
+    const stepConfig = this.dashboardViewStepConfigByStep[stepName];
+    if (_isUndefined(stepConfig)) {
       return;
     }
 
-    this.rowLevelRules = ruleConfig.rowLevelRules;
-    this.groupRowConfig = ruleConfig.groupRowConfig;
-    this.groupRowRules = ruleConfig.groupRowRules;
+    this.rowLevelRules = stepConfig.rowLevelRules;
+    this.groupRowConfig = stepConfig.groupRowConfig;
+    this.groupRowRules = stepConfig.groupRowRules;
+    this.formatRules = stepConfig.formatRules;
   }
 
   private async initWorkflowSteps(recordType: string) {
@@ -924,7 +928,7 @@ export class DashboardComponent extends BaseComponent {
       const stepName = dashboardViewStep.fetchMode == 'workflowStage'
         ? (dashboardViewStep.sourceWorkflowStage || evaluateStepName)
         : '';
-      this.restoreDashboardViewRuleConfig(evaluateStepName);
+      this.restoreDashboardViewStepConfig(evaluateStepName);
       await this.initStep(stepName, evaluateStepName, recordType, '', event.page, {});
       this.isProcessingPageChange = false;
     }


### PR DESCRIPTION
## Summary

Restores row-level and group-level dashboard rule rendering through the CSP-safe Handlebars pipeline. Consolidated dashboards can once again execute their configured action rules instead of logging missing-helper errors and rendering blank action cells.

---

## Context / Motivation

The CSP-safe dashboard migration moved dashboard templates from Lodash evaluation to server-precompiled Handlebars templates. The dashboard component retained its rule-evaluation methods, but did not expose them under the names referenced by configured Handlebars templates. At runtime, Handlebars therefore resolved the calls through `helperMissing`, causing configured actions to disappear.

---

## Key Features

### Dashboard rule context

- Exposes component-bound row and group rule evaluators to grouped and non-grouped dashboard template contexts.
- Supplies the active record type and workflow step so nested precompiled rule templates resolve through the correct dashboard module keys.
- Makes row rule configuration available to non-grouped templates as well as consolidated grouped dashboards.

### Rendered action markup

- Preserves HTML produced by trusted dashboard rule configuration using the shared Handlebars `SafeString` implementation.
- Keeps evaluator state scoped to the dashboard component rather than registering mutable global helpers.

---

## Testing

- Added regression coverage that exercises row and group evaluator calls through Handlebars templates and verifies the resulting action markup is not escaped.
- Passed all 55 tests in the dashboard Angular project.
- Manually verified a consolidated dashboard in the mounted development environment, including a pagination rerender, with configured actions visible and no missing-helper console errors.

---

## Architectural / Operational Impact

### Handlebars integration

The change reconnects the existing dashboard rule engine to the precompiled Handlebars execution context. It does not add runtime template compilation or introduce a new global helper registry.

### CSP and HTML handling

Rule output continues to originate from trusted administrator/deployment dashboard configuration. Marking that nested output as safe prevents the outer Handlebars template from escaping configured action markup while retaining the existing CSP-safe precompiled-template path and Angular `innerHTML` sanitization.

---

## Backwards Compatibility

Existing dashboard configurations using `evaluateRowLevelRules` and `evaluateGroupRowRules` retain their current syntax. Standard dashboards that do not use rule evaluators are unaffected.

---

## Deployment Notes

Rebuild and deploy the dashboard Angular assets. No database, record, form configuration, or language migration is required.

---

## Impact

Configured dashboard actions render reliably again across grouped and non-grouped views without weakening the CSP-safe dashboard template architecture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard rule rendering for grouped and ungrouped tables.
  * Edit links and conferral buttons now display correctly when generated from row and group rules.
  * Dashboard rule configurations are now preserved and restored correctly when moving between workflow steps or pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->