### PR TITLE
Support DOI related materials in Figshare sync

### DIFF
--- a/language-defaults/en/translation.json
+++ b/language-defaults/en/translation.json
@@ -1304,6 +1304,8 @@
   "@validator-error-different-values": "The {{controlCount}} field(s) must have different values.",
   "@validator-error-orcid": "Please enter a valid ORCID identifier in the format: 0000-0000-0000-0000.",
   "@validator-error-url": "Please enter a valid URL.",
+  "@validator-error-doi": "Please enter a valid DOI without a resolver URL, for example 10.1234/example.",
+  "@validator-error-any-of": "The value must match at least one of the allowed formats: {{description}}.",
   "@rich-text-editor-source-toggle-rich-text": "Rich Text",
   "@rich-text-editor-source-toggle-markdown": "Markdown",
   "@rich-text-editor-source-toggle-html": "HTML",

--- a/language-defaults/meta.json
+++ b/language-defaults/meta.json
@@ -6049,6 +6049,16 @@
     "description":  "Error message for a failed url validator",
     "contentFormat":  "plain"
   },
+  "@validator-error-doi": {
+    "category": "validator",
+    "description": "Error message for a failed DOI validator",
+    "contentFormat": "plain"
+  },
+  "@validator-error-any-of": {
+    "category": "validator",
+    "description": "Error message for a failed any-of validator",
+    "contentFormat": "plain"
+  },
   "@lookup-placeholder-party": {
     "category": "lookup",
     "description": "Placeholder text in lookup field for party records",

--- a/packages/redbox-core/src/services/figshare-v2/metadata.ts
+++ b/packages/redbox-core/src/services/figshare-v2/metadata.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import { FORM_VALIDATOR_DOI_REGEXP } from '@researchdatabox/sails-ng-common';
 import { FigsharePublishingConfigData } from '../../configmodels/FigsharePublishing';
 import { RBValidationError } from '../../model/RBValidationError';
 import { FigshareClient } from './http';
@@ -227,6 +228,10 @@ function extractRelatedMaterialValue(value: unknown, candidateKeys: string[]): s
   return normalizeRelatedMaterialValue(value);
 }
 
+function inferRelatedMaterialIdentifierType(identifier: string): 'DOI' | 'URL' {
+  return FORM_VALIDATOR_DOI_REGEXP.test(identifier) ? 'DOI' : 'URL';
+}
+
 function buildRelatedMaterials(titleValue: unknown, identifierValue: unknown): NonNullable<FigshareArticlePayload['related_materials']> {
   const titleItems = toRelatedMaterialItems(titleValue);
   const identifierItems = toRelatedMaterialItems(identifierValue);
@@ -241,7 +246,11 @@ function buildRelatedMaterials(titleValue: unknown, identifierValue: unknown): N
     const identifier = extractRelatedMaterialValue(identifierSource, relatedMaterialIdentifierKeys)
       || (isRelatedMaterialObject(titleSource) ? extractRelatedMaterialValue(titleSource, relatedMaterialIdentifierKeys) : '');
     if (title !== '' && identifier !== '') {
-      relatedMaterials.push({ title, identifier });
+      relatedMaterials.push({
+        title,
+        identifier,
+        identifier_type: inferRelatedMaterialIdentifierType(identifier),
+      });
     }
   }
 

--- a/packages/redbox-core/src/services/figshare-v2/runtime.ts
+++ b/packages/redbox-core/src/services/figshare-v2/runtime.ts
@@ -1,4 +1,5 @@
 import { Context, Effect, Layer } from 'effect';
+import * as Cause from 'effect/Cause';
 import { FigsharePublishingConfigData } from '../../configmodels/FigsharePublishing';
 import { RBValidationError } from '../../model/RBValidationError';
 import { ResolvedFigsharePublishingConfigData, getBrandName } from './config';
@@ -60,6 +61,24 @@ export function makeRuntimeLayer(config: ResolvedFigsharePublishingConfigData, r
   );
 }
 
+/**
+ * Run an Effect program without replacing domain/HTTP failures with Effect's
+ * FiberFailure wrapper. The original error carries Figshare statusCode,
+ * responseBody and cause fields used by the integration audit and UI.
+ */
+async function runProgram<A>(program: Effect.Effect<A, unknown, never>): Promise<A> {
+  const exit = await Effect.runPromiseExit(program);
+  if (exit._tag === 'Success') {
+    return exit.value;
+  }
+
+  const failure = Cause.failureOrCause(exit.cause);
+  if (failure._tag === 'Left') {
+    throw failure.left;
+  }
+  throw Cause.squash(failure.right);
+}
+
 export async function runBuildMetadataPayload(config: ResolvedFigsharePublishingConfigData, record: RecordModel): Promise<Record<string, unknown>> {
   const runContext: FigshareRunContext = {
     recordOid: record.redboxOid ?? record.id ?? '',
@@ -73,7 +92,7 @@ export async function runBuildMetadataPayload(config: ResolvedFigsharePublishing
     return yield* Effect.promise(() => buildMetadataPayload(config, record, client));
   }).pipe(Effect.provide(makeRuntimeLayer(config, runContext)));
 
-  return Effect.runPromise(program);
+  return runProgram(program);
 }
 
 export async function runSyncMetadataProgram(config: ResolvedFigsharePublishingConfigData, runContext: FigshareRunContext, record: RecordModel, plan: FigsharePublicationPlan): Promise<FigshareArticle> {
@@ -89,5 +108,5 @@ export async function runSyncMetadataProgram(config: ResolvedFigsharePublishingC
     return yield* Effect.promise(() => syncMetadataPhase(client, config, record, plan));
   }).pipe(Effect.provide(makeRuntimeLayer(config, runContext)));
 
-  return Effect.runPromise(program);
+  return runProgram(program);
 }

--- a/packages/redbox-core/src/services/figshare-v2/types.ts
+++ b/packages/redbox-core/src/services/figshare-v2/types.ts
@@ -112,7 +112,7 @@ export interface FigshareArticlePayload {
   categories?: number[];
   license?: unknown;
   authors?: Array<{ id?: number | string; name?: string }>;
-  related_materials?: Array<{ title: unknown; identifier: unknown }>;
+  related_materials?: Array<{ title: unknown; identifier: unknown; identifier_type: 'DOI' | 'URL' }>;
   custom_fields?: Record<string, unknown>;
   [key: string]: unknown;
 }

--- a/packages/redbox-core/test/services/FigshareService.test.ts
+++ b/packages/redbox-core/test/services/FigshareService.test.ts
@@ -998,12 +998,12 @@ describe('FigshareService', function () {
         related_data: [
           {
             related_title: 'Related dataset one',
-            related_url: 'https://doi.org/10.1234/related-one',
+            related_url: '10.1234/related-one',
             related_notes: 'First related data publication',
           },
           {
             related_title: 'Related dataset two',
-            related_url: 'https://doi.org/10.1234/related-two',
+            related_url: 'https://example.org/related-two',
             related_notes: 'Second related data publication',
           },
           {
@@ -1032,11 +1032,13 @@ describe('FigshareService', function () {
     expect(payload.related_materials).to.deep.equal([
       {
         title: 'Related dataset one',
-        identifier: 'https://doi.org/10.1234/related-one',
+        identifier: '10.1234/related-one',
+        identifier_type: 'DOI',
       },
       {
         title: 'Related dataset two',
-        identifier: 'https://doi.org/10.1234/related-two',
+        identifier: 'https://example.org/related-two',
+        identifier_type: 'URL',
       },
     ]);
   });
@@ -1099,10 +1101,12 @@ describe('FigshareService', function () {
       {
         title: 'Related dataset one',
         identifier: 'https://doi.org/10.1234/related-one',
+        identifier_type: 'URL',
       },
       {
         title: 'Related dataset two',
         identifier: 'https://doi.org/10.1234/related-two',
+        identifier_type: 'URL',
       },
     ]);
   });
@@ -1157,6 +1161,7 @@ describe('FigshareService', function () {
       {
         title: 'Related dataset',
         identifier: 'https://doi.org/10.1234/related',
+        identifier_type: 'URL',
       },
     ]);
   });
@@ -1360,6 +1365,12 @@ describe('FigshareService', function () {
         'Invalid identifier format'
       );
     }
+    const auditDetails = (global as any).IntegrationAuditService.failAudit.firstCall.args[2];
+    expect(auditDetails.httpStatusCode).to.equal(400);
+    expect(auditDetails.responseSummary.error).to.deep.equal({
+      message: 'Invalid identifier format',
+      code: 'BadRequest',
+    });
   });
 
   it('audits publishAfterUploadFilesJob success and failure paths', async function () {

--- a/packages/redbox-core/test/services/figshare-v2/runtime.test.ts
+++ b/packages/redbox-core/test/services/figshare-v2/runtime.test.ts
@@ -1,0 +1,84 @@
+import * as sinon from 'sinon';
+import { Layer } from 'effect';
+import { FigsharePublishing } from '../../../src/configmodels/FigsharePublishing';
+import { FigshareClientTag, FigshareHttpError } from '../../../src/services/figshare-v2/http';
+import * as httpModule from '../../../src/services/figshare-v2/http';
+import { runBuildMetadataPayload } from '../../../src/services/figshare-v2/runtime';
+
+let expect: Chai.ExpectStatic;
+
+describe('figshare-v2 runtime', function () {
+  before(async function () {
+    ({ expect } = await import('chai'));
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it('rethrows HTTP failures with status and response details instead of a FiberFailure wrapper', async function () {
+    const httpError = new FigshareHttpError('Figshare HTTP request failed for post /account/articles', {
+      statusCode: 400,
+      responseBody: {
+        message: 'Invalid identifier format',
+        code: 'BadRequest',
+      },
+    });
+    sinon.stub(httpModule, 'makeClientLayer').returns(
+      Layer.succeed(FigshareClientTag, {
+        listLicenses: sinon.stub().rejects(httpError),
+      } as any)
+    );
+
+    const defaults = new FigsharePublishing();
+    const config = {
+      ...defaults,
+      runtime: { mode: 'live' },
+      metadata: {
+        ...defaults.metadata,
+        title: { kind: 'path', path: 'metadata.title', defaultValue: '' },
+        description: { kind: 'path', path: 'metadata.description', defaultValue: '' },
+        keywords: { kind: 'path', path: 'metadata.keywords', defaultValue: [] },
+        license: {
+          source: { kind: 'path', path: 'metadata.license', defaultValue: '' },
+          matchBy: 'valueExact',
+          required: true,
+        },
+        categories: {
+          source: { kind: 'path', path: 'metadata.categories', defaultValue: [] },
+        },
+        relatedResource: undefined,
+      },
+      categories: {
+        ...defaults.categories,
+        allowUnmapped: true,
+      },
+    } as any;
+
+    let thrown: unknown;
+    try {
+      await runBuildMetadataPayload(config, {
+        redboxOid: 'oid-1',
+        metaMetadata: { brandId: 'default' },
+        metadata: {
+          title: 'Dataset title',
+          description: 'Dataset description',
+          keywords: ['one'],
+          license: '52',
+          categories: [],
+        },
+      } as any);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).to.equal(httpError);
+    expect(thrown).to.be.instanceOf(FigshareHttpError);
+    expect((thrown as FigshareHttpError).name).to.equal('FigshareHttpError');
+    expect((thrown as FigshareHttpError).statusCode).to.equal(400);
+    expect((thrown as FigshareHttpError).responseBody).to.deep.equal({
+      message: 'Invalid identifier format',
+      code: 'BadRequest',
+    });
+  });
+});

--- a/packages/sails-ng-common/src/validation/validators.ts
+++ b/packages/sails-ng-common/src/validation/validators.ts
@@ -1,4 +1,9 @@
-import { FormValidatorDefinition } from "./form.model";
+import {
+  FormSyncValidatorDefinition,
+  FormValidatorConfig,
+  FormValidatorDefinition,
+  FormValidatorFn,
+} from "./form.model";
 import {
   formValidatorBuildError,
   formValidatorGetDefinitionArray,
@@ -57,6 +62,30 @@ function hasRequiredFieldValue(value: unknown, fieldNames: string[]): boolean {
  * Based on the angular email validation regex. MIT-style license https://angular.dev/license
  */
 export const FORM_VALIDATOR_EMAIL_REGEXP = /^(?=.{1,254}$)(?=.{1,64}@)[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+)*@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+
+/**
+ * A regular expression for a bare DOI (without a doi.org resolver URL).
+ *
+ * This follows the Crossref-recommended broad DOI syntax and is intentionally
+ * case-insensitive for DOI suffixes.
+ */
+export const FORM_VALIDATOR_DOI_REGEXP = /^10\.\d{4,9}\/[-._;()/:a-zA-Z0-9]+$/i;
+
+function createNestedSyncValidator(validatorConfig: FormValidatorConfig): FormValidatorFn {
+  const definition = formValidatorsSharedDefinitions.find(item => item.class === validatorConfig.class);
+  if (definition == null) {
+    throw new Error(`No validator definition with class '${validatorConfig.class}' in 'any-of' validator.`);
+  }
+  if (!("create" in definition)) {
+    throw new Error(`Validator '${validatorConfig.class}' in 'any-of' must be synchronous.`);
+  }
+  const syncDefinition = definition as FormSyncValidatorDefinition;
+  return syncDefinition.create({
+    ...(validatorConfig.config ?? {}),
+    class: validatorConfig.class,
+    message: validatorConfig.message ?? syncDefinition.message,
+  });
+}
 
 /**
  * Definitions of form validators.
@@ -482,6 +511,62 @@ export const formValidatorsSharedDefinitions: FormValidatorDefinition[] = [
           return buildError();
         }
         return null;
+      };
+    },
+  },
+  // Validates a bare DOI. DOI resolver URLs are URLs, not bare DOI identifiers,
+  // and can be accepted separately by composing this validator with `url`.
+  {
+    class: "doi",
+    message: "@validator-error-doi",
+    create: (config) => {
+      const optionDescriptionValue = formValidatorGetDefinitionString(config, "description", "");
+      return (control) => {
+        if (control.value == null || formValidatorLengthOrSize(control.value) === 0) {
+          return null; // don't validate empty values to allow optional controls
+        }
+        const candidate = control.value.toString().trim();
+        if (candidate.length === 0) {
+          return null; // treat whitespace-only values as empty/optional
+        }
+        return FORM_VALIDATOR_DOI_REGEXP.test(candidate)
+          ? null
+          : formValidatorBuildError(config, {
+            description: optionDescriptionValue,
+            requiredPattern: FORM_VALIDATOR_DOI_REGEXP.source,
+            actual: control.value,
+          });
+      };
+    },
+  },
+  // Applies nested synchronous validators with OR semantics. The value is valid
+  // when at least one nested validator accepts it. This allows reusable validators
+  // such as `url` and `doi` to be combined on a single input without duplicating
+  // their validation rules in form configuration.
+  {
+    class: "any-of",
+    message: "@validator-error-any-of",
+    create: (config) => {
+      const optionDescriptionValue = formValidatorGetDefinitionString(config, "description", "");
+      const validatorConfigs = formValidatorGetDefinitionArray(config, "validators") as FormValidatorConfig[];
+      if (validatorConfigs.length === 0) {
+        throw new Error("Validator 'any-of' requires at least one nested validator.");
+      }
+      const validators = validatorConfigs.map((validatorConfig) => {
+        if (validatorConfig == null || typeof validatorConfig !== "object" || typeof validatorConfig.class !== "string" || validatorConfig.class === "") {
+          throw new Error(`Invalid nested validator in 'any-of': ${JSON.stringify(validatorConfig)}.`);
+        }
+        return createNestedSyncValidator(validatorConfig);
+      });
+      return (control) => {
+        const accepted = validators.some(validator => validator(control) == null);
+        return accepted
+          ? null
+          : formValidatorBuildError(config, {
+            description: optionDescriptionValue,
+            validatorClasses: validatorConfigs.map(item => item.class),
+            actual: control.value,
+          });
       };
     },
   },

--- a/packages/sails-ng-common/test/unit/validators.test.ts
+++ b/packages/sails-ng-common/test/unit/validators.test.ts
@@ -3,6 +3,7 @@ import {
   FormValidatorDefinition,
   FormValidatorErrors,
   SimpleServerFormValidatorControl,
+  FORM_VALIDATOR_DOI_REGEXP,
   FORM_VALIDATOR_EMAIL_REGEXP,
   formValidatorsSharedDefinitions,
   ValidatorsSupport,
@@ -636,6 +637,141 @@ describe("Validator", async () => {
           expected: null,
         },
       ];
+    cases.forEach(({ title, args, expected }) => {
+      it(`should validate ${title}`, async () => {
+        await checkValidator({ title, args, expected });
+      });
+    });
+  });
+
+  describe("doi", async () => {
+    const doiError = (actual: unknown): FormValidatorErrors => ({
+      doi: {
+        message: "@validator-error-doi",
+        params: {
+          description: "",
+          requiredPattern: FORM_VALIDATOR_DOI_REGEXP.source,
+          actual,
+        },
+      },
+    });
+
+    const cases: TestCase[] = [
+      {
+        title: "doi - expect pass (bare DOI)",
+        args: {
+          value: "10.1016/j.futures.2015.03.003",
+          definition: formValidatorsSharedDefinitions,
+          block: { class: "doi" },
+        },
+        expected: null,
+      },
+      {
+        title: "doi - expect pass (mixed-case suffix and surrounding whitespace)",
+        args: {
+          value: "  10.0166/FK2.stagefigshare.10122493  ",
+          definition: formValidatorsSharedDefinitions,
+          block: { class: "doi" },
+        },
+        expected: null,
+      },
+      {
+        title: "doi - expect failure (resolver URL is not a bare DOI)",
+        args: {
+          value: "https://doi.org/10.1016/j.futures.2015.03.003",
+          definition: formValidatorsSharedDefinitions,
+          block: { class: "doi" },
+        },
+        expected: doiError("https://doi.org/10.1016/j.futures.2015.03.003"),
+      },
+      {
+        title: "doi - expect failure (invalid registrant)",
+        args: {
+          value: "10.123/example",
+          definition: formValidatorsSharedDefinitions,
+          block: { class: "doi" },
+        },
+        expected: doiError("10.123/example"),
+      },
+      {
+        title: "doi - expect pass (empty optional value)",
+        args: {
+          value: "",
+          definition: formValidatorsSharedDefinitions,
+          block: { class: "doi" },
+        },
+        expected: null,
+      },
+    ];
+
+    cases.forEach(({ title, args, expected }) => {
+      it(`should validate ${title}`, async () => {
+        await checkValidator({ title, args, expected });
+      });
+    });
+  });
+
+  describe("any-of", async () => {
+    const urlOrDoiValidator: FormValidatorConfig = {
+      class: "any-of",
+      message: "@url-or-doi-invalid",
+      config: {
+        description: "an absolute HTTP(S) URL or a bare DOI",
+        validators: [
+          { class: "url", config: { schemes: ["http", "https"] } },
+          { class: "doi" },
+        ],
+      },
+    };
+
+    const cases: TestCase[] = [
+      {
+        title: "any-of - expect pass when URL validator accepts",
+        args: {
+          value: "https://example.org/resource",
+          definition: formValidatorsSharedDefinitions,
+          block: urlOrDoiValidator,
+        },
+        expected: null,
+      },
+      {
+        title: "any-of - expect pass when DOI validator accepts",
+        args: {
+          value: "10.1016/j.futures.2015.03.003",
+          definition: formValidatorsSharedDefinitions,
+          block: urlOrDoiValidator,
+        },
+        expected: null,
+      },
+      {
+        title: "any-of - expect failure when neither validator accepts",
+        args: {
+          value: "not a URL or DOI",
+          definition: formValidatorsSharedDefinitions,
+          block: urlOrDoiValidator,
+        },
+        expected: {
+          "any-of": {
+            message: "@url-or-doi-invalid",
+            params: {
+              description: "an absolute HTTP(S) URL or a bare DOI",
+              validatorClasses: ["url", "doi"],
+              actual: "not a URL or DOI",
+            },
+          },
+        },
+      },
+      {
+        title: "any-of - expect pass for an empty optional value",
+        args: {
+          value: "",
+          definition: formValidatorsSharedDefinitions,
+          block: urlOrDoiValidator,
+        },
+        expected: null,
+      },
+    ];
+
     cases.forEach(({ title, args, expected }) => {
       it(`should validate ${title}`, async () => {
         await checkValidator({ title, args, expected });


### PR DESCRIPTION
## Summary

Add reusable DOI and OR-composition form validators, classify Figshare related-material identifiers as DOI or URL, and preserve structured Figshare HTTP failures through the Effect runtime.

---

## Context / Motivation

Figshare treats related-material identifiers as URLs unless an `identifier_type` is supplied. Records containing bare DOI values therefore failed during article creation with `Invalid identifier format`, even though the DOI itself was valid. The Effect promise boundary also wrapped the underlying `FigshareHttpError` in a `FiberFailure`, causing integration audits and UI errors to lose the HTTP status and response body needed for diagnosis.

---

## Key Features

### Validation

- Add a reusable, case-insensitive validator for bare DOI identifiers.
- Add an `any-of` synchronous validator that composes existing validators with OR semantics, allowing a single control to accept formats such as URL or DOI.
- Add default translations and metadata for both validator errors.

### Figshare related materials

- Infer `identifier_type` as `DOI` for bare DOI values and `URL` for URL values.
- Include the inferred type in every related-material payload sent to Figshare.
- Share the DOI recognition rule between form validation and payload construction.

### Error observability

- Run Figshare Effect programs through their exit value so expected domain and HTTP failures are rethrown unchanged.
- Preserve `FigshareHttpError` status codes, response bodies, and causes for integration audits and user-facing validation errors.

---

## Testing

- Added unit coverage for valid, invalid, optional, and mixed-case DOI values.
- Added unit coverage for URL-or-DOI composition and rejection when neither validator accepts the value.
- Updated Figshare payload tests to verify DOI and URL identifier types.
- Added a runtime regression test proving HTTP failures are not replaced by `FiberFailure`.
- Verified 274 shared-validator tests and 61 focused Figshare tests pass, and the core package builds successfully.
- Exercised the change against CQU Figshare with two bare DOIs and two URLs; Figshare stored all four related materials with the expected identifier types.

---

## Architectural / Operational Impact

### Shared form validation

The DOI and `any-of` validators are available to server and Angular form validation through the existing shared validator registry. Consuming form configurations can combine synchronous validators without duplicating their validation rules.

### Figshare integration diagnostics

Figshare request failures now retain their structured HTTP metadata across the Effect boundary, allowing audit records to report the actual status and response details instead of a generic status code of zero.

---

## Backwards Compatibility

Existing URL validation and form configurations are unchanged. Related materials now include the Figshare-supported `identifier_type` property; existing URL values continue to be sent as `URL`. No stored-record migration is required.

---

## Deployment Notes

Deploy the updated shared and core packages together so payload construction uses the same DOI rule exposed to form configurations. Consuming branding or hook form configurations may opt into `doi` and `any-of`; no database or configuration migration is required.

---

## Impact

Bare DOI related materials can be submitted to Figshare successfully, invalid identifiers can be rejected before submission, and future Figshare failures retain actionable diagnostic detail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DOI validation for bare DOI identifiers, including clear validation errors.
  * Added an “any of” validator for combining multiple validation rules.
  * Related materials now identify references as either DOI or URL.
* **Bug Fixes**
  * Preserved detailed HTTP status and response information when Figshare requests fail.
* **Documentation**
  * Added English translations and localization metadata for new validation messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->