### PR TITLE
Bugfix: Sync array-backed repeatable permission sources

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/repeatable.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/repeatable.component.spec.ts
@@ -39,6 +39,7 @@ describe('RepeatableComponent', () => {
     const result = component.upsertSyncedSource(
       [{ name: 'Existing user', email: 'existing@example.com', role: 'View' }],
       [
+        { name: 'Updated existing user', email: 'existing@example.com', username: 'existing-user' },
         { name: 'Alice Smith', email: 'alice@example.com' },
         { name: 'Bob Jones', email: 'bob@example.com' },
       ],
@@ -46,7 +47,12 @@ describe('RepeatableComponent', () => {
     );
 
     expect(result).toEqual([
-      { name: 'Existing user', email: 'existing@example.com', role: 'View' },
+      {
+        name: 'Updated existing user',
+        email: 'existing@example.com',
+        username: 'existing-user',
+        role: 'View'
+      },
       { name: 'Alice Smith', email: 'alice@example.com', username: null, role: 'View&Edit' },
       { name: 'Bob Jones', email: 'bob@example.com', username: null, role: 'View&Edit' },
     ]);

--- a/angular/projects/researchdatabox/form/src/app/component/repeatable.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/repeatable.component.spec.ts
@@ -26,6 +26,44 @@ describe('RepeatableComponent', () => {
     expect(component).toBeDefined();
   });
 
+  it('should upsert array sync source values item by item', () => {
+    const fixture = TestBed.createComponent(RepeatableComponent);
+    const component = fixture.componentInstance as any;
+    const syncSource = {
+      fieldName: 'contributors',
+      syncKey: 'email',
+      blankCheckFields: ['name', 'email', 'username'],
+      defaultTemplate: { username: null, role: 'View&Edit' },
+    };
+
+    const result = component.upsertSyncedSource(
+      [{ name: 'Existing user', email: 'existing@example.com', role: 'View' }],
+      [
+        { name: 'Alice Smith', email: 'alice@example.com' },
+        { name: 'Bob Jones', email: 'bob@example.com' },
+      ],
+      syncSource,
+    );
+
+    expect(result).toEqual([
+      { name: 'Existing user', email: 'existing@example.com', role: 'View' },
+      { name: 'Alice Smith', email: 'alice@example.com', username: null, role: 'View&Edit' },
+      { name: 'Bob Jones', email: 'bob@example.com', username: null, role: 'View&Edit' },
+    ]);
+  });
+
+  it('should recognize nested repeatable source event paths', () => {
+    const fixture = TestBed.createComponent(RepeatableComponent);
+    const component = fixture.componentInstance as any;
+
+    expect(
+      component.isSyncSourceTriggerEvent(
+        { fieldId: '/mainTab/project/contributors/0', type: 'field.value.changed' },
+        [{ fieldName: 'contributors' }],
+      ),
+    ).toBeTrue();
+  });
+
   for (const [description, value] of [
     ['object', {title: 'First'}],
     ['array', [{title: 'First'}]],

--- a/angular/projects/researchdatabox/form/src/app/component/repeatable.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/repeatable.component.ts
@@ -252,9 +252,19 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
     const fieldId = event.fieldId || '';
     return syncSources.some(
       source =>
-        fieldId.endsWith(`/${source.fieldName}`) ||
-        (!!source.visibilityConditionField && fieldId.endsWith(`/${source.visibilityConditionField}`))
+        this.matchesSyncSourcePath(fieldId, source.fieldName) ||
+        (!!source.visibilityConditionField &&
+          this.matchesSyncSourcePath(fieldId, source.visibilityConditionField))
     );
+  }
+
+  private matchesSyncSourcePath(fieldId: string, fieldName: string): boolean {
+    const normalizedFieldName = fieldName.replace(/^\/+/, '');
+    if (!normalizedFieldName) {
+      return false;
+    }
+    const sourcePath = `/${normalizedFieldName}`;
+    return fieldId.endsWith(sourcePath) || fieldId.includes(`${sourcePath}/`);
   }
 
   private async syncFromCurrentSources(emitEvent: boolean): Promise<void> {
@@ -309,6 +319,14 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
   }
 
   private upsertSyncedSource(existing: unknown[], sourceValue: unknown, syncSource: SyncSourceEntry): unknown[] {
+    const sourceValues = Array.isArray(sourceValue) ? sourceValue : [sourceValue];
+    return sourceValues.reduce(
+      (items, value) => this.upsertSyncedSourceItem(items, value, syncSource),
+      existing
+    );
+  }
+
+  private upsertSyncedSourceItem(existing: unknown[], sourceValue: unknown, syncSource: SyncSourceEntry): unknown[] {
     const source =
       typeof sourceValue === 'object' && sourceValue !== null
         ? _cloneDeep(sourceValue as Record<string, unknown>)
@@ -330,16 +348,16 @@ export class RepeatableComponent extends FormFieldBaseComponent<Array<unknown>> 
     if (hasSyncKey) {
       const existingIndex = items.findIndex(item => item?.[syncKey] === syncValue);
       if (existingIndex >= 0) {
-        items[existingIndex] = { ...items[existingIndex], ...source, ...template };
+        items[existingIndex] = { ...template, ...items[existingIndex], ...source };
         return items;
       }
     }
 
     if (items.length === 1 && this.isBlankPlaceholder(items[0], syncSource, source)) {
-      return [{ ...items[0], ...source, ...template }];
+      return [{ ...template, ...items[0], ...source }];
     }
 
-    return [...items, { ...source, ...template }];
+    return [...items, { ...template, ...source }];
   }
 
   private isBlankPlaceholder(

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-item-select-event-consumer.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-item-select-event-consumer.spec.ts
@@ -222,7 +222,11 @@ describe('FormComponentItemSelectEventConsumer', () => {
     }));
     expect(eventBus.publish).toHaveBeenCalledWith(jasmine.objectContaining({
       fieldId: '/record/contributors/0',
-      sourceId: '*'
+      sourceId: '*',
+      value: {
+        funderName: 'https://example.org/funder/parent',
+        funderSearch: ''
+      }
     }));
   });
 

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-item-select-event-consumer.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-item-select-event-consumer.spec.ts
@@ -220,6 +220,10 @@ describe('FormComponentItemSelectEventConsumer', () => {
     expect(scopedBus.publish).toHaveBeenCalledWith(jasmine.objectContaining({
       fieldId: '/record/contributors/0'
     }));
+    expect(eventBus.publish).toHaveBeenCalledWith(jasmine.objectContaining({
+      fieldId: '/record/contributors/0',
+      sourceId: '*'
+    }));
   });
 
   it('should ignore events from same field (self)', () => {

--- a/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-item-select-event-consumer.ts
+++ b/angular/projects/researchdatabox/form/src/app/form-state/events/form-component-item-select-event-consumer.ts
@@ -158,6 +158,14 @@ export class FormComponentItemSelectEventConsumer extends FormComponentEventBase
       previousValue: previousValue === undefined ? undefined : this.cloneEventValue(previousValue),
       sourceId: parentPointer,
     });
+    // Keep the row-scoped event for consumers that intentionally listen to this
+    // exact group, and also publish the completed group value on the broadcast
+    // channel so cross-tree expressions can react to sibling autofill (for
+    // example, DMP permissions syncing the selected contributor email).
+    this.eventBus.publish({
+      ...scopedEvent,
+      sourceId: '*',
+    } as Omit<typeof scopedEvent, 'timestamp'>);
     this.eventBus.scoped(parentPointer).publish(scopedEvent as Omit<typeof scopedEvent, 'timestamp' | 'sourceId'>);
   }
 

--- a/packages/sails-ng-common/src/config/base-field-component.outline.ts
+++ b/packages/sails-ng-common/src/config/base-field-component.outline.ts
@@ -6,7 +6,9 @@ import {FieldDefinitionFrame, FieldDefinitionOutline} from "./field.outline";
  */
 export interface SyncSourceEntry {
     /**
-     * formData key to read the source data from.
+     * formData key to read the source data from. The source value may be a
+     * single object or an array of objects; array values are synced item by
+     * item.
      */
     fieldName: string;
     /**


### PR DESCRIPTION
## Summary

Fix repeatable form synchronisation for array-valued sources so DMP permission rows receive the selected contributor's current email address immediately.

---

## Context / Motivation

The DMP permissions fields synchronise from contributor records held in repeatable arrays. The existing implementation assumed a single source object and did not consistently observe nested repeatable field paths or completed sibling-row selections. As a result, the last permission row could remain without an email until another row was edited.

---

## Key Features

### Array-aware repeatable synchronisation

- Accept object or array sync sources and upsert array entries item by item.
- Match existing rows by the configured sync key while preserving values already entered in the permission row.
- Apply defaults only when creating or filling a new row.

### Repeatable event propagation

- Recognise source changes from nested repeatable paths such as contributor row indexes.
- Broadcast the completed selected group to cross-tree synchronisation consumers while retaining the existing row-scoped event.

### Configuration contract

- Document that `syncSources` accepts either a single object or an array of objects.

---

## Testing

- Added regression coverage for array source upserts and nested repeatable source paths.
- Added regression coverage for broadcast item-selection events.
- Angular form test suite passes: 800 tests.
- Angular form compilation succeeds.
- Visually verified the affected UANZ form in T3 Browser after restarting the development service.

---

## Architectural / Operational Impact

### Form state synchronisation

The shared repeatable component now supports the source shapes used by linked repeatable records without requiring hook-specific JSONata workarounds for direct contributor changes.

### Event handling

Item-selection events continue to be available to consumers scoped to the same repeatable group, while the completed row is also available to consumers synchronising related form trees.

---

## Backwards Compatibility

Single-object sync sources retain their existing behaviour. Existing row-scoped events are preserved; the additional broadcast event is additive.

---

## Deployment Notes

No data migration is required. Deploy the portal assets containing the updated form component and event consumer.

---

## Impact

DMP permission repeatables now stay in sync with contributor selections, including the current last row, eliminating the delayed or blank email population observed during data entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved synchronization for repeatable fields, including nested fields and visibility-condition fields.
  - Synced arrays now update items individually while preserving default values and applying source values correctly.
  - New repeatable items are populated with configured defaults and synchronized values.
  - Item selections now trigger broader form value-change updates, improving dependent field behavior.

- **Documentation**
  - Clarified that synchronization sources can provide either single objects or arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->