### PR TITLE
Bugfix: add separators between view rows

### DIFF
--- a/assets/styles/default-theme.scss
+++ b/assets/styles/default-theme.scss
@@ -315,6 +315,16 @@ input[type="submit"]:hover, button[type=submit]:hover {background-color: var(--r
     gap: 0.25rem;
 }
 
+.rb-view-group > .rb-view-row {
+    border-bottom: 1px solid var(--rb-view-row-divider-color, #e5e5e5);
+    padding-bottom: var(--rb-view-row-divider-padding, 0.5rem);
+}
+
+.rb-view-group > .rb-view-row:last-child {
+    border-bottom: 0;
+    padding-bottom: 0;
+}
+
 .rb-view-label {
     font-weight: 600;
 }


### PR DESCRIPTION
## Summary

Adds visual separators between rows in view mode, so grouped view values are easier to scan. Rows within a `.rb-view-group` now render with a light divider line and consistent bottom padding, with the divider suppressed on the final row.

---

## Context / Motivation

View mode renders record values as grouped rows, but adjacent rows previously had no visual boundary, making it hard to distinguish one value from the next at a glance. This is part of the view-mode rendering cleanup that also normalised empty option values (see `bugfix/view-option-empty-normalization`).

---

## Key Features

### View row separators

- Rows inside a `.rb-view-group` receive a `border-bottom` divider in a neutral tone
- Divider color and row padding are exposed as CSS variables (`--rb-view-row-divider-color`, `--rb-view-row-divider-padding`) so themes can override them
- The last row in a group drops the border and extra padding to avoid a trailing rule

---

## Testing

- Pure styling change; verified via visual inspection of view mode rendering
- No unit or integration tests required for the CSS-only diff
- Existing CI runs unchanged

---

## Architectural / Operational Impact

### Theming

The divider color and padding default to sensible values but are overridable through existing theme variables, keeping the change non-breaking for custom themes.

---

## Backwards Compatibility

Fully backwards compatible. The rules apply only to `.rb-view-row` elements inside a `.rb-view-group`, and existing view markup is unaffected structurally.

---

## Deployment Notes

No configuration or migration steps required. Ships as a static asset change.

---

## Impact

Improves readability of view mode forms with no functional or structural changes.
