### PR TITLE
Bugfix: honour focusTabId query parameter

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/tab.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/tab.component.spec.ts
@@ -389,7 +389,7 @@ describe('TabComponent', () => {
     url.search = '?focusTabId=tab1';
     window.history.replaceState({}, '', url.toString());
 
-    const {formComponent, componentDefinitions} = await createFormAndWaitForReady(formConfig);
+    const {fixture, formComponent, componentDefinitions} = await createFormAndWaitForReady(formConfig);
     if (!componentDefinitions?.component) {
       throw new Error('Component definition is not defined');
     }
@@ -403,6 +403,35 @@ describe('TabComponent', () => {
     const mainTab = mainTabDef.component as TabComponent;
     expect(mainTab.selectedTabId).toBe('tab1');
     expect(mainTab.activeTabId).toBe('tab1');
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const tab1Button = compiled.querySelector('#tab1-tab-button');
+    const tab2Button = compiled.querySelector('#tab2-tab-button');
+    expect(tab1Button?.classList).toContain('active');
+    expect(tab1Button?.getAttribute('aria-selected')).toBe('true');
+    expect(tab2Button?.classList).not.toContain('active');
+    expect(tab2Button?.getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('should fall back to configured selected tab when focusTabId is invalid', async () => {
+    const url = new URL(window.location.href);
+    url.search = '?focusTabId=unknown-tab';
+    window.history.replaceState({}, '', url.toString());
+
+    const {formComponent, componentDefinitions} = await createFormAndWaitForReady(formConfig);
+    if (!componentDefinitions?.component) {
+      throw new Error('Component definition is not defined');
+    }
+
+    const mainTabDef = formComponent.getComponentDefByName('main_tab');
+    expect(mainTabDef).toBeDefined();
+    if (mainTabDef === undefined) {
+      throw new Error('Main tab component is not defined');
+    }
+
+    const mainTab = mainTabDef.component as TabComponent;
+    expect(mainTab.selectedTabId).toBe('tab2');
+    expect(mainTab.activeTabId).toBe('tab2');
   });
 
   it('should mark non-selected tabs as inactive on initial load', async () => {

--- a/angular/projects/researchdatabox/form/src/app/component/tab.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/tab.component.spec.ts
@@ -237,6 +237,12 @@ describe('TabComponent', () => {
 
   });
 
+  afterEach(() => {
+    const url = new URL(window.location.href);
+    url.search = '';
+    window.history.replaceState({}, '', url.toString());
+  });
+
   it('should create component', () => {
     let fixture = TestBed.createComponent(TabComponent);
     let component = fixture.componentInstance;
@@ -376,6 +382,27 @@ describe('TabComponent', () => {
     // Verify that selectedTabId is set correctly after initialization
     expect(mainTab.selectedTabId).toBe('tab2');
     expect(mainTab.activeTabId).toBe('tab2');
+  });
+
+  it('should select the tab named by the focusTabId request parameter', async () => {
+    const url = new URL(window.location.href);
+    url.search = '?focusTabId=tab1';
+    window.history.replaceState({}, '', url.toString());
+
+    const {formComponent, componentDefinitions} = await createFormAndWaitForReady(formConfig);
+    if (!componentDefinitions?.component) {
+      throw new Error('Component definition is not defined');
+    }
+
+    const mainTabDef = formComponent.getComponentDefByName('main_tab');
+    expect(mainTabDef).toBeDefined();
+    if (mainTabDef === undefined) {
+      throw new Error('Main tab component is not defined');
+    }
+
+    const mainTab = mainTabDef.component as TabComponent;
+    expect(mainTab.selectedTabId).toBe('tab1');
+    expect(mainTab.activeTabId).toBe('tab1');
   });
 
   it('should mark non-selected tabs as inactive on initial load', async () => {

--- a/angular/projects/researchdatabox/form/src/app/component/tab.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/tab.component.ts
@@ -168,6 +168,10 @@ export class TabComponent extends FormFieldBaseComponent<undefined> {
   protected formService = inject(FormService);
   public override componentDefinition?: TabFieldComponentDefinitionFrame;
 
+  protected get getFormComponent(): FormComponent {
+    return this.formComponent;
+  }
+
   protected get tabConfig(): TabFieldComponentConfigFrame {
     return this.componentDefinition?.config || { tabs: [] };
   }
@@ -230,9 +234,19 @@ export class TabComponent extends FormFieldBaseComponent<undefined> {
         selectedTabName = tab.name;
       }
     }
+    // A record link may request a particular tab (the legacy portal contract is
+    // `?focusTabId=<tab name>`). Only honour it when it names a tab in this
+    // container; malformed or unrelated values must not leave the form with no
+    // selected tab.
+    const requestedTabId = this.getFormComponent.getRequestParam('focusTabId');
+    const requestedTabName = typeof requestedTabId === 'string' &&
+      this.tabs.some(tab => tab.name === requestedTabId)
+      ? requestedTabId
+      : null;
+
     // Note: selection is deferred to the layout component to avoid flashes and incorrect display of content. For now, we just set the selectedTabId here for the layout to pick up.
     // This will select the first tab if none are marked as selected.
-    this.selectedTabId = selectedTabName ?? this.tabs[0]?.name ?? '0';
+    this.selectedTabId = requestedTabName ?? selectedTabName ?? this.tabs[0]?.name ?? '0';
     await super.setComponentReady();
   }
 


### PR DESCRIPTION
## Summary

Fixes the tab component to properly honour the `focusTabId` query parameter when navigating to a record, ensuring the specified tab is selected on initial load.

---

## Context / Motivation

The legacy Redbox portal supported a `?focusTabId=<tab name>` query parameter that allowed deep-linking to specific tabs within a record form. This functionality was not being honoured in the current Angular form implementation, causing users to always land on the default tab regardless of the URL parameter.

---

## Key Features

### Query Parameter Support

- Added logic to read the `focusTabId` request parameter from the URL
- Validates that the requested tab name exists in the current tab container before applying it
- Prevents malformed or unrelated parameter values from breaking tab selection

### Tab Selection Priority

- Tab selection now follows the priority: `focusTabId` parameter > `selectedTabName` from config > first tab
- Ensures backward compatibility while adding new deep-linking capability

---

## Testing

- Added cleanup in `afterEach` to reset URL search parameters between tests
- Added new test case `should select the tab named by the focusTabId request parameter` that verifies:
  - Setting `?focusTabId=tab1` in the URL
  - Component correctly selects the specified tab
  - Both `selectedTabId` and `activeTabId` are set correctly

---

## Architectural / Operational Impact

### Form Component Access

- Added protected `getFormComponent` getter to provide access to the parent form component for request parameter retrieval

### Backward Compatibility

- Fully backward compatible - existing tab selection behavior is preserved
- Only affects navigation when `focusTabId` parameter is explicitly provided in the URL

---

## Backwards Compatibility

This change is fully backward compatible. The existing tab selection logic is preserved and only extended to support the optional `focusTabId` query parameter. No breaking changes to existing functionality.

---

## Deployment Notes

No special deployment notes or migration steps required. This is a frontend-only change that will take effect immediately upon deployment.

---

## Impact

This fix restores deep-linking functionality to specific tabs within record forms, improving user navigation and workflow efficiency when referencing specific sections of a record.