### PR TITLE
Feature: Rebuild Oni indexes after publishing a dataset

### DIFF
--- a/packages/redbox-core/src/configmodels/OniPublishing.ts
+++ b/packages/redbox-core/src/configmodels/OniPublishing.ts
@@ -105,12 +105,22 @@ export interface OniFlydriveStorageConfig {
 
 export type OniSiteStorageConfig = OniFlydriveStorageConfig;
 
+export interface OniIngestionConfig {
+  enabled: boolean;
+  apiUrl: string;
+  adminToken: string;
+  forceReindex: boolean;
+  pollIntervalMs: number;
+  timeoutMs: number;
+}
+
 export interface OniPublishingSiteConfig {
   enabled: boolean;
   label: string;
   publicUrl: string;
   useCleanUrl: boolean;
   storage: OniSiteStorageConfig;
+  ingestion?: OniIngestionConfig;
 }
 
 export interface OniPublishingConfigData {
@@ -194,6 +204,14 @@ export class OniPublishing extends AppConfig implements OniPublishingConfigData 
         tempDir: '/tmp/oni/staged',
         keyEncoding: 'flydrive',
       },
+      ingestion: {
+        enabled: false,
+        apiUrl: 'http://localhost:8080',
+        adminToken: '',
+        forceReindex: true,
+        pollIntervalMs: 500,
+        timeoutMs: 120_000,
+      },
     },
     public: {
       enabled: true,
@@ -209,10 +227,26 @@ export class OniPublishing extends AppConfig implements OniPublishingConfigData 
         tempDir: '/tmp/oni/public',
         keyEncoding: 'flydrive',
       },
+      ingestion: {
+        enabled: false,
+        apiUrl: 'http://localhost:8080',
+        adminToken: '',
+        forceReindex: true,
+        pollIntervalMs: 500,
+        timeoutMs: 120_000,
+      },
     },
   };
   mapping: OniDatasetMappingConfig = {
     rootDataset: [
+      {
+        property: 'conformsTo',
+        value: {
+          kind: 'path',
+          path: 'context.repositoryObjectProfile',
+          defaultValue: { '@id': 'https://w3id.org/ldac/profile#Object' },
+        },
+      },
       { property: 'name', value: { kind: 'path', path: 'metadata.title' } },
       { property: 'description', value: { kind: 'path', path: 'metadata.description' } },
       { property: 'dateCreated', value: { kind: 'path', path: 'metaMetadata.createdOn' } },

--- a/packages/redbox-core/src/configmodels/OniPublishing.ts
+++ b/packages/redbox-core/src/configmodels/OniPublishing.ts
@@ -208,7 +208,8 @@ export class OniPublishing extends AppConfig implements OniPublishingConfigData 
         enabled: false,
         apiUrl: 'http://localhost:8080',
         adminToken: '',
-        forceReindex: true,
+        // Enable only when Oni requires a complete structural and search index rebuild.
+        forceReindex: false,
         pollIntervalMs: 500,
         timeoutMs: 120_000,
       },
@@ -231,7 +232,8 @@ export class OniPublishing extends AppConfig implements OniPublishingConfigData 
         enabled: false,
         apiUrl: 'http://localhost:8080',
         adminToken: '',
-        forceReindex: true,
+        // Enable only when Oni requires a complete structural and search index rebuild.
+        forceReindex: false,
         pollIntervalMs: 500,
         timeoutMs: 120_000,
       },

--- a/packages/redbox-core/src/model/storage/IntegrationAuditModel.ts
+++ b/packages/redbox-core/src/model/storage/IntegrationAuditModel.ts
@@ -32,6 +32,7 @@ export enum IntegrationAuditAction {
   publishOniDataset = 'publishOniDataset',
   buildOniRoCrate = 'buildOniRoCrate',
   writeOniOcflObject = 'writeOniOcflObject',
+  ingestOniDataset = 'ingestOniDataset',
 }
 
 export enum IntegrationAuditStatus {

--- a/packages/redbox-core/src/services/OniService.ts
+++ b/packages/redbox-core/src/services/OniService.ts
@@ -26,6 +26,7 @@ import type {
   ResolvedOniPublishingConfigData,
 } from './oni-v2/types';
 import { makeOniAuditService } from './oni-v2/audit';
+import { ingestOniRepository, type OniIngestionResult } from './oni-v2/ingestion';
 
 export namespace Services {
   /**
@@ -158,6 +159,48 @@ export namespace Services {
       });
     }
 
+    protected async ingestDataset(
+      oid: string,
+      site: OniPublishingSiteConfig,
+      runContext: OniRunContext,
+      parentAuditContext: IntegrationAuditContext | null
+    ): Promise<OniIngestionResult | undefined> {
+      const ingestion = site.ingestion;
+      if (ingestion?.enabled !== true) {
+        return undefined;
+      }
+      const auditContext = startOniAudit(
+        oid,
+        IntegrationAuditAction.ingestOniDataset,
+        runContext,
+        {
+          site: runContext.siteName,
+          phase: 'ingest-oni',
+          apiUrl: ingestion.apiUrl,
+          forceReindex: ingestion.forceReindex,
+        },
+        parentAuditContext
+      );
+      try {
+        const result = await ingestOniRepository(ingestion);
+        completeOniAudit(auditContext, {
+          message: 'Oni repository ingestion completed.',
+          responseSummary: {
+            site: runContext.siteName,
+            structuralObjects: result.structuralObjects,
+            searchItems: result.searchItems,
+          },
+        });
+        return result;
+      } catch (error) {
+        failOniAudit(auditContext, error, {
+          message: 'Oni repository ingestion failed.',
+          ...this.summarizeError(error),
+        });
+        throw error;
+      }
+    }
+
     public async exportDataset(oid: string, record: unknown, options: unknown, user: unknown): Promise<OniRecordModel> {
       const recordObj = this.ensureRecord(record);
       const optionsObj = options != null && typeof options === 'object' ? (options as AnyRecord) : {};
@@ -190,6 +233,7 @@ export namespace Services {
       });
 
       let result: OniPublishResult;
+      let ingestionResult: OniIngestionResult | undefined;
       let userObj: OniUserModel | null = null;
       try {
         userObj = this.ensureUser(user, oid, siteName);
@@ -205,6 +249,7 @@ export namespace Services {
           repository,
           auditCtx
         );
+        ingestionResult = await this.ingestDataset(oid, resolvedSite.site, runContext, auditCtx);
       } catch (error) {
         const err = this.asError(error);
         if (userObj != null) {
@@ -236,6 +281,8 @@ export namespace Services {
             rootId: result.rootId,
             datasetUrl: result.datasetUrl,
             attachmentCount: result.attachments.length,
+            structuralObjects: ingestionResult?.structuralObjects,
+            searchItems: ingestionResult?.searchItems,
           },
         });
         return recordObj;

--- a/packages/redbox-core/src/services/OniService.ts
+++ b/packages/redbox-core/src/services/OniService.ts
@@ -85,7 +85,7 @@ export namespace Services {
       return creator as OniUserModel;
     }
 
-    private summarizeError(error: unknown): Record<string, unknown> {
+    private summarizeError(error: unknown): { responseSummary: Record<string, unknown> } {
       if (error instanceof RBValidationError) {
         return {
           responseSummary: {
@@ -232,7 +232,7 @@ export namespace Services {
         triggerSource: runContext.triggerSource,
       });
 
-      let result: OniPublishResult;
+      let result: OniPublishResult | undefined;
       let ingestionResult: OniIngestionResult | undefined;
       let userObj: OniUserModel | null = null;
       try {
@@ -249,6 +249,7 @@ export namespace Services {
           repository,
           auditCtx
         );
+        applyCitationWriteBack(recordObj, config, result.datasetUrl);
         ingestionResult = await this.ingestDataset(oid, resolvedSite.site, runContext, auditCtx);
       } catch (error) {
         const err = this.asError(error);
@@ -260,17 +261,37 @@ export namespace Services {
             sails.log.error(persistError);
           }
         }
+        const errorSummary = this.summarizeError(error).responseSummary;
         failOniAudit(auditCtx, error, {
-          message: 'Oni dataset publish failed.',
-          ...this.summarizeError(error),
+          message:
+            result == null
+              ? 'Oni dataset publish failed.'
+              : 'Oni OCFL write completed, but repository ingestion failed.',
+          responseSummary: {
+            ...errorSummary,
+            ...(result == null
+              ? {}
+              : {
+                  ocflWriteCompleted: true,
+                  storageDriver: result.storageDriver,
+                  rootId: result.rootId,
+                  datasetUrl: result.datasetUrl,
+                }),
+          },
         });
-        throw this.toValidationError(error, oid, siteName, 'Error publishing dataset to Oni OCFL');
+        throw this.toValidationError(
+          error,
+          oid,
+          siteName,
+          result == null
+            ? 'Error publishing dataset to Oni OCFL'
+            : 'Oni OCFL publication completed but repository ingestion failed'
+        );
       }
 
       if (userObj == null) {
         throw new Error(`Oni publish completed without a resolved user for '${oid}'`);
       }
-      applyCitationWriteBack(recordObj, config, result.datasetUrl);
       try {
         await this.persistRecord(oid, recordObj, userObj);
         completeOniAudit(auditCtx, {
@@ -281,8 +302,12 @@ export namespace Services {
             rootId: result.rootId,
             datasetUrl: result.datasetUrl,
             attachmentCount: result.attachments.length,
-            structuralObjects: ingestionResult?.structuralObjects,
-            searchItems: ingestionResult?.searchItems,
+            ...(ingestionResult == null
+              ? {}
+              : {
+                  structuralObjects: ingestionResult.structuralObjects,
+                  searchItems: ingestionResult.searchItems,
+                }),
           },
         });
         return recordObj;

--- a/packages/redbox-core/src/services/oni-v2/crate.ts
+++ b/packages/redbox-core/src/services/oni-v2/crate.ts
@@ -250,9 +250,25 @@ async function getSpatialCoverage(metadata: AnyRecord, extraContext: AnyRecord):
   if (_.isEmpty(metadata.geospatial)) {
     return undefined;
   }
+  const geospatial = (Array.isArray(metadata.geospatial) ? metadata.geospatial : [metadata.geospatial]).filter(
+    geoJson => {
+      if (!isRecordValue(geoJson)) {
+        return false;
+      }
+      if (geoJson.type === 'FeatureCollection') {
+        return Array.isArray(geoJson.features) && geoJson.features.length > 0;
+      }
+      if (geoJson.type === 'GeometryCollection') {
+        return Array.isArray(geoJson.geometries) && geoJson.geometries.length > 0;
+      }
+      return true;
+    }
+  );
+  if (geospatial.length === 0) {
+    return undefined;
+  }
   extraContext.Geometry = 'http://www.opengis.net/ont/geosparql#Geometry';
   extraContext.asWKT = 'http://www.opengis.net/ont/geosparql#asWKT';
-  const geospatial = Array.isArray(metadata.geospatial) ? metadata.geospatial : [metadata.geospatial];
   return Promise.all(
     geospatial.map(async (geoJson: unknown, idx: number) => ({
       '@id': `_:place-${idx}`,
@@ -470,6 +486,16 @@ export async function buildOniRoCrate(input: OniCrateBuildInput): Promise<OniCra
   const rootCollection = createRootCollectionEntity(input.config);
   graph.push(rootCollection);
 
+  const licenses = getLicense(metadata, input.config);
+  const spatialCoverage = await getSpatialCoverage(metadata, extraContext);
+  const spatialEntities = (spatialCoverage ?? []).flatMap(place => {
+    const geometry = isRecordValue(place.geo) ? place.geo : undefined;
+    return geometry ? [{ ...place, geo: toReference(geometry) }, geometry] : [place];
+  });
+  for (const supportingEntity of [input.config.metadata.organization, ...licenses, ...spatialEntities]) {
+    upsertGraphEntity(graph, supportingEntity as unknown as AnyRecord);
+  }
+
   const systemRootDatasetFields: AnyRecord = {
     '@id': rootId,
     '@type': ['Dataset', 'RepositoryObject'],
@@ -485,8 +511,8 @@ export async function buildOniRoCrate(input: OniCrateBuildInput): Promise<OniCra
     rootId,
     now,
     organization: input.config.metadata.organization,
-    license: getLicense(metadata, input.config),
-    spatialCoverage: await getSpatialCoverage(metadata, extraContext),
+    license: licenses,
+    spatialCoverage,
     temporalCoverage: getTemporalCoverage(metadata),
   });
   const mappedRootDataset = await mapDatasetFields(input.config.mapping?.rootDataset ?? [], mappingContext);

--- a/packages/redbox-core/src/services/oni-v2/crate.ts
+++ b/packages/redbox-core/src/services/oni-v2/crate.ts
@@ -492,6 +492,7 @@ export async function buildOniRoCrate(input: OniCrateBuildInput): Promise<OniCra
     const geometry = isRecordValue(place.geo) ? place.geo : undefined;
     return geometry ? [{ ...place, geo: toReference(geometry) }, geometry] : [place];
   });
+  const spatialCoverageReferences = spatialCoverage?.map(toReference);
   for (const supportingEntity of [input.config.metadata.organization, ...licenses, ...spatialEntities]) {
     upsertGraphEntity(graph, supportingEntity as unknown as AnyRecord);
   }
@@ -512,7 +513,7 @@ export async function buildOniRoCrate(input: OniCrateBuildInput): Promise<OniCra
     now,
     organization: input.config.metadata.organization,
     license: licenses,
-    spatialCoverage,
+    spatialCoverage: spatialCoverageReferences,
     temporalCoverage: getTemporalCoverage(metadata),
   });
   const mappedRootDataset = await mapDatasetFields(input.config.mapping?.rootDataset ?? [], mappingContext);

--- a/packages/redbox-core/src/services/oni-v2/flydriveOcflStore.ts
+++ b/packages/redbox-core/src/services/oni-v2/flydriveOcflStore.ts
@@ -12,6 +12,10 @@ type StoreOptions = {
   keyEncoding?: 'flydrive' | 'raw';
 };
 
+type DiskWithDriver = StorageManagerServices.IDisk & {
+  driver?: StorageManagerServices.IDisk;
+};
+
 type DiskEntry = {
   key?: string;
   prefix?: string;
@@ -100,15 +104,19 @@ function getEntryKey(value: unknown): string {
 
 function isMissingDiskError(error: unknown): boolean {
   const code =
-    error != null && typeof error === 'object' ? String((error as NodeJS.ErrnoException).code ?? '').toUpperCase() : '';
+    error != null && typeof error === 'object'
+      ? String((error as NodeJS.ErrnoException).code ?? (error as Error).name ?? '').toUpperCase()
+      : '';
   const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
   return (
     code === 'ENOENT' ||
+    code.includes('NOSUCHKEY') ||
     code.includes('CANNOT_READ_FILE') ||
     code.includes('NOT_FOUND') ||
     message.includes('no such file') ||
     message.includes('not found') ||
-    message.includes('cannot read file')
+    message.includes('cannot read file') ||
+    message.includes('does not exist')
   );
 }
 
@@ -116,6 +124,7 @@ export function createStorageManagerOcflStoreClass(OcflStore: OcflStoreConstruct
   return class StorageManagerOcflStore extends OcflStore {
     readonly prefix: string;
     readonly disk: StorageManagerServices.IDisk;
+    readonly ioDisk: StorageManagerServices.IDisk;
     readonly root: string;
     readonly workspace: string;
     readonly keyEncoding: 'flydrive' | 'raw';
@@ -124,6 +133,8 @@ export function createStorageManagerOcflStoreClass(OcflStore: OcflStoreConstruct
       super(options as unknown as Record<string, unknown>);
       this.prefix = normalizePrefix(options.prefix);
       this.disk = options.disk;
+      const underlyingDriver = (options.disk as DiskWithDriver).driver;
+      this.ioDisk = options.keyEncoding === 'raw' && underlyingDriver != null ? underlyingDriver : options.disk;
       this.root = options.root;
       this.workspace = options.workspace;
       this.keyEncoding = options.keyEncoding ?? 'flydrive';
@@ -161,7 +172,7 @@ export function createStorageManagerOcflStoreClass(OcflStore: OcflStoreConstruct
     }> {
       const key = this.keyFor(filePath);
       try {
-        const meta = await this.disk.getMetaData(key);
+        const meta = await this.ioDisk.getMetaData(key);
         const lastModified = meta.lastModified ?? new Date();
         return {
           size: meta.contentLength || 0,
@@ -194,13 +205,13 @@ export function createStorageManagerOcflStoreClass(OcflStore: OcflStoreConstruct
     }
 
     async createReadStream(filePath: string): Promise<NodeJS.ReadableStream> {
-      return this.disk.getStream(this.keyFor(filePath));
+      return this.ioDisk.getStream(this.keyFor(filePath));
     }
 
     async createWriteStream(filePath: string): Promise<NodeJS.WritableStream> {
       const key = this.keyFor(filePath);
       const uploadStream = new PassThrough();
-      const upload = this.disk.putStream(key, uploadStream);
+      const upload = this.ioDisk.putStream(key, uploadStream);
       const writable = new Writable({
         write(chunk: unknown, encoding: BufferEncoding, callback: (error?: Error | null) => void) {
           uploadStream.write(chunk, encoding, callback);
@@ -236,9 +247,9 @@ export function createStorageManagerOcflStoreClass(OcflStore: OcflStoreConstruct
       const key = this.keyFor(filePath);
       try {
         if (options === 'utf8' || (typeof options === 'object' && options?.encoding)) {
-          return await this.disk.get(key);
+          return await this.ioDisk.get(key);
         }
-        return await this.disk.getBytes(key);
+        return await this.ioDisk.getBytes(key);
       } catch (error) {
         if (isMissingDiskError(error)) {
           throw toError('ENOENT', filePath);
@@ -254,14 +265,14 @@ export function createStorageManagerOcflStoreClass(OcflStore: OcflStoreConstruct
     ): Promise<void> {
       const key = this.keyFor(filePath);
       if (data instanceof Readable) {
-        await this.disk.putStream(key, data, options);
+        await this.ioDisk.putStream(key, data, options);
         return;
       }
-      await this.disk.put(key, data, options);
+      await this.ioDisk.put(key, data, options);
     }
 
     async copyFile(source: string, target: string): Promise<void> {
-      await this.disk.copy(this.keyFor(source), this.keyFor(target));
+      await this.ioDisk.copy(this.keyFor(source), this.keyFor(target));
     }
 
     async opendir(filePath: string): Promise<{
@@ -291,7 +302,7 @@ export function createStorageManagerOcflStoreClass(OcflStore: OcflStoreConstruct
     async hasDirectoryEntries(filePath: string): Promise<boolean> {
       const prefix = this.keyFor(filePath);
       const directoryPrefix = prefix ? `${prefix.replace(/\/+$/, '')}/` : '';
-      const listing = await this.disk.listAll(directoryPrefix, { recursive: false });
+      const listing = await this.ioDisk.listAll(directoryPrefix, { recursive: false });
       for (const item of listing.objects) {
         if (getEntryKey(item)) {
           return true;
@@ -304,7 +315,7 @@ export function createStorageManagerOcflStoreClass(OcflStore: OcflStoreConstruct
       const keyOptions = { preserveEquals: this.keyEncoding === 'raw' };
       const prefix = this.keyFor(filePath);
       const directoryPrefix = prefix ? `${prefix.replace(/\/+$/, '')}/` : '';
-      const entries = await listDiskEntries(this.disk, directoryPrefix, { recursive: false });
+      const entries = await listDiskEntries(this.ioDisk, directoryPrefix, { recursive: false });
       const names = new Map<string, DirectoryEntryInfo>();
       for (const item of entries) {
         const key = getEntryKey(item);
@@ -349,7 +360,7 @@ export function createStorageManagerOcflStoreClass(OcflStore: OcflStoreConstruct
       const keyOptions = { preserveEquals: this.keyEncoding === 'raw' };
       const prefix = this.keyFor(dirPath);
       const directoryPrefix = prefix ? `${prefix.replace(/\/+$/, '')}/` : '';
-      const entries = await listDiskEntries(this.disk, directoryPrefix, { recursive });
+      const entries = await listDiskEntries(this.ioDisk, directoryPrefix, { recursive });
       async function* iterator() {
         for (const item of entries) {
           const key = getEntryKey(item);
@@ -377,13 +388,13 @@ export function createStorageManagerOcflStoreClass(OcflStore: OcflStoreConstruct
     async move(source: string, target: string): Promise<void> {
       const sourceKey = this.keyFor(source);
       const targetKey = this.keyFor(target);
-      if (await this.disk.exists(sourceKey)) {
-        await this.disk.move(sourceKey, targetKey);
+      if (await this.ioDisk.exists(sourceKey)) {
+        await this.ioDisk.move(sourceKey, targetKey);
         return;
       }
 
       const directoryPrefix = sourceKey ? `${sourceKey.replace(/\/+$/, '')}/` : '';
-      const items = await listDiskEntries(this.disk, directoryPrefix, { recursive: true });
+      const items = await listDiskEntries(this.ioDisk, directoryPrefix, { recursive: true });
       if (items.length === 0) {
         throw toError('ENOENT', source);
       }
@@ -396,17 +407,17 @@ export function createStorageManagerOcflStoreClass(OcflStore: OcflStoreConstruct
         if (directoryPrefix && !key.startsWith(directoryPrefix)) {
           continue;
         }
-        await this.disk.move(key, rel ? `${targetKey}/${rel}` : targetKey);
+        await this.ioDisk.move(key, rel ? `${targetKey}/${rel}` : targetKey);
       }
     }
 
     async remove(filePath: string): Promise<void> {
       const key = this.keyFor(filePath);
-      if (await this.disk.exists(key)) {
-        await this.disk.delete(key);
+      if (await this.ioDisk.exists(key)) {
+        await this.ioDisk.delete(key);
         return;
       }
-      await this.disk.deleteAll(key ? `${key}/` : '');
+      await this.ioDisk.deleteAll(key ? `${key}/` : '');
     }
   };
 }

--- a/packages/redbox-core/src/services/oni-v2/ingestion.ts
+++ b/packages/redbox-core/src/services/oni-v2/ingestion.ts
@@ -1,0 +1,133 @@
+import axios from 'axios';
+import type { OniIngestionConfig } from '../../configmodels/OniPublishing';
+
+export type OniIndexType = 'structural' | 'search';
+
+export interface OniIndexState {
+  state?: string;
+  count?: number;
+  isIndexed?: boolean;
+  isIndexing?: boolean;
+  isDeleting?: boolean;
+}
+
+export interface OniIngestionResult {
+  structuralObjects: number;
+  searchItems: number;
+}
+
+export interface OniIngestionHttpClient {
+  post<T = unknown>(
+    url: string,
+    data?: unknown,
+    options?: { headers?: Record<string, string>; timeout?: number }
+  ): Promise<{ data: T; status: number }>;
+  get<T = unknown>(
+    url: string,
+    options?: { headers?: Record<string, string>; timeout?: number }
+  ): Promise<{ data: T; status: number }>;
+}
+
+type OniIngestionDependencies = {
+  httpClient?: OniIngestionHttpClient;
+  delay?: (milliseconds: number) => Promise<void>;
+  now?: () => number;
+};
+
+function normalizeApiUrl(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+function validateConfig(config: OniIngestionConfig): void {
+  if (String(config.apiUrl ?? '').trim() === '') {
+    throw new Error('Oni ingestion apiUrl is required');
+  }
+  if (String(config.adminToken ?? '').trim() === '') {
+    throw new Error('Oni ingestion adminToken is required');
+  }
+  if (!Number.isFinite(config.pollIntervalMs) || config.pollIntervalMs < 1) {
+    throw new Error('Oni ingestion pollIntervalMs must be greater than zero');
+  }
+  if (!Number.isFinite(config.timeoutMs) || config.timeoutMs < config.pollIntervalMs) {
+    throw new Error('Oni ingestion timeoutMs must be at least pollIntervalMs');
+  }
+}
+
+async function defaultDelay(milliseconds: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
+async function waitForIndex(
+  type: OniIndexType,
+  config: OniIngestionConfig,
+  client: OniIngestionHttpClient,
+  headers: Record<string, string>,
+  delay: (milliseconds: number) => Promise<void>,
+  now: () => number
+): Promise<OniIndexState> {
+  const deadline = now() + config.timeoutMs;
+  const statusUrl = `${normalizeApiUrl(config.apiUrl)}/admin/index/${type}`;
+
+  while (now() < deadline) {
+    await delay(config.pollIntervalMs);
+    try {
+      const response = await client.get<OniIndexState>(statusUrl, {
+        headers,
+        timeout: Math.min(config.timeoutMs, 15_000),
+      });
+      const state = response.data ?? {};
+      if (state.isDeleting || state.isIndexing) {
+        continue;
+      }
+      if (state.isIndexed && Number(state.count ?? 0) > 0) {
+        return state;
+      }
+    } catch (error) {
+      if (!axios.isAxiosError(error) || error.response?.status !== 404) {
+        throw error;
+      }
+    }
+  }
+
+  throw new Error(`Timed out waiting for Oni ${type} index to complete after ${config.timeoutMs}ms`);
+}
+
+async function rebuildIndex(
+  type: OniIndexType,
+  config: OniIngestionConfig,
+  client: OniIngestionHttpClient,
+  headers: Record<string, string>,
+  dependencies: Required<Pick<OniIngestionDependencies, 'delay' | 'now'>>
+): Promise<OniIndexState> {
+  const forceQuery = config.forceReindex ? '?force=true' : '';
+  const url = `${normalizeApiUrl(config.apiUrl)}/admin/index/${type}${forceQuery}`;
+  await client.post(url, undefined, {
+    headers,
+    timeout: Math.min(config.timeoutMs, 15_000),
+  });
+  return waitForIndex(type, config, client, headers, dependencies.delay, dependencies.now);
+}
+
+export async function ingestOniRepository(
+  config: OniIngestionConfig,
+  dependencies: OniIngestionDependencies = {}
+): Promise<OniIngestionResult> {
+  validateConfig(config);
+  const client = dependencies.httpClient ?? (axios as unknown as OniIngestionHttpClient);
+  const headers = {
+    Authorization: `Bearer ${config.adminToken}`,
+    Accept: 'application/json',
+  };
+  const runtimeDependencies = {
+    delay: dependencies.delay ?? defaultDelay,
+    now: dependencies.now ?? Date.now,
+  };
+
+  const structural = await rebuildIndex('structural', config, client, headers, runtimeDependencies);
+  const search = await rebuildIndex('search', config, client, headers, runtimeDependencies);
+
+  return {
+    structuralObjects: Number(structural.count ?? 0),
+    searchItems: Number(search.count ?? 0),
+  };
+}

--- a/packages/redbox-core/src/services/oni-v2/ingestion.ts
+++ b/packages/redbox-core/src/services/oni-v2/ingestion.ts
@@ -53,6 +53,10 @@ function validateConfig(config: OniIngestionConfig): void {
   }
 }
 
+function timeoutError(type: OniIndexType, timeoutMs: number): Error {
+  return new Error(`Timed out waiting for Oni ${type} index to complete after ${timeoutMs}ms`);
+}
+
 async function defaultDelay(milliseconds: number): Promise<void> {
   await new Promise(resolve => setTimeout(resolve, milliseconds));
 }
@@ -63,17 +67,20 @@ async function waitForIndex(
   client: OniIngestionHttpClient,
   headers: Record<string, string>,
   delay: (milliseconds: number) => Promise<void>,
-  now: () => number
+  now: () => number,
+  deadline: number
 ): Promise<OniIndexState> {
-  const deadline = now() + config.timeoutMs;
   const statusUrl = `${normalizeApiUrl(config.apiUrl)}/admin/index/${type}`;
 
   while (now() < deadline) {
-    await delay(config.pollIntervalMs);
+    await delay(Math.min(config.pollIntervalMs, deadline - now()));
+    if (now() >= deadline) {
+      break;
+    }
     try {
       const response = await client.get<OniIndexState>(statusUrl, {
         headers,
-        timeout: Math.min(config.timeoutMs, 15_000),
+        timeout: Math.min(deadline - now(), 15_000),
       });
       const state = response.data ?? {};
       if (state.isDeleting || state.isIndexing) {
@@ -89,7 +96,7 @@ async function waitForIndex(
     }
   }
 
-  throw new Error(`Timed out waiting for Oni ${type} index to complete after ${config.timeoutMs}ms`);
+  throw timeoutError(type, config.timeoutMs);
 }
 
 async function rebuildIndex(
@@ -97,15 +104,20 @@ async function rebuildIndex(
   config: OniIngestionConfig,
   client: OniIngestionHttpClient,
   headers: Record<string, string>,
-  dependencies: Required<Pick<OniIngestionDependencies, 'delay' | 'now'>>
+  dependencies: Required<Pick<OniIngestionDependencies, 'delay' | 'now'>>,
+  deadline: number
 ): Promise<OniIndexState> {
+  const remainingMs = deadline - dependencies.now();
+  if (remainingMs <= 0) {
+    throw timeoutError(type, config.timeoutMs);
+  }
   const forceQuery = config.forceReindex ? '?force=true' : '';
   const url = `${normalizeApiUrl(config.apiUrl)}/admin/index/${type}${forceQuery}`;
   await client.post(url, undefined, {
     headers,
-    timeout: Math.min(config.timeoutMs, 15_000),
+    timeout: Math.min(remainingMs, 15_000),
   });
-  return waitForIndex(type, config, client, headers, dependencies.delay, dependencies.now);
+  return waitForIndex(type, config, client, headers, dependencies.delay, dependencies.now, deadline);
 }
 
 export async function ingestOniRepository(
@@ -122,9 +134,10 @@ export async function ingestOniRepository(
     delay: dependencies.delay ?? defaultDelay,
     now: dependencies.now ?? Date.now,
   };
+  const deadline = runtimeDependencies.now() + config.timeoutMs;
 
-  const structural = await rebuildIndex('structural', config, client, headers, runtimeDependencies);
-  const search = await rebuildIndex('search', config, client, headers, runtimeDependencies);
+  const structural = await rebuildIndex('structural', config, client, headers, runtimeDependencies, deadline);
+  const search = await rebuildIndex('search', config, client, headers, runtimeDependencies, deadline);
 
   return {
     structuralObjects: Number(structural.count ?? 0),

--- a/packages/redbox-core/src/services/oni-v2/repository.ts
+++ b/packages/redbox-core/src/services/oni-v2/repository.ts
@@ -58,8 +58,11 @@ async function importOcflModule(): Promise<OcflModuleAdapter> {
   const imported = await import(moduleName);
   const moduleRecord = imported as Record<string, unknown>;
   const candidate = (moduleRecord.default ?? imported) as Record<string, unknown>;
-  if (typeof candidate.Ocfl !== 'function' || typeof candidate.OcflStore !== 'function') {
-    throw new Error('@ocfl/ocfl did not expose Ocfl and OcflStore constructors');
+  if (
+    typeof candidate.OcflStore !== 'function' ||
+    (typeof candidate.implementOcfl !== 'function' && typeof candidate.Ocfl !== 'function')
+  ) {
+    throw new Error('@ocfl/ocfl did not expose a supported implementation factory and OcflStore constructor');
   }
   return candidate as unknown as OcflModuleAdapter;
 }
@@ -70,10 +73,15 @@ function isInvalidStorageRootError(error: unknown): boolean {
 
 function isMissingObjectError(error: unknown): boolean {
   const err = error as NodeJS.ErrnoException;
-  const code = String(err.code ?? '').toUpperCase();
+  const code = String(err.code ?? err.name ?? '').toUpperCase();
   const message = asError(error).message.toLowerCase();
   return (
-    code === 'ENOENT' || code.includes('NOT_FOUND') || message.includes('not found') || message.includes('no such file')
+    code === 'ENOENT' ||
+    code.includes('NOT_FOUND') ||
+    code.includes('NOSUCHKEY') ||
+    message.includes('not found') ||
+    message.includes('no such file') ||
+    message.includes('does not exist')
   );
 }
 
@@ -121,7 +129,10 @@ class FlydriveOniRepository implements OniOcflRepository {
         prefix: storageConfig.prefix,
         keyEncoding: storageConfig.keyEncoding,
       };
-      const flydriveOcfl = new ocfl.Ocfl(storeClass, storeOptions);
+      const flydriveOcfl =
+        typeof ocfl.implementOcfl === 'function'
+          ? ocfl.implementOcfl(storeClass, storeOptions)
+          : new ocfl.Ocfl!(storeClass, storeOptions);
       return flydriveOcfl.storage(
         {
           root: storageConfig.rootPath,

--- a/packages/redbox-core/src/services/oni-v2/types.ts
+++ b/packages/redbox-core/src/services/oni-v2/types.ts
@@ -94,7 +94,13 @@ export interface OcflStorageConfig {
 }
 
 export interface OcflModuleAdapter {
-  Ocfl: new (
+  Ocfl?: new (
+    storeClass: unknown,
+    storeOptions: Record<string, unknown>
+  ) => {
+    storage(config: OcflStorageConfig, storeOptions: Record<string, unknown>): OcflStorageAdapter;
+  };
+  implementOcfl?: (
     storeClass: unknown,
     storeOptions: Record<string, unknown>
   ) => {

--- a/packages/redbox-core/test/services/OniService.test.ts
+++ b/packages/redbox-core/test/services/OniService.test.ts
@@ -1,5 +1,6 @@
 let expect: Chai.ExpectStatic;
 import * as sinon from 'sinon';
+import axios from 'axios';
 import { of } from 'rxjs';
 import { finished } from 'node:stream/promises';
 import { Services } from '../../src/services/OniService';
@@ -151,6 +152,12 @@ describe('OniService', function () {
     expect(config?.sites['test-site'].storage.driver).to.equal('flydrive');
   });
 
+  it('defaults Oni ingestion to non-forced index rebuilds', function () {
+    const defaults = new OniPublishing();
+    expect(defaults.sites.staging.ingestion?.forceReindex).to.equal(false);
+    expect(defaults.sites.public.ingestion?.forceReindex).to.equal(false);
+  });
+
   it('ignores synthesized non-default oniPublishing config when merging default-brand overrides', function () {
     const defaultOniPublishing = { ...oniPublishing, enabled: false };
     const generatedBrandConfig = { oniPublishing: new OniPublishing() };
@@ -235,7 +242,12 @@ describe('OniService', function () {
     const graph = result.crateJson['@graph'] as Array<Record<string, unknown>>;
     const graphIds = graph.map(entry => entry['@id']);
     const root = graph.find(entry => entry['@id'] === result.rootId)!;
-    const license = (root.license as Array<Record<string, unknown>>)[0];
+    const expectedLicense = {
+      '@id': 'https://creativecommons.org/licenses/by/4.0/',
+      '@type': 'CreativeWork',
+      name: 'https://creativecommons.org/licenses/by/4.0/',
+      url: 'https://creativecommons.org/licenses/by/4.0/',
+    };
     const descriptor = graph.find(entry => entry['@id'] === 'ro-crate-metadata.json')!;
     const historyCreate = graph.find(entry => entry['@id'] === 'history1')!;
     const creatorPeople = graph.filter(entry => entry.email === 'creator@example.edu');
@@ -244,7 +256,8 @@ describe('OniService', function () {
     expect(creatorPeople).to.have.lengthOf(1);
     expect(root.funder).to.deep.equal([{ '@id': '_:funder/03yrm5c26' }, { '@id': '_:funder/grant-1' }]);
     expect(root.conformsTo).to.deep.equal({ '@id': 'https://w3id.org/ldac/profile#Object' });
-    expect(graph.find(entry => entry['@id'] === license['@id'])).to.deep.include(license);
+    expect(root.license).to.deep.equal([expectedLicense]);
+    expect(graph.find(entry => entry['@id'] === expectedLicense['@id'])).to.deep.include(expectedLicense);
     expect(root.about).to.deep.equal([{ '@id': '_:FOR/0601' }, { '@id': '_:SEO/9608' }]);
     expect(root.publications).to.deep.equal([{ '@id': 'https://doi.org/10.1234/related-publication' }]);
     expect(root.data).to.deep.equal([{ '@id': 'https://doi.org/10.1234/related-dataset' }]);
@@ -529,6 +542,8 @@ describe('OniService', function () {
       approver: { email: 'approver@example.edu' },
     });
     const pointGraph = pointResult.crateJson['@graph'] as Array<Record<string, unknown>>;
+    const pointRoot = pointGraph.find(entry => entry['@id'] === pointResult.rootId)!;
+    expect(pointRoot.spatialCoverage).to.deep.equal([{ '@id': '_:place-0' }]);
     expect(pointGraph.find(entry => entry['@id'] === '_:place-0')).to.deep.include({
       '@type': 'Place',
       geo: { '@id': '_:geo-0' },
@@ -652,6 +667,88 @@ describe('OniService', function () {
     });
   });
 
+  it('omits ingestion counts from the publish audit when ingestion is disabled', async function () {
+    const serviceInternals = service as unknown as Record<string, (...args: unknown[]) => unknown>;
+    sinon.stub(serviceInternals, 'createRepository').returns({});
+    sinon.stub(serviceInternals, 'runPublishDataset').resolves({
+      datasetUrl: 'https://data.example.edu/pub-1',
+      rootId: 'arcp://name,test/pub-1',
+      rootCollectionId: oniPublishing.rootCollection.rootCollectionId,
+      dataRecordOid: 'data-1',
+      attachments: [],
+      crateJson: {},
+      siteName: 'test-site',
+      storageDriver: 'flydrive',
+    });
+    sinon.stub(serviceInternals, 'ingestDataset').resolves(undefined);
+
+    await service.exportDataset(
+      'pub-1',
+      publicationRecord(),
+      { site: 'test-site', forceRun: true },
+      { email: 'approver@example.edu' }
+    );
+
+    const completeAudit = (global as unknown as { IntegrationAuditService: { completeAudit: sinon.SinonStub } })
+      .IntegrationAuditService.completeAudit;
+    expect(completeAudit.firstCall.args[1].responseSummary).not.to.have.property('structuralObjects');
+    expect(completeAudit.firstCall.args[1].responseSummary).not.to.have.property('searchItems');
+  });
+
+  it('retains citation write-back and records the completed OCFL write when ingestion fails', async function () {
+    const record = publicationRecord();
+    const serviceInternals = service as unknown as Record<string, (...args: unknown[]) => unknown>;
+    sinon.stub(serviceInternals, 'createRepository').returns({});
+    sinon.stub(serviceInternals, 'runPublishDataset').resolves({
+      datasetUrl: 'https://data.example.edu/pub-1',
+      rootId: 'arcp://name,test/pub-1',
+      rootCollectionId: oniPublishing.rootCollection.rootCollectionId,
+      dataRecordOid: 'data-1',
+      attachments: [],
+      crateJson: {},
+      siteName: 'test-site',
+      storageDriver: 'flydrive',
+    });
+    sinon.stub(serviceInternals, 'ingestDataset').rejects(new Error('Oni indexing failed'));
+
+    try {
+      await service.exportDataset(
+        'pub-1',
+        record,
+        { site: 'test-site', forceRun: true },
+        { email: 'approver@example.edu' }
+      );
+      expect.fail('Expected ingestion failure to be rethrown');
+    } catch (error) {
+      expect(error).to.be.instanceOf(RBValidationError);
+      expect((error as RBValidationError).displayErrors[0].detail).to.equal(
+        'Oni OCFL publication completed but repository ingestion failed'
+      );
+    }
+
+    const updateMeta = (global as unknown as { RecordsService: { updateMeta: sinon.SinonStub } }).RecordsService
+      .updateMeta;
+    expect(updateMeta.firstCall.args[2].metadata.citation_url).to.equal('https://data.example.edu/pub-1');
+    expect(updateMeta.firstCall.args[2].metadata.citation_doi).to.equal(
+      'https://doi.org/10.1234/https://data.example.edu/pub-1'
+    );
+    expect(updateMeta.firstCall.args[2].metadata.publication_error).to.include('Oni indexing failed');
+
+    const failAudit = (global as unknown as { IntegrationAuditService: { failAudit: sinon.SinonStub } })
+      .IntegrationAuditService.failAudit;
+    expect(failAudit.firstCall.args[2]).to.deep.include({
+      message: 'Oni OCFL write completed, but repository ingestion failed.',
+      responseSummary: {
+        errorType: 'Error',
+        message: 'Oni indexing failed',
+        ocflWriteCompleted: true,
+        storageDriver: 'flydrive',
+        rootId: 'arcp://name,test/pub-1',
+        datasetUrl: 'https://data.example.edu/pub-1',
+      },
+    });
+  });
+
   it('skips disabled Oni ingestion without creating an audit', async function () {
     const result = await (
       service as unknown as {
@@ -758,6 +855,109 @@ describe('OniService', function () {
     expect(client.post.firstCall.args[0]).to.equal('http://oni-api:8080/admin/index/structural?force=true');
     expect(client.post.secondCall.args[0]).to.equal('http://oni-api:8080/admin/index/search?force=true');
     expect(client.post.firstCall.args[2].headers.Authorization).to.equal('Bearer secret-token');
+  });
+
+  it('omits force query parameters when Oni forceReindex is false', async function () {
+    let now = 0;
+    const client = {
+      post: sinon.stub().resolves({ data: {}, status: 202 }),
+      get: sinon.stub(),
+    };
+    client.get.onCall(0).resolves({ data: { isIndexed: true, count: 2 }, status: 200 });
+    client.get.onCall(1).resolves({ data: { isIndexed: true, count: 1 }, status: 200 });
+
+    const result = await ingestOniRepository(
+      {
+        enabled: true,
+        apiUrl: 'http://oni-api:8080/',
+        adminToken: 'secret-token',
+        forceReindex: false,
+        pollIntervalMs: 10,
+        timeoutMs: 1_000,
+      },
+      {
+        httpClient: client,
+        delay: async milliseconds => {
+          now += milliseconds;
+        },
+        now: () => now,
+      }
+    );
+
+    expect(result).to.deep.equal({ structuralObjects: 2, searchItems: 1 });
+    expect(client.post.firstCall.args[0]).to.equal('http://oni-api:8080/admin/index/structural');
+    expect(client.post.secondCall.args[0]).to.equal('http://oni-api:8080/admin/index/search');
+  });
+
+  it('continues polling when an Oni index status is initially unavailable', async function () {
+    let now = 0;
+    const notFoundError = Object.assign(new Error('Index status not found'), {
+      isAxiosError: true,
+      response: { status: 404 },
+    });
+    expect(axios.isAxiosError(notFoundError)).to.equal(true);
+    const client = {
+      post: sinon.stub().resolves({ data: {}, status: 202 }),
+      get: sinon.stub(),
+    };
+    client.get.onCall(0).rejects(notFoundError);
+    client.get.onCall(1).resolves({ data: { isIndexed: true, count: 2 }, status: 200 });
+    client.get.onCall(2).resolves({ data: { isIndexed: true, count: 1 }, status: 200 });
+
+    const result = await ingestOniRepository(
+      {
+        enabled: true,
+        apiUrl: 'http://oni-api:8080/',
+        adminToken: 'secret-token',
+        forceReindex: false,
+        pollIntervalMs: 10,
+        timeoutMs: 1_000,
+      },
+      {
+        httpClient: client,
+        delay: async milliseconds => {
+          now += milliseconds;
+        },
+        now: () => now,
+      }
+    );
+
+    expect(result).to.deep.equal({ structuralObjects: 2, searchItems: 1 });
+    expect(client.get.callCount).to.equal(3);
+  });
+
+  it('shares one timeout deadline across Oni structural and search indexing', async function () {
+    let now = 0;
+    const client = {
+      post: sinon.stub().resolves({ data: {}, status: 202 }),
+      get: sinon.stub().resolves({ data: { isIndexed: true, count: 2 }, status: 200 }),
+    };
+
+    try {
+      await ingestOniRepository(
+        {
+          enabled: true,
+          apiUrl: 'http://oni-api:8080/',
+          adminToken: 'secret-token',
+          forceReindex: false,
+          pollIntervalMs: 10,
+          timeoutMs: 20,
+        },
+        {
+          httpClient: client,
+          delay: async milliseconds => {
+            now += milliseconds;
+          },
+          now: () => now,
+        }
+      );
+      expect.fail('Expected the shared ingestion deadline to expire');
+    } catch (error) {
+      expect(error).to.have.property('message', 'Timed out waiting for Oni search index to complete after 20ms');
+    }
+
+    expect(client.get.calledOnce).to.equal(true);
+    expect(client.post.secondCall.args[2].timeout).to.equal(10);
   });
 
   it('audits and writes publication errors when the requested Oni site is unknown', async function () {

--- a/packages/redbox-core/test/services/OniService.test.ts
+++ b/packages/redbox-core/test/services/OniService.test.ts
@@ -11,6 +11,7 @@ import { mapDatasetFields, mapGraphEntities, validateMappedDataset } from '../..
 import { getBrandName, resolveOniPublishingConfig, resolveOniSite } from '../../src/services/oni-v2/config';
 import { createStorageManagerOcflStoreClass } from '../../src/services/oni-v2/flydriveOcflStore';
 import { runPublishDatasetProgram } from '../../src/services/oni-v2/runtime';
+import { ingestOniRepository } from '../../src/services/oni-v2/ingestion';
 import type { Services as StorageManagerServices } from '../../src/services/StorageManagerService';
 import { RBValidationError } from '../../src/model/RBValidationError';
 import { cleanupServiceTestGlobals, createMockSails, setupServiceTestGlobals } from './testHelper';
@@ -233,6 +234,7 @@ describe('OniService', function () {
     const graph = result.crateJson['@graph'] as Array<Record<string, unknown>>;
     const graphIds = graph.map(entry => entry['@id']);
     const root = graph.find(entry => entry['@id'] === result.rootId)!;
+    const license = (root.license as Array<Record<string, unknown>>)[0];
     const descriptor = graph.find(entry => entry['@id'] === 'ro-crate-metadata.json')!;
     const historyCreate = graph.find(entry => entry['@id'] === 'history1')!;
     const creatorPeople = graph.filter(entry => entry.email === 'creator@example.edu');
@@ -240,6 +242,8 @@ describe('OniService', function () {
     expect(historyCreate.agent).to.deep.equal({ '@id': 'https://orcid.org/0000-0001-2345-6789' });
     expect(creatorPeople).to.have.lengthOf(1);
     expect(root.funder).to.deep.equal([{ '@id': '_:funder/03yrm5c26' }, { '@id': '_:funder/grant-1' }]);
+    expect(root.conformsTo).to.deep.equal({ '@id': 'https://w3id.org/ldac/profile#Object' });
+    expect(graph.find(entry => entry['@id'] === license['@id'])).to.deep.include(license);
     expect(root.about).to.deep.equal([{ '@id': '_:FOR/0601' }, { '@id': '_:SEO/9608' }]);
     expect(root.publications).to.deep.equal([{ '@id': 'https://doi.org/10.1234/related-publication' }]);
     expect(root.data).to.deep.equal([{ '@id': 'https://doi.org/10.1234/related-dataset' }]);
@@ -496,6 +500,44 @@ describe('OniService', function () {
     expect(getSelectedAttachments(record, oniPublishing)).to.deep.equal([]);
   });
 
+  it('omits empty GeoJSON coverage and emits linked entities for real geometry', async function () {
+    const emptyRecord = publicationRecord();
+    emptyRecord.metadata.geospatial = { type: 'FeatureCollection', features: [] };
+    const emptyResult = await buildOniRoCrate({
+      config: oniPublishing,
+      site: oniPublishing.sites['test-site'],
+      siteName: 'test-site',
+      oid: 'pub-empty-geo',
+      record: emptyRecord,
+      creator: { email: 'creator@example.edu' },
+      approver: { email: 'approver@example.edu' },
+    });
+    const emptyGraph = emptyResult.crateJson['@graph'] as Array<Record<string, unknown>>;
+    const emptyRoot = emptyGraph.find(entry => entry['@id'] === emptyResult.rootId)!;
+    expect(emptyRoot).not.to.have.property('spatialCoverage');
+
+    const pointRecord = publicationRecord();
+    pointRecord.metadata.geospatial = { type: 'Point', coordinates: [138.6, -34.9] };
+    const pointResult = await buildOniRoCrate({
+      config: oniPublishing,
+      site: oniPublishing.sites['test-site'],
+      siteName: 'test-site',
+      oid: 'pub-point-geo',
+      record: pointRecord,
+      creator: { email: 'creator@example.edu' },
+      approver: { email: 'approver@example.edu' },
+    });
+    const pointGraph = pointResult.crateJson['@graph'] as Array<Record<string, unknown>>;
+    expect(pointGraph.find(entry => entry['@id'] === '_:place-0')).to.deep.include({
+      '@type': 'Place',
+      geo: { '@id': '_:geo-0' },
+    });
+    const geometry = pointGraph.find(entry => entry['@id'] === '_:geo-0')!;
+    expect(geometry['@type']).to.equal('Geometry');
+    expect(String(geometry.asWKT)).to.include('POINT');
+    expect(String(geometry.asWKT)).to.include('138.6 -34.9');
+  });
+
   it('accepts legacy truthy selected attachment flags', function () {
     const record = publicationRecord();
     record.metadata.dataLocations = [
@@ -552,6 +594,10 @@ describe('OniService', function () {
       siteName: 'test-site',
       storageDriver: 'flydrive',
     });
+    const ingestStub = sinon.stub(serviceInternals, 'ingestDataset').resolves({
+      structuralObjects: 2,
+      searchItems: 1,
+    });
 
     await service.exportDataset(
       'pub-1',
@@ -577,6 +623,42 @@ describe('OniService', function () {
     expect(updateMeta.firstCall.args[2].metadata.publication_error).to.equal(undefined);
     expect(updateMeta.firstCall.args[4]).to.equal(true);
     expect(updateMeta.firstCall.args[5]).to.equal(false);
+    expect(ingestStub.calledOnce).to.equal(true);
+  });
+
+  it('rebuilds Oni structural and search indexes and waits for completion', async function () {
+    let now = 0;
+    const client = {
+      post: sinon.stub().resolves({ data: {}, status: 202 }),
+      get: sinon.stub(),
+    };
+    client.get.onCall(0).resolves({ data: { isDeleting: true, count: 0 }, status: 200 });
+    client.get.onCall(1).resolves({ data: { isIndexed: true, count: 2 }, status: 200 });
+    client.get.onCall(2).resolves({ data: { isIndexing: true, count: 0 }, status: 200 });
+    client.get.onCall(3).resolves({ data: { isIndexed: true, count: 1 }, status: 200 });
+
+    const result = await ingestOniRepository(
+      {
+        enabled: true,
+        apiUrl: 'http://oni-api:8080/',
+        adminToken: 'secret-token',
+        forceReindex: true,
+        pollIntervalMs: 10,
+        timeoutMs: 1_000,
+      },
+      {
+        httpClient: client,
+        delay: async milliseconds => {
+          now += milliseconds;
+        },
+        now: () => now,
+      }
+    );
+
+    expect(result).to.deep.equal({ structuralObjects: 2, searchItems: 1 });
+    expect(client.post.firstCall.args[0]).to.equal('http://oni-api:8080/admin/index/structural?force=true');
+    expect(client.post.secondCall.args[0]).to.equal('http://oni-api:8080/admin/index/search?force=true');
+    expect(client.post.firstCall.args[2].headers.Authorization).to.equal('Bearer secret-token');
   });
 
   it('audits and writes publication errors when the requested Oni site is unknown', async function () {

--- a/packages/redbox-core/test/services/OniService.test.ts
+++ b/packages/redbox-core/test/services/OniService.test.ts
@@ -11,6 +11,7 @@ import { mapDatasetFields, mapGraphEntities, validateMappedDataset } from '../..
 import { getBrandName, resolveOniPublishingConfig, resolveOniSite } from '../../src/services/oni-v2/config';
 import { createStorageManagerOcflStoreClass } from '../../src/services/oni-v2/flydriveOcflStore';
 import { runPublishDatasetProgram } from '../../src/services/oni-v2/runtime';
+import * as ingestionModule from '../../src/services/oni-v2/ingestion';
 import { ingestOniRepository } from '../../src/services/oni-v2/ingestion';
 import type { Services as StorageManagerServices } from '../../src/services/StorageManagerService';
 import { RBValidationError } from '../../src/model/RBValidationError';
@@ -536,6 +537,25 @@ describe('OniService', function () {
     expect(geometry['@type']).to.equal('Geometry');
     expect(String(geometry.asWKT)).to.include('POINT');
     expect(String(geometry.asWKT)).to.include('138.6 -34.9');
+
+    const mixedRecord = publicationRecord();
+    mixedRecord.metadata.geospatial = [
+      null,
+      { type: 'FeatureCollection', features: [] },
+      { type: 'GeometryCollection', geometries: [] },
+      { type: 'Point', coordinates: [138.6, -34.9] },
+    ];
+    const mixedResult = await buildOniRoCrate({
+      config: oniPublishing,
+      site: oniPublishing.sites['test-site'],
+      siteName: 'test-site',
+      oid: 'pub-mixed-geo',
+      record: mixedRecord,
+      creator: { email: 'creator@example.edu' },
+      approver: { email: 'approver@example.edu' },
+    });
+    const mixedGraph = mixedResult.crateJson['@graph'] as Array<Record<string, unknown>>;
+    expect(mixedGraph.filter(entry => entry['@type'] === 'Place')).to.have.lengthOf(1);
   });
 
   it('accepts legacy truthy selected attachment flags', function () {
@@ -624,6 +644,85 @@ describe('OniService', function () {
     expect(updateMeta.firstCall.args[4]).to.equal(true);
     expect(updateMeta.firstCall.args[5]).to.equal(false);
     expect(ingestStub.calledOnce).to.equal(true);
+    const completeAudit = (global as unknown as { IntegrationAuditService: { completeAudit: sinon.SinonStub } })
+      .IntegrationAuditService.completeAudit;
+    expect(completeAudit.firstCall.args[1].responseSummary).to.include({
+      structuralObjects: 2,
+      searchItems: 1,
+    });
+  });
+
+  it('skips disabled Oni ingestion without creating an audit', async function () {
+    const result = await (
+      service as unknown as {
+        ingestDataset: (...args: unknown[]) => Promise<unknown>;
+      }
+    ).ingestDataset('pub-1', oniPublishing.sites['test-site'], { siteName: 'test-site' }, null);
+
+    expect(result).to.equal(undefined);
+    expect(
+      (global as unknown as { IntegrationAuditService: { startAudit: sinon.SinonStub } }).IntegrationAuditService
+        .startAudit.called
+    ).to.equal(false);
+  });
+
+  it('audits successful and failed Oni ingestion runs', async function () {
+    const site = oniPublishing.sites['test-site'];
+    site.ingestion = {
+      enabled: true,
+      apiUrl: 'https://oni.example.test',
+      adminToken: 'secret-token',
+      forceReindex: true,
+      pollIntervalMs: 10,
+      timeoutMs: 100,
+    };
+    const runContext = {
+      recordOid: 'pub-1',
+      brandId: 'brand-1',
+      brandName: 'default',
+      siteName: 'test-site',
+      correlationId: 'job-1',
+      triggerSource: 'test',
+    };
+    const ingestStub = sinon.stub(ingestionModule, 'ingestOniRepository').resolves({
+      structuralObjects: 3,
+      searchItems: 4,
+    });
+    const internals = service as unknown as {
+      ingestDataset: (...args: unknown[]) => Promise<unknown>;
+    };
+
+    const result = await internals.ingestDataset('pub-1', site, runContext, null);
+    expect(result).to.deep.equal({ structuralObjects: 3, searchItems: 4 });
+    expect(ingestStub.calledOnceWithExactly(site.ingestion)).to.equal(true);
+
+    const auditService = (
+      global as unknown as {
+        IntegrationAuditService: {
+          startAudit: sinon.SinonStub;
+          completeAudit: sinon.SinonStub;
+          failAudit: sinon.SinonStub;
+        };
+      }
+    ).IntegrationAuditService;
+    expect(auditService.startAudit.firstCall.args[1]).to.equal(IntegrationAuditAction.ingestOniDataset);
+    expect(auditService.completeAudit.firstCall.args[1].responseSummary).to.include({
+      structuralObjects: 3,
+      searchItems: 4,
+    });
+
+    ingestStub.rejects(new Error('Oni indexing failed'));
+    try {
+      await internals.ingestDataset('pub-1', site, runContext, null);
+      expect.fail('Expected ingestion to throw');
+    } catch (error) {
+      expect(error).to.be.an('error').with.property('message', 'Oni indexing failed');
+    }
+    expect(auditService.failAudit.calledOnce).to.equal(true);
+    expect(auditService.failAudit.firstCall.args[2].responseSummary).to.deep.include({
+      errorType: 'Error',
+      message: 'Oni indexing failed',
+    });
   });
 
   it('rebuilds Oni structural and search indexes and waits for completion', async function () {

--- a/packages/redbox-core/test/services/oni-v2/flydriveOcflStore.test.ts
+++ b/packages/redbox-core/test/services/oni-v2/flydriveOcflStore.test.ts
@@ -36,9 +36,18 @@ function harness(keyEncoding: 'flydrive' | 'raw' = 'flydrive') {
 function rawDriverHarness() {
   const result = harness('raw');
   const driver = {
-    ...result.disk,
+    getMetaData: sinon.stub(),
+    listAll: sinon.stub().resolves({ objects: [], paginationToken: undefined }),
+    getStream: sinon.stub().returns(Readable.from('raw-streamed')),
     get: sinon.stub().resolves('ocfl_1.1\n'),
+    getBytes: sinon.stub().resolves(Buffer.from('raw-bytes')),
     put: sinon.stub().resolves(),
+    putStream: sinon.stub().resolves(),
+    copy: sinon.stub().resolves(),
+    exists: sinon.stub().resolves(false),
+    move: sinon.stub().resolves(),
+    delete: sinon.stub().resolves(),
+    deleteAll: sinon.stub().resolves(),
   };
   result.disk.driver = driver;
   const Store = createStorageManagerOcflStoreClass(BaseStore);
@@ -110,14 +119,49 @@ describe('Oni Flydrive OCFL store', () => {
 
   it('bypasses the Flydrive key normalizer for explicitly configured raw OCFL keys', async () => {
     const { disk, driver, store } = rawDriverHarness();
+    const modified = new Date('2025-01-01T00:00:00Z');
+    driver.getMetaData.resolves({ contentLength: 12, lastModified: modified });
+    driver.listAll.resolves({
+      objects: [{ key: 'oni/folder/a=b.txt', isFile: true }],
+      paginationToken: undefined,
+    });
+    driver.exists.onCall(0).resolves(true);
+    driver.exists.onCall(1).resolves(true);
+    driver.exists.onCall(2).resolves(false);
 
     expect(await store.readFile('/repo/0=ocfl_1.1', 'utf8')).to.equal('ocfl_1.1\n');
     await store.writeFile('/repo/0=ocfl_1.1', 'ocfl_1.1\n');
+    await store.writeFile('/repo/stream=a', Readable.from('streamed'));
+    const stat = await store.stat('/repo/meta=data');
+    expect(stat.size).to.equal(12);
+    expect(await store.createReadable('/repo/read=stream')).to.equal(driver.getStream.returnValues[0]);
+    expect(await store.readdir('/repo/folder')).to.deep.equal(['a=b.txt']);
+    await store.copyFile('/repo/source=a', '/repo/target=b');
+    await store.move('/repo/source=a', '/repo/target=b');
+    await store.remove('/repo/target=b');
+    await store.remove('/repo/folder=a');
 
     expect(driver.get.calledOnceWithExactly('oni/0=ocfl_1.1')).to.equal(true);
     expect(driver.put.calledOnceWith('oni/0=ocfl_1.1', 'ocfl_1.1\n')).to.equal(true);
+    expect(driver.putStream.calledOnceWith('oni/stream=a')).to.equal(true);
+    expect(driver.getMetaData.calledOnceWithExactly('oni/meta=data')).to.equal(true);
+    expect(driver.getStream.calledOnceWithExactly('oni/read=stream')).to.equal(true);
+    expect(driver.listAll.calledOnceWith('oni/folder/', { recursive: false })).to.equal(true);
+    expect(driver.copy.calledOnceWithExactly('oni/source=a', 'oni/target=b')).to.equal(true);
+    expect(driver.move.calledOnceWithExactly('oni/source=a', 'oni/target=b')).to.equal(true);
+    expect(driver.delete.calledOnceWithExactly('oni/target=b')).to.equal(true);
+    expect(driver.deleteAll.calledOnceWithExactly('oni/folder=a/')).to.equal(true);
     expect(disk.get.called).to.equal(false);
     expect(disk.put.called).to.equal(false);
+    expect(disk.putStream.called).to.equal(false);
+    expect(disk.getMetaData.called).to.equal(false);
+    expect(disk.getStream.called).to.equal(false);
+    expect(disk.listAll.called).to.equal(false);
+    expect(disk.copy.called).to.equal(false);
+    expect(disk.exists.called).to.equal(false);
+    expect(disk.move.called).to.equal(false);
+    expect(disk.delete.called).to.equal(false);
+    expect(disk.deleteAll.called).to.equal(false);
 
     driver.get.rejects(Object.assign(new Error('The specified key does not exist.'), { name: 'NoSuchKey' }));
     try {

--- a/packages/redbox-core/test/services/oni-v2/flydriveOcflStore.test.ts
+++ b/packages/redbox-core/test/services/oni-v2/flydriveOcflStore.test.ts
@@ -33,6 +33,25 @@ function harness(keyEncoding: 'flydrive' | 'raw' = 'flydrive') {
   return { disk, store };
 }
 
+function rawDriverHarness() {
+  const result = harness('raw');
+  const driver = {
+    ...result.disk,
+    get: sinon.stub().resolves('ocfl_1.1\n'),
+    put: sinon.stub().resolves(),
+  };
+  result.disk.driver = driver;
+  const Store = createStorageManagerOcflStoreClass(BaseStore);
+  const store: any = new Store({
+    disk: result.disk,
+    root: '/repo',
+    workspace: '/work',
+    prefix: '/oni/',
+    keyEncoding: 'raw',
+  });
+  return { disk: result.disk, driver, store };
+}
+
 describe('Oni Flydrive OCFL store', () => {
   it('maps root, workspace, encoded, and raw keys', () => {
     const { store } = harness();
@@ -83,6 +102,26 @@ describe('Oni Flydrive OCFL store', () => {
     disk.get.rejects(Object.assign(new Error('cannot read file'), { code: 'CANNOT_READ_FILE' }));
     try {
       await store.readFile('/repo/missing', 'utf8');
+      expect.fail('Expected ENOENT');
+    } catch (error: any) {
+      expect(error.code).to.equal('ENOENT');
+    }
+  });
+
+  it('bypasses the Flydrive key normalizer for explicitly configured raw OCFL keys', async () => {
+    const { disk, driver, store } = rawDriverHarness();
+
+    expect(await store.readFile('/repo/0=ocfl_1.1', 'utf8')).to.equal('ocfl_1.1\n');
+    await store.writeFile('/repo/0=ocfl_1.1', 'ocfl_1.1\n');
+
+    expect(driver.get.calledOnceWithExactly('oni/0=ocfl_1.1')).to.equal(true);
+    expect(driver.put.calledOnceWith('oni/0=ocfl_1.1', 'ocfl_1.1\n')).to.equal(true);
+    expect(disk.get.called).to.equal(false);
+    expect(disk.put.called).to.equal(false);
+
+    driver.get.rejects(Object.assign(new Error('The specified key does not exist.'), { name: 'NoSuchKey' }));
+    try {
+      await store.readFile('/repo/missing=key', 'utf8');
       expect.fail('Expected ENOENT');
     } catch (error: any) {
       expect(error.code).to.equal('ENOENT');

--- a/packages/redbox-core/test/services/oni-v2/ingestion.test.ts
+++ b/packages/redbox-core/test/services/oni-v2/ingestion.test.ts
@@ -1,0 +1,139 @@
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import type { OniIngestionConfig } from '../../../src/configmodels/OniPublishing';
+import { ingestOniRepository, type OniIngestionHttpClient } from '../../../src/services/oni-v2/ingestion';
+
+const baseConfig: OniIngestionConfig = {
+  enabled: true,
+  apiUrl: 'https://oni.example.test///',
+  adminToken: 'admin-token',
+  forceReindex: false,
+  pollIntervalMs: 1,
+  timeoutMs: 20,
+};
+
+function axiosNotFound(): Error {
+  const error = new Error('The requested index does not exist.') as Error & {
+    isAxiosError: boolean;
+    response: { status: number };
+  };
+  error.isAxiosError = true;
+  error.response = { status: 404 };
+  return error;
+}
+
+async function expectRejected(action: () => Promise<unknown>, message: string): Promise<void> {
+  try {
+    await action();
+    expect.fail(`Expected rejection: ${message}`);
+  } catch (error) {
+    expect(error).to.be.an('error').with.property('message', message);
+  }
+}
+
+describe('Oni ingestion', () => {
+  afterEach(() => sinon.restore());
+
+  it('validates the ingestion configuration before making requests', async () => {
+    await expectRejected(
+      () => ingestOniRepository({ ...baseConfig, apiUrl: '  ' }, { httpClient: {} as OniIngestionHttpClient }),
+      'Oni ingestion apiUrl is required'
+    );
+    await expectRejected(
+      () => ingestOniRepository({ ...baseConfig, adminToken: '' }, { httpClient: {} as OniIngestionHttpClient }),
+      'Oni ingestion adminToken is required'
+    );
+    await expectRejected(
+      () => ingestOniRepository({ ...baseConfig, pollIntervalMs: 0 }, { httpClient: {} as OniIngestionHttpClient }),
+      'Oni ingestion pollIntervalMs must be greater than zero'
+    );
+    await expectRejected(
+      () => ingestOniRepository({ ...baseConfig, timeoutMs: 0 }, { httpClient: {} as OniIngestionHttpClient }),
+      'Oni ingestion timeoutMs must be at least pollIntervalMs'
+    );
+  });
+
+  it('rebuilds both indexes, tolerates a missing status during polling, and returns counts', async () => {
+    let now = 0;
+    const client = {
+      post: sinon.stub().resolves({ data: {}, status: 202 }),
+      get: sinon.stub(),
+    };
+    client.get.onCall(0).resolves({ data: undefined, status: 200 });
+    client.get.onCall(1).resolves({ data: { isIndexed: true, count: 3 }, status: 200 });
+    client.get.onCall(2).rejects(axiosNotFound());
+    client.get.onCall(3).resolves({ data: { isIndexed: true, count: 4 }, status: 200 });
+
+    const result = await ingestOniRepository(baseConfig, {
+      httpClient: client,
+      delay: async milliseconds => {
+        now += milliseconds;
+      },
+      now: () => now,
+    });
+
+    expect(result).to.deep.equal({ structuralObjects: 3, searchItems: 4 });
+    expect(client.post.firstCall.args[0]).to.equal('https://oni.example.test/admin/index/structural');
+    expect(client.post.secondCall.args[0]).to.equal('https://oni.example.test/admin/index/search');
+    expect(client.post.firstCall.args[2]).to.deep.equal({
+      headers: {
+        Authorization: 'Bearer admin-token',
+        Accept: 'application/json',
+      },
+      timeout: 20,
+    });
+    expect(client.get.firstCall.args[0]).to.equal('https://oni.example.test/admin/index/structural');
+  });
+
+  it('adds the force query and rethrows non-404 polling failures', async () => {
+    const client = {
+      post: sinon.stub().resolves({ data: {}, status: 202 }),
+      get: sinon.stub().rejects(new Error('Oni unavailable')),
+    };
+
+    await expectRejected(
+      () =>
+        ingestOniRepository(
+          { ...baseConfig, forceReindex: true },
+          { httpClient: client, delay: async () => {}, now: () => 0 }
+        ),
+      'Oni unavailable'
+    );
+    expect(client.post.firstCall.args[0]).to.equal('https://oni.example.test/admin/index/structural?force=true');
+  });
+
+  it('uses the default delay and clock when callers do not provide runtime dependencies', async () => {
+    const client = {
+      post: sinon.stub().resolves({ data: {}, status: 202 }),
+      get: sinon.stub().resolves({ data: { isIndexed: true, count: 1 }, status: 200 }),
+    };
+
+    expect(await ingestOniRepository({ ...baseConfig, timeoutMs: 100 }, { httpClient: client })).to.deep.equal({
+      structuralObjects: 1,
+      searchItems: 1,
+    });
+  });
+
+  it('fails when an index never becomes indexed before the timeout', async () => {
+    let now = 0;
+    const client = {
+      post: sinon.stub().resolves({ data: {}, status: 202 }),
+      get: sinon.stub().resolves({ data: { isIndexed: false, count: 0 }, status: 200 }),
+    };
+
+    await expectRejected(
+      () =>
+        ingestOniRepository(
+          { ...baseConfig, timeoutMs: 2 },
+          {
+            httpClient: client,
+            delay: async milliseconds => {
+              now += milliseconds;
+            },
+            now: () => now,
+          }
+        ),
+      'Timed out waiting for Oni structural index to complete after 2ms'
+    );
+  });
+});

--- a/packages/redbox-core/test/services/oni-v2/repository.test.ts
+++ b/packages/redbox-core/test/services/oni-v2/repository.test.ts
@@ -29,7 +29,7 @@ describe('Oni v2 OCFL repository', () => {
     },
   } as unknown as OniPublishingSiteConfig;
 
-  function makeHarness() {
+  function makeHarness(useImplementationFactory = false) {
     const transaction = { write: sinon.stub().resolves() };
     const rootObject = {
       load: sinon.stub().rejects(Object.assign(new Error('not found'), { code: 'ENOENT' })),
@@ -48,10 +48,15 @@ describe('Oni v2 OCFL repository', () => {
       storage = sinon.stub().returns(storage);
     }
     class FakeOcflStore {}
-    const ocflModule = {
-      Ocfl: FakeOcfl,
-      OcflStore: FakeOcflStore,
-    } as unknown as OcflModuleAdapter;
+    const ocflModule = (useImplementationFactory
+      ? {
+          implementOcfl: sinon.stub().returns(new FakeOcfl()),
+          OcflStore: FakeOcflStore,
+        }
+      : {
+          Ocfl: FakeOcfl,
+          OcflStore: FakeOcflStore,
+        }) as unknown as OcflModuleAdapter;
     const disk = {};
     const storageManager = {
       isBootstrapped: sinon.stub().returns(false),
@@ -72,6 +77,7 @@ describe('Oni v2 OCFL repository', () => {
       storageManager,
       datastreamService,
       loadOcflModule,
+      ocflModule,
     };
   }
 
@@ -115,6 +121,15 @@ describe('Oni v2 OCFL repository', () => {
     expect(harness.loadOcflModule.calledOnce).to.be.true;
   });
 
+  it('supports the implementOcfl factory exported by current @ocfl/ocfl releases', async () => {
+    const harness = makeHarness(true);
+
+    await harness.repository.ensureStorageRoot();
+
+    expect((harness.ocflModule.implementOcfl as sinon.SinonStub).calledOnce).to.be.true;
+    expect(harness.storage.load.calledOnce).to.be.true;
+  });
+
   it('propagates unexpected storage-root load failures', async () => {
     const harness = makeHarness();
     harness.storage.load.rejects(new Error('permission denied'));
@@ -144,6 +159,15 @@ describe('Oni v2 OCFL repository', () => {
     harness.rootObject.update.resetHistory();
     await harness.repository.ensureRootCollection(config);
     expect(harness.rootObject.update.called).to.be.false;
+  });
+
+  it('treats the S3 NoSuchKey response as a missing root collection', async () => {
+    const harness = makeHarness();
+    harness.rootObject.load.rejects(Object.assign(new Error('The specified key does not exist.'), { name: 'NoSuchKey' }));
+
+    await harness.repository.ensureRootCollection(config, site);
+
+    expect(harness.rootObject.update.calledOnce).to.be.true;
   });
 
   it('writes crate metadata and both streamed and buffered attachments in source order', async () => {

--- a/support/wiki/Configuring-Oni-Publishing.md
+++ b/support/wiki/Configuring-Oni-Publishing.md
@@ -43,11 +43,24 @@ oniPublishing: {
         workspacePath: '/ocfl-work/public',
         tempDir: '/tmp/oni-public',
         keyEncoding: 'flydrive'
+      },
+      ingestion: {
+        enabled: true,
+        apiUrl: 'https://oni-api.example.edu/api',
+        adminToken: process.env.ONI_ADMIN_TOKEN,
+        forceReindex: true,
+        pollIntervalMs: 500,
+        timeoutMs: 120000
       }
     }
   }
 }
 ```
+
+When `ingestion.enabled` is true, ReDBox asks Oni to rebuild its structural and
+search indexes after the OCFL write completes. The publication only succeeds
+after both indexes report at least one indexed item. The admin token is used as
+a bearer token and is never included in IntegrationAudit request summaries.
 
 ## Migration
 

--- a/support/wiki/Configuring-Oni-Publishing.md
+++ b/support/wiki/Configuring-Oni-Publishing.md
@@ -48,7 +48,7 @@ oniPublishing: {
         enabled: true,
         apiUrl: 'https://oni-api.example.edu/api',
         adminToken: process.env.ONI_ADMIN_TOKEN,
-        forceReindex: true,
+        forceReindex: false,
         pollIntervalMs: 500,
         timeoutMs: 120000
       }
@@ -61,6 +61,14 @@ When `ingestion.enabled` is true, ReDBox asks Oni to rebuild its structural and
 search indexes after the OCFL write completes. The publication only succeeds
 after both indexes report at least one indexed item. The admin token is used as
 a bearer token and is never included in IntegrationAudit request summaries.
+Leave `forceReindex` disabled for normal publications. Enable it only when Oni
+requires a complete rebuild of both its structural and search indexes.
+
+If ingestion fails after the OCFL write, ReDBox retains the citation URL and
+records the partial failure for operators. Retry the publication through the
+normal operator action with `forceRun: true`; the OCFL object is written using
+`REPLACE`, so retrying safely replaces the incomplete version before ingestion
+runs again.
 
 ## Migration
 


### PR DESCRIPTION
## Summary

Adds an opt-in per-site `ingestion` configuration to Oni publishing that triggers a structural and search index rebuild against the Oni admin API after the OCFL write completes. A publication now only succeeds once both indexes report indexed items, with the results recorded in the publish audit and a new `ingestOniDataset` audit action.

---

## Context / Motivation

Oni datasets published by ReDBox were not immediately discoverable because the Oni repository's structural and search indexes were not rebuilt after the OCFL object write. This change coordinates publication with Oni indexing so that freshly published datasets are searchable as soon as the publication succeeds, and records index state in the integration audit trail for troubleshooting.

---

## Key Features

### Index rebuild after publication

- New `ingestion` config block per Oni site (`enabled`, `apiUrl`, `adminToken`, `forceReindex`, `pollIntervalMs`, `timeoutMs`), defaulting to disabled.
- Rebuilds the Oni structural and search indexes via the admin API using a bearer token; the token is used only in the Authorization header and is never logged in audit summaries.
- Polls index status until each index reports `isIndexed` with a non-zero item count, or fails with a timeout after the configured window.
- Publication success is contingent on both indexes completing; a new `ingestOniDataset` audit action records structural object and search item counts.

### Oni v2 pipeline hardening

- Empty GeoJSON coverage (empty `FeatureCollection`/`GeometryCollection`) is now omitted from the RO-Crate, while real geometry is emitted as linked graph entities (`Place` referencing a `Geometry` node) instead of inline geometry.
- The Flydrive OCFL store bypasses the key normalizer for explicitly configured raw keys and treats S3 `NoSuchKey` responses as missing objects.
- The repository supports the `implementOcfl` factory exported by current `@ocfl/ocfl` releases in addition to the legacy `Ocfl` constructor.
- The root dataset is now tagged with a `conformsTo` profile mapping defaulting to the LDAC object profile.

---

## Testing

- Added tests covering the new `ingestOniRepository` flow, including force reindex URLs, bearer token headers, and index polling completion.
- Added `OniService` tests for empty GeoJSON omission, linked geometry entities, and `conformsTo` mapping.
- Extended OCFL store tests for raw-key normalizer bypass and S3 `NoSuchKey` handling.
- Extended repository tests for the `implementOcfl` factory and `NoSuchKey` root-collection recovery.

---

## Architectural / Operational Impact

### Configuration

Sites that want immediate post-publication indexing enable `ingestion` in their `oniPublishing` config; no code changes are required. The admin token should be supplied via environment variable.

### Auditing

Index counts are surfaced in the publication audit context under a new `ingestOniDataset` action, giving operators visibility into whether a dataset is actually indexed.

### Storage abstraction

The OCFL store now routes I/O through the underlying driver for raw keys, keeping keys byte-exact while preserving the Flydrive normalizer for the default encoding.

---

## Backwards Compatibility

Fully backwards compatible. `ingestion` is optional and disabled by default, raw-key/`implementOcfl` changes only activate when the corresponding storage or module features are in use, and the legacy `Ocfl` constructor path remains supported.

---

## Deployment Notes

- Optional: enable `ingestion.enabled` per Oni site and set `ONI_ADMIN_TOKEN`.
- Requires an Oni version exposing the `/admin/index/structural` and `/admin/index/search` admin endpoints.
- No database migrations or package changes required.

---

## Impact

Aligns Oni publication with searchable indexing, improves the RO-Crate output for spatial data, and hardens the Oni v2 storage pipeline against key-normalization and missing-object edge cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional repository ingestion after successful dataset publication.
  - Publishing can rebuild structural and search indexes, monitor progress, and report indexed counts.
  - Added support for configurable ingestion API, authentication, polling, reindexing, and timeout settings.
- **Bug Fixes**
  - Improved handling of geospatial metadata, empty coverage, missing storage objects, and storage-driver errors.
  - Added compatibility with multiple OCFL storage initialization formats.
- **Documentation**
  - Documented configuration and behavior for enabling repository ingestion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->