### PR TITLE
Bugfix: normalize empty option values in view mode

### DIFF
--- a/packages/sails-ng-common/src/config/form-override.model.ts
+++ b/packages/sails-ng-common/src/config/form-override.model.ts
@@ -2007,14 +2007,15 @@ export class FormOverride {
       return;
     }
     const targetCompConf = target.component.config;
+    const normalizedValues = values.filter(value => value !== '');
 
-    if (values.length === 0) {
+    if (normalizedValues.length === 0) {
       // Empty
       targetCompConf.content = undefined;
       targetCompConf.template = this.resolveReusableViewTemplate(this.reusableViewTemplateKeys.leafOptionEmpty, `<span></span>`);
-    } else if (values.length === 1) {
+    } else if (normalizedValues.length === 1) {
       // One value
-      const value = values[0];
+      const value = normalizedValues[0];
       const label = options?.find(option => option.value === value)?.label ?? value;
       targetCompConf.content = { value, label };
       targetCompConf.template = this.resolveReusableViewTemplate(
@@ -2023,7 +2024,7 @@ export class FormOverride {
       );
     } else {
       // More than one value
-      targetCompConf.content = values.map(
+      targetCompConf.content = normalizedValues.map(
         value =>
           options?.find(option => option.value === value) ?? {
             label: value,

--- a/packages/sails-ng-common/test/unit/form-override.test.ts
+++ b/packages/sails-ng-common/test/unit/form-override.test.ts
@@ -201,6 +201,61 @@ describe('FormOverride reusable expansion', () => {
     );
   });
 
+  it('normalizes empty dropdown values before selecting the view template', () => {
+    const formOverride = new FormOverride(createLogger());
+    const options = [
+      { value: 'heritage', label: 'Heritage' },
+      { value: 'research', label: 'Research' },
+    ];
+
+    const transform = (value: unknown) =>
+      formOverride.applyOverrideTransform(
+        {
+          name: 'retentionReason',
+          component: {
+            class: DropdownInputComponentName,
+            config: { options },
+          },
+          model: {
+            class: 'DropdownInputModel',
+            config: { value },
+          },
+        } as never,
+        'view',
+        { phase: 'client' }
+      );
+
+    const getViewConfig = (value: unknown) =>
+      transform(value).component.config as { content?: unknown; template?: string };
+
+    const emptyArray = getViewConfig([]);
+    expect(emptyArray.content).to.equal(undefined);
+    expect(emptyArray.template).to.equal('<span></span>');
+
+    const emptyValueArray = getViewConfig(['']);
+    expect(emptyValueArray.content).to.equal(undefined);
+    expect(emptyValueArray.template).to.equal('<span></span>');
+
+    const emptyScalar = getViewConfig('');
+    expect(emptyScalar.content).to.equal(undefined);
+    expect(emptyScalar.template).to.equal('<span></span>');
+
+    const mixedValues = getViewConfig(['', 'heritage']);
+    expect(mixedValues.content).to.deep.equal({ value: 'heritage', label: 'Heritage' });
+    expect(mixedValues.template).to.contain('content.label');
+
+    const populatedValue = getViewConfig(['heritage']);
+    expect(populatedValue.content).to.deep.equal({ value: 'heritage', label: 'Heritage' });
+    expect(populatedValue.template).to.contain('content.label');
+
+    const populatedValues = getViewConfig(['heritage', 'research']);
+    expect(populatedValues.content).to.deep.equal([
+      { value: 'heritage', label: 'Heritage' },
+      { value: 'research', label: 'Research' },
+    ]);
+    expect(populatedValues.template).to.contain('<li data-value="{{this.value}}">');
+  });
+
   it('renders checkbox leaf option labels in generated view templates', () => {
     const formOverride = new FormOverride(createLogger());
 

--- a/test/integration/services/FormsService.test.ts
+++ b/test/integration/services/FormsService.test.ts
@@ -494,7 +494,7 @@ describe('The FormsService', function () {
             model: {
               class: 'DropdownInputModel',
               config: {
-                defaultValue: '',
+                defaultValue: 'onedrive',
               },
             },
             component: {
@@ -516,8 +516,8 @@ describe('The FormsService', function () {
 
       expect(field?.component?.class).to.equal('ContentComponent');
       expect(config?.content).to.deep.equal({
-        value: '',
-        label: '@dmpt-select:Empty',
+        value: 'onedrive',
+        label: '@dmpt-storage-onedrive',
       });
       expect(config?.template).to.equal(
         '<span data-value="{{content.value}}">{{#with @root}}{{t content.label}}{{/with}}</span>'


### PR DESCRIPTION
## Summary

Normalizes empty dropdown option values before selecting the view-mode template, so empty values render as the empty placeholder instead of a populated single- or multi-value template.

---

## Context / Motivation

When a dropdown's model value is an empty string, an array containing empty strings, or a mix of empty and populated values, the view-mode template selection logic counted empty strings as real values. This produced incorrect rendering: an empty string triggered the single-value template and blank entries leaked into the multi-value template.

---

## Key Features

### View-mode template selection normalization

- Filters empty string values before choosing between the empty, single-value, and multi-value view templates
- Empty strings, empty arrays, and arrays containing only empty strings now render the empty placeholder template
- Mixed arrays (e.g. `['', 'heritage']`) resolve against their populated subset

---

## Testing

- Added unit coverage in the FormOverride reusable expansion suite for empty arrays, empty-string scalars, empty-string arrays, mixed arrays, and fully populated arrays

---

## Architectural / Operational Impact

None. Rendering-only change contained within the view-mode template resolution logic.

---

## Backwards Compatibility

No behavioral change for inputs that already contain non-empty values; existing populated dropdowns render exactly as before.

---

## Deployment Notes

None.

---

## Impact

Fixes incorrect view-mode rendering for dropdowns whose value is empty or contains empty-string entries.
