### PR TITLE
Fix CircleCI Dependabot lockfile refresh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,7 @@ jobs:
               packages/agenda-sqs-backend \
               packages/redbox-core \
               packages/redbox-dev-tools \
+              packages/sails-ng-common \
               packages/sails-hook-redbox-storage-mongo
       - run:
           name: Commit refreshed package locks
@@ -483,6 +484,8 @@ jobs:
       - run:
           name: Install packages
           command: |
+            nvm install
+            nvm use
             npm install --no-save --ignore-scripts
             cd ./packages/sails-ng-common
             npm ci --include=dev


### PR DESCRIPTION
The Dependabot lockfile refresh job did not include packages/sails-ng-common, so its package-lock.json was left incompatible with the package test.

This also makes the package test load the repository .nvmrc before npm install, matching the Node/npm toolchain used by the lock refresh job.

The affected Dependabot lockfiles require the same alignment because npm 10 rejects lockfiles generated by npm 11 when nested glob dependencies are omitted.