### PR TITLE
Chore: extract wiki publishing into dedicated CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1012,30 +1012,37 @@ jobs:
             git config user.email "ci-build@redboxresearchdata.com.au"
             git config user.name "ci-build"
             gh-pages --dotfiles --message "[ci skip] Updating documents" --dist support/docs/generated/ng2
-      - run:
-          name: Publish wiki docs
-          command: |
-            git config user.email "ci-build@redboxresearchdata.com.au"
-            git config user.name "ci-build"
-            mkdir -p ~/.ssh
-            ssh-keyscan github.com >> ~/.ssh/known_hosts
-            tmp_dir=$(mktemp -d)
-            git clone git@github.com:redbox-mint/redbox-portal.wiki.git "$tmp_dir"
-            git -C "$tmp_dir" rm -r --ignore-unmatch .
-            cp -a support/wiki/. "$tmp_dir"/
-            cd "$tmp_dir"
-            git add -A
-            if git diff --cached --quiet; then
-              echo "Wiki up to date; no changes to push."
-            else
-              git commit -m "[ci skip] Update wiki docs"
-              branch=$(git symbolic-ref --short HEAD)
-              git push origin "$branch"
-            fi
       - save_cache:
           key: v1-npm-cache-{{ arch }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
           paths:
             - ~/.npm
+  publish-wiki:
+    docker:
+      - image: 'cimg/node:24.16.0'
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - '50:0c:a1:7f:b6:64:84:42:01:61:0f:76:3f:e4:78:ff'
+      - checkout
+      - run:
+          name: Publish wiki docs
+          command: |
+            git config --global user.email "ci-build@redboxresearchdata.com.au"
+            git config --global user.name "ci-build"
+
+            wiki_dir=$(mktemp -d)
+            git clone git@github.com:redbox-mint/redbox-portal.wiki.git "$wiki_dir"
+            git -C "$wiki_dir" rm -r --ignore-unmatch .
+            cp -a support/wiki/. "$wiki_dir"/
+            git -C "$wiki_dir" add -A
+
+            if git -C "$wiki_dir" diff --cached --quiet; then
+              echo "Wiki is already up to date."
+              exit 0
+            fi
+
+            git -C "$wiki_dir" commit -m "[ci skip] Update wiki docs from ${CIRCLE_SHA1}"
+            git -C "$wiki_dir" push origin HEAD
 orbs:
   node: circleci/node@7.2.1
   docker: circleci/docker@3.0.1
@@ -1080,6 +1087,14 @@ workflows:
           filters:
             branches:
               ignore: /^dependabot.*/
+      - publish-wiki:
+          filters:
+            branches:
+              only:
+                - master
+                - chore/wiki-publication
+            tags:
+              ignore: /.*/
       - build-runtime-pdfgen:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1088,11 +1088,12 @@ workflows:
             branches:
               ignore: /^dependabot.*/
       - publish-wiki:
+          requires:
+            - deploy
+            - deploy-arm64
           filters:
             branches:
-              only:
-                - master
-                - chore/wiki-publication
+              only: master
             tags:
               ignore: /.*/
       - build-runtime-pdfgen:


### PR DESCRIPTION
## Summary

Extract wiki documentation publishing into a dedicated CircleCI job that runs only on the master branch after deployment completes, replacing the previous inline step that ran on all branches.

---

## Context / Motivation

The wiki publishing step was not wired into any CircleCI workflows. Wiki docs should be published when master is deployed, and running it as a separate job improves clarity and isolation.

---

## Key Features

### Dedicated publish-wiki job

- New standalone CircleCI job with its own Docker image (`cimg/node:24.16.0`)
- Uses `add_ssh_keys` with a specific fingerprint for GitHub access
- Clones the wiki repo, replaces contents with `support/wiki/`, and pushes if changes exist

### Master-only workflow trigger

- `publish-wiki` job requires both `deploy` and `deploy-arm64` to complete first
- Filtered to run only on the `master` branch, ignoring all tags

### Improved wiki commit messaging

- Commit messages now include the source SHA (`CIRCLE_SHA1`) for traceability
- Uses `--global` for git config to avoid scope issues in the standalone job

---

## Testing

- CI/CD workflow change only; no unit or integration test changes required
- Verified via dry-run that branch is up to date with remote

---

## Architectural / Operational Impact

### CI pipeline clarity

- Wiki publishing is now clearly separated from deployment logic
- Easier to troubleshoot wiki-specific failures independently

### Security

- Uses a dedicated SSH key fingerprint for wiki repo access
- Git config is set globally within the job container, avoiding local config leaks

---

## Backwards Compatibility

No breaking changes. The wiki publishing behavior is functionally equivalent but runs in a more isolated and appropriate context.

---

## Deployment Notes

No special deployment steps required. The CI workflow changes take effect once merged to master.

---

## Impact

Improves CI pipeline organization by separating wiki publishing into its own controlled, master-only job with better traceability and operational clarity.

Closes #3618

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

- Automated documentation updates are now published to the project wiki after successful deployments from the main branch.
- Wiki content is refreshed only when changes are detected, reducing unnecessary update activity.
- Documentation generation and publishing now run as separate workflow steps, improving the reliability and visibility of documentation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->