### PR TITLE
Dismiss stale typeahead no-results feedback

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from "@angular/core/testing";
 import { TypeaheadModule } from "ngx-bootstrap/typeahead";
 import { By } from "@angular/platform-browser";
 import { firstValueFrom } from "rxjs";
-import {FormConfigFrame} from "@researchdatabox/sails-ng-common";
+import {FormConfigFrame, TypeaheadOption} from "@researchdatabox/sails-ng-common";
 import {createFormAndWaitForReady, createTestbedModule, DynamicAssetOptions} from "../helpers.spec";
 import { TypeaheadDataService } from "../service/typeahead-data.service";
 import { TypeaheadInputComponent } from "./typeahead-input.component";
@@ -510,6 +510,82 @@ describe("TypeaheadInputComponent", () => {
 
         expect((formComponent as any).form.get("person_lookup")?.value).toBe("jane");
         expect((formComponent as any).form.get("person_lookup")?.dirty).toBeTrue();
+    });
+
+    it("dismisses the no matches status when the input loses focus", async () => {
+        const formConfig: FormConfigFrame = {
+            name: "testing",
+            componentDefinitions: [
+                {
+                    name: "person_lookup",
+                    component: {
+                        class: "TypeaheadInputComponent",
+                        config: {
+                            sourceType: "static",
+                            staticOptions: [{ label: "Jane Doe", value: "jane" }],
+                            minChars: 1
+                        }
+                    },
+                    model: { class: "TypeaheadInputModel", config: {} }
+                }
+            ]
+        };
+
+        const { fixture } = await createFormAndWaitForReady(formConfig);
+        const component = fixture.debugElement.query(By.directive(TypeaheadInputComponent)).componentInstance as TypeaheadInputComponent;
+        const input = fixture.nativeElement.querySelector("input") as HTMLInputElement;
+        component.displayControl.setValue("unknown");
+        await firstValueFrom(component.suggestions$);
+        fixture.detectChanges();
+
+        expect(component.searchState).toBe("no-results");
+        expect(String((fixture.nativeElement as HTMLElement).textContent ?? "")).toContain("No matches found");
+
+        input.dispatchEvent(new Event("blur"));
+        fixture.detectChanges();
+
+        expect(component.searchState).toBe("idle");
+        expect(String((fixture.nativeElement as HTMLElement).textContent ?? "")).not.toContain("No matches found");
+    });
+
+    it("does not restore the no matches status when a lookup completes after blur", async () => {
+        const typeaheadDataService = TestBed.inject(TypeaheadDataService);
+        let resolveSearch: (options: TypeaheadOption[]) => void = () => undefined;
+        spyOn(typeaheadDataService, "searchStatic").and.returnValue(new Promise<TypeaheadOption[]>(resolve => {
+            resolveSearch = resolve;
+        }));
+        const formConfig: FormConfigFrame = {
+            name: "testing",
+            componentDefinitions: [
+                {
+                    name: "person_lookup",
+                    component: {
+                        class: "TypeaheadInputComponent",
+                        config: {
+                            sourceType: "static",
+                            staticOptions: [{ label: "Jane Doe", value: "jane" }],
+                            minChars: 1
+                        }
+                    },
+                    model: { class: "TypeaheadInputModel", config: {} }
+                }
+            ]
+        };
+
+        const { fixture } = await createFormAndWaitForReady(formConfig);
+        const component = fixture.debugElement.query(By.directive(TypeaheadInputComponent)).componentInstance as TypeaheadInputComponent;
+        const input = fixture.nativeElement.querySelector("input") as HTMLInputElement;
+        component.displayControl.setValue("unknown");
+        const lookup = firstValueFrom(component.suggestions$);
+        expect(component.searchState).toBe("loading");
+
+        input.dispatchEvent(new Event("blur"));
+        resolveSearch([]);
+        await lookup;
+        fixture.detectChanges();
+
+        expect(component.searchState).toBe("idle");
+        expect(String((fixture.nativeElement as HTMLElement).textContent ?? "")).not.toContain("No matches found");
     });
 
     it("keeps the display control in sync with disabled state changes", async () => {

--- a/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.spec.ts
@@ -643,6 +643,59 @@ describe("TypeaheadInputComponent", () => {
         expect(String((fixture.nativeElement as HTMLElement).textContent ?? "")).not.toContain("No matches found");
     });
 
+    it("does not apply an earlier valid lookup after another valid query is entered", async () => {
+        const typeaheadDataService = TestBed.inject(TypeaheadDataService);
+        let resolveFirstSearch: (options: TypeaheadOption[]) => void = () => undefined;
+        let resolveReplacementSearch: (options: TypeaheadOption[]) => void = () => undefined;
+        const searchStatic = spyOn(typeaheadDataService, "searchStatic").and.callFake((search: string) =>
+            new Promise<TypeaheadOption[]>(resolve => {
+                if (search === "first") {
+                    resolveFirstSearch = resolve;
+                    return;
+                }
+                resolveReplacementSearch = resolve;
+            })
+        );
+        const formConfig: FormConfigFrame = {
+            name: "testing",
+            componentDefinitions: [
+                {
+                    name: "person_lookup",
+                    component: {
+                        class: "TypeaheadInputComponent",
+                        config: {
+                            sourceType: "static",
+                            staticOptions: [{ label: "Jane Doe", value: "jane" }],
+                            minChars: 1
+                        }
+                    },
+                    model: { class: "TypeaheadInputModel", config: {} }
+                }
+            ]
+        };
+
+        const { fixture } = await createFormAndWaitForReady(formConfig);
+        const component = fixture.debugElement.query(By.directive(TypeaheadInputComponent)).componentInstance as TypeaheadInputComponent;
+        component.displayControl.setValue("first");
+        const firstLookup = firstValueFrom(component.suggestions$);
+        expect(searchStatic).toHaveBeenCalledTimes(1);
+
+        component.displayControl.setValue("second");
+        expect(searchStatic).toHaveBeenCalledTimes(1);
+        resolveFirstSearch([]);
+        await firstLookup;
+
+        expect(component.searchState).not.toBe("no-results");
+
+        const replacementLookup = firstValueFrom(component.suggestions$);
+        expect(searchStatic).toHaveBeenCalledTimes(2);
+        expect(searchStatic.calls.mostRecent().args[0]).toBe("second");
+        resolveReplacementSearch([{ label: "Second result", value: "second" }]);
+        await replacementLookup;
+
+        expect(component.searchState).toBe("idle");
+    });
+
     it("keeps the display control in sync with disabled state changes", async () => {
         const formConfig: FormConfigFrame = {
             name: "testing",

--- a/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.spec.ts
@@ -2,7 +2,11 @@ import { TestBed } from "@angular/core/testing";
 import { TypeaheadModule } from "ngx-bootstrap/typeahead";
 import { By } from "@angular/platform-browser";
 import { firstValueFrom } from "rxjs";
-import {FormConfigFrame, TypeaheadOption} from "@researchdatabox/sails-ng-common";
+import {
+  FormConfigFrame,
+  TypeaheadInputDefaultNoResultsMessageKey,
+  TypeaheadOption
+} from "@researchdatabox/sails-ng-common";
 import {createFormAndWaitForReady, createTestbedModule, DynamicAssetOptions} from "../helpers.spec";
 import { TypeaheadDataService } from "../service/typeahead-data.service";
 import { TypeaheadInputComponent } from "./typeahead-input.component";
@@ -15,6 +19,20 @@ import {GroupFieldComponent} from "./group.component";
 
 describe("TypeaheadInputComponent", () => {
   let translationService: any;
+
+  async function registerTranslations(items: Record<string, string>): Promise<void> {
+    if (!i18next.isInitialized) {
+      await i18next.init({
+        lng: 'en',
+        fallbackLng: 'en',
+        returnEmptyString: false,
+        resources: { en: { translation: {} } },
+      });
+    }
+    i18next.addResourceBundle('en', 'translation', items, true, true);
+    await i18next.changeLanguage('en');
+    Object.assign(translationService.translationMap, items);
+  }
 
     beforeEach(async () => {
       ({ translationService } = await createTestbedModule({
@@ -513,6 +531,9 @@ describe("TypeaheadInputComponent", () => {
     });
 
     it("dismisses the no matches status when the input loses focus", async () => {
+        await registerTranslations({
+            [TypeaheadInputDefaultNoResultsMessageKey]: "No matches found"
+        });
         const formConfig: FormConfigFrame = {
             name: "testing",
             componentDefinitions: [
@@ -546,6 +567,40 @@ describe("TypeaheadInputComponent", () => {
 
         expect(component.searchState).toBe("idle");
         expect(String((fixture.nativeElement as HTMLElement).textContent ?? "")).not.toContain("No matches found");
+    });
+
+    it("renders the configured no results translation key", async () => {
+        await registerTranslations({
+            "@custom-typeahead-no-results": "No people matched this search"
+        });
+        const formConfig: FormConfigFrame = {
+            name: "testing",
+            componentDefinitions: [
+                {
+                    name: "person_lookup",
+                    component: {
+                        class: "TypeaheadInputComponent",
+                        config: {
+                            sourceType: "static",
+                            staticOptions: [{ label: "Jane Doe", value: "jane" }],
+                            minChars: 1,
+                            noResultsMessageKey: "@custom-typeahead-no-results"
+                        }
+                    },
+                    model: { class: "TypeaheadInputModel", config: {} }
+                }
+            ]
+        };
+
+        const { fixture } = await createFormAndWaitForReady(formConfig);
+        const component = fixture.debugElement.query(By.directive(TypeaheadInputComponent)).componentInstance as TypeaheadInputComponent;
+        component.displayControl.setValue("unknown");
+        await firstValueFrom(component.suggestions$);
+        fixture.detectChanges();
+
+        expect(component.noResultsMessageKey).toBe("@custom-typeahead-no-results");
+        expect(String((fixture.nativeElement as HTMLElement).textContent ?? ""))
+            .toContain("No people matched this search");
     });
 
     it("does not restore the no matches status when a lookup completes after blur", async () => {
@@ -1132,22 +1187,7 @@ describe("TypeaheadInputComponent", () => {
       const translationMapItems = {
         '@lookup-placeholder-party': "Start typing a party name...",
       }
-      if (!i18next.isInitialized) {
-        await i18next.init({
-          lng: 'en',
-          fallbackLng: 'en',
-          returnEmptyString: false,
-          resources: {
-            en: {
-              translation: {},
-            },
-          },
-        });
-      }
-      i18next.addResourceBundle('en', 'translation', translationMapItems, true, true);
-      await i18next.changeLanguage('en');
-
-      Object.assign(translationService.translationMap, translationMapItems);
+      await registerTranslations(translationMapItems);
 
       const formConfig: FormConfigFrame = {
         name: "testing",

--- a/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.ts
@@ -124,6 +124,7 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
   private hasHistoricalOrUnknownModelValue = false;
   private staticOptions: TypeaheadOption[] = [];
   private cache = new Map<string, TypeaheadOption[]>();
+  private lookupRequestId = 0;
   private programmaticDisplayUpdate = false;
   private lastConfirmedDisplayValue = '';
   private modelSubscriptionInitialised = false;
@@ -230,6 +231,7 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
     if (!selected || selected.disabled === true) {
       return;
     }
+    this.lookupRequestId += 1;
     this.isOpen = false;
     this.searchState = 'idle';
     this.statusMessage = '';
@@ -245,7 +247,12 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
   }
 
   public onBlur(): void {
+    this.lookupRequestId += 1;
     this.isOpen = false;
+    if (this.searchState !== 'misconfigured') {
+      this.searchState = 'idle';
+      this.statusMessage = '';
+    }
     const text = String(this.displayControl.value ?? '').trim();
     if (!text) {
       this.setModelValue(null);
@@ -293,6 +300,7 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
     }
     this.isOpen = text.length >= this.minChars;
     if (!text) {
+      this.lookupRequestId += 1;
       this.searchState = 'idle';
       this.statusMessage = '';
       this.isOpen = false;
@@ -302,6 +310,7 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
       return;
     }
     if (text.length < this.minChars) {
+      this.lookupRequestId += 1;
       this.searchState = 'idle';
       this.statusMessage = '';
       this.isOpen = false;
@@ -348,6 +357,7 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
   }
 
   private async lookup(term: string, includeHistoricalValues = this.shouldIncludeHistoricalValues()): Promise<TypeaheadOption[]> {
+    const requestId = ++this.lookupRequestId;
     if (!this.validateConfiguration()) {
       return [];
     }
@@ -358,7 +368,9 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
     const cacheKey = `${this.sourceType}:${includeHistoricalValues ? 'historical' : 'current'}:${trimmedTerm}`;
     if (this.cacheResults && this.cache.has(cacheKey)) {
       const cached = this.cache.get(cacheKey) ?? [];
-      this.searchState = cached.length > 0 ? 'idle' : 'no-results';
+      if (requestId === this.lookupRequestId) {
+        this.searchState = cached.length > 0 ? 'idle' : 'no-results';
+      }
       return cached;
     }
 
@@ -404,15 +416,19 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
       options = this.filterHistoricalOptions(options);
       options = this.applyTemplateLabels(options);
 
-      this.searchState = options.length > 0 ? 'idle' : 'no-results';
+      if (requestId === this.lookupRequestId) {
+        this.searchState = options.length > 0 ? 'idle' : 'no-results';
+      }
       if (this.cacheResults) {
         this.cache.set(cacheKey, options);
       }
       return options;
     } catch (error) {
       this.loggerService.warn(`${this.logName}: typeahead lookup failed`, error);
-      this.searchState = 'error';
-      this.statusMessage = 'Unable to fetch matches';
+      if (requestId === this.lookupRequestId) {
+        this.searchState = 'error';
+        this.statusMessage = 'Unable to fetch matches';
+      }
       return [];
     }
   }

--- a/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.ts
@@ -126,8 +126,8 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
   private hasHistoricalOrUnknownModelValue = false;
   private staticOptions: TypeaheadOption[] = [];
   private cache = new Map<string, TypeaheadOption[]>();
-  // Promise-backed lookups continue after blur or selection. Incrementing this
-  // identifier prevents their late completions from restoring stale UI feedback.
+  // Promise-backed lookups continue after input changes, blur, or selection.
+  // Incrementing this identifier prevents late results from restoring stale feedback.
   private lookupRequestId = 0;
   private programmaticDisplayUpdate = false;
   private lastConfirmedDisplayValue = '';
@@ -307,9 +307,9 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
     if (this.isDisabled || this.isReadonly || this.readOnlyAfterSelectLocked) {
       return;
     }
+    this.lookupRequestId += 1;
     this.isOpen = text.length >= this.minChars;
     if (!text) {
-      this.lookupRequestId += 1;
       this.searchState = 'idle';
       this.statusMessage = '';
       this.isOpen = false;
@@ -319,7 +319,6 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
       return;
     }
     if (text.length < this.minChars) {
-      this.lookupRequestId += 1;
       this.searchState = 'idle';
       this.statusMessage = '';
       this.isOpen = false;
@@ -425,7 +424,7 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
       options = this.filterHistoricalOptions(options);
       options = this.applyTemplateLabels(options);
 
-      // A blur, selection, or newer request invalidates this result for UI status,
+      // A newer input value, blur, selection, or request invalidates this UI status,
       // although its options may still be safely cached below for a future lookup.
       if (requestId === this.lookupRequestId) {
         this.searchState = options.length > 0 ? 'idle' : 'no-results';

--- a/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/typeahead-input.component.ts
@@ -13,6 +13,7 @@ import {
   handlebarsTemplate,
   HistoricalVocabMode,
   TypeaheadInputComponentName,
+  TypeaheadInputDefaultNoResultsMessageKey,
   TypeaheadInputFieldComponentConfig,
   TypeaheadInputModelOptionValue,
   TypeaheadInputModelName,
@@ -72,7 +73,7 @@ export class TypeaheadInputModel extends FormFieldModel<TypeaheadInputModelValue
           Searching...
         }
         @if (searchState === 'no-results') {
-          No matches found
+          {{ noResultsMessageKey | i18next }}
         }
         @if (searchState === 'error') {
           {{ statusMessage || 'Lookup failed' }}
@@ -106,6 +107,7 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
   public searchState: TypeaheadStatus = 'idle';
   public statusMessage = '';
   public statusElementId = 'typeahead-status';
+  public noResultsMessageKey: string = TypeaheadInputDefaultNoResultsMessageKey;
   public isOpen = false;
   public readOnlyAfterSelectLocked = false;
 
@@ -124,6 +126,8 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
   private hasHistoricalOrUnknownModelValue = false;
   private staticOptions: TypeaheadOption[] = [];
   private cache = new Map<string, TypeaheadOption[]>();
+  // Promise-backed lookups continue after blur or selection. Incrementing this
+  // identifier prevents their late completions from restoring stale UI feedback.
   private lookupRequestId = 0;
   private programmaticDisplayUpdate = false;
   private lastConfirmedDisplayValue = '';
@@ -158,6 +162,9 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
       new TypeaheadInputFieldComponentConfig();
     this.tooltip = this.getStringProperty('tooltip');
     this.placeholder = String(cfg.placeholder ?? '');
+    this.noResultsMessageKey = String(
+      cfg.noResultsMessageKey ?? TypeaheadInputDefaultNoResultsMessageKey
+    ).trim() || TypeaheadInputDefaultNoResultsMessageKey;
     this.sourceType = cfg.sourceType ?? 'static';
     this.queryId = String(cfg.queryId ?? '').trim();
     this.serviceId = String(cfg.serviceId ?? '').trim();
@@ -247,6 +254,8 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
   }
 
   public onBlur(): void {
+    // Lookup feedback belongs to the active interaction. Clear it as focus leaves,
+    // while retaining configuration errors that the form author needs to see.
     this.lookupRequestId += 1;
     this.isOpen = false;
     if (this.searchState !== 'misconfigured') {
@@ -416,6 +425,8 @@ export class TypeaheadInputComponent extends FormFieldBaseComponent<TypeaheadInp
       options = this.filterHistoricalOptions(options);
       options = this.applyTemplateLabels(options);
 
+      // A blur, selection, or newer request invalidates this result for UI status,
+      // although its options may still be safely cached below for a future lookup.
       if (requestId === this.lookupRequestId) {
         this.searchState = options.length > 0 ? 'idle' : 'no-results';
       }

--- a/language-defaults/en/translation.json
+++ b/language-defaults/en/translation.json
@@ -1448,6 +1448,7 @@
   "manage-users-audit-event-link-secondary": "This account was linked as a secondary alias to another account",
   "manage-users-audit-event-link-generic": "Account linking event",
   "@lookup-placeholder-party": "Start typing a party name...",
+  "@typeahead-no-matches-found": "No matches found",
   "@integration-status-heading": "Integrations",
   "@integration-status-started": "In progress",
   "@integration-status-success": "Success",

--- a/packages/redbox-core/src/visitor/construct.visitor.ts
+++ b/packages/redbox-core/src/visitor/construct.visitor.ts
@@ -1975,6 +1975,7 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
     this.sharedProps.setPropOverride('cacheResults', itemConfig, config);
     this.sharedProps.setPropOverride('multiSelect', itemConfig, config);
     this.sharedProps.setPropOverride('placeholder', itemConfig, config);
+    this.sharedProps.setPropOverride('noResultsMessageKey', itemConfig, config);
     this.sharedProps.setPropOverride('readOnlyAfterSelect', itemConfig, config);
     this.sharedProps.setPropOverride('historicalVocabMode', itemConfig, config);
 

--- a/packages/redbox-core/test/unit/construct.visitor.test.ts
+++ b/packages/redbox-core/test/unit/construct.visitor.test.ts
@@ -284,7 +284,8 @@ describe("Construct Visitor", async () => {
                                 class: "TypeaheadInputComponent",
                                 config: {
                                     sourceType: "namedQuery",
-                                    queryId: "contributors"
+                                    queryId: "contributors",
+                                    noResultsMessageKey: "@custom-typeahead-no-results"
                                 }
                             },
                             model: { class: "TypeaheadInputModel", config: {} }
@@ -297,6 +298,7 @@ describe("Construct Visitor", async () => {
             expect(cfg?.labelField).to.equal("label");
             expect(cfg?.valueField).to.equal("value");
             expect(cfg?.cacheResults).to.equal(false);
+            expect(cfg?.noResultsMessageKey).to.equal("@custom-typeahead-no-results");
         });
 
         it("should preserve typeahead optionObjectFields config", async function () {

--- a/packages/sails-ng-common/src/config/component/typeahead-input.model.ts
+++ b/packages/sails-ng-common/src/config/component/typeahead-input.model.ts
@@ -13,6 +13,7 @@ import { AvailableFieldLayoutDefinitionOutlines } from "../dictionary.outline";
 import type { HistoricalVocabMode } from "./dropdown-input.outline";
 import {
     TypeaheadInputComponentName,
+    TypeaheadInputDefaultNoResultsMessageKey,
     TypeaheadInputFieldComponentConfigOutline,
     TypeaheadInputFieldComponentDefinitionOutline,
     TypeaheadInputFieldModelConfigOutline,
@@ -50,6 +51,7 @@ export class TypeaheadInputFieldComponentConfig extends FieldComponentConfig imp
     cacheResults = true;
     multiSelect = false;
     placeholder?: string;
+    noResultsMessageKey = TypeaheadInputDefaultNoResultsMessageKey;
     readOnlyAfterSelect?: boolean;
     historicalVocabMode?: HistoricalVocabMode;
 

--- a/packages/sails-ng-common/src/config/component/typeahead-input.outline.ts
+++ b/packages/sails-ng-common/src/config/component/typeahead-input.outline.ts
@@ -29,6 +29,7 @@ import type { HistoricalVocabMode } from "./dropdown-input.outline";
 /* Typeahead Input Component */
 export const TypeaheadInputComponentName = "TypeaheadInputComponent" as const;
 export type TypeaheadInputComponentNameType = typeof TypeaheadInputComponentName;
+export const TypeaheadInputDefaultNoResultsMessageKey = "@typeahead-no-matches-found" as const;
 
 export const TypeaheadSourceTypes = ["static", "vocabulary", "namedQuery", "external", "service"] as const;
 export type TypeaheadSourceType = typeof TypeaheadSourceTypes[number];
@@ -84,6 +85,11 @@ export interface TypeaheadInputFieldComponentConfigCommonFrame extends FieldComp
     cacheResults?: boolean;
     multiSelect?: boolean;
     placeholder?: string;
+    /**
+     * Translation key rendered when a completed lookup returns no options.
+     * Omit it to use TypeaheadInputDefaultNoResultsMessageKey.
+     */
+    noResultsMessageKey?: string;
     readOnlyAfterSelect?: boolean;
     historicalVocabMode?: HistoricalVocabMode;
 }


### PR DESCRIPTION
## Summary

Fixes typeahead lookup feedback so transient "No matches found" state is dismissed when focus leaves the component and cannot be restored by a lookup that completes afterward. The no-results text is also exposed through an optional translation-key configuration property with the existing English message retained as the default.

---

## Context / Motivation

Typeahead fields could leave their no-results status visible after the user exited the field. Promise-backed lookups also created a race in which a late response could restore that stale status after blur. In addition, the message was hardcoded in the Angular template, preventing deployments from managing it through the standard translation workflow.

---

## Key Features

### Typeahead interaction state

- Clears transient lookup feedback and closes the suggestion state when the input loses focus.
- Invalidates earlier requests after blur, selection, or shortened input so late results and errors do not overwrite the current UI state.
- Preserves configuration-error feedback because it remains actionable for form authors.

### Configurable no-results translation

- Adds the optional `noResultsMessageKey` typeahead component setting and carries overrides through form-config construction.
- Uses `@typeahead-no-matches-found` when no override is supplied, so existing form configurations require no changes.
- Adds the default English translation and renders the selected key through the existing i18next pipeline.

---

## Testing

- Added Angular regression coverage for blur dismissal, late lookup completion, and custom translation-key rendering.
- Updated construct-visitor unit coverage to verify that a configured translation key is preserved.
- Verified the targeted Angular component suite with 32 successful tests.
- Verified sails-ng-common compilation and the targeted redbox-core construct-visitor test.
- Verified the branch diff with `git diff --check`.

---

## Architectural / Operational Impact

### Form configuration contract

The shared typeahead outline and model now expose an optional translation key, and the core construct visitor propagates it into the runtime component configuration.

### Asynchronous UI state

Lookup responses remain cacheable, but only the newest active request can change visible lookup status. This separates useful result caching from focus-sensitive user feedback.

---

## Backwards Compatibility

The new configuration property is optional. Existing forms retain the current "No matches found" message through the default core English translation key.

---

## Deployment Notes

No migration or form-configuration update is required. Deployments may optionally add or edit `@typeahead-no-matches-found`, or set `noResultsMessageKey` on individual typeahead components for field-specific wording.

---

## Impact

Typeahead no-results feedback now follows the active interaction correctly and can be administered through the translation system without disrupting existing forms.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable, localized messages for typeahead searches with no matching results.
  * Added the default “No matches found” translation.
  * Typeahead configuration now supports custom no-results messages.

* **Bug Fixes**
  * Prevented outdated asynchronous search responses from replacing current results.
  * Cleared no-results feedback when the field loses focus while preserving configuration errors.

* **Tests**
  * Added coverage for custom translations, blur behavior, and stale lookup responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->