### PR TITLE
Chore: publish REST API docs from master CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1003,15 +1003,20 @@ jobs:
             npm run compile:sails-ng-common
             npm run compile:core
       - run:
-          name: Generate angular docs
-          command: npm run doc-ng2
+          name: Generate REST API docs
+          command: |
+            npm run doc:api -- --branding=default --portal=rdmp
+            api_site=.tmp/api-docs-site/additional-documentation
+            mkdir -p "$api_site"
+            cp -a support/docs/generated/api/. "$api_site"/
+            mv "$api_site/index.html" "$api_site/rest-api.html"
       - run:
-          name: Deploy docs by adding commit to gh-pages branch
+          name: Deploy REST API docs by adding commit to gh-pages branch
           command: |
             npm install -g --silent gh-pages@2.0.1
             git config user.email "ci-build@redboxresearchdata.com.au"
             git config user.name "ci-build"
-            gh-pages --dotfiles --message "[ci skip] Updating documents" --dist support/docs/generated/ng2
+            gh-pages --dotfiles --message "[ci skip] Updating REST API documents" --dist .tmp/api-docs-site
       - save_cache:
           key: v1-npm-cache-{{ arch }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1096,6 +1096,15 @@ workflows:
               only: master
             tags:
               ignore: /.*/
+      - generate-docs:
+          requires:
+            - deploy
+            - deploy-arm64
+          filters:
+            branches:
+              only: master
+            tags:
+              ignore: /.*/
       - build-runtime-pdfgen:
           requires:
             - build


### PR DESCRIPTION
## Summary

Wire the existing documentation job into the CircleCI deployment workflow so only the rendered REST API documentation is published to the GitHub Pages `gh-pages` branch from master builds.

---

## Context / Motivation

The API documentation generation workflow added by PR #4057 is present on master, and the `generate-docs` job already contains the GitHub Pages publishing step. However, that job was not referenced by any CircleCI workflow. Its previous `doc-ng2` command also generated and published outdated Angular/Compodoc documentation alongside the REST API reference.

---

## Key Features

### Master-only REST API documentation publication

- Adds the existing `generate-docs` job to the standard deployment workflow
- Runs only on the `master` branch and ignores tag pipelines
- Requires both `deploy` and `deploy-arm64` to complete successfully first
- Generates API artifacts with `npm run doc:api` without running the Angular documentation build

### API-only GitHub Pages output

- Stages the generated API artifacts under `additional-documentation/`
- Publishes the Redoc HTML as `additional-documentation/rest-api.html`
- Keeps the accompanying OpenAPI JSON, YAML, and API Blueprint files beside the HTML document
- Removes outdated Angular/Compodoc documentation from the published site output

---

## Testing

- CircleCI configuration validated with `circleci config validate .circleci/config.yml`
- `git diff --check` passed
- API documentation generation smoke test passed with `npm run doc:api -- --branding=default --portal=rdmp`
- Verified the staged publication output contains only REST API documentation artifacts and no Angular documentation

---

## Architectural / Operational Impact

### CI pipeline behavior

Master deployments now have an explicit post-deployment REST API documentation publication stage. The generated site no longer includes the outdated Angular/Compodoc output, making the published documentation smaller and focused on the supported API reference.

### Security

No new credentials or permissions are introduced. The job reuses the existing SSH key and GitHub Pages publishing behavior.

---

## Backwards Compatibility

No application behavior or API compatibility changes. The public REST API documentation path remains `additional-documentation/rest-api.html`; only the obsolete Angular documentation output is removed.

---

## Deployment Notes

No special deployment steps are required. The workflow change takes effect after merging to `master`; the documentation job will run after successful deployment jobs on subsequent master pipelines.

---

## Impact

Ensures master builds publish the current REST API HTML documentation without publishing the outdated Angular documentation set.

Closes #3570
