### PR TITLE
Bugfix: Fix word wrapping in repeatable view tables

### DIFF
--- a/assets/styles/default-theme.scss
+++ b/assets/styles/default-theme.scss
@@ -282,6 +282,13 @@ input[type="submit"]:hover, button[type=submit]:hover {background-color: var(--r
     margin-bottom: 1rem;
 }
 
+.rb-view-repeatable-table th,
+.rb-view-repeatable-table td,
+.rb-view-repeatable-table td a {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
 .rb-view-repeatable-list {
     display: grid;
     gap: 0.75rem;


### PR DESCRIPTION
## Summary

Fix word wrapping in repeatable view tables to prevent long content from overflowing table cells.

Changes made:

* Add CSS rules to handle word wrapping in repeatable view tables
* Apply `overflow-wrap: anywhere` and `word-break: break-word` to table headers, cells, and links

---

## Context / related work

* This addresses display issues where long text content in repeatable view tables would overflow table cell boundaries, causing layout problems
* The fix targets the `.rb-view-repeatable-table` component used throughout the portal

---

## Technical implementation details

* Added CSS properties to `assets/styles/default-theme.scss`:
  - `overflow-wrap: anywhere` allows long words to break at any character position
  - `word-break: break-word` provides fallback word breaking for older browsers
* Applied to `th`, `td`, and `td a` elements within repeatable view tables

---

## Testing

* Visual verification of repeatable view tables with long text content
* Verified tables display correctly without horizontal overflow

---

## Future work

* None anticipated - this is a targeted CSS fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved repeatable table layouts so long headers, cell content, and links wrap cleanly.
  * Added word breaking for unusually long content to prevent horizontal overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->