### PR TITLE
Feature: Effect-based record hook execution with timeout, retry, and detached audit finalization

### DIFF
--- a/packages/redbox-core/src/action-execution/audit.ts
+++ b/packages/redbox-core/src/action-execution/audit.ts
@@ -3,10 +3,13 @@ import type {
   ActionExecutionOperation,
   ActionExecutionPhase,
   ActionExecutionReport,
+  ActionExecutionResult,
   ActionExecutionStatus,
   ActionFailureKind,
   ActionSkippedReason,
 } from './types';
+
+export type DetachedAuditFinalization = 'complete' | 'grace-expired';
 
 export interface RecordHookExecutionAuditAction {
   actionId: string;
@@ -28,6 +31,8 @@ export interface RecordHookExecutionAuditSummary {
   operation: 'create' | 'update' | 'delete' | 'transition';
   partial: boolean;
   completedThrough?: 'pre' | 'persistence' | 'postSync' | 'post-dispatch';
+  detachedFinalization?: DetachedAuditFinalization;
+  detachedPending?: number;
   durationMs: number;
   totalActions: number;
   counts: Partial<Record<ActionExecutionStatus, number>>;
@@ -66,7 +71,9 @@ function projectAction(action: ActionExecutionReport['actions'][number]): Record
   return projected;
 }
 
-function totalCounts(actions: readonly ActionExecutionReport['actions'][number][]): Partial<Record<ActionExecutionStatus, number>> {
+function totalCounts(
+  actions: readonly ActionExecutionReport['actions'][number][]
+): Partial<Record<ActionExecutionStatus, number>> {
   const totals: Partial<Record<ActionExecutionStatus, number>> = {};
   for (const action of actions) {
     totals[action.status] = (totals[action.status] ?? 0) + 1;
@@ -74,9 +81,22 @@ function totalCounts(actions: readonly ActionExecutionReport['actions'][number][
   return totals;
 }
 
+type ProjectableAction = ActionExecutionReport['actions'][number] | ActionExecutionResult;
+
+/**
+ * Detached dispatch and terminal reports have the same action identity. Keep
+ * this key internal so a terminal result can replace its launch marker without
+ * changing the historical phase report.
+ */
+function actionKey(action: ProjectableAction): string {
+  return [action.mode, action.phase, action.index, action.actionId].join('\u0000');
+}
+
 function elapsedMs(operation: ActionExecutionOperation): number {
   const lastReport = operation.reports[operation.reports.length - 1];
-  const completedAt = new Date(operation.detachedCompletedAt ?? lastReport?.completedAt ?? operation.startedAt).getTime();
+  const completedAt = new Date(
+    operation.detachedCompletedAt ?? lastReport?.completedAt ?? operation.startedAt
+  ).getTime();
   return Math.max(0, Math.round(completedAt - new Date(operation.startedAt).getTime()));
 }
 
@@ -90,22 +110,50 @@ export function projectRecordHookExecutionAuditSummary(
   options: {
     partial?: boolean;
     completedThrough?: RecordHookExecutionAuditSummary['completedThrough'];
+    detachedFinalization?: DetachedAuditFinalization;
     durationMs?: number;
   } = {}
 ): RecordHookExecutionAuditSummary {
   // Before detached work finishes, the operation log may honestly expose its
-  // dispatch entries. The durable audit is projected after pending detached
-  // actions reach terminal results, at which point those launch markers are
-  // replaced by the compact completed results below.
+  // dispatch entries. A terminal result replaces the matching launch marker
+  // even while other detached actions remain pending. The historical reports
+  // themselves are never mutated.
   const includeDispatched = operation.detachedPending === undefined || operation.detachedPending > 0;
-  const phaseActions = operation.reports.flatMap(report =>
-    report.actions.filter(action => includeDispatched || action.status !== 'dispatched')
-  );
   const detachedResults = [...(operation.detachedResults ?? [])].sort((left, right) => {
     const phaseOrder: Record<ActionExecutionReport['context']['phase'], number> = { pre: 0, postSync: 1, post: 2 };
     return phaseOrder[left.phase] - phaseOrder[right.phase] || left.index - right.index;
   });
-  const allActions = [...phaseActions, ...detachedResults];
+  const terminalByKey = new Map(detachedResults.map(result => [actionKey(result), result]));
+  const projectedKeys = new Set<string>();
+  const allActions: ProjectableAction[] = [];
+
+  for (const report of operation.reports) {
+    for (const action of report.actions) {
+      let projected: ProjectableAction | undefined = action;
+      if (action.status === 'dispatched') {
+        const terminal = terminalByKey.get(actionKey(action));
+        if (terminal) {
+          projected = terminal;
+        } else if (!includeDispatched) {
+          projected = undefined;
+        }
+      }
+      if (projected) {
+        allActions.push(projected);
+        projectedKeys.add(actionKey(projected));
+      }
+    }
+  }
+
+  // Defensive compatibility path: a terminal callback may be observed before
+  // its dispatch report is appended. It still contributes exactly once.
+  for (const result of detachedResults) {
+    if (!projectedKeys.has(actionKey(result))) {
+      allActions.push(result);
+      projectedKeys.add(actionKey(result));
+    }
+  }
+
   const summary: RecordHookExecutionAuditSummary = {
     schemaVersion: 1,
     executionId: operation.executionId,
@@ -123,6 +171,12 @@ export function projectRecordHookExecutionAuditSummary(
   }
   if (options.completedThrough ?? operation.completedThrough) {
     summary.completedThrough = options.completedThrough ?? operation.completedThrough;
+  }
+  if (options.detachedFinalization) {
+    summary.detachedFinalization = options.detachedFinalization;
+  }
+  if ((operation.detachedPending ?? 0) > 0) {
+    summary.detachedPending = operation.detachedPending;
   }
   return summary;
 }

--- a/packages/redbox-core/src/action-execution/audit.ts
+++ b/packages/redbox-core/src/action-execution/audit.ts
@@ -1,0 +1,119 @@
+import type {
+  ActionExecutionCounts,
+  ActionExecutionMode,
+  ActionExecutionOperation,
+  ActionExecutionPhase,
+  ActionExecutionReport,
+  ActionExecutionStatus,
+  ActionFailureKind,
+  ActionSkippedReason,
+} from './types';
+
+export interface RecordHookExecutionAuditAction {
+  actionId: string;
+  mode: ActionExecutionMode;
+  phase: ActionExecutionPhase;
+  status: ActionExecutionStatus;
+  attempts: number;
+  durationMs: number;
+  failureKind?: ActionFailureKind;
+  failureCode?: string;
+  skippedReason?: ActionSkippedReason;
+}
+
+export interface RecordHookExecutionAuditSummary {
+  schemaVersion: 1;
+  executionId: string;
+  requestId?: string;
+  trigger: 'record-hook';
+  operation: 'create' | 'update' | 'delete' | 'transition';
+  partial: boolean;
+  completedThrough?: 'pre' | 'persistence' | 'postSync' | 'post-dispatch';
+  durationMs: number;
+  totalActions: number;
+  counts: Partial<Record<ActionExecutionStatus, number>>;
+  actions: RecordHookExecutionAuditAction[];
+  truncated: boolean;
+}
+
+/** The design caps a persisted summary at the first 100 actions. */
+const MAX_AUDIT_ACTIONS = 100;
+
+const OPERATION_BY_MODE: Record<ActionExecutionMode, RecordHookExecutionAuditSummary['operation']> = {
+  onCreate: 'create',
+  onUpdate: 'update',
+  onDelete: 'delete',
+  onTransitionWorkflow: 'transition',
+};
+
+function projectAction(action: ActionExecutionReport['actions'][number]): RecordHookExecutionAuditAction {
+  const projected: RecordHookExecutionAuditAction = {
+    actionId: action.actionId,
+    mode: action.mode,
+    phase: action.phase,
+    status: action.status,
+    attempts: action.attempts,
+    durationMs: Math.max(0, Math.round(action.durationMs)),
+  };
+  if (action.failure?.kind) {
+    projected.failureKind = action.failure.kind;
+  }
+  if (action.failure?.code) {
+    projected.failureCode = action.failure.code;
+  }
+  if (action.skippedReason) {
+    projected.skippedReason = action.skippedReason;
+  }
+  return projected;
+}
+
+function totalCounts(reports: readonly ActionExecutionReport[]): Partial<Record<ActionExecutionStatus, number>> {
+  const totals: Partial<Record<ActionExecutionStatus, number>> = {};
+  for (const report of reports) {
+    for (const [status, count] of Object.entries(report.counts) as Array<[keyof ActionExecutionCounts, number]>) {
+      totals[status] = (totals[status] ?? 0) + count;
+    }
+  }
+  return totals;
+}
+
+function elapsedMs(operation: ActionExecutionOperation): number {
+  const lastReport = operation.reports[operation.reports.length - 1];
+  const completedAt = new Date(lastReport?.completedAt ?? operation.startedAt).getTime();
+  return Math.max(0, Math.round(completedAt - new Date(operation.startedAt).getTime()));
+}
+
+/**
+ * Project the in-memory execution reports onto the bounded, whitelisted shape
+ * that is safe to persist. Aggregate counts always describe the complete
+ * report even when the action list is truncated.
+ */
+export function projectRecordHookExecutionAuditSummary(
+  operation: ActionExecutionOperation,
+  options: {
+    partial?: boolean;
+    completedThrough?: RecordHookExecutionAuditSummary['completedThrough'];
+    durationMs?: number;
+  } = {}
+): RecordHookExecutionAuditSummary {
+  const allActions = operation.reports.flatMap(report => report.actions);
+  const summary: RecordHookExecutionAuditSummary = {
+    schemaVersion: 1,
+    executionId: operation.executionId,
+    trigger: 'record-hook',
+    operation: OPERATION_BY_MODE[operation.mode],
+    partial: options.partial === true,
+    durationMs: options.durationMs ?? elapsedMs(operation),
+    totalActions: allActions.length,
+    counts: totalCounts(operation.reports),
+    actions: allActions.slice(0, MAX_AUDIT_ACTIONS).map(projectAction),
+    truncated: allActions.length > MAX_AUDIT_ACTIONS,
+  };
+  if (operation.requestId) {
+    summary.requestId = operation.requestId;
+  }
+  if (options.completedThrough ?? operation.completedThrough) {
+    summary.completedThrough = options.completedThrough ?? operation.completedThrough;
+  }
+  return summary;
+}

--- a/packages/redbox-core/src/action-execution/audit.ts
+++ b/packages/redbox-core/src/action-execution/audit.ts
@@ -1,5 +1,4 @@
 import type {
-  ActionExecutionCounts,
   ActionExecutionMode,
   ActionExecutionOperation,
   ActionExecutionPhase,
@@ -67,19 +66,17 @@ function projectAction(action: ActionExecutionReport['actions'][number]): Record
   return projected;
 }
 
-function totalCounts(reports: readonly ActionExecutionReport[]): Partial<Record<ActionExecutionStatus, number>> {
+function totalCounts(actions: readonly ActionExecutionReport['actions'][number][]): Partial<Record<ActionExecutionStatus, number>> {
   const totals: Partial<Record<ActionExecutionStatus, number>> = {};
-  for (const report of reports) {
-    for (const [status, count] of Object.entries(report.counts) as Array<[keyof ActionExecutionCounts, number]>) {
-      totals[status] = (totals[status] ?? 0) + count;
-    }
+  for (const action of actions) {
+    totals[action.status] = (totals[action.status] ?? 0) + 1;
   }
   return totals;
 }
 
 function elapsedMs(operation: ActionExecutionOperation): number {
   const lastReport = operation.reports[operation.reports.length - 1];
-  const completedAt = new Date(lastReport?.completedAt ?? operation.startedAt).getTime();
+  const completedAt = new Date(operation.detachedCompletedAt ?? lastReport?.completedAt ?? operation.startedAt).getTime();
   return Math.max(0, Math.round(completedAt - new Date(operation.startedAt).getTime()));
 }
 
@@ -96,7 +93,19 @@ export function projectRecordHookExecutionAuditSummary(
     durationMs?: number;
   } = {}
 ): RecordHookExecutionAuditSummary {
-  const allActions = operation.reports.flatMap(report => report.actions);
+  // Before detached work finishes, the operation log may honestly expose its
+  // dispatch entries. The durable audit is projected after pending detached
+  // actions reach terminal results, at which point those launch markers are
+  // replaced by the compact completed results below.
+  const includeDispatched = operation.detachedPending === undefined || operation.detachedPending > 0;
+  const phaseActions = operation.reports.flatMap(report =>
+    report.actions.filter(action => includeDispatched || action.status !== 'dispatched')
+  );
+  const detachedResults = [...(operation.detachedResults ?? [])].sort((left, right) => {
+    const phaseOrder: Record<ActionExecutionReport['context']['phase'], number> = { pre: 0, postSync: 1, post: 2 };
+    return phaseOrder[left.phase] - phaseOrder[right.phase] || left.index - right.index;
+  });
+  const allActions = [...phaseActions, ...detachedResults];
   const summary: RecordHookExecutionAuditSummary = {
     schemaVersion: 1,
     executionId: operation.executionId,
@@ -105,7 +114,7 @@ export function projectRecordHookExecutionAuditSummary(
     partial: options.partial === true,
     durationMs: options.durationMs ?? elapsedMs(operation),
     totalActions: allActions.length,
-    counts: totalCounts(operation.reports),
+    counts: totalCounts(allActions),
     actions: allActions.slice(0, MAX_AUDIT_ACTIONS).map(projectAction),
     truncated: allActions.length > MAX_AUDIT_ACTIONS,
   };

--- a/packages/redbox-core/src/action-execution/executor.ts
+++ b/packages/redbox-core/src/action-execution/executor.ts
@@ -216,6 +216,12 @@ function shouldRetry(action: ActionExecutionAction, attemptNumber: number, failu
   if (!retry || attemptNumber >= retry.maxAttempts) {
     return false;
   }
+  // An opaque Promise keeps running after Effect times out. Retrying it here
+  // would overlap the original side effect with a second invocation. The
+  // idempotent acknowledgement alone is not enough to make that safe.
+  if ((failure.kind === 'timeout' || failure.kind === 'interrupted') && failure.cancellationCooperative === false) {
+    return false;
+  }
   return (retry.retryOn ?? ['transient']).includes(failure.kind);
 }
 
@@ -358,6 +364,11 @@ export function createActionExecutionSupervisor(): ActionExecutionDependencies['
         fibers.add(fiber as Fiber.Fiber<unknown, unknown>);
       }
     },
+    unregister(fiber: unknown): void {
+      if (fiber !== null && typeof fiber === 'object') {
+        fibers.delete(fiber as Fiber.Fiber<unknown, unknown>);
+      }
+    },
     interruptAll(): void {
       const active = Array.from(fibers);
       fibers.clear();
@@ -466,8 +477,9 @@ export function runSequentialActionPlan(
 
 /**
  * Detached dispatch strategy, used for `post`. Each action is forked in
- * configuration order and its completion is logged later; the returned report
- * describes only the dispatch and is never revised.
+ * configuration order and its terminal result is delivered through the
+ * optional completion callback; the dispatch report itself remains an honest
+ * record of launch rather than being rewritten after the fact.
  */
 export function dispatchDetachedActionPlan(
   actions: readonly ActionExecutionAction[],
@@ -499,13 +511,36 @@ export function dispatchDetachedActionPlan(
     // each action still happens in configuration order.
     const fiber = Effect.runFork(
       executeAction(action, dependencies, context, true).pipe(
+        Effect.tap(executed =>
+          Effect.sync(() => dependencies.onDetachedActionComplete?.(context, executed.result))
+        ),
         Effect.onExit(exit => {
-          if (exit._tag === 'Failure' && Cause.isInterruptedOnly(exit.cause)) {
+          if (exit._tag === 'Failure') {
+            const interrupted = Cause.isInterruptedOnly(exit.cause);
             const interruptedFields = commonFields(context, action, 1);
-            interruptedFields.status = 'interrupted';
-            interruptedFields.failure_kind = 'interrupted';
-            interruptedFields.failure_code = 'action-interrupted';
-            interruptedFields.cancellation_cooperative = isCooperativelyCancellable(action);
+            const failure = interrupted
+              ? normalizeActionFailure(
+                  new ActionInterruptedFailure(isCooperativelyCancellable(action)),
+                  isCooperativelyCancellable(action)
+                )
+              : normalizeActionFailure(failureCause(exit.cause), isCooperativelyCancellable(action));
+            const result: ActionExecutionResult = {
+              actionId: action.actionId,
+              mode: action.mode,
+              phase: action.phase,
+              index: action.index,
+              status: statusForFailure(failure),
+              attempts: 1,
+              startedAt: iso(now(dependencies)),
+              completedAt: iso(now(dependencies)),
+              durationMs: 0,
+              failure,
+            };
+            dependencies.onDetachedActionComplete?.(context, result);
+            interruptedFields.status = result.status;
+            interruptedFields.failure_kind = failure.kind;
+            interruptedFields.failure_code = failure.code;
+            interruptedFields.cancellation_cooperative = failure.cancellationCooperative;
             interruptedFields.duration_ms = 0;
             dependencies.logger?.warn?.('record_hook_detached_action_failed', interruptedFields);
           }
@@ -514,6 +549,16 @@ export function dispatchDetachedActionPlan(
       )
     );
     dependencies.supervisor?.register?.(fiber);
+    // Awaiting the fiber from a separate watcher avoids retaining completed
+    // fibers in the supervisor set while keeping shutdown interruption cheap.
+    if (dependencies.supervisor?.unregister) {
+      Effect.runFork(
+        Fiber.await(fiber).pipe(
+          Effect.flatMap(() => Effect.sync(() => dependencies.supervisor?.unregister?.(fiber))),
+          Effect.catchAll(() => Effect.sync(() => dependencies.supervisor?.unregister?.(fiber)))
+        )
+      );
+    }
   }
 
   return { report: makeReport(context, results, startedAt, dependencies, 'dispatched'), values: [] };

--- a/packages/redbox-core/src/action-execution/executor.ts
+++ b/packages/redbox-core/src/action-execution/executor.ts
@@ -8,7 +8,6 @@ import type {
   ActionExecutionAction,
   ActionExecutionContext,
   ActionExecutionDependencies,
-  ActionExecutionCounts,
   ActionExecutionOperation,
   ActionExecutionOutcome,
   ActionExecutionReport,
@@ -18,7 +17,6 @@ import type {
   ActionSkippedReason,
   SafeActionFailure,
 } from './types';
-import { EMPTY_ACTION_COUNTS } from './types';
 
 /** A single attempt that fulfilled. */
 interface AttemptSuccess {
@@ -70,19 +68,8 @@ function durationMs(startedAt: string, completedAt: string): number {
   return Math.max(0, Math.round(new Date(completedAt).getTime() - new Date(startedAt).getTime()));
 }
 
-function countByStatus(results: readonly ActionExecutionResult[]): ActionExecutionCounts {
-  const counts = { ...EMPTY_ACTION_COUNTS };
-  for (const result of results) {
-    counts[result.status] += 1;
-  }
-  return counts;
-}
-
 function isCooperativelyCancellable(action: ActionExecutionAction): boolean {
-  if (typeof action.cooperativeCancellation === 'function') {
-    return action.cooperativeCancellation();
-  }
-  return action.cooperativeCancellation !== false;
+  return action.cooperativeCancellation?.() ?? true;
 }
 
 function maxAttempts(action: Pick<ActionExecutionAction, 'policy'>): number {
@@ -337,7 +324,6 @@ export function createActionExecutionOperation(
 ): ActionExecutionOperation {
   const operation: ActionExecutionOperation = {
     executionId: newId(dependencies),
-    trigger: 'record-hook',
     mode,
     reports: [],
     startedAt: iso(now(dependencies)),
@@ -357,17 +343,11 @@ export function createActionExecutionOperation(
  * a closed datastore.
  */
 export function createActionExecutionSupervisor(): ActionExecutionDependencies['supervisor'] {
-  const fibers = new Set<Fiber.Fiber<unknown, unknown>>();
+  const fibers = new Set<Fiber.RuntimeFiber<unknown, unknown>>();
   return {
-    register(fiber: unknown): void {
-      if (fiber !== null && typeof fiber === 'object') {
-        fibers.add(fiber as Fiber.Fiber<unknown, unknown>);
-      }
-    },
-    unregister(fiber: unknown): void {
-      if (fiber !== null && typeof fiber === 'object') {
-        fibers.delete(fiber as Fiber.Fiber<unknown, unknown>);
-      }
+    register(fiber): void {
+      fibers.add(fiber);
+      fiber.addObserver(() => fibers.delete(fiber));
     },
     interruptAll(): void {
       const active = Array.from(fibers);
@@ -388,7 +368,6 @@ export function createPhaseContext(
   const context: ActionExecutionContext = {
     executionId: operation.executionId,
     phaseExecutionId: newId(dependencies),
-    trigger: 'record-hook',
     mode,
     phase,
   };
@@ -410,16 +389,12 @@ function makeReport(
 ): ActionExecutionReport {
   const completedAt = iso(now(dependencies));
   const report: ActionExecutionReport = {
-    schemaVersion: 1,
-    executionId: context.executionId,
-    phaseExecutionId: context.phaseExecutionId,
     context,
     status,
     startedAt,
     completedAt,
     durationMs: durationMs(startedAt, completedAt),
     actions: results,
-    counts: countByStatus(results),
   };
 
   const fields = commonFields(context, { actionId: 'phase', mode: context.mode, phase: context.phase, index: -1 });
@@ -444,16 +419,12 @@ export function runSequentialActionPlan(
   const plan = validatedPlan(actions);
   return Effect.gen(function* () {
     const startedAt = iso(now(dependencies));
-    const values: unknown[] = [];
     const results: ActionExecutionResult[] = [];
     let terminalCause: unknown;
     let failed = false;
 
     for (const [index, action] of plan.entries()) {
-      const executed = yield* executeAction(action, dependencies, context, false, value => {
-        onSuccess?.(value, index);
-        values.push(value);
-      });
+      const executed = yield* executeAction(action, dependencies, context, false, value => onSuccess?.(value, index));
       results.push(executed.result);
       if (executed.attempt.ok) {
         continue;
@@ -467,7 +438,7 @@ export function runSequentialActionPlan(
     }
 
     const report = makeReport(context, results, startedAt, dependencies, failed ? 'failed' : 'completed');
-    const outcome: ActionExecutionOutcome = { report, values };
+    const outcome: ActionExecutionOutcome = { report };
     if (terminalCause !== undefined) {
       outcome.terminalCause = terminalCause;
     }
@@ -549,26 +520,7 @@ export function dispatchDetachedActionPlan(
       )
     );
     dependencies.supervisor?.register?.(fiber);
-    // Awaiting the fiber from a separate watcher avoids retaining completed
-    // fibers in the supervisor set while keeping shutdown interruption cheap.
-    if (dependencies.supervisor?.unregister) {
-      Effect.runFork(
-        Fiber.await(fiber).pipe(
-          Effect.flatMap(() => Effect.sync(() => dependencies.supervisor?.unregister?.(fiber))),
-          Effect.catchAll(() => Effect.sync(() => dependencies.supervisor?.unregister?.(fiber)))
-        )
-      );
-    }
   }
 
-  return { report: makeReport(context, results, startedAt, dependencies, 'dispatched'), values: [] };
-}
-
-/** Promise bridge for callers outside an Effect program. */
-export async function runActionPlan(
-  actions: readonly ActionExecutionAction[],
-  context: ActionExecutionContext,
-  dependencies: ActionExecutionDependencies = {}
-): Promise<ActionExecutionOutcome> {
-  return Effect.runPromise(runSequentialActionPlan(actions, context, dependencies));
+  return { report: makeReport(context, results, startedAt, dependencies, 'dispatched') };
 }

--- a/packages/redbox-core/src/action-execution/executor.ts
+++ b/packages/redbox-core/src/action-execution/executor.ts
@@ -1,0 +1,529 @@
+import { Effect } from 'effect';
+import * as Cause from 'effect/Cause';
+import * as Fiber from 'effect/Fiber';
+import { randomUUID } from 'node:crypto';
+import { ActionInterruptedFailure, ActionTimeoutFailure, normalizeActionFailure } from './failure';
+import { retryDelayMs, validateActionExecutionPolicy } from './policy';
+import type {
+  ActionExecutionAction,
+  ActionExecutionContext,
+  ActionExecutionDependencies,
+  ActionExecutionCounts,
+  ActionExecutionOperation,
+  ActionExecutionOutcome,
+  ActionExecutionReport,
+  ActionExecutionResult,
+  ActionExecutionStatus,
+  ActionFailureKind,
+  ActionSkippedReason,
+  SafeActionFailure,
+} from './types';
+import { EMPTY_ACTION_COUNTS } from './types';
+
+/** A single attempt that fulfilled. */
+interface AttemptSuccess {
+  ok: true;
+  value: unknown;
+}
+
+/** A single attempt that failed, keeping the raw cause for the legacy adapter. */
+interface AttemptFailure {
+  ok: false;
+  failure: SafeActionFailure;
+  cause: unknown;
+}
+
+type Attempt = AttemptSuccess | AttemptFailure;
+
+/** An action after all of its attempts, paired with its serializable result. */
+interface ExecutedAction {
+  attempt: Attempt;
+  result: ActionExecutionResult;
+}
+
+/**
+ * A failed action is reported as its own status when the executor itself ended
+ * the attempt; everything else is an ordinary failure.
+ */
+const STATUS_BY_FAILURE_KIND: Partial<Record<ActionFailureKind, ActionExecutionStatus>> = {
+  timeout: 'timed_out',
+  interrupted: 'interrupted',
+};
+
+function statusForFailure(failure: SafeActionFailure): ActionExecutionStatus {
+  return STATUS_BY_FAILURE_KIND[failure.kind] ?? 'failed';
+}
+
+function now(dependencies: ActionExecutionDependencies): Date {
+  return dependencies.now?.() ?? new Date();
+}
+
+function iso(value: Date): string {
+  return value.toISOString();
+}
+
+function newId(dependencies: ActionExecutionDependencies): string {
+  return dependencies.uuid?.() ?? randomUUID();
+}
+
+function durationMs(startedAt: string, completedAt: string): number {
+  return Math.max(0, Math.round(new Date(completedAt).getTime() - new Date(startedAt).getTime()));
+}
+
+function countByStatus(results: readonly ActionExecutionResult[]): ActionExecutionCounts {
+  const counts = { ...EMPTY_ACTION_COUNTS };
+  for (const result of results) {
+    counts[result.status] += 1;
+  }
+  return counts;
+}
+
+function isCooperativelyCancellable(action: ActionExecutionAction): boolean {
+  if (typeof action.cooperativeCancellation === 'function') {
+    return action.cooperativeCancellation();
+  }
+  return action.cooperativeCancellation !== false;
+}
+
+function maxAttempts(action: Pick<ActionExecutionAction, 'policy'>): number {
+  return action.policy?.retry?.maxAttempts ?? 1;
+}
+
+type LoggableAction = Pick<ActionExecutionAction, 'actionId' | 'mode' | 'phase' | 'index' | 'policy'>;
+
+function commonFields(
+  context: ActionExecutionContext,
+  action: LoggableAction,
+  attempt?: number
+): Record<string, unknown> {
+  const fields: Record<string, unknown> = {
+    execution_id: context.executionId,
+    phase_execution_id: context.phaseExecutionId,
+  };
+  if (context.requestId) {
+    fields.request_id = context.requestId;
+  }
+  if (context.recordOid) {
+    fields.record_oid = context.recordOid;
+  }
+  fields.hook_mode = context.mode;
+  fields.hook_phase = context.phase;
+  fields.action_id = action.actionId;
+  fields.action_index = action.index;
+  if (attempt !== undefined) {
+    fields.attempt = attempt;
+  }
+  fields.max_attempts = maxAttempts(action);
+  return fields;
+}
+
+function finalEventName(status: ActionExecutionStatus, detached: boolean): string {
+  if (status === 'succeeded' || status === 'dispatched') {
+    return detached ? 'record_hook_detached_action_completed' : 'record_hook_action_completed';
+  }
+  if (status === 'timed_out') {
+    return 'record_hook_action_timed_out';
+  }
+  return detached ? 'record_hook_detached_action_failed' : 'record_hook_action_failed';
+}
+
+function logActionResult(
+  dependencies: ActionExecutionDependencies,
+  context: ActionExecutionContext,
+  action: LoggableAction,
+  result: ActionExecutionResult,
+  detached: boolean
+): void {
+  const fields = commonFields(context, action, result.attempts);
+  fields.status = result.status;
+  fields.duration_ms = result.durationMs;
+  if (result.failure) {
+    fields.failure_kind = result.failure.kind;
+    fields.failure_code = result.failure.code;
+    if (result.failure.cancellationCooperative !== undefined) {
+      fields.cancellation_cooperative = result.failure.cancellationCooperative;
+    }
+  }
+
+  const event = finalEventName(result.status, detached);
+  if (!result.failure) {
+    dependencies.logger?.info?.(event, fields);
+    return;
+  }
+  // Only a genuinely unexpected failure is an operator error; everything else
+  // is a hook reporting a problem it already knows about.
+  const level = result.failure.kind === 'unexpected' ? 'error' : 'warn';
+  dependencies.logger?.[level]?.(event, fields);
+}
+
+function logActionStart(
+  dependencies: ActionExecutionDependencies,
+  context: ActionExecutionContext,
+  action: LoggableAction,
+  attempt: number,
+  detached: boolean
+): void {
+  const fields = commonFields(context, action, attempt);
+  fields.detached = detached;
+  dependencies.logger?.debug?.('record_hook_action_started', fields);
+}
+
+/**
+ * Extract the value the legacy adapter needs to rethrow. Defects and
+ * interruptions are converted to branded failures so normalization stays
+ * deterministic.
+ */
+function failureCause(cause: Cause.Cause<unknown>): unknown {
+  const failure = Cause.failureOrCause(cause);
+  if (failure._tag === 'Left') {
+    return failure.left;
+  }
+  if (Cause.isInterruptedOnly(cause)) {
+    return new ActionInterruptedFailure(true);
+  }
+  return Cause.squash(failure.right);
+}
+
+function runAttempt(action: ActionExecutionAction) {
+  return Effect.gen(function* () {
+    // suspend is deliberate: the legacy adapter invokes the resolved function
+    // only when the attempt starts, so retries receive the same live arguments.
+    let effect: Effect.Effect<unknown, unknown, never> = Effect.suspend(() => action.invoke());
+    if (action.policy?.timeoutMs !== undefined) {
+      effect = effect.pipe(
+        Effect.timeoutFail({
+          duration: `${action.policy.timeoutMs} millis`,
+          onTimeout: () => new ActionTimeoutFailure(isCooperativelyCancellable(action)),
+        })
+      );
+    }
+
+    const exit = yield* Effect.exit(effect);
+    if (exit._tag === 'Success') {
+      return { ok: true, value: exit.value } satisfies AttemptSuccess;
+    }
+    const cause = failureCause(exit.cause);
+    return {
+      ok: false,
+      cause,
+      failure: normalizeActionFailure(cause, isCooperativelyCancellable(action)),
+    } satisfies AttemptFailure;
+  });
+}
+
+function shouldRetry(action: ActionExecutionAction, attemptNumber: number, failure: SafeActionFailure): boolean {
+  const retry = action.policy?.retry;
+  if (!retry || attemptNumber >= retry.maxAttempts) {
+    return false;
+  }
+  return (retry.retryOn ?? ['transient']).includes(failure.kind);
+}
+
+/**
+ * Run one action to completion, including retries and backoff. The reported
+ * duration deliberately spans every attempt and every delay between them.
+ *
+ * `project` lets the caller consume a successful value while the action is
+ * still open: if projecting the value fails, the action itself is reported as
+ * failed rather than the phase silently continuing.
+ */
+function executeAction(
+  action: ActionExecutionAction,
+  dependencies: ActionExecutionDependencies,
+  context: ActionExecutionContext,
+  detached = false,
+  project?: (value: unknown) => void
+): Effect.Effect<ExecutedAction, never, never> {
+  return Effect.gen(function* () {
+    const startedAt = iso(now(dependencies));
+    let attemptNumber = 0;
+    let attempt: Attempt;
+
+    for (;;) {
+      attemptNumber += 1;
+      logActionStart(dependencies, context, action, attemptNumber, detached);
+      attempt = yield* runAttempt(action);
+      if (attempt.ok) {
+        const successFields = commonFields(context, action, attemptNumber);
+        successFields.status = 'succeeded';
+        dependencies.logger?.debug?.('record_hook_action_attempt_succeeded', successFields);
+      }
+      if (attempt.ok || !shouldRetry(action, attemptNumber, attempt.failure)) {
+        break;
+      }
+      const delay = retryDelayMs(action.policy?.retry?.schedule, attemptNumber, dependencies.random);
+      const retryFields = commonFields(context, action, attemptNumber);
+      retryFields.failure_kind = attempt.failure.kind;
+      retryFields.failure_code = attempt.failure.code;
+      retryFields.delay_ms = delay;
+      dependencies.logger?.warn?.('record_hook_action_retry_scheduled', retryFields);
+      if (delay > 0) {
+        yield* (dependencies.sleep?.(delay) ?? Effect.sleep(`${delay} millis`));
+      }
+    }
+
+    if (attempt.ok && project) {
+      try {
+        project(attempt.value);
+      } catch (error) {
+        attempt = {
+          ok: false,
+          cause: error,
+          failure: normalizeActionFailure(error, isCooperativelyCancellable(action)),
+        };
+      }
+    }
+
+    const completedAt = iso(now(dependencies));
+    const result: ActionExecutionResult = {
+      actionId: action.actionId,
+      mode: action.mode,
+      phase: action.phase,
+      index: action.index,
+      status: attempt.ok ? 'succeeded' : statusForFailure(attempt.failure),
+      attempts: attemptNumber,
+      startedAt,
+      completedAt,
+      durationMs: durationMs(startedAt, completedAt),
+    };
+    if (!attempt.ok) {
+      result.failure = attempt.failure;
+    }
+    logActionResult(dependencies, context, action, result, detached);
+    return { attempt, result };
+  });
+}
+
+function skippedResult(
+  action: ActionExecutionAction,
+  reason: ActionSkippedReason,
+  dependencies: ActionExecutionDependencies
+): ActionExecutionResult {
+  const timestamp = iso(now(dependencies));
+  return {
+    actionId: action.actionId,
+    mode: action.mode,
+    phase: action.phase,
+    index: action.index,
+    status: 'skipped',
+    attempts: 0,
+    startedAt: timestamp,
+    completedAt: timestamp,
+    durationMs: 0,
+    skippedReason: reason,
+  };
+}
+
+/**
+ * Validate every configured policy before any side effect runs, so an invalid
+ * policy is a plain configuration error at the plan boundary rather than a
+ * failure discovered halfway through a phase.
+ */
+function validatedPlan(actions: readonly ActionExecutionAction[]): ActionExecutionAction[] {
+  return actions.map(action => ({ ...action, policy: validateActionExecutionPolicy(action.policy) }));
+}
+
+export function createActionExecutionOperation(
+  mode: ActionExecutionOperation['mode'],
+  requestId?: string,
+  recordOid?: string,
+  dependencies: ActionExecutionDependencies = {}
+): ActionExecutionOperation {
+  const operation: ActionExecutionOperation = {
+    executionId: newId(dependencies),
+    trigger: 'record-hook',
+    mode,
+    reports: [],
+    startedAt: iso(now(dependencies)),
+  };
+  if (requestId) {
+    operation.requestId = requestId;
+  }
+  if (recordOid) {
+    operation.recordOid = recordOid;
+  }
+  return operation;
+}
+
+/**
+ * Owns detached fibers for the lifetime of a service. A Sails `lower` hook can
+ * interrupt the set so shutdown does not leave post-save work running against
+ * a closed datastore.
+ */
+export function createActionExecutionSupervisor(): ActionExecutionDependencies['supervisor'] {
+  const fibers = new Set<Fiber.Fiber<unknown, unknown>>();
+  return {
+    register(fiber: unknown): void {
+      if (fiber !== null && typeof fiber === 'object') {
+        fibers.add(fiber as Fiber.Fiber<unknown, unknown>);
+      }
+    },
+    interruptAll(): void {
+      const active = Array.from(fibers);
+      fibers.clear();
+      for (const fiber of active) {
+        Effect.runFork(Fiber.interruptFork(fiber));
+      }
+    },
+  };
+}
+
+export function createPhaseContext(
+  operation: ActionExecutionOperation,
+  phase: ActionExecutionContext['phase'],
+  dependencies: ActionExecutionDependencies = {},
+  mode: ActionExecutionContext['mode'] = operation.mode
+): ActionExecutionContext {
+  const context: ActionExecutionContext = {
+    executionId: operation.executionId,
+    phaseExecutionId: newId(dependencies),
+    trigger: 'record-hook',
+    mode,
+    phase,
+  };
+  if (operation.requestId) {
+    context.requestId = operation.requestId;
+  }
+  if (operation.recordOid) {
+    context.recordOid = operation.recordOid;
+  }
+  return context;
+}
+
+function makeReport(
+  context: ActionExecutionContext,
+  results: ActionExecutionResult[],
+  startedAt: string,
+  dependencies: ActionExecutionDependencies,
+  status: ActionExecutionReport['status']
+): ActionExecutionReport {
+  const completedAt = iso(now(dependencies));
+  const report: ActionExecutionReport = {
+    schemaVersion: 1,
+    executionId: context.executionId,
+    phaseExecutionId: context.phaseExecutionId,
+    context,
+    status,
+    startedAt,
+    completedAt,
+    durationMs: durationMs(startedAt, completedAt),
+    actions: results,
+    counts: countByStatus(results),
+  };
+
+  const fields = commonFields(context, { actionId: 'phase', mode: context.mode, phase: context.phase, index: -1 });
+  fields.status = status;
+  fields.duration_ms = report.durationMs;
+  fields.total_actions = results.length;
+  dependencies.logger?.info?.('record_hook_phase_completed', fields);
+  return report;
+}
+
+/**
+ * Sequential fail-fast strategy, used for the awaited `pre` and `postSync`
+ * phases. `onSuccess` lets the caller thread record/response state between
+ * actions without teaching the executor anything about records.
+ */
+export function runSequentialActionPlan(
+  actions: readonly ActionExecutionAction[],
+  context: ActionExecutionContext,
+  dependencies: ActionExecutionDependencies = {},
+  onSuccess?: (value: unknown, actionIndex: number) => void
+): Effect.Effect<ActionExecutionOutcome, never, never> {
+  const plan = validatedPlan(actions);
+  return Effect.gen(function* () {
+    const startedAt = iso(now(dependencies));
+    const values: unknown[] = [];
+    const results: ActionExecutionResult[] = [];
+    let terminalCause: unknown;
+    let failed = false;
+
+    for (const [index, action] of plan.entries()) {
+      const executed = yield* executeAction(action, dependencies, context, false, value => {
+        onSuccess?.(value, index);
+        values.push(value);
+      });
+      results.push(executed.result);
+      if (executed.attempt.ok) {
+        continue;
+      }
+      failed = true;
+      terminalCause = executed.attempt.cause;
+      for (const remaining of plan.slice(index + 1)) {
+        results.push(skippedResult(remaining, 'prior_action_failed', dependencies));
+      }
+      break;
+    }
+
+    const report = makeReport(context, results, startedAt, dependencies, failed ? 'failed' : 'completed');
+    const outcome: ActionExecutionOutcome = { report, values };
+    if (terminalCause !== undefined) {
+      outcome.terminalCause = terminalCause;
+    }
+    return outcome;
+  });
+}
+
+/**
+ * Detached dispatch strategy, used for `post`. Each action is forked in
+ * configuration order and its completion is logged later; the returned report
+ * describes only the dispatch and is never revised.
+ */
+export function dispatchDetachedActionPlan(
+  actions: readonly ActionExecutionAction[],
+  context: ActionExecutionContext,
+  dependencies: ActionExecutionDependencies = {}
+): ActionExecutionOutcome {
+  const plan = validatedPlan(actions);
+  const startedAt = iso(now(dependencies));
+  const results: ActionExecutionResult[] = [];
+
+  for (const action of plan) {
+    const timestamp = iso(now(dependencies));
+    results.push({
+      actionId: action.actionId,
+      mode: action.mode,
+      phase: action.phase,
+      index: action.index,
+      status: 'dispatched',
+      attempts: 0,
+      startedAt: timestamp,
+      completedAt: timestamp,
+      durationMs: 0,
+    });
+    const fields = commonFields(context, action);
+    fields.status = 'dispatched';
+    fields.duration_ms = 0;
+    dependencies.logger?.info?.('record_hook_action_dispatched', fields);
+    // runFork starts the fiber immediately, so the first legacy invocation of
+    // each action still happens in configuration order.
+    const fiber = Effect.runFork(
+      executeAction(action, dependencies, context, true).pipe(
+        Effect.onExit(exit => {
+          if (exit._tag === 'Failure' && Cause.isInterruptedOnly(exit.cause)) {
+            const interruptedFields = commonFields(context, action, 1);
+            interruptedFields.status = 'interrupted';
+            interruptedFields.failure_kind = 'interrupted';
+            interruptedFields.failure_code = 'action-interrupted';
+            interruptedFields.cancellation_cooperative = isCooperativelyCancellable(action);
+            interruptedFields.duration_ms = 0;
+            dependencies.logger?.warn?.('record_hook_detached_action_failed', interruptedFields);
+          }
+          return Effect.void;
+        })
+      )
+    );
+    dependencies.supervisor?.register?.(fiber);
+  }
+
+  return { report: makeReport(context, results, startedAt, dependencies, 'dispatched'), values: [] };
+}
+
+/** Promise bridge for callers outside an Effect program. */
+export async function runActionPlan(
+  actions: readonly ActionExecutionAction[],
+  context: ActionExecutionContext,
+  dependencies: ActionExecutionDependencies = {}
+): Promise<ActionExecutionOutcome> {
+  return Effect.runPromise(runSequentialActionPlan(actions, context, dependencies));
+}

--- a/packages/redbox-core/src/action-execution/failure.ts
+++ b/packages/redbox-core/src/action-execution/failure.ts
@@ -1,11 +1,10 @@
 import { RBValidationError } from '../model/RBValidationError';
-import type { ActionFailureKind, SafeActionFailure } from './types';
+import { ACTION_FAILURE_KINDS, type ActionFailureKind, type SafeActionFailure } from './types';
 
 interface TaggedActionFailure {
   _tag?: string;
   code?: unknown;
   message?: unknown;
-  safeSummary?: unknown;
   cancellationCooperative?: unknown;
 }
 
@@ -32,26 +31,22 @@ export class ActionValidationFailure extends Error {
 export class ActionDomainFailure extends Error {
   readonly _tag = 'ActionDomainFailure';
   readonly code: string;
-  readonly safeSummary?: string;
 
-  constructor(message: string, code = 'action-domain-failed', safeSummary?: string, options?: { cause?: unknown }) {
+  constructor(message: string, code = 'action-domain-failed', options?: { cause?: unknown }) {
     super(message, options);
     this.name = this._tag;
     this.code = code;
-    this.safeSummary = safeSummary;
   }
 }
 
 export class ActionTransientFailure extends Error {
   readonly _tag = 'ActionTransientFailure';
   readonly code: string;
-  readonly safeSummary?: string;
 
-  constructor(message: string, code = 'action-transient-failed', safeSummary?: string, options?: { cause?: unknown }) {
+  constructor(message: string, code = 'action-transient-failed', options?: { cause?: unknown }) {
     super(message, options);
     this.name = this._tag;
     this.code = code;
-    this.safeSummary = safeSummary;
   }
 }
 
@@ -79,35 +74,8 @@ export class ActionInterruptedFailure extends Error {
   }
 }
 
-const ACTION_FAILURE_KINDS: readonly ActionFailureKind[] = [
-  'configuration',
-  'validation',
-  'domain',
-  'transient',
-  'timeout',
-  'interrupted',
-  'unexpected',
-];
-
 export function isActionFailureKind(value: unknown): value is ActionFailureKind {
   return ACTION_FAILURE_KINDS.includes(value as ActionFailureKind);
-}
-
-const MAX_SUMMARY_LENGTH = 160;
-
-/**
- * A summary is only carried through when a failure deliberately provided one.
- * Arbitrary thrown text never reaches a serialized result.
- */
-function boundedSafeSummary(value: unknown): string | undefined {
-  if (typeof value !== 'string') {
-    return undefined;
-  }
-  const summary = value.trim();
-  if (!summary || summary.length > MAX_SUMMARY_LENGTH || /[\r\n]/.test(summary)) {
-    return undefined;
-  }
-  return summary;
 }
 
 function fields(value: unknown): TaggedActionFailure {
@@ -148,14 +116,12 @@ export function normalizeActionFailure(cause: unknown, fallbackCancellationCoope
     return {
       kind: 'domain',
       code: safeCode(cause, 'action-domain-failed'),
-      summary: boundedSafeSummary(fields(cause).safeSummary),
     };
   }
   if (hasTag(cause, 'ActionTransientFailure')) {
     return {
       kind: 'transient',
       code: safeCode(cause, 'action-transient-failed'),
-      summary: boundedSafeSummary(fields(cause).safeSummary),
     };
   }
   if (hasTag(cause, 'ActionTimeoutFailure')) {

--- a/packages/redbox-core/src/action-execution/failure.ts
+++ b/packages/redbox-core/src/action-execution/failure.ts
@@ -1,0 +1,176 @@
+import { RBValidationError } from '../model/RBValidationError';
+import type { ActionFailureKind, SafeActionFailure } from './types';
+
+interface TaggedActionFailure {
+  _tag?: string;
+  code?: unknown;
+  message?: unknown;
+  safeSummary?: unknown;
+  cancellationCooperative?: unknown;
+}
+
+export class ActionConfigurationError extends Error {
+  readonly _tag = 'ActionConfigurationError';
+  readonly code = 'invalid-hook-execution-policy';
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = this._tag;
+  }
+}
+
+export class ActionValidationFailure extends Error {
+  readonly _tag = 'ActionValidationFailure';
+  readonly code = 'action-validation-failed';
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = this._tag;
+  }
+}
+
+export class ActionDomainFailure extends Error {
+  readonly _tag = 'ActionDomainFailure';
+  readonly code: string;
+  readonly safeSummary?: string;
+
+  constructor(message: string, code = 'action-domain-failed', safeSummary?: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = this._tag;
+    this.code = code;
+    this.safeSummary = safeSummary;
+  }
+}
+
+export class ActionTransientFailure extends Error {
+  readonly _tag = 'ActionTransientFailure';
+  readonly code: string;
+  readonly safeSummary?: string;
+
+  constructor(message: string, code = 'action-transient-failed', safeSummary?: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = this._tag;
+    this.code = code;
+    this.safeSummary = safeSummary;
+  }
+}
+
+export class ActionTimeoutFailure extends Error {
+  readonly _tag = 'ActionTimeoutFailure';
+  readonly code = 'action-timeout';
+  readonly cancellationCooperative: boolean;
+
+  constructor(cancellationCooperative: boolean) {
+    super('Action execution timed out');
+    this.name = this._tag;
+    this.cancellationCooperative = cancellationCooperative;
+  }
+}
+
+export class ActionInterruptedFailure extends Error {
+  readonly _tag = 'ActionInterruptedFailure';
+  readonly code = 'action-interrupted';
+  readonly cancellationCooperative: boolean;
+
+  constructor(cancellationCooperative: boolean) {
+    super('Action execution was interrupted');
+    this.name = this._tag;
+    this.cancellationCooperative = cancellationCooperative;
+  }
+}
+
+const ACTION_FAILURE_KINDS: readonly ActionFailureKind[] = [
+  'configuration',
+  'validation',
+  'domain',
+  'transient',
+  'timeout',
+  'interrupted',
+  'unexpected',
+];
+
+export function isActionFailureKind(value: unknown): value is ActionFailureKind {
+  return ACTION_FAILURE_KINDS.includes(value as ActionFailureKind);
+}
+
+const MAX_SUMMARY_LENGTH = 160;
+
+/**
+ * A summary is only carried through when a failure deliberately provided one.
+ * Arbitrary thrown text never reaches a serialized result.
+ */
+function boundedSafeSummary(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const summary = value.trim();
+  if (!summary || summary.length > MAX_SUMMARY_LENGTH || /[\r\n]/.test(summary)) {
+    return undefined;
+  }
+  return summary;
+}
+
+function fields(value: unknown): TaggedActionFailure {
+  return value !== null && typeof value === 'object' ? (value as TaggedActionFailure) : {};
+}
+
+/** True for both a real instance and a structurally tagged look-alike. */
+function hasTag(value: unknown, tag: string): boolean {
+  return fields(value)._tag === tag;
+}
+
+function safeCode(value: unknown, fallback: string): string {
+  const code = fields(value).code;
+  return typeof code === 'string' && code.trim() ? code : fallback;
+}
+
+function cooperative(value: unknown, fallback?: boolean): boolean | undefined {
+  const flag = fields(value).cancellationCooperative;
+  return typeof flag === 'boolean' ? flag : fallback;
+}
+
+/**
+ * Normalization order is fixed by the design: configuration, validation,
+ * branded domain/transient, executor timeout, interruption, then everything
+ * else as unexpected. Message text is never inspected.
+ */
+export function normalizeActionFailure(cause: unknown, fallbackCancellationCooperative?: boolean): SafeActionFailure {
+  if (hasTag(cause, 'ActionConfigurationError')) {
+    return { kind: 'configuration', code: 'invalid-hook-execution-policy' };
+  }
+  if (RBValidationError.isRBValidationError(cause)) {
+    return { kind: 'validation', code: 'record-validation-failed' };
+  }
+  if (hasTag(cause, 'ActionValidationFailure')) {
+    return { kind: 'validation', code: 'action-validation-failed' };
+  }
+  if (hasTag(cause, 'ActionDomainFailure')) {
+    return {
+      kind: 'domain',
+      code: safeCode(cause, 'action-domain-failed'),
+      summary: boundedSafeSummary(fields(cause).safeSummary),
+    };
+  }
+  if (hasTag(cause, 'ActionTransientFailure')) {
+    return {
+      kind: 'transient',
+      code: safeCode(cause, 'action-transient-failed'),
+      summary: boundedSafeSummary(fields(cause).safeSummary),
+    };
+  }
+  if (hasTag(cause, 'ActionTimeoutFailure')) {
+    return {
+      kind: 'timeout',
+      code: 'action-timeout',
+      cancellationCooperative: cooperative(cause, fallbackCancellationCooperative),
+    };
+  }
+  if (hasTag(cause, 'ActionInterruptedFailure')) {
+    return {
+      kind: 'interrupted',
+      code: 'action-interrupted',
+      cancellationCooperative: cooperative(cause, fallbackCancellationCooperative),
+    };
+  }
+  return { kind: 'unexpected', code: 'action-unexpected-failure' };
+}

--- a/packages/redbox-core/src/action-execution/index.ts
+++ b/packages/redbox-core/src/action-execution/index.ts
@@ -1,0 +1,6 @@
+export * from './types';
+export * from './failure';
+export * from './policy';
+export * from './legacy-result';
+export * from './executor';
+export * from './audit';

--- a/packages/redbox-core/src/action-execution/legacy-result.ts
+++ b/packages/redbox-core/src/action-execution/legacy-result.ts
@@ -1,0 +1,115 @@
+import { Effect } from 'effect';
+import { isObservable, Observable } from 'rxjs';
+
+/**
+ * A mutable cell reporting whether the value a hook returned can genuinely be
+ * cancelled. It is only known after the hook has been invoked, which is later
+ * than the point where the action is described.
+ */
+export interface CancellationCell {
+  value: boolean;
+}
+
+export interface LegacyEffectAdaptation {
+  effect: Effect.Effect<unknown, unknown, never>;
+  cooperativeCancellation: boolean;
+}
+
+/** Legacy Observable hooks are first-value: later emissions are ignored. */
+function observableEffect(observable: Observable<unknown>): Effect.Effect<unknown, unknown, never> {
+  return Effect.async((resume, signal) => {
+    let settled = false;
+
+    const settle = (effect: Effect.Effect<unknown, unknown, never>): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resume(effect);
+      // A synchronous Observable settles while `subscribe` is still running,
+      // so unsubscribing waits until `subscription` has been assigned.
+      queueMicrotask(() => subscription.unsubscribe());
+    };
+
+    const subscription = observable.subscribe({
+      next: value => settle(Effect.succeed(value)),
+      error: (error: unknown) => settle(Effect.fail(error)),
+      complete: () => settle(Effect.fail(new Error('Observable hook completed without a value'))),
+    });
+
+    signal.addEventListener(
+      'abort',
+      () => {
+        settled = true;
+        subscription.unsubscribe();
+      },
+      { once: true }
+    );
+  });
+}
+
+/**
+ * There is deliberately no attempt to abort the Promise. Effect stops waiting
+ * once the fiber is interrupted, but an opaque Promise side effect continues,
+ * which is why Promise-backed hooks report non-cooperative cancellation.
+ */
+function promiseEffect(promise: PromiseLike<unknown>): Effect.Effect<unknown, unknown, never> {
+  return Effect.async((resume, signal) => {
+    let interrupted = false;
+    signal.addEventListener(
+      'abort',
+      () => {
+        interrupted = true;
+      },
+      { once: true }
+    );
+    Promise.resolve(promise).then(
+      value => {
+        if (!interrupted) {
+          resume(Effect.succeed(value));
+        }
+      },
+      (error: unknown) => {
+        if (!interrupted) {
+          resume(Effect.fail(error));
+        }
+      }
+    );
+  });
+}
+
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  if (value === null || (typeof value !== 'object' && typeof value !== 'function')) {
+    return false;
+  }
+  return typeof (value as PromiseLike<unknown>).then === 'function';
+}
+
+/** Adapt whatever a legacy hook returned to an Effect. */
+export function adaptLegacyHookResult(value: unknown): LegacyEffectAdaptation {
+  if (Effect.isEffect(value)) {
+    return { effect: value as Effect.Effect<unknown, unknown, never>, cooperativeCancellation: true };
+  }
+  if (isObservable(value)) {
+    return { effect: observableEffect(value), cooperativeCancellation: true };
+  }
+  if (isThenable(value)) {
+    return { effect: promiseEffect(value), cooperativeCancellation: false };
+  }
+  return { effect: Effect.succeed(value), cooperativeCancellation: true };
+}
+
+/**
+ * Wrap a legacy hook call so a synchronous throw is captured as a failure and
+ * the call itself is deferred until the attempt starts.
+ */
+export function legacyHookToEffect(
+  invoke: () => unknown,
+  cancellation: CancellationCell = { value: true }
+): Effect.Effect<unknown, unknown, never> {
+  return Effect.suspend(() => {
+    const adaptation = adaptLegacyHookResult(invoke());
+    cancellation.value = adaptation.cooperativeCancellation;
+    return adaptation.effect;
+  });
+}

--- a/packages/redbox-core/src/action-execution/legacy-result.ts
+++ b/packages/redbox-core/src/action-execution/legacy-result.ts
@@ -54,28 +54,7 @@ function observableEffect(observable: Observable<unknown>): Effect.Effect<unknow
  * which is why Promise-backed hooks report non-cooperative cancellation.
  */
 function promiseEffect(promise: PromiseLike<unknown>): Effect.Effect<unknown, unknown, never> {
-  return Effect.async((resume, signal) => {
-    let interrupted = false;
-    signal.addEventListener(
-      'abort',
-      () => {
-        interrupted = true;
-      },
-      { once: true }
-    );
-    Promise.resolve(promise).then(
-      value => {
-        if (!interrupted) {
-          resume(Effect.succeed(value));
-        }
-      },
-      (error: unknown) => {
-        if (!interrupted) {
-          resume(Effect.fail(error));
-        }
-      }
-    );
-  });
+  return Effect.tryPromise({ try: () => promise, catch: error => error });
 }
 
 function isThenable(value: unknown): value is PromiseLike<unknown> {

--- a/packages/redbox-core/src/action-execution/policy.ts
+++ b/packages/redbox-core/src/action-execution/policy.ts
@@ -162,9 +162,3 @@ export function retryDelayMs(
   const sample = Math.min(1, Math.max(0, random()));
   return Math.min(MAX_DELAY_MS, Math.round(base * (0.5 + sample)));
 }
-
-export const ACTION_EXECUTION_LIMITS = {
-  maxTimeoutMs: MAX_TIMEOUT_MS,
-  maxDelayMs: MAX_DELAY_MS,
-  maxAttempts: MAX_ATTEMPTS,
-} as const;

--- a/packages/redbox-core/src/action-execution/policy.ts
+++ b/packages/redbox-core/src/action-execution/policy.ts
@@ -1,0 +1,170 @@
+import { createHash } from 'node:crypto';
+import { ActionConfigurationError, isActionFailureKind } from './failure';
+import type {
+  ActionExecutionMode,
+  ActionExecutionPhase,
+  ActionExecutionPolicy,
+  ActionFailureKind,
+  RetryScheduleConfig,
+} from './types';
+
+const MAX_TIMEOUT_MS = 600_000;
+const MAX_DELAY_MS = 60_000;
+const MAX_ATTEMPTS = 5;
+const ACTION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+
+function isIntegerInRange(value: unknown, min: number, max: number): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= min && value <= max;
+}
+
+function configurationError(message: string): never {
+  throw new ActionConfigurationError(message);
+}
+
+function validateJitter(value: unknown): boolean | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'boolean') {
+    configurationError('Retry jitter must be a boolean.');
+  }
+  return value;
+}
+
+function validateSchedule(schedule: unknown): RetryScheduleConfig {
+  if (!schedule || typeof schedule !== 'object') {
+    configurationError('Retry schedule must be an object.');
+  }
+  const value = schedule as Record<string, unknown>;
+  if (value.type !== 'fixed' && value.type !== 'exponential') {
+    configurationError('Retry schedule type must be fixed or exponential.');
+  }
+  if (!isIntegerInRange(value.delayMs, 0, MAX_DELAY_MS)) {
+    configurationError('Retry delayMs must be an integer from 0 through 60000.');
+  }
+  const jitter = validateJitter(value.jitter);
+
+  if (value.type === 'fixed') {
+    const result: RetryScheduleConfig = { type: 'fixed', delayMs: value.delayMs };
+    if (jitter !== undefined) {
+      result.jitter = jitter;
+    }
+    return result;
+  }
+
+  if (!isIntegerInRange(value.maxDelayMs, 0, MAX_DELAY_MS) || value.maxDelayMs < value.delayMs) {
+    configurationError('Exponential maxDelayMs must be an integer no smaller than delayMs and no greater than 60000.');
+  }
+  const result: RetryScheduleConfig = {
+    type: 'exponential',
+    delayMs: value.delayMs,
+    maxDelayMs: value.maxDelayMs,
+  };
+  if (jitter !== undefined) {
+    result.jitter = jitter;
+  }
+  return result;
+}
+
+export function validateActionId(id: unknown): string {
+  if (typeof id !== 'string' || !ACTION_ID_PATTERN.test(id.trim())) {
+    configurationError('Action id must be a non-empty string of at most 128 safe characters.');
+  }
+  return id.trim();
+}
+
+export function deriveActionId(
+  mode: ActionExecutionMode | string,
+  phase: ActionExecutionPhase | string,
+  index: number,
+  functionExpression: string
+): string {
+  const digest = createHash('sha256').update(functionExpression).digest('hex').slice(0, 12);
+  return `${mode}.${phase}.${index}.${digest}`;
+}
+
+export function resolveActionId(
+  configuredId: unknown,
+  mode: ActionExecutionMode | string,
+  phase: ActionExecutionPhase | string,
+  index: number,
+  functionExpression: string
+): string {
+  if (configuredId === undefined) {
+    return deriveActionId(mode, phase, index, functionExpression);
+  }
+  return validateActionId(configuredId);
+}
+
+export function validateActionExecutionPolicy(policy: unknown): ActionExecutionPolicy | undefined {
+  if (policy === undefined || policy === null) {
+    return undefined;
+  }
+  if (typeof policy !== 'object' || Array.isArray(policy)) {
+    configurationError('Action execution policy must be an object.');
+  }
+  const value = policy as Record<string, unknown>;
+  const result: ActionExecutionPolicy = {};
+  if (value.timeoutMs !== undefined) {
+    if (!isIntegerInRange(value.timeoutMs, 1, MAX_TIMEOUT_MS)) {
+      configurationError('Action timeoutMs must be an integer from 1 through 600000.');
+    }
+    result.timeoutMs = value.timeoutMs;
+  }
+  if (value.retry !== undefined) {
+    if (!value.retry || typeof value.retry !== 'object' || Array.isArray(value.retry)) {
+      configurationError('Retry policy must be an object.');
+    }
+    const retry = value.retry as Record<string, unknown>;
+    if (retry.idempotent !== true) {
+      configurationError('Retry policy requires idempotent: true.');
+    }
+    if (!isIntegerInRange(retry.maxAttempts, 1, MAX_ATTEMPTS)) {
+      configurationError('Retry maxAttempts must be an integer from 1 through 5.');
+    }
+    let retryOn: ActionFailureKind[] | undefined;
+    if (retry.retryOn !== undefined) {
+      if (!Array.isArray(retry.retryOn) || retry.retryOn.some(kind => !isActionFailureKind(kind))) {
+        configurationError('Retry retryOn contains an unknown failure kind.');
+      }
+      retryOn = Array.from(new Set(retry.retryOn)) as ActionFailureKind[];
+    }
+    result.retry = {
+      maxAttempts: retry.maxAttempts,
+      retryOn: retryOn ?? ['transient'],
+      schedule: retry.schedule === undefined ? undefined : validateSchedule(retry.schedule),
+      idempotent: true,
+    };
+  }
+  return result;
+}
+
+/**
+ * Delay before retry number `retryNumber` (1 is the delay after the first
+ * failed attempt). Jitter spreads the delay over 50%-150% of the base and is
+ * still capped at the configured maximum delay.
+ */
+export function retryDelayMs(
+  schedule: RetryScheduleConfig | undefined,
+  retryNumber: number,
+  random: () => number = Math.random
+): number {
+  if (!schedule) {
+    return 0;
+  }
+  let base = schedule.delayMs;
+  if (schedule.type === 'exponential') {
+    base = Math.min(schedule.maxDelayMs, schedule.delayMs * 2 ** Math.max(0, retryNumber - 1));
+  }
+  if (!schedule.jitter || base === 0) {
+    return base;
+  }
+  const sample = Math.min(1, Math.max(0, random()));
+  return Math.min(MAX_DELAY_MS, Math.round(base * (0.5 + sample)));
+}
+
+export const ACTION_EXECUTION_LIMITS = {
+  maxTimeoutMs: MAX_TIMEOUT_MS,
+  maxDelayMs: MAX_DELAY_MS,
+  maxAttempts: MAX_ATTEMPTS,
+} as const;

--- a/packages/redbox-core/src/action-execution/types.ts
+++ b/packages/redbox-core/src/action-execution/types.ts
@@ -1,0 +1,158 @@
+import { Effect } from 'effect';
+
+export type ActionFailureKind =
+  | 'configuration'
+  | 'validation'
+  | 'domain'
+  | 'transient'
+  | 'timeout'
+  | 'interrupted'
+  | 'unexpected';
+
+export type ActionExecutionStatus = 'succeeded' | 'failed' | 'timed_out' | 'interrupted' | 'skipped' | 'dispatched';
+
+export type ActionSkippedReason =
+  | 'prior_action_failed'
+  | 'phase_not_reached'
+  | 'save_not_persisted'
+  | 'trigger_disabled';
+
+export type ActionExecutionMode = 'onCreate' | 'onUpdate' | 'onDelete' | 'onTransitionWorkflow';
+
+export type ActionExecutionPhase = 'pre' | 'postSync' | 'post';
+
+export interface ActionExecutionContext {
+  executionId: string;
+  phaseExecutionId: string;
+  trigger: 'record-hook';
+  mode: ActionExecutionMode;
+  phase: ActionExecutionPhase;
+  requestId?: string;
+  recordOid?: string;
+}
+
+export interface SafeActionFailure {
+  kind: ActionFailureKind;
+  code: string;
+  summary?: string;
+  cancellationCooperative?: boolean;
+}
+
+export interface ActionExecutionResult {
+  actionId: string;
+  mode: ActionExecutionMode;
+  phase: ActionExecutionPhase;
+  index: number;
+  status: ActionExecutionStatus;
+  attempts: number;
+  startedAt: string;
+  completedAt: string;
+  durationMs: number;
+  failure?: SafeActionFailure;
+  skippedReason?: ActionSkippedReason;
+}
+
+export interface ActionExecutionCounts {
+  succeeded: number;
+  failed: number;
+  timed_out: number;
+  interrupted: number;
+  skipped: number;
+  dispatched: number;
+}
+
+export interface ActionExecutionReport {
+  schemaVersion: 1;
+  executionId: string;
+  phaseExecutionId: string;
+  context: ActionExecutionContext;
+  status: 'completed' | 'failed' | 'partial' | 'dispatched';
+  startedAt: string;
+  completedAt: string;
+  durationMs: number;
+  actions: ActionExecutionResult[];
+  counts: ActionExecutionCounts;
+}
+
+export interface ActionExecutionPolicy {
+  timeoutMs?: number;
+  retry?: {
+    maxAttempts: number;
+    retryOn?: ActionFailureKind[];
+    schedule?: RetryScheduleConfig;
+    idempotent: true;
+  };
+}
+
+export type RetryScheduleConfig =
+  | {
+      type: 'fixed';
+      delayMs: number;
+      jitter?: boolean;
+    }
+  | {
+      type: 'exponential';
+      delayMs: number;
+      maxDelayMs: number;
+      jitter?: boolean;
+    };
+
+export interface ActionExecutionDependencies {
+  now?: () => Date;
+  random?: () => number;
+  /** Injectable backoff sleep. Defaults to Effect's live Clock service. */
+  sleep?: (durationMs: number) => Effect.Effect<void>;
+  uuid?: () => string;
+  logger?: ActionExecutionLogger;
+  supervisor?: ActionExecutionSupervisor;
+}
+
+export interface ActionExecutionLogger {
+  debug?: (message: string, fields?: Record<string, unknown>) => void;
+  info?: (message: string, fields?: Record<string, unknown>) => void;
+  warn?: (message: string, fields?: Record<string, unknown>) => void;
+  error?: (message: string, fields?: Record<string, unknown>) => void;
+}
+
+export interface ActionExecutionSupervisor {
+  register?: (fiber: unknown) => void;
+  interruptAll?: () => void;
+}
+
+export interface ActionExecutionAction<A = unknown> {
+  actionId: string;
+  mode: ActionExecutionMode;
+  phase: ActionExecutionPhase;
+  index: number;
+  policy?: ActionExecutionPolicy;
+  /** Legacy Promise work is not cancellable even when the wait is timed out. */
+  cooperativeCancellation?: boolean | (() => boolean);
+  invoke: () => Effect.Effect<A, unknown, never>;
+}
+
+export interface ActionExecutionOutcome<A = unknown> {
+  report: ActionExecutionReport;
+  values: A[];
+  /** Kept in memory only for the compatibility adapter. */
+  terminalCause?: unknown;
+}
+
+export interface ActionExecutionOperation {
+  executionId: string;
+  trigger: 'record-hook';
+  mode: ActionExecutionMode;
+  requestId?: string;
+  recordOid?: string;
+  reports: ActionExecutionReport[];
+  startedAt: string;
+  completedThrough?: 'pre' | 'persistence' | 'postSync' | 'post-dispatch';
+}
+
+export const EMPTY_ACTION_COUNTS: ActionExecutionCounts = {
+  succeeded: 0,
+  failed: 0,
+  timed_out: 0,
+  interrupted: 0,
+  skipped: 0,
+  dispatched: 0,
+};

--- a/packages/redbox-core/src/action-execution/types.ts
+++ b/packages/redbox-core/src/action-execution/types.ts
@@ -102,6 +102,9 @@ export interface ActionExecutionDependencies {
   random?: () => number;
   /** Injectable backoff sleep. Defaults to Effect's live Clock service. */
   sleep?: (durationMs: number) => Effect.Effect<void>;
+  /** Injectable wall-clock scheduling for bounded save-side handoffs. */
+  schedule?: (durationMs: number, task: () => void) => unknown;
+  cancelSchedule?: (handle: unknown) => void;
   uuid?: () => string;
   logger?: ActionExecutionLogger;
   supervisor?: ActionExecutionSupervisor;
@@ -154,6 +157,11 @@ export interface ActionExecutionOperation {
   detachedResults?: ActionExecutionResult[];
   onDetachedComplete?: () => void;
   detachedCompletedAt?: string;
+  /** In-memory guard/state for the exactly-once audit handoff. */
+  detachedAuditFinalized?: boolean;
+  detachedAuditTimer?: unknown;
+  cancelDetachedAuditTimer?: (handle: unknown) => void;
+  operationCompletedLogged?: boolean;
 }
 
 export const EMPTY_ACTION_COUNTS: ActionExecutionCounts = {

--- a/packages/redbox-core/src/action-execution/types.ts
+++ b/packages/redbox-core/src/action-execution/types.ts
@@ -1,21 +1,32 @@
 import { Effect } from 'effect';
+import type { RuntimeFiber } from 'effect/Fiber';
 
-export type ActionFailureKind =
-  | 'configuration'
-  | 'validation'
-  | 'domain'
-  | 'transient'
-  | 'timeout'
-  | 'interrupted'
-  | 'unexpected';
+export const ACTION_FAILURE_KINDS = [
+  'configuration',
+  'validation',
+  'domain',
+  'transient',
+  'timeout',
+  'interrupted',
+  'unexpected',
+] as const;
 
-export type ActionExecutionStatus = 'succeeded' | 'failed' | 'timed_out' | 'interrupted' | 'skipped' | 'dispatched';
+export type ActionFailureKind = (typeof ACTION_FAILURE_KINDS)[number];
 
-export type ActionSkippedReason =
-  | 'prior_action_failed'
-  | 'phase_not_reached'
-  | 'save_not_persisted'
-  | 'trigger_disabled';
+export const ACTION_EXECUTION_STATUSES = [
+  'succeeded',
+  'failed',
+  'timed_out',
+  'interrupted',
+  'skipped',
+  'dispatched',
+] as const;
+
+export type ActionExecutionStatus = (typeof ACTION_EXECUTION_STATUSES)[number];
+
+export const ACTION_SKIPPED_REASONS = ['prior_action_failed'] as const;
+
+export type ActionSkippedReason = (typeof ACTION_SKIPPED_REASONS)[number];
 
 export type ActionExecutionMode = 'onCreate' | 'onUpdate' | 'onDelete' | 'onTransitionWorkflow';
 
@@ -24,7 +35,6 @@ export type ActionExecutionPhase = 'pre' | 'postSync' | 'post';
 export interface ActionExecutionContext {
   executionId: string;
   phaseExecutionId: string;
-  trigger: 'record-hook';
   mode: ActionExecutionMode;
   phase: ActionExecutionPhase;
   requestId?: string;
@@ -34,7 +44,6 @@ export interface ActionExecutionContext {
 export interface SafeActionFailure {
   kind: ActionFailureKind;
   code: string;
-  summary?: string;
   cancellationCooperative?: boolean;
 }
 
@@ -52,26 +61,13 @@ export interface ActionExecutionResult {
   skippedReason?: ActionSkippedReason;
 }
 
-export interface ActionExecutionCounts {
-  succeeded: number;
-  failed: number;
-  timed_out: number;
-  interrupted: number;
-  skipped: number;
-  dispatched: number;
-}
-
 export interface ActionExecutionReport {
-  schemaVersion: 1;
-  executionId: string;
-  phaseExecutionId: string;
   context: ActionExecutionContext;
   status: 'completed' | 'failed' | 'partial' | 'dispatched';
   startedAt: string;
   completedAt: string;
   durationMs: number;
   actions: ActionExecutionResult[];
-  counts: ActionExecutionCounts;
 }
 
 export interface ActionExecutionPolicy {
@@ -102,9 +98,6 @@ export interface ActionExecutionDependencies {
   random?: () => number;
   /** Injectable backoff sleep. Defaults to Effect's live Clock service. */
   sleep?: (durationMs: number) => Effect.Effect<void>;
-  /** Injectable wall-clock scheduling for bounded save-side handoffs. */
-  schedule?: (durationMs: number, task: () => void) => unknown;
-  cancelSchedule?: (handle: unknown) => void;
   uuid?: () => string;
   logger?: ActionExecutionLogger;
   supervisor?: ActionExecutionSupervisor;
@@ -120,8 +113,7 @@ export interface ActionExecutionLogger {
 }
 
 export interface ActionExecutionSupervisor {
-  register?: (fiber: unknown) => void;
-  unregister?: (fiber: unknown) => void;
+  register?: (fiber: RuntimeFiber<unknown, unknown>) => void;
   interruptAll?: () => void;
 }
 
@@ -132,20 +124,18 @@ export interface ActionExecutionAction<A = unknown> {
   index: number;
   policy?: ActionExecutionPolicy;
   /** Legacy Promise work is not cancellable even when the wait is timed out. */
-  cooperativeCancellation?: boolean | (() => boolean);
+  cooperativeCancellation?: () => boolean;
   invoke: () => Effect.Effect<A, unknown, never>;
 }
 
-export interface ActionExecutionOutcome<A = unknown> {
+export interface ActionExecutionOutcome {
   report: ActionExecutionReport;
-  values: A[];
   /** Kept in memory only for the compatibility adapter. */
   terminalCause?: unknown;
 }
 
 export interface ActionExecutionOperation {
   executionId: string;
-  trigger: 'record-hook';
   mode: ActionExecutionMode;
   requestId?: string;
   recordOid?: string;
@@ -159,16 +149,5 @@ export interface ActionExecutionOperation {
   detachedCompletedAt?: string;
   /** In-memory guard/state for the exactly-once audit handoff. */
   detachedAuditFinalized?: boolean;
-  detachedAuditTimer?: unknown;
-  cancelDetachedAuditTimer?: (handle: unknown) => void;
   operationCompletedLogged?: boolean;
 }
-
-export const EMPTY_ACTION_COUNTS: ActionExecutionCounts = {
-  succeeded: 0,
-  failed: 0,
-  timed_out: 0,
-  interrupted: 0,
-  skipped: 0,
-  dispatched: 0,
-};

--- a/packages/redbox-core/src/action-execution/types.ts
+++ b/packages/redbox-core/src/action-execution/types.ts
@@ -105,6 +105,8 @@ export interface ActionExecutionDependencies {
   uuid?: () => string;
   logger?: ActionExecutionLogger;
   supervisor?: ActionExecutionSupervisor;
+  /** Receives the terminal result of each detached action. */
+  onDetachedActionComplete?: (context: ActionExecutionContext, result: ActionExecutionResult) => void;
 }
 
 export interface ActionExecutionLogger {
@@ -116,6 +118,7 @@ export interface ActionExecutionLogger {
 
 export interface ActionExecutionSupervisor {
   register?: (fiber: unknown) => void;
+  unregister?: (fiber: unknown) => void;
   interruptAll?: () => void;
 }
 
@@ -146,6 +149,11 @@ export interface ActionExecutionOperation {
   reports: ActionExecutionReport[];
   startedAt: string;
   completedThrough?: 'pre' | 'persistence' | 'postSync' | 'post-dispatch';
+  /** In-memory lifecycle state for detached actions; never persisted directly. */
+  detachedPending?: number;
+  detachedResults?: ActionExecutionResult[];
+  onDetachedComplete?: () => void;
+  detachedCompletedAt?: string;
 }
 
 export const EMPTY_ACTION_COUNTS: ActionExecutionCounts = {

--- a/packages/redbox-core/src/config/recordtype.config.ts
+++ b/packages/redbox-core/src/config/recordtype.config.ts
@@ -5,25 +5,30 @@
  * Record type definitions with hooks and permissions.
  */
 
+import type { ActionExecutionPolicy } from '../action-execution/types';
+
 export interface RecordHookOptions {
     [key: string]: unknown;
 }
 
 export interface RecordHookDefinition {
+    id?: string;
     function: string;
     options?: RecordHookOptions;
+    execution?: ActionExecutionPolicy;
+}
+
+export interface RecordHookModeConfig {
+    pre?: RecordHookDefinition[];
+    post?: RecordHookDefinition[];
+    postSync?: RecordHookDefinition[];
 }
 
 export interface RecordHooksConfig {
-    onCreate?: {
-        pre?: RecordHookDefinition[];
-        post?: RecordHookDefinition[];
-        postSync?: RecordHookDefinition[];
-    };
-    onUpdate?: {
-        pre?: RecordHookDefinition[];
-        post?: RecordHookDefinition[];
-    };
+    onCreate?: RecordHookModeConfig;
+    onUpdate?: RecordHookModeConfig;
+    onDelete?: RecordHookModeConfig;
+    onTransitionWorkflow?: RecordHookModeConfig;
 }
 
 export interface RecordRelation {

--- a/packages/redbox-core/src/index.ts
+++ b/packages/redbox-core/src/index.ts
@@ -183,6 +183,7 @@ export { Responses };
 
 // Config types and default values
 export * from './config';
+export * from './action-execution';
 export { Config, SailsConfig } from './config';
 
 // Bootstrap functions

--- a/packages/redbox-core/src/model/storage/RecordAuditModel.ts
+++ b/packages/redbox-core/src/model/storage/RecordAuditModel.ts
@@ -1,10 +1,13 @@
+import type { RecordHookExecutionAuditSummary } from '../../action-execution/audit';
+
 export class RecordAuditModel {
     redboxOid: string;
     action:RecordAuditActionType;
     user: Record<string, unknown> | null;
     record: Record<string, unknown>;
+    executionSummary?: RecordHookExecutionAuditSummary;
 
-    constructor(oid: string, record: Record<string, unknown>, user: Record<string, unknown> | null, action: RecordAuditActionType = RecordAuditActionType.updated) {
+    constructor(oid: string, record: Record<string, unknown>, user: Record<string, unknown> | null, action: RecordAuditActionType = RecordAuditActionType.updated, executionSummary?: RecordHookExecutionAuditSummary) {
         if (user!= null && !_.isEmpty(user.password)) {
             delete user.password;
         }
@@ -12,6 +15,7 @@ export class RecordAuditModel {
         this.record = record;
         this.user = user;
         this.action = action;
+        this.executionSummary = executionSummary;
     }
 }
 

--- a/packages/redbox-core/src/services/RecordsService.ts
+++ b/packages/redbox-core/src/services/RecordsService.ts
@@ -176,7 +176,17 @@ export namespace Services {
         (summary.counts.failed ?? 0) > 0 ||
         (summary.counts.timed_out ?? 0) > 0 ||
         (summary.counts.interrupted ?? 0) > 0;
-      fields.status = summary.partial ? 'partial' : hasFailure ? 'failed' : 'completed';
+      fields.status =
+        summary.partial
+          ? 'partial'
+          : (operation.detachedPending ?? 0) > 0
+            ? 'dispatched'
+            : hasFailure
+              ? 'failed'
+              : 'completed';
+      if ((operation.detachedPending ?? 0) > 0) {
+        fields.detached_pending = operation.detachedPending;
+      }
       fields.duration_ms = summary.durationMs;
       fields.total_actions = summary.totalActions;
       sails.log.info(`${this.logHeader}record_hook_operation_completed`, fields);
@@ -334,19 +344,29 @@ export namespace Services {
             sails.log.error(`${this.logHeader} index submission failed`, error);
           });
       }
-      void Promise.resolve()
-        .then(() =>
-          this.auditRecord(
-            oid,
-            persistedRecord,
-            user,
-            action,
-            operation ? projectRecordHookExecutionAuditSummary(operation) : undefined
+      const submitAudit = (): void => {
+        if (operation && (operation.detachedPending ?? 0) > 0) {
+          this.completeHookOperation(operation);
+        }
+        void Promise.resolve()
+          .then(() =>
+            this.auditRecord(
+              oid,
+              persistedRecord,
+              user,
+              action,
+              operation ? projectRecordHookExecutionAuditSummary(operation) : undefined
+            )
           )
-        )
-        .catch((error: unknown) => {
-          sails.log.error(`${this.logHeader} persistence audit submission failed`, error);
-        });
+          .catch((error: unknown) => {
+            sails.log.error(`${this.logHeader} persistence audit submission failed`, error);
+          });
+      };
+      if (operation && (operation.detachedPending ?? 0) > 0) {
+        operation.onDetachedComplete = submitAudit;
+      } else {
+        submitAudit();
+      }
       return tracker;
     }
 
@@ -780,8 +800,7 @@ export namespace Services {
     private validateHookConfiguration(recordType: unknown, modes: readonly string[]): void {
       try {
         validateRecordHookConfiguration(recordType, modes, (hook, mode, phase) =>
-          this.configuredHookFunction(hook, mode, phase)
-        );
+          this.configuredHookFunction(hook, mode, phase), ['pre']);
       } catch (error) {
         if (RBValidationError.isRBValidationError(error)) {
           throw error;

--- a/packages/redbox-core/src/services/RecordsService.ts
+++ b/packages/redbox-core/src/services/RecordsService.ts
@@ -77,10 +77,17 @@ import type { Services as AttachmentMetadataServices } from './AttachmentMetadat
 import { createActionExecutionOperation, createActionExecutionSupervisor } from '../action-execution/executor';
 import {
   projectRecordHookExecutionAuditSummary,
+  type DetachedAuditFinalization,
   type RecordHookExecutionAuditSummary,
 } from '../action-execution/audit';
 import type { ActionExecutionDependencies, ActionExecutionOperation } from '../action-execution/types';
 import { RecordHookCoordinator, validateRecordHookConfiguration } from './record-hooks/coordinator';
+
+/**
+ * Detached post hooks remain fire-and-forget to the save caller, but audit
+ * persistence gets this bounded opportunity to collect terminal outcomes.
+ */
+const DETACHED_AUDIT_GRACE_MS = 1000;
 
 export namespace Services {
   type AnyRecord = Record<string, unknown>;
@@ -138,6 +145,8 @@ export namespace Services {
           error: (message, fields) => sails.log.error(`${this.logHeader}${message}`, fields),
         },
         supervisor: this.hookExecutionSupervisor,
+        schedule: (durationMs, task) => setTimeout(task, durationMs),
+        cancelSchedule: handle => clearTimeout(handle as ReturnType<typeof setTimeout>),
       };
     }
 
@@ -157,13 +166,41 @@ export namespace Services {
       });
     }
 
+    /** Emit the save-boundary event without calling it a completed operation. */
+    private dispatchHookOperation(operation: ActionExecutionOperation): void {
+      const summary = projectRecordHookExecutionAuditSummary(operation);
+      const fields: AnyRecord = {
+        event: 'record_hook_operation_dispatched',
+        execution_id: summary.executionId,
+        hook_mode: operation.mode,
+        status: 'dispatched',
+        duration_ms: summary.durationMs,
+        total_actions: summary.totalActions,
+      };
+      if (summary.requestId) {
+        fields.request_id = summary.requestId;
+      }
+      if ((operation.detachedPending ?? 0) > 0) {
+        fields.detached_pending = operation.detachedPending;
+      }
+      sails.log.info(`${this.logHeader}record_hook_operation_dispatched`, fields);
+    }
+
     /**
-     * Emit the single operation summary for one record operation. It is logged
-     * once, by whichever caller owns the operation, so a create that runs pre,
-     * post-sync, and detached phases still produces one summary event.
+     * Emit exactly one final operation summary once audit finalization has
+     * been reached. Detached completion remains independently observable in
+     * action-level logs after this point.
      */
-    private completeHookOperation(operation: ActionExecutionOperation, partial = false): void {
-      const summary = projectRecordHookExecutionAuditSummary(operation, { partial });
+    private completeHookOperation(
+      operation: ActionExecutionOperation,
+      partial = false,
+      detachedFinalization?: DetachedAuditFinalization
+    ): void {
+      if (operation.operationCompletedLogged) {
+        return;
+      }
+      operation.operationCompletedLogged = true;
+      const summary = projectRecordHookExecutionAuditSummary(operation, { partial, detachedFinalization });
       const fields: AnyRecord = {
         event: 'record_hook_operation_completed',
         execution_id: summary.executionId,
@@ -176,16 +213,12 @@ export namespace Services {
         (summary.counts.failed ?? 0) > 0 ||
         (summary.counts.timed_out ?? 0) > 0 ||
         (summary.counts.interrupted ?? 0) > 0;
-      fields.status =
-        summary.partial
-          ? 'partial'
-          : (operation.detachedPending ?? 0) > 0
-            ? 'dispatched'
-            : hasFailure
-              ? 'failed'
-              : 'completed';
+      fields.status = summary.partial ? 'partial' : hasFailure ? 'failed' : 'completed';
       if ((operation.detachedPending ?? 0) > 0) {
         fields.detached_pending = operation.detachedPending;
+      }
+      if (summary.detachedFinalization) {
+        fields.detached_finalization = summary.detachedFinalization;
       }
       fields.duration_ms = summary.durationMs;
       fields.total_actions = summary.totalActions;
@@ -321,11 +354,14 @@ export namespace Services {
       searchable: boolean
     ): Promise<RecordSaveResponse> {
       const operation = this.saveHookOperations.get(tracker);
-      if (operation) {
-        this.completeHookOperation(operation);
+      if (operation && (operation.detachedPending ?? 0) > 0) {
+        this.dispatchHookOperation(operation);
       }
       const oid = String(tracker.oid ?? '').trim();
       if (!tracker.wasPersisted() || !oid) {
+        if (operation) {
+          this.completeHookOperation(operation, true);
+        }
         return tracker;
       }
 
@@ -334,6 +370,9 @@ export namespace Services {
         persistedRecord = (await this.getMeta(oid)) as unknown as AnyRecord;
       } catch (error) {
         sails.log.warn(`${this.logHeader} unable to reload committed record before side effects`, error);
+        if (operation) {
+          this.completeHookOperation(operation, true);
+        }
         return tracker;
       }
 
@@ -344,9 +383,19 @@ export namespace Services {
             sails.log.error(`${this.logHeader} index submission failed`, error);
           });
       }
-      const submitAudit = (): void => {
-        if (operation && (operation.detachedPending ?? 0) > 0) {
-          this.completeHookOperation(operation);
+      const submitAudit = (detachedFinalization: DetachedAuditFinalization = 'complete'): void => {
+        if (operation?.detachedAuditFinalized) {
+          return;
+        }
+        if (operation) {
+          operation.detachedAuditFinalized = true;
+          operation.onDetachedComplete = undefined;
+          if (operation.detachedAuditTimer !== undefined) {
+            operation.cancelDetachedAuditTimer?.(operation.detachedAuditTimer);
+            operation.detachedAuditTimer = undefined;
+            operation.cancelDetachedAuditTimer = undefined;
+          }
+          this.completeHookOperation(operation, detachedFinalization === 'grace-expired', detachedFinalization);
         }
         void Promise.resolve()
           .then(() =>
@@ -355,7 +404,12 @@ export namespace Services {
               persistedRecord,
               user,
               action,
-              operation ? projectRecordHookExecutionAuditSummary(operation) : undefined
+              operation
+                ? projectRecordHookExecutionAuditSummary(operation, {
+                    partial: detachedFinalization === 'grace-expired',
+                    detachedFinalization,
+                  })
+                : undefined
             )
           )
           .catch((error: unknown) => {
@@ -363,9 +417,25 @@ export namespace Services {
           });
       };
       if (operation && (operation.detachedPending ?? 0) > 0) {
-        operation.onDetachedComplete = submitAudit;
+        operation.onDetachedComplete = () => submitAudit('complete');
+        const dependencies = this.hookExecutionDependencies();
+        const schedule =
+          dependencies.schedule ?? ((durationMs: number, task: () => void) => setTimeout(task, durationMs));
+        operation.cancelDetachedAuditTimer =
+          dependencies.cancelSchedule ?? (handle => clearTimeout(handle as ReturnType<typeof setTimeout>));
+        const timer = schedule(DETACHED_AUDIT_GRACE_MS, () => submitAudit('grace-expired'));
+        if (operation.detachedAuditFinalized) {
+          operation.cancelDetachedAuditTimer(timer);
+        } else {
+          operation.detachedAuditTimer = timer;
+        }
+        // A detached action may have completed during the awaited snapshot
+        // reload. Do not leave a zero-pending operation waiting on a callback.
+        if ((operation.detachedPending ?? 0) === 0) {
+          submitAudit('complete');
+        }
       } else {
-        submitAudit();
+        submitAudit('complete');
       }
       return tracker;
     }
@@ -799,8 +869,12 @@ export namespace Services {
 
     private validateHookConfiguration(recordType: unknown, modes: readonly string[]): void {
       try {
-        validateRecordHookConfiguration(recordType, modes, (hook, mode, phase) =>
-          this.configuredHookFunction(hook, mode, phase), ['pre']);
+        validateRecordHookConfiguration(
+          recordType,
+          modes,
+          (hook, mode, phase) => this.configuredHookFunction(hook, mode, phase),
+          ['pre']
+        );
       } catch (error) {
         if (RBValidationError.isRBValidationError(error)) {
           throw error;

--- a/packages/redbox-core/src/services/RecordsService.ts
+++ b/packages/redbox-core/src/services/RecordsService.ts
@@ -45,10 +45,8 @@ const luceneEscapeQuery: (value: string) => string =
   typeof luceneEscapeQueryModule === 'function'
     ? luceneEscapeQueryModule
     : (((luceneEscapeQueryModule as Record<string, unknown>).escape ||
-      (luceneEscapeQueryModule as Record<string, unknown>).default) as (value: string) => string);
+        (luceneEscapeQueryModule as Record<string, unknown>).default) as (value: string) => string);
 import { DateTime } from 'luxon';
-
-import { isObservable } from 'rxjs';
 
 import { Readable } from 'node:stream';
 import { createHash, randomUUID } from 'node:crypto';
@@ -76,6 +74,13 @@ import type {
   RecordSaveProblemKind,
 } from '@researchdatabox/sails-ng-common';
 import type { Services as AttachmentMetadataServices } from './AttachmentMetadataService';
+import { createActionExecutionOperation, createActionExecutionSupervisor } from '../action-execution/executor';
+import {
+  projectRecordHookExecutionAuditSummary,
+  type RecordHookExecutionAuditSummary,
+} from '../action-execution/audit';
+import type { ActionExecutionDependencies, ActionExecutionOperation } from '../action-execution/types';
+import { RecordHookCoordinator, validateRecordHookConfiguration } from './record-hooks/coordinator';
 
 export namespace Services {
   type AnyRecord = Record<string, unknown>;
@@ -111,11 +116,70 @@ export namespace Services {
 
     searchService!: SearchService;
     protected queueService!: QueueService;
-    private readonly configuredHookFunctions = new WeakMap<object, { expression: string; fn: (...args: unknown[]) => unknown }>();
+    private readonly configuredHookFunctions = new WeakMap<
+      object,
+      { expression: string; fn: (...args: unknown[]) => unknown }
+    >();
+    private readonly saveHookOperations = new WeakMap<RecordSaveResponse, ActionExecutionOperation>();
+    private readonly hookExecutionSupervisor = createActionExecutionSupervisor();
 
     constructor() {
       super();
       this.logHeader = 'RecordsService::';
+    }
+
+    private hookExecutionDependencies(): ActionExecutionDependencies {
+      return {
+        uuid: randomUUID,
+        logger: {
+          debug: (message, fields) => sails.log.debug(`${this.logHeader}${message}`, fields),
+          info: (message, fields) => sails.log.info(`${this.logHeader}${message}`, fields),
+          warn: (message, fields) => sails.log.warn(`${this.logHeader}${message}`, fields),
+          error: (message, fields) => sails.log.error(`${this.logHeader}${message}`, fields),
+        },
+        supervisor: this.hookExecutionSupervisor,
+      };
+    }
+
+    private createHookExecutionOperation(
+      mode: 'onCreate' | 'onUpdate' | 'onDelete' | 'onTransitionWorkflow',
+      requestId?: string,
+      recordOid?: string
+    ): ActionExecutionOperation {
+      return createActionExecutionOperation(mode, requestId, recordOid, this.hookExecutionDependencies());
+    }
+
+    private hookCoordinator(operation: ActionExecutionOperation): RecordHookCoordinator {
+      return new RecordHookCoordinator({
+        operation,
+        dependencies: this.hookExecutionDependencies(),
+        resolveHook: (hook, mode, phase) => this.configuredHookFunction(hook, mode, phase),
+      });
+    }
+
+    /**
+     * Emit the single operation summary for one record operation. It is logged
+     * once, by whichever caller owns the operation, so a create that runs pre,
+     * post-sync, and detached phases still produces one summary event.
+     */
+    private completeHookOperation(operation: ActionExecutionOperation, partial = false): void {
+      const summary = projectRecordHookExecutionAuditSummary(operation, { partial });
+      const fields: AnyRecord = {
+        event: 'record_hook_operation_completed',
+        execution_id: summary.executionId,
+      };
+      if (summary.requestId) {
+        fields.request_id = summary.requestId;
+      }
+      fields.hook_mode = operation.mode;
+      const hasFailure =
+        (summary.counts.failed ?? 0) > 0 ||
+        (summary.counts.timed_out ?? 0) > 0 ||
+        (summary.counts.interrupted ?? 0) > 0;
+      fields.status = summary.partial ? 'partial' : hasFailure ? 'failed' : 'completed';
+      fields.duration_ms = summary.durationMs;
+      fields.total_actions = summary.totalActions;
+      sails.log.info(`${this.logHeader}record_hook_operation_completed`, fields);
     }
 
     private describeError(error: unknown, depth = 0): string {
@@ -171,7 +235,7 @@ export namespace Services {
     private saveProblem(
       phase: RecordSavePhase,
       kind: RecordSaveProblemKind = 'system',
-      code?: string,
+      code?: string
     ): RecordSaveProblem {
       return recordSaveProblem(kind, phase, code ? `@record-save-${code}` : '@record-save-failed', code);
     }
@@ -180,14 +244,16 @@ export namespace Services {
       error: unknown,
       phase: RecordSavePhase,
       fallbackKind: RecordSaveProblemKind = 'processing',
-      fallbackCode = 'save-precondition',
+      fallbackCode = 'save-precondition'
     ): RecordSaveProblem {
       const displayErrors = RBValidationError.isRBValidationError(error)
         ? (error as RBValidationError).displayErrors
         : [];
-      const displayError = displayErrors[0] as (Record<string, unknown> & {
-        source?: { pointer?: unknown };
-      }) | undefined;
+      const displayError = displayErrors[0] as
+        | (Record<string, unknown> & {
+            source?: { pointer?: unknown };
+          })
+        | undefined;
       const issue: Partial<RecordSaveIssue> = {};
       const field = displayError?.field;
       const pointer = displayError?.source?.pointer;
@@ -197,24 +263,19 @@ export namespace Services {
       if (typeof pointer === 'string' && pointer.trim()) {
         issue.pointer = pointer.trim();
       }
-      const code = typeof displayError?.code === 'string' && displayError.code.trim()
-        ? displayError.code.trim()
-        : fallbackCode;
+      const code =
+        typeof displayError?.code === 'string' && displayError.code.trim() ? displayError.code.trim() : fallbackCode;
       const detail = typeof displayError?.detail === 'string' ? displayError.detail.trim() : '';
       const title = typeof displayError?.title === 'string' ? displayError.title.trim() : '';
       // Save responses are rendered by multiple clients. Only expose
       // translation codes; arbitrary validator text belongs in server logs.
-      const message = detail.startsWith('@')
-        ? detail
-        : title.startsWith('@')
-          ? title
-          : `@record-save-${code}`;
+      const message = detail.startsWith('@') ? detail : title.startsWith('@') ? title : `@record-save-${code}`;
       return recordSaveProblem(
         RBValidationError.isRBValidationError(error) ? RBValidationError.classify(error) : fallbackKind,
         phase,
         message,
         code,
-        issue,
+        issue
       );
     }
 
@@ -247,8 +308,12 @@ export namespace Services {
       tracker: RecordSaveResponse,
       user: AnyRecord,
       action: RecordAuditActionType,
-      searchable: boolean,
+      searchable: boolean
     ): Promise<RecordSaveResponse> {
+      const operation = this.saveHookOperations.get(tracker);
+      if (operation) {
+        this.completeHookOperation(operation);
+      }
       const oid = String(tracker.oid ?? '').trim();
       if (!tracker.wasPersisted() || !oid) {
         return tracker;
@@ -270,7 +335,15 @@ export namespace Services {
           });
       }
       void Promise.resolve()
-        .then(() => this.auditRecord(oid, persistedRecord, user, action))
+        .then(() =>
+          this.auditRecord(
+            oid,
+            persistedRecord,
+            user,
+            action,
+            operation ? projectRecordHookExecutionAuditSummary(operation) : undefined
+          )
+        )
         .catch((error: unknown) => {
           sails.log.error(`${this.logHeader} persistence audit submission failed`, error);
         });
@@ -324,7 +397,11 @@ export namespace Services {
 
     private attachmentJournalService(): AttachmentJournalService | undefined {
       const service = sails.services?.attachmentmetadataservice as unknown as AttachmentJournalService | undefined;
-      if (!service || typeof service.prepareMutations !== 'function' || typeof service.findUnresolvedByOid !== 'function') {
+      if (
+        !service ||
+        typeof service.prepareMutations !== 'function' ||
+        typeof service.findUnresolvedByOid !== 'function'
+      ) {
         return undefined;
       }
       return service;
@@ -345,7 +422,7 @@ export namespace Services {
       record: AnyRecord,
       attachmentFields: readonly unknown[],
       generation: string,
-      unresolvedRows: readonly AnyRecord[] = [],
+      unresolvedRows: readonly AnyRecord[] = []
     ): AttachmentMutationPlanItem[] {
       const plan: AttachmentMutationPlanItem[] = [];
       const planned = new Set<string>();
@@ -355,11 +432,12 @@ export namespace Services {
         field: string,
         entry: AnyRecord,
         operation: RecordAttachmentOperation,
-        generationOverride?: string,
+        generationOverride?: string
       ): void => {
         const rawAttachmentId = String(entry.attachmentId ?? '').trim();
         const fileId = String(entry.fileId ?? '').trim();
-        const attachmentId = rawAttachmentId || (operation === 'delete' && fileId ? this.legacyAttachmentId(fileId) : '');
+        const attachmentId =
+          rawAttachmentId || (operation === 'delete' && fileId ? this.legacyAttachmentId(fileId) : '');
         if (!attachmentId || !fileId) {
           return;
         }
@@ -391,15 +469,22 @@ export namespace Services {
         const fileId = String(row.mutationFileId ?? row.fileId ?? '').trim();
         const operation = row.operation === 'delete' || row.operation === 'finalize' ? row.operation : 'add';
         const rowGeneration = String(row.generation ?? '').trim() || generation;
-        if (!attachmentId || !fileId || (row.mutationState !== 'prepared' && row.mutationState !== 'pending'
-          && row.mutationState !== 'incomplete' && row.mutationState !== 'unknown')) {
+        if (
+          !attachmentId ||
+          !fileId ||
+          (row.mutationState !== 'prepared' &&
+            row.mutationState !== 'pending' &&
+            row.mutationState !== 'incomplete' &&
+            row.mutationState !== 'unknown')
+        ) {
           continue;
         }
         const fieldName = String(row.attachmentField ?? '').trim();
         const currentEntry = fieldName
-          ? ((_.get(metadata, fieldName) as unknown[] | undefined) ?? []).find((entry: unknown) =>
-            !!entry && typeof entry === 'object' && String((entry as AnyRecord).attachmentId ?? '') === attachmentId
-          ) as AnyRecord | undefined
+          ? (((_.get(metadata, fieldName) as unknown[] | undefined) ?? []).find(
+              (entry: unknown) =>
+                !!entry && typeof entry === 'object' && String((entry as AnyRecord).attachmentId ?? '') === attachmentId
+            ) as AnyRecord | undefined)
           : undefined;
         addPlanItem(fieldName, { ...(currentEntry ?? {}), ...row, attachmentId, fileId }, operation, rowGeneration);
       }
@@ -409,22 +494,34 @@ export namespace Services {
         if (!fieldName) {
           continue;
         }
-        const originalEntries = (_.get(originalMetadata, fieldName) as unknown[] | undefined)
-          ?.filter((entry): entry is AnyRecord => !!entry && typeof entry === 'object') ?? [];
-        const currentEntries = (_.get(metadata, fieldName) as unknown[] | undefined)
-          ?.filter((entry): entry is AnyRecord => !!entry && typeof entry === 'object') ?? [];
-        const originalById = new Map(originalEntries
-          .filter(entry => String(entry.attachmentId ?? '').trim())
-          .map(entry => [String(entry.attachmentId).trim(), entry]));
-        const originalByFileId = new Map(originalEntries
-          .filter(entry => String(entry.fileId ?? '').trim())
-          .map(entry => [String(entry.fileId).trim(), entry]));
-        const currentById = new Map(currentEntries
-          .filter(entry => String(entry.attachmentId ?? '').trim())
-          .map(entry => [String(entry.attachmentId).trim(), entry]));
-        const currentByFileId = new Map(currentEntries
-          .filter(entry => String(entry.fileId ?? '').trim())
-          .map(entry => [String(entry.fileId).trim(), entry]));
+        const originalEntries =
+          (_.get(originalMetadata, fieldName) as unknown[] | undefined)?.filter(
+            (entry): entry is AnyRecord => !!entry && typeof entry === 'object'
+          ) ?? [];
+        const currentEntries =
+          (_.get(metadata, fieldName) as unknown[] | undefined)?.filter(
+            (entry): entry is AnyRecord => !!entry && typeof entry === 'object'
+          ) ?? [];
+        const originalById = new Map(
+          originalEntries
+            .filter(entry => String(entry.attachmentId ?? '').trim())
+            .map(entry => [String(entry.attachmentId).trim(), entry])
+        );
+        const originalByFileId = new Map(
+          originalEntries
+            .filter(entry => String(entry.fileId ?? '').trim())
+            .map(entry => [String(entry.fileId).trim(), entry])
+        );
+        const currentById = new Map(
+          currentEntries
+            .filter(entry => String(entry.attachmentId ?? '').trim())
+            .map(entry => [String(entry.attachmentId).trim(), entry])
+        );
+        const currentByFileId = new Map(
+          currentEntries
+            .filter(entry => String(entry.fileId ?? '').trim())
+            .map(entry => [String(entry.fileId).trim(), entry])
+        );
 
         for (const entry of currentEntries) {
           const attachmentId = String(entry.attachmentId ?? '');
@@ -453,29 +550,28 @@ export namespace Services {
       return plan;
     }
 
-    private async prepareAttachmentJournal(
-      oid: string,
-      plan: readonly AttachmentMutationPlanItem[],
-    ): Promise<void> {
+    private async prepareAttachmentJournal(oid: string, plan: readonly AttachmentMutationPlanItem[]): Promise<void> {
       const journal = this.attachmentJournalService();
       if (!journal || plan.length === 0) {
         return;
       }
-      await journal.prepareMutations(plan.map(item => ({
-        oid,
-        fileId: item.fileId,
-        storageKey: this.attachmentJournalStorageKey(oid, item.attachmentId, item.generation, item.fileId),
-        attachmentId: item.attachmentId,
-        operation: item.operation,
-        mutationState: 'prepared',
-        generation: item.generation,
-        attachmentField: item.field || undefined,
-      })));
+      await journal.prepareMutations(
+        plan.map(item => ({
+          oid,
+          fileId: item.fileId,
+          storageKey: this.attachmentJournalStorageKey(oid, item.attachmentId, item.generation, item.fileId),
+          attachmentId: item.attachmentId,
+          operation: item.operation,
+          mutationState: 'prepared',
+          generation: item.generation,
+          attachmentField: item.field || undefined,
+        }))
+      );
     }
 
     private async executeAttachmentPlan(
       oid: string,
-      plan: readonly AttachmentMutationPlanItem[],
+      plan: readonly AttachmentMutationPlanItem[]
     ): Promise<RecordAttachmentCompletionItem[]> {
       const journal = this.attachmentJournalService();
       const items: RecordAttachmentCompletionItem[] = [];
@@ -492,7 +588,10 @@ export namespace Services {
             );
           } catch (error) {
             journalStateKnown = false;
-            sails.log.error(`${this.logHeader} attachment journal pending update failed for ${item.attachmentId}`, error);
+            sails.log.error(
+              `${this.logHeader} attachment journal pending update failed for ${item.attachmentId}`,
+              error
+            );
           }
         }
         try {
@@ -513,7 +612,10 @@ export namespace Services {
               )) && journalStateKnown;
             } catch (error) {
               journalStateKnown = false;
-              sails.log.error(`${this.logHeader} attachment journal applied update failed for ${item.attachmentId}`, error);
+              sails.log.error(
+                `${this.logHeader} attachment journal applied update failed for ${item.attachmentId}`,
+                error
+              );
             }
           }
           items.push({
@@ -535,7 +637,10 @@ export namespace Services {
                 item.fileId,
               );
             } catch (journalError) {
-              sails.log.error(`${this.logHeader} attachment journal unknown update failed for ${item.attachmentId}`, journalError);
+              sails.log.error(
+                `${this.logHeader} attachment journal unknown update failed for ${item.attachmentId}`,
+                journalError
+              );
             }
           }
           sails.log.error(`${this.logHeader} attachment operation failed for ${item.attachmentId}`, error);
@@ -565,7 +670,10 @@ export namespace Services {
         try {
           await journal.markMutation(oid, item.attachmentId, item.generation, state, item.fileId);
         } catch (error) {
-          sails.log.error(`${this.logHeader} attachment journal ${state} update failed for ${item.attachmentId}`, error);
+          sails.log.error(
+            `${this.logHeader} attachment journal ${state} update failed for ${item.attachmentId}`,
+            error
+          );
         }
       }
     }
@@ -608,11 +716,9 @@ export namespace Services {
 
     private incompleteAttachmentItems(
       items: readonly RecordAttachmentCompletionItem[],
-      code: string,
+      code: string
     ): RecordAttachmentCompletionItem[] {
-      return items.map(item => item.status === 'unknown'
-        ? { ...item }
-        : { ...item, status: 'incomplete', code });
+      return items.map(item => (item.status === 'unknown' ? { ...item } : { ...item, status: 'incomplete', code }));
     }
 
     private clearPendingAttachmentOids(record: AnyRecord, attachmentFields: readonly unknown[]): void {
@@ -632,7 +738,7 @@ export namespace Services {
 
     private markPlannedAttachmentReferencesPending(
       record: AnyRecord,
-      plan: readonly AttachmentMutationPlanItem[],
+      plan: readonly AttachmentMutationPlanItem[]
     ): void {
       for (const item of plan) {
         if (item.operation === 'delete' || !item.field) {
@@ -642,9 +748,11 @@ export namespace Services {
         if (!Array.isArray(entries)) {
           continue;
         }
-        const entry = entries.find((candidate: unknown) =>
-          !!candidate && typeof candidate === 'object'
-          && String((candidate as AnyRecord).attachmentId ?? '') === item.attachmentId
+        const entry = entries.find(
+          (candidate: unknown) =>
+            !!candidate &&
+            typeof candidate === 'object' &&
+            String((candidate as AnyRecord).attachmentId ?? '') === item.attachmentId
         ) as AnyRecord | undefined;
         if (entry) {
           entry.pending = true;
@@ -657,7 +765,7 @@ export namespace Services {
       oid: string,
       record: AnyRecord,
       user: AnyRecord,
-      attachmentFields: readonly unknown[],
+      attachmentFields: readonly unknown[]
     ): Promise<boolean> {
       const finalizedRecord = _.cloneDeep(record) as AnyRecord;
       this.clearPendingAttachmentOids(finalizedRecord, attachmentFields);
@@ -670,31 +778,23 @@ export namespace Services {
     }
 
     private validateHookConfiguration(recordType: unknown, modes: readonly string[]): void {
-      for (const mode of modes) {
-        for (const phase of ['pre', 'postSync', 'post']) {
-          const configuredHooks = _.get(recordType, `hooks.${mode}.${phase}`, undefined) as unknown;
-          if (configuredHooks === undefined) {
-            continue;
-          }
-          if (!Array.isArray(configuredHooks)) {
-            throw new RBValidationError({
-              message: `Invalid ${phase} hook configuration for ${mode}.`,
-              displayErrors: [{ title: '@record-save-invalid-hook-configuration', code: 'invalid-hook-configuration' }],
-            });
-          }
-          const hooks = configuredHooks;
-          for (const hook of hooks) {
-            this.configuredHookFunction(hook, mode, phase);
-          }
+      try {
+        validateRecordHookConfiguration(recordType, modes, (hook, mode, phase) =>
+          this.configuredHookFunction(hook, mode, phase)
+        );
+      } catch (error) {
+        if (RBValidationError.isRBValidationError(error)) {
+          throw error;
         }
+        throw new RBValidationError({
+          message: 'Invalid record hook configuration.',
+          options: { cause: error },
+          displayErrors: [{ title: '@record-save-invalid-hook-configuration', code: 'invalid-hook-configuration' }],
+        });
       }
     }
 
-    private configuredHookFunction(
-      hook: unknown,
-      mode: string,
-      phase: string,
-    ): (...args: unknown[]) => unknown {
+    private configuredHookFunction(hook: unknown, mode: string, phase: string): (...args: unknown[]) => unknown {
       if (!hook || typeof hook !== 'object') {
         throw new RBValidationError({
           message: `Invalid ${phase} hook configuration for ${mode}.`,
@@ -867,6 +967,9 @@ export namespace Services {
           that.getServices(that);
         }
       );
+      this.registerSailsHook('on', 'lower', function () {
+        that.hookExecutionSupervisor?.interruptAll?.();
+      });
     }
 
     private getServices(ref: Records = this) {
@@ -986,7 +1089,7 @@ export namespace Services {
       recordMetadata: AnyRecord,
       attachmentFields: unknown[],
       oid: string,
-      clearPending = true,
+      clearPending = true
     ): void {
       const fieldsToCheck = ['location', 'uploadUrl'];
       _.each(attachmentFields, (attFieldName: unknown) => {
@@ -1021,7 +1124,7 @@ export namespace Services {
       triggerPreSaveTriggers = true,
       triggerPostSaveTriggers = true,
       targetStep = null,
-      context?: RecordSaveContext,
+      context?: RecordSaveContext
     ): Promise<RecordSaveResponse> {
       const tracker = new RecordSaveResponse(createRecordSaveContext({
         ...(context ?? {}),
@@ -1032,6 +1135,12 @@ export namespace Services {
       let recordObj = this.normalizeRecord(record);
       const userObj = user as AnyRecord;
       const recordTypeName = String(recordTypeObj?.name ?? _.get(recordObj, 'metaMetadata.type', '')).trim();
+      const hookOperation = this.createHookExecutionOperation(
+        'onCreate',
+        tracker.context.requestId,
+        String(recordObj.redboxOid ?? '').trim() || undefined
+      );
+      this.saveHookOperations.set(tracker, hookOperation);
 
       // Bootstrap-safe path when no configured RecordType/workflow exists.
       if (!recordTypeObj?.name) {
@@ -1069,7 +1178,12 @@ export namespace Services {
         const mutationState = resolveStorageMutationState(createResponse, this.logLegacyMutationResponse);
         if (mutationState === 'applied') {
           tracker.confirmPrimaryPersistence(createResponse.oid);
-          if (this.searchService && typeof this.searchService.index === 'function' && recordTypeObj.searchable !== false) {
+          hookOperation.completedThrough = 'persistence';
+          if (
+            this.searchService &&
+            typeof this.searchService.index === 'function' &&
+            recordTypeObj.searchable !== false
+          ) {
             void Promise.resolve(this.searchService.index(createResponse.oid, recordObj)).catch((error: unknown) => {
               sails.log.error(`${this.logHeader} index submission failed`, error);
             });
@@ -1127,7 +1241,8 @@ export namespace Services {
           recordObj,
           recordTypeObj,
           wfStep,
-          userObj
+          userObj,
+          hookOperation
         );
         this.setWorkflowStepRelatedMetadata(recordObj, wfStep);
       }
@@ -1136,7 +1251,14 @@ export namespace Services {
       // trigger the pre-save
       if (triggerPreSaveTriggers) {
         try {
-          recordObj = await this.triggerPreSaveTriggers(null, recordObj, recordTypeObj, 'onCreate', userObj);
+          recordObj = await this.triggerPreSaveTriggers(
+            null,
+            recordObj,
+            recordTypeObj,
+            'onCreate',
+            userObj,
+            hookOperation
+          );
         } catch (err) {
           sails.log.error(`${this.logHeader} Failed to run pre-save hooks when onCreate...`);
           sails.log.error(err);
@@ -1157,6 +1279,7 @@ export namespace Services {
 
       const createOid = String(recordObj.redboxOid ?? '').trim() || randomUUID();
       recordObj.redboxOid = createOid;
+      hookOperation.recordOid = createOid;
       const createGeneration = tracker.context.requestId;
       const createAttachmentPlan = this.attachmentMutationPlan(
         { metadata: {} },
@@ -1187,6 +1310,7 @@ export namespace Services {
       if (primaryMutationState === 'applied') {
         const persistedOid = String(createResponse.oid ?? '').trim() || createOid;
         tracker.confirmPrimaryPersistence(persistedOid, createResponse);
+        hookOperation.completedThrough = 'persistence';
         const oid = persistedOid;
         if (oid !== createOid) {
           try {
@@ -1201,7 +1325,12 @@ export namespace Services {
               'attachment-journal-failed',
             ));
             this.logSaveOutcome(tracker, 'attachments', error);
-            return await this.finishSave(tracker, userObj, RecordAuditActionType.created, recordTypeObj.searchable !== false);
+            return await this.finishSave(
+              tracker,
+              userObj,
+              RecordAuditActionType.created,
+              recordTypeObj.searchable !== false
+            );
           }
         }
         sails.log.verbose(`RecordsService - create - oid ${oid}`);
@@ -1222,21 +1351,37 @@ export namespace Services {
               recordTypeObj,
               'onCreate',
               userObj,
-              createResponse as unknown as AnyRecord
+              createResponse as unknown as AnyRecord,
+              hookOperation
             )) as unknown as StorageServiceResponse;
             tracker.mergeLegacyHookFields(hookResponse);
             if (this.hookResponseFailed(hookResponse)) {
               tracker.recordPostPersistenceProblem(this.saveProblem('post-save', 'processing', 'post-save-failed'));
               this.logSaveOutcome(tracker, 'post-save');
-              return await this.finishSave(tracker, userObj, RecordAuditActionType.created, recordTypeObj.searchable !== false);
+              return await this.finishSave(
+                tracker,
+                userObj,
+                RecordAuditActionType.created,
+                recordTypeObj.searchable !== false
+              );
             }
+            // The awaited post-sync phase succeeded; later work is detached.
+            hookOperation.completedThrough = 'postSync';
             if (this.hasPostSaveSyncHooks(recordTypeObj, 'onCreate')) {
               const hookMetadataResponse = await this.storageService.updateMeta(brandObj, oid, recordObj, userObj);
-              const hookMutationState = resolveStorageMutationState(hookMetadataResponse, this.logLegacyMutationResponse);
+              const hookMutationState = resolveStorageMutationState(
+                hookMetadataResponse,
+                this.logLegacyMutationResponse
+              );
               if (hookMutationState !== 'applied') {
                 tracker.recordPostPersistenceProblem(this.saveProblem('post-save', 'processing', 'post-save-metadata-failed'));
                 this.logSaveOutcome(tracker, 'post-save');
-                return await this.finishSave(tracker, userObj, RecordAuditActionType.created, recordTypeObj.searchable !== false);
+                return await this.finishSave(
+                  tracker,
+                  userObj,
+                  RecordAuditActionType.created,
+                  recordTypeObj.searchable !== false
+                );
               }
             }
           } catch (err) {
@@ -1246,10 +1391,16 @@ export namespace Services {
             sails.log.error(JSON.stringify(err));
             tracker.recordPostPersistenceProblem(this.saveProblem('post-save', 'processing', 'post-save-failed'));
             this.logSaveOutcome(tracker, 'post-save');
-            return await this.finishSave(tracker, userObj, RecordAuditActionType.created, recordTypeObj.searchable !== false);
+            return await this.finishSave(
+              tracker,
+              userObj,
+              RecordAuditActionType.created,
+              recordTypeObj.searchable !== false
+            );
           }
           // Fire Post-save hooks async ...
-          this.triggerPostSaveTriggers(oid, recordObj, recordTypeObj, 'onCreate', userObj);
+          this.triggerPostSaveTriggers(oid, recordObj, recordTypeObj, 'onCreate', userObj, hookOperation);
+          hookOperation.completedThrough = 'post-dispatch';
 
           if (!_.isEmpty(targetStep)) {
             try {
@@ -1259,22 +1410,41 @@ export namespace Services {
                 recordTypeObj,
                 wfStep,
                 userObj,
-                createResponse
+                createResponse,
+                hookOperation
               )) as unknown as StorageServiceResponse;
               if (!this.hookResponseFailed(transitionResponse)) {
                 if (this.hasPostSaveSyncHooks(recordTypeObj, 'onTransitionWorkflow')) {
-                  const transitionMetadataResponse = await this.storageService.updateMeta(brandObj, oid, recordObj, userObj);
-                  const transitionMutationState = resolveStorageMutationState(transitionMetadataResponse, this.logLegacyMutationResponse);
+                  const transitionMetadataResponse = await this.storageService.updateMeta(
+                    brandObj,
+                    oid,
+                    recordObj,
+                    userObj
+                  );
+                  const transitionMutationState = resolveStorageMutationState(
+                    transitionMetadataResponse,
+                    this.logLegacyMutationResponse
+                  );
                   if (transitionMutationState !== 'applied') {
                     tracker.recordPostPersistenceProblem(this.saveProblem('post-save', 'processing', 'transition-metadata-failed'));
                     this.logSaveOutcome(tracker, 'post-save');
-                    return await this.finishSave(tracker, userObj, RecordAuditActionType.created, recordTypeObj.searchable !== false);
+                    return await this.finishSave(
+                      tracker,
+                      userObj,
+                      RecordAuditActionType.created,
+                      recordTypeObj.searchable !== false
+                    );
                   }
                 }
               } else {
                 tracker.recordPostPersistenceProblem(this.saveProblem('post-save', 'processing', 'transition-failed'));
                 this.logSaveOutcome(tracker, 'post-save');
-                return await this.finishSave(tracker, userObj, RecordAuditActionType.created, recordTypeObj.searchable !== false);
+                return await this.finishSave(
+                  tracker,
+                  userObj,
+                  RecordAuditActionType.created,
+                  recordTypeObj.searchable !== false
+                );
               }
             } catch (tErr) {
               sails.log.error(
@@ -1283,11 +1453,15 @@ export namespace Services {
               sails.log.error(tErr);
               tracker.recordPostPersistenceProblem(this.saveProblem('post-save', 'processing', 'transition-failed'));
               this.logSaveOutcome(tracker, 'post-save');
-              return await this.finishSave(tracker, userObj, RecordAuditActionType.created, recordTypeObj.searchable !== false);
+              return await this.finishSave(
+                tracker,
+                userObj,
+                RecordAuditActionType.created,
+                recordTypeObj.searchable !== false
+              );
             }
           }
         }
-
       } else {
         sails.log.error(`${this.logHeader} Failed to create record, storage service response:`);
         sails.log.error(JSON.stringify(createResponse));
@@ -1299,12 +1473,7 @@ export namespace Services {
         }
         this.logSaveOutcome(tracker, 'persistence');
       }
-      return await this.finishSave(
-        tracker,
-        userObj,
-        RecordAuditActionType.created,
-        recordTypeObj.searchable !== false,
-      );
+      return await this.finishSave(tracker, userObj, RecordAuditActionType.created, recordTypeObj.searchable !== false);
     }
 
     async updateMeta(
@@ -1316,12 +1485,18 @@ export namespace Services {
       triggerPostSaveTriggers: boolean = true,
       nextStep: unknown = {},
       metadata?: AnyRecord,
-      context?: RecordSaveContext,
+      context?: RecordSaveContext
     ): Promise<RecordSaveResponse> {
       const tracker = new RecordSaveResponse(createRecordSaveContext({
         ...(context ?? {}),
         operation: context?.operation ?? (_.isEmpty(nextStep) ? 'update' : 'transition'),
       }));
+      const hookOperation = this.createHookExecutionOperation(
+        _.isEmpty(nextStep) ? 'onUpdate' : 'onTransitionWorkflow',
+        tracker.context.requestId,
+        oid
+      );
+      this.saveHookOperations.set(tracker, hookOperation);
       const brandObj = brand as BrandingModel;
       let recordObj = this.normalizeRecord(record);
       const recordMeta = recordObj.metaMetadata as AnyRecord;
@@ -1385,7 +1560,8 @@ export namespace Services {
               recordObj,
               recordType,
               nextStepObj,
-              userObj
+              userObj,
+              hookOperation
             );
             this.transitionWorkflowStepMetadata(recordObj, nextStepObj);
           } catch (err) {
@@ -1398,15 +1574,17 @@ export namespace Services {
         }
       }
 
-      const brandId = recordMeta.brandId ?? brandObj?.id ? String(recordMeta.brandId ?? brandObj?.id) : undefined;
-      const form: FormAttributes | null = await firstValueFrom(FormsService.getFormByName(String(recordMeta.form ?? ''), true, brandId));
-      recordMeta.attachmentFields = form != undefined ? form.configuration?.attachmentFields ?? [] : [];
+      const brandId = (recordMeta.brandId ?? brandObj?.id) ? String(recordMeta.brandId ?? brandObj?.id) : undefined;
+      const form: FormAttributes | null = await firstValueFrom(
+        FormsService.getFormByName(String(recordMeta.form ?? ''), true, brandId)
+      );
+      recordMeta.attachmentFields = form != undefined ? (form.configuration?.attachmentFields ?? []) : [];
 
       // process pre-save
       if (!_.isEmpty(brand) && triggerPreSaveTriggers === true) {
         try {
           sails.log.verbose('RecordService - updateMeta - calling triggerPreSaveTriggers');
-          recordObj = await this.triggerPreSaveTriggers(oid, recordObj, recordType, 'onUpdate', userObj);
+          recordObj = await this.triggerPreSaveTriggers(oid, recordObj, recordType, 'onUpdate', userObj, hookOperation);
         } catch (err) {
           sails.log.error(`${this.logHeader} Failed to run pre-save hooks when onUpdate...`);
           sails.log.error(err);
@@ -1432,7 +1610,8 @@ export namespace Services {
       const updateGeneration = tracker.context.requestId;
       let unresolvedAttachmentRows: Array<Record<string, unknown>> = [];
       try {
-        unresolvedAttachmentRows = (await this.attachmentJournalService()?.findUnresolvedByOid(oid) ?? []) as unknown as Array<Record<string, unknown>>;
+        unresolvedAttachmentRows = ((await this.attachmentJournalService()?.findUnresolvedByOid(oid)) ??
+          []) as unknown as Array<Record<string, unknown>>;
       } catch (error) {
         tracker.recordPrimaryNotApplied(this.saveProblem('pre-save', 'processing', 'attachment-journal-failed'));
         this.logSaveOutcome(tracker, 'pre-save', error);
@@ -1443,7 +1622,7 @@ export namespace Services {
         recordObj,
         attachmentFields,
         updateGeneration,
-        unresolvedAttachmentRows,
+        unresolvedAttachmentRows
       );
       this.markPlannedAttachmentReferencesPending(recordObj, updateAttachmentPlan);
       try {
@@ -1486,6 +1665,7 @@ export namespace Services {
         return tracker;
       }
       tracker.confirmPrimaryPersistence(oid, updateResponse);
+      hookOperation.completedThrough = 'persistence';
 
       if (!(await this.finalizeAttachmentPlan(tracker, brandObj, oid, recordObj, userObj, attachmentFields, updateAttachmentPlan))) {
         return await this.finishSave(tracker, userObj, RecordAuditActionType.updated, recordType?.searchable !== false);
@@ -1503,7 +1683,12 @@ export namespace Services {
               'post-save-failed',
             ));
             this.logSaveOutcome(tracker, 'post-save', error);
-            return await this.finishSave(tracker, userObj, RecordAuditActionType.updated, recordType?.searchable !== false);
+            return await this.finishSave(
+              tracker,
+              userObj,
+              RecordAuditActionType.updated,
+              recordType?.searchable !== false
+            );
           }
         }
         // post-save async
@@ -1517,21 +1702,37 @@ export namespace Services {
               recordType,
               'onUpdate',
               userObj,
-              updateResponse as unknown as AnyRecord
+              updateResponse as unknown as AnyRecord,
+              hookOperation
             )) as unknown as StorageServiceResponse;
             tracker.mergeLegacyHookFields(hookResponse);
             if (this.hookResponseFailed(hookResponse)) {
               tracker.recordPostPersistenceProblem(this.saveProblem('post-save', 'processing', 'post-save-failed'));
               this.logSaveOutcome(tracker, 'post-save');
-              return await this.finishSave(tracker, userObj, RecordAuditActionType.updated, recordType?.searchable !== false);
+              return await this.finishSave(
+                tracker,
+                userObj,
+                RecordAuditActionType.updated,
+                recordType?.searchable !== false
+              );
             }
+            // The awaited post-sync phase succeeded; later work is detached.
+            hookOperation.completedThrough = 'postSync';
             if (this.hasPostSaveSyncHooks(recordType, 'onUpdate')) {
               const hookMetadataResponse = await this.storageService.updateMeta(brandObj, oid, recordObj, userObj);
-              const hookMutationState = resolveStorageMutationState(hookMetadataResponse, this.logLegacyMutationResponse);
+              const hookMutationState = resolveStorageMutationState(
+                hookMetadataResponse,
+                this.logLegacyMutationResponse
+              );
               if (hookMutationState !== 'applied') {
                 tracker.recordPostPersistenceProblem(this.saveProblem('post-save', 'processing', 'post-save-metadata-failed'));
                 this.logSaveOutcome(tracker, 'post-save');
-                return await this.finishSave(tracker, userObj, RecordAuditActionType.updated, recordType?.searchable !== false);
+                return await this.finishSave(
+                  tracker,
+                  userObj,
+                  RecordAuditActionType.updated,
+                  recordType?.searchable !== false
+                );
               }
             }
           } catch (err) {
@@ -1539,11 +1740,24 @@ export namespace Services {
             sails.log.error(JSON.stringify(err));
             tracker.recordPostPersistenceProblem(this.saveProblem('post-save', 'processing', 'post-save-failed'));
             this.logSaveOutcome(tracker, 'post-save');
-            return await this.finishSave(tracker, userObj, RecordAuditActionType.updated, recordType?.searchable !== false);
+            return await this.finishSave(
+              tracker,
+              userObj,
+              RecordAuditActionType.updated,
+              recordType?.searchable !== false
+            );
           }
           sails.log.verbose('RecordService - updateMeta - calling triggerPostSaveTriggers');
           // Fire Post-save hooks async ...
-          this.triggerPostSaveTriggers(updateResponse['oid'], recordObj, recordType, 'onUpdate', userObj);
+          this.triggerPostSaveTriggers(
+            updateResponse['oid'],
+            recordObj,
+            recordType,
+            'onUpdate',
+            userObj,
+            hookOperation
+          );
+          hookOperation.completedThrough = 'post-dispatch';
 
           if (hasPermissionToTransition && !_.isEmpty(nextStepObj)) {
             try {
@@ -1553,7 +1767,8 @@ export namespace Services {
                 recordType,
                 nextStepObj,
                 userObj,
-                updateResponse
+                updateResponse,
+                hookOperation
               )) as unknown as StorageServiceResponse;
 
               sails.log.verbose(
@@ -1563,12 +1778,25 @@ export namespace Services {
               if (!this.hookResponseFailed(transitionResponse)) {
                 sails.log.verbose(`RecordService - updateMeta - triggerPostSaveTransitionWorkflowTriggers ajaxOk`);
                 if (this.hasPostSaveSyncHooks(recordType, 'onTransitionWorkflow')) {
-                  const transitionMetadataResponse = await this.storageService.updateMeta(brandObj, oid, recordObj, userObj);
-                  const transitionMutationState = resolveStorageMutationState(transitionMetadataResponse, this.logLegacyMutationResponse);
+                  const transitionMetadataResponse = await this.storageService.updateMeta(
+                    brandObj,
+                    oid,
+                    recordObj,
+                    userObj
+                  );
+                  const transitionMutationState = resolveStorageMutationState(
+                    transitionMetadataResponse,
+                    this.logLegacyMutationResponse
+                  );
                   if (transitionMutationState !== 'applied') {
                     tracker.recordPostPersistenceProblem(this.saveProblem('post-save', 'processing', 'transition-metadata-failed'));
                     this.logSaveOutcome(tracker, 'post-save');
-                    return await this.finishSave(tracker, userObj, RecordAuditActionType.updated, recordType?.searchable !== false);
+                    return await this.finishSave(
+                      tracker,
+                      userObj,
+                      RecordAuditActionType.updated,
+                      recordType?.searchable !== false
+                    );
                   }
                 }
               } else {
@@ -1577,7 +1805,12 @@ export namespace Services {
                 );
                 tracker.recordPostPersistenceProblem(this.saveProblem('post-save', 'processing', 'transition-failed'));
                 this.logSaveOutcome(tracker, 'post-save');
-                return await this.finishSave(tracker, userObj, RecordAuditActionType.updated, recordType?.searchable !== false);
+                return await this.finishSave(
+                  tracker,
+                  userObj,
+                  RecordAuditActionType.updated,
+                  recordType?.searchable !== false
+                );
               }
             } catch (tErr) {
               sails.log.error(
@@ -1586,7 +1819,12 @@ export namespace Services {
               sails.log.error(tErr);
               tracker.recordPostPersistenceProblem(this.saveProblem('post-save', 'processing', 'transition-failed'));
               this.logSaveOutcome(tracker, 'post-save');
-              return await this.finishSave(tracker, userObj, RecordAuditActionType.updated, recordType?.searchable !== false);
+              return await this.finishSave(
+                tracker,
+                userObj,
+                RecordAuditActionType.updated,
+                recordType?.searchable !== false
+              );
             }
           }
         }
@@ -1654,8 +1892,12 @@ export namespace Services {
       const workflowStateFilter = _.isString(params.workflowState) ? params.workflowState.trim().toLowerCase() : '';
 
       return audit.filter(auditRow => {
-        const action = String(auditRow['action'] ?? '').trim().toLowerCase();
-        const workflowStageLabel = String(_.get(auditRow, 'record.workflow.stageLabel', '')).trim().toLowerCase();
+        const action = String(auditRow['action'] ?? '')
+          .trim()
+          .toLowerCase();
+        const workflowStageLabel = String(_.get(auditRow, 'record.workflow.stageLabel', ''))
+          .trim()
+          .toLowerCase();
         const actionMatches = _.isEmpty(actionFilter) || action === actionFilter;
         const workflowMatches = _.isEmpty(workflowStateFilter) || workflowStageLabel.includes(workflowStateFilter);
         return actionMatches && workflowMatches;
@@ -1668,7 +1910,7 @@ export namespace Services {
         throw new Error(`Record not found: ${oid}`);
       }
 
-      const authorization = (((record as unknown) as RecordWithMeta).authorization ?? {}) as AnyRecord;
+      const authorization = ((record as unknown as RecordWithMeta).authorization ?? {}) as AnyRecord;
       const resolveUsers = async (value: unknown) => {
         const usernames = Array.isArray(value) ? value : [];
         const resolvedUsers = [];
@@ -1685,7 +1927,9 @@ export namespace Services {
               email: String(_.get(user, 'email', '')),
             });
           } catch (error) {
-            sails.log.warn(`RecordsService.getResolvedPermissionsSummary could not resolve user '${username}' for record '${oid}'.`);
+            sails.log.warn(
+              `RecordsService.getResolvedPermissionsSummary could not resolve user '${username}' for record '${oid}'.`
+            );
             sails.log.warn(error);
             resolvedUsers.push({
               username,
@@ -1715,7 +1959,11 @@ export namespace Services {
       this.storageService.provideUserAccessAndRemovePendingAccess(oid, userid, pendingValue);
     }
 
-    getRelatedRecords(oid: string, brand: unknown, options: RecordRelationshipExpandOptions = {}): Promise<RecordRelationshipGraph> {
+    getRelatedRecords(
+      oid: string,
+      brand: unknown,
+      options: RecordRelationshipExpandOptions = {}
+    ): Promise<RecordRelationshipGraph> {
       return this.storageService.getRelatedRecords(oid, brand, options);
     }
 
@@ -1740,20 +1988,31 @@ export namespace Services {
         packageType: String(_.get(recordType, 'packageType', '')),
         searchFilters: (_.get(recordType, 'searchFilters', []) ?? []) as unknown[],
         searchable: Boolean(_.get(recordType, 'searchable', true)),
-        relatedTo: normalizeRecordRelations(String(_.get(recordType, 'name', recordTypeName)), _.get(recordType, 'relatedTo', [])),
+        relatedTo: normalizeRecordRelations(
+          String(_.get(recordType, 'name', recordTypeName)),
+          _.get(recordType, 'relatedTo', [])
+        ),
       };
     }
 
     async delete(oid: string, permanentlyDelete: boolean, currentRec: unknown, recordType: unknown, user: AnyRecord) {
       let currentRecObj = currentRec as AnyRecord;
       const recordTypeObj = recordType as RecordTypeLike;
+      const hookOperation = this.createHookExecutionOperation('onDelete', undefined, oid);
       const preTriggerResponse = new StorageServiceResponse();
       const failedMessage = 'Failed to delete record, please check server logs.';
       try {
         this.validateHookConfiguration(recordTypeObj, ['onDelete']);
         sails.log.verbose('RecordsService - delete - triggerPreSaveTriggers onDelete');
         preTriggerResponse.oid = oid;
-        currentRecObj = await this.triggerPreSaveTriggers(oid, currentRecObj, recordTypeObj, 'onDelete', user);
+        currentRecObj = await this.triggerPreSaveTriggers(
+          oid,
+          currentRecObj,
+          recordTypeObj,
+          'onDelete',
+          user,
+          hookOperation
+        );
       } catch (err) {
         sails.log.verbose('RecordsService - delete - triggerPreSaveTriggers onDelete error');
         sails.log.error(JSON.stringify(err));
@@ -1771,7 +2030,13 @@ export namespace Services {
         const action: RecordAuditActionType = permanentlyDelete
           ? RecordAuditActionType.destroyed
           : RecordAuditActionType.deleted;
-        await this.auditRecord(oid, {}, user, action);
+        await this.auditRecord(
+          oid,
+          {},
+          user,
+          action,
+          projectRecordHookExecutionAuditSummary(hookOperation, { partial: true, completedThrough: 'persistence' })
+        );
         this.searchService.remove(oid);
 
         try {
@@ -1782,7 +2047,8 @@ export namespace Services {
             recordTypeObj,
             'onDelete',
             user,
-            response as unknown as AnyRecord
+            response as unknown as AnyRecord,
+            hookOperation
           )) as unknown as StorageServiceResponse;
         } catch (err) {
           sails.log.error(`RecordsService - delete - Exception while running post delate sync hooks when updating:`);
@@ -1800,7 +2066,8 @@ export namespace Services {
         }
         sails.log.verbose('RecordService - delete - calling triggerPostSaveTriggers');
 
-        this.triggerPostSaveTriggers(oid, currentRecObj, recordTypeObj, 'onDelete', user);
+        this.triggerPostSaveTriggers(oid, currentRecObj, recordTypeObj, 'onDelete', user, hookOperation);
+        this.completeHookOperation(hookOperation, true);
       }
       return response;
     }
@@ -1871,13 +2138,14 @@ export namespace Services {
       _.each(datastreams, (datastream: unknown) => {
         const datastreamObj = datastream as AnyRecord;
         let attachment: Record<string, unknown> = {};
-        const rawDateUpdated = datastreamObj['uploadDate'] ?? datastreamObj['lastModified'] ?? _.get(datastreamObj.metadata, 'dateUpdated');
+        const rawDateUpdated =
+          datastreamObj['uploadDate'] ?? datastreamObj['lastModified'] ?? _.get(datastreamObj.metadata, 'dateUpdated');
         const normalizedDateUpdated = rawDateUpdated
-          ? DateTime.fromJSDate(new Date(rawDateUpdated as string | number | Date)).toUTC().toISO()
+          ? DateTime.fromJSDate(new Date(rawDateUpdated as string | number | Date))
+              .toUTC()
+              .toISO()
           : null;
-        attachment['dateUpdated'] = rawDateUpdated
-          ? normalizedDateUpdated
-          : null;
+        attachment['dateUpdated'] = rawDateUpdated ? normalizedDateUpdated : null;
         attachment['label'] = _.get(datastreamObj.metadata, 'name');
         attachment['contentType'] = _.get(datastreamObj.metadata, 'mimeType');
         attachment = _.merge(attachment, datastreamObj.metadata);
@@ -1921,7 +2189,8 @@ export namespace Services {
       id: string,
       record: AnyRecord,
       user: AnyRecord,
-      action: RecordAuditActionType = RecordAuditActionType.updated
+      action: RecordAuditActionType = RecordAuditActionType.updated,
+      executionSummary?: RecordHookExecutionAuditSummary
     ) {
       const auditingEnabled = sails.config.record.auditing.enabled as unknown;
       if (auditingEnabled !== true && auditingEnabled !== 'true') {
@@ -1932,7 +2201,7 @@ export namespace Services {
       _.unset(user, 'password');
       _.unset(user, 'token');
       // storage_id is used as the main ID in searches
-      const data = new RecordAuditModel(id, record, user, action);
+      const data = new RecordAuditModel(id, record, user, action, executionSummary);
       sails.log.verbose(JSON.stringify(data));
       const envName = String((sails.config as AnyRecord).environment ?? process.env.NODE_ENV ?? '');
       if (envName === 'integrationtest') {
@@ -2359,7 +2628,12 @@ export namespace Services {
           }
         }
       }
-      await this.auditRecord(oid, recordStorageServiceResponse as unknown as AnyRecord, user, RecordAuditActionType.restored);
+      await this.auditRecord(
+        oid,
+        recordStorageServiceResponse as unknown as AnyRecord,
+        user,
+        RecordAuditActionType.restored
+      );
       return recordStorageServiceResponse as unknown as StorageServiceResponse;
     }
 
@@ -2475,10 +2749,11 @@ export namespace Services {
       record: AnyRecord,
       recordType: unknown,
       nextStep: unknown,
-      user: unknown = {}
+      user: unknown = {},
+      operation?: ActionExecutionOperation
     ) {
       if (!_.isEmpty(nextStep)) {
-        record = await this.triggerPreSaveTriggers(oid, record, recordType, 'onTransitionWorkflow', user);
+        record = await this.triggerPreSaveTriggers(oid, record, recordType, 'onTransitionWorkflow', user, operation);
       }
       return record;
     }
@@ -2489,7 +2764,8 @@ export namespace Services {
       recordType: unknown,
       nextStep: unknown,
       user: unknown = {},
-      response: unknown = {}
+      response: unknown = {},
+      operation?: ActionExecutionOperation
     ) {
       let responseObj = response as AnyRecord;
       try {
@@ -2500,7 +2776,8 @@ export namespace Services {
             recordType,
             'onTransitionWorkflow',
             user,
-            responseObj
+            responseObj,
+            operation
           )) as AnyRecord;
         }
       } catch (err) {
@@ -2521,7 +2798,7 @@ export namespace Services {
       }
 
       if (!_.isEmpty(nextStep)) {
-        this.triggerPostSaveTriggers(oid, record, recordType, 'onTransitionWorkflow', user);
+        this.triggerPostSaveTriggers(oid, record, recordType, 'onTransitionWorkflow', user, operation);
       }
       return responseObj;
     }
@@ -2531,49 +2808,37 @@ export namespace Services {
       record: AnyRecord,
       recordType: unknown,
       mode: string = 'onUpdate',
-      user: unknown = {}
+      user: unknown = {},
+      operation?: ActionExecutionOperation
     ) {
-      sails.log.verbose('Triggering pre save triggers for record type: ');
-      sails.log.verbose(`hooks.${mode}.pre`);
-      sails.log.verbose(JSON.stringify(recordType));
-
-      const preSaveUpdateHooks = _.get(recordType, `hooks.${mode}.pre`, null) as AnyRecord[] | null;
-      sails.log.debug(preSaveUpdateHooks);
-
-      if (Array.isArray(preSaveUpdateHooks)) {
-        for (let i = 0; i < preSaveUpdateHooks.length; i++) {
-          const preSaveUpdateHook = preSaveUpdateHooks[i];
-          const preSaveUpdateHookFunctionString = _.get(preSaveUpdateHook, 'function', null);
-          if (typeof preSaveUpdateHookFunctionString === 'string' && preSaveUpdateHookFunctionString.trim()) {
-            try {
-              const preSaveUpdateHookFunction = this.configuredHookFunction(preSaveUpdateHook, mode, 'pre');
-              const options = _.get(preSaveUpdateHook, 'options', {}) as AnyRecord;
-              sails.log.verbose(`Triggering pre save triggers: ${preSaveUpdateHookFunctionString}`);
-              const hookResponse = preSaveUpdateHookFunction(oid, record, options, user);
-              record = (await this.resolveHookResponse(hookResponse)) as AnyRecord;
-              sails.log.debug(`${preSaveUpdateHookFunctionString} response now is:`);
-              sails.log.verbose(JSON.stringify(record));
-              sails.log.debug(`pre-save sync trigger ${preSaveUpdateHookFunctionString} completed for ${oid}`);
-            } catch (err) {
-              sails.log.error(
-                `pre-save trigger ${preSaveUpdateHookFunctionString} failed to complete for oid ${oid} mode ${mode} user ${user}`
-              );
-              sails.log.error(err);
-              throw new RBValidationError({
-                message: `pre-save trigger ${preSaveUpdateHookFunctionString} failed to complete for oid ${oid} mode ${mode} user ${user}`,
-                options: { cause: err },
-                displayErrors: [{ title: '@record-save-pre-save-processing-failed', meta: { oid } }],
-              });
-            }
-          } else {
-            throw new RBValidationError({
-              message: `Invalid pre-save trigger configuration for ${mode}.`,
-              displayErrors: [{ title: '@record-save-invalid-hook-configuration', code: 'invalid-hook-configuration' }],
-            });
-          }
+      // A standalone call owns its operation summary; a call that is part of a
+      // save lets the save emit one summary for every phase.
+      const execution =
+        operation ??
+        this.createHookExecutionOperation(mode as ActionExecutionOperation['mode'], undefined, oid ?? undefined);
+      try {
+        const outcome = await this.hookCoordinator(execution).runPre(oid, record, recordType, mode, user);
+        if (operation === undefined) {
+          this.completeHookOperation(execution);
         }
+        if (outcome.terminalCause !== undefined) {
+          throw new RBValidationError({
+            message: `pre-save trigger failed to complete for oid ${oid} mode ${mode}`,
+            options: { cause: outcome.terminalCause },
+            displayErrors: [{ title: '@record-save-pre-save-processing-failed', meta: { oid } }],
+          });
+        }
+        return outcome.record;
+      } catch (error) {
+        if (RBValidationError.isRBValidationError(error)) {
+          throw error;
+        }
+        throw new RBValidationError({
+          message: `pre-save trigger failed to complete for oid ${oid} mode ${mode}`,
+          options: { cause: error },
+          displayErrors: [{ title: '@record-save-pre-save-processing-failed', meta: { oid } }],
+        });
       }
-      return record;
     }
 
     public async triggerPostSaveSyncTriggers(
@@ -2582,80 +2847,42 @@ export namespace Services {
       recordType: unknown,
       mode: string = 'onUpdate',
       user: unknown = {},
-      response: AnyRecord = {}
+      response: AnyRecord = {},
+      operation?: ActionExecutionOperation
     ): Promise<AnyRecord> {
-      sails.log.debug('Triggering post save sync triggers ');
-      sails.log.debug(`hooks.${mode}.postSync`);
-      sails.log.debug(recordType);
-      const postSaveSyncHooks = _.get(recordType, `hooks.${mode}.postSync`, null) as AnyRecord[] | null;
-      if (Array.isArray(postSaveSyncHooks)) {
-        for (let i = 0; i < postSaveSyncHooks.length; i++) {
-          const postSaveSyncHook = postSaveSyncHooks[i];
-          sails.log.debug(postSaveSyncHooks);
-          const postSaveSyncHooksFunctionString = _.get(postSaveSyncHook, 'function', null);
-          if (typeof postSaveSyncHooksFunctionString === 'string' && postSaveSyncHooksFunctionString.trim()) {
-            const postSaveSyncHookFunction = this.configuredHookFunction(postSaveSyncHook, mode, 'postSync');
-            const options = _.get(postSaveSyncHook, 'options', {}) as AnyRecord;
-            if (_.isFunction(postSaveSyncHookFunction)) {
-              try {
-                sails.log.debug(`Triggering post-save sync trigger: ${postSaveSyncHooksFunctionString}`);
-                const hookInput = _.cloneDeep(response);
-                const hookResponse = postSaveSyncHookFunction(oid, record, options, user, hookInput);
-                const returnType = options.returnType == undefined ? 'record' : options.returnType;
-                const resolvedHookResponse = await this.resolveHookResponse(hookResponse);
-                // Hooks may transform the record or report a legacy response,
-                // but they cannot replace the tracked OID/outcome/completion.
-                if (returnType === 'record') {
-                  if (!resolvedHookResponse || typeof resolvedHookResponse !== 'object') {
-                    throw new Error('Post-save record hook did not return a record');
-                  }
-                  record = resolvedHookResponse as AnyRecord;
-                } else if (resolvedHookResponse && typeof resolvedHookResponse === 'object') {
-                  const returned = resolvedHookResponse as AnyRecord;
-                  response = {
-                    ...response,
-                    ...(typeof returned.success === 'boolean' ? { success: returned.success } : {}),
-                    ...(typeof returned.message === 'string' ? { message: returned.message } : {}),
-                    ...(Object.hasOwn(returned, 'data') ? { data: returned.data } : {}),
-                    ...(Object.hasOwn(returned, 'metadata') ? { metadata: returned.metadata } : {}),
-                  };
-                }
-                response = {
-                  ...response,
-                  ...(typeof hookInput.workspaceOid === 'string' && hookInput.workspaceOid.trim()
-                    ? { workspaceOid: hookInput.workspaceOid }
-                    : {}),
-                  ...(Object.hasOwn(hookInput, 'workspaceData') ? { workspaceData: hookInput.workspaceData } : {}),
-                };
-                sails.log.debug(`${postSaveSyncHooksFunctionString} response now is:`);
-                sails.log.verbose(JSON.stringify(response));
-                sails.log.debug(`post-save sync trigger ${postSaveSyncHooksFunctionString} completed for ${oid}`);
-              } catch (err) {
-                sails.log.error(
-                  `post-save async trigger ${postSaveSyncHooksFunctionString} failed to complete for oid ${oid} mode ${mode} user ${user}`
-                );
-                sails.log.error(err);
-                throw new RBValidationError({
-                  message: `post-save async trigger ${postSaveSyncHooksFunctionString} failed to complete for oid ${oid} mode ${mode} user ${user}`,
-                  options: { cause: err },
-                  displayErrors: [{ title: '@record-save-post-save-failed', meta: { oid } }],
-                });
-              }
-            } else {
-              throw new RBValidationError({
-                message: `Configured post-save sync hook for ${mode} is not callable.`,
-                displayErrors: [{ title: '@record-save-invalid-hook-configuration', code: 'invalid-hook-configuration' }],
-              });
-            }
-          } else {
-            throw new RBValidationError({
-              message: `Invalid post-save sync trigger configuration for ${mode}.`,
-              displayErrors: [{ title: '@record-save-invalid-hook-configuration', code: 'invalid-hook-configuration' }],
-            });
-          }
+      const execution =
+        operation ??
+        this.createHookExecutionOperation(mode as ActionExecutionOperation['mode'], undefined, oid ?? undefined);
+      try {
+        const outcome = await this.hookCoordinator(execution).runPostSync(
+          oid,
+          record,
+          recordType,
+          mode,
+          user,
+          response
+        );
+        if (operation === undefined) {
+          this.completeHookOperation(execution);
         }
+        if (outcome.terminalCause !== undefined) {
+          throw new RBValidationError({
+            message: `post-save trigger failed to complete for oid ${oid} mode ${mode}`,
+            options: { cause: outcome.terminalCause },
+            displayErrors: [{ title: '@record-save-post-save-failed', meta: { oid } }],
+          });
+        }
+        return outcome.response;
+      } catch (error) {
+        if (RBValidationError.isRBValidationError(error)) {
+          throw error;
+        }
+        throw new RBValidationError({
+          message: `post-save trigger failed to complete for oid ${oid} mode ${mode}`,
+          options: { cause: error },
+          displayErrors: [{ title: '@record-save-post-save-failed', meta: { oid } }],
+        });
       }
-      return response;
     }
 
     public triggerPostSaveTriggers(
@@ -2663,60 +2890,20 @@ export namespace Services {
       record: AnyRecord,
       recordType: unknown,
       mode: string = 'onUpdate',
-      user: unknown = {}
+      user: unknown = {},
+      operation?: ActionExecutionOperation
     ): void {
-      sails.log.debug('Triggering post save triggers ');
-      sails.log.debug(`hooks.${mode}.post`);
-      sails.log.debug(recordType);
-      const postSaveCreateHooks = _.get(recordType, `hooks.${mode}.post`, null) as AnyRecord[] | null;
-      if (Array.isArray(postSaveCreateHooks)) {
-        _.each(postSaveCreateHooks, (postSaveCreateHook: unknown) => {
-          sails.log.debug(postSaveCreateHook);
-          const postSaveCreateHookFunctionString = _.get(postSaveCreateHook, 'function', null) as unknown;
-          if (typeof postSaveCreateHookFunctionString === 'string' && postSaveCreateHookFunctionString.trim()) {
-            let postSaveCreateHookFunction: (...args: unknown[]) => unknown;
-            try {
-              postSaveCreateHookFunction = this.configuredHookFunction(postSaveCreateHook, mode, 'post');
-            } catch (error) {
-              sails.log.error(`Invalid post-save trigger configuration for ${mode}; skipping fire-and-forget hook`, error);
-              return;
-            }
-            const options = _.get(postSaveCreateHook, 'options', {}) as AnyRecord;
-            if (_.isFunction(postSaveCreateHookFunction)) {
-              //add try/catch just as an extra safety measure in case the function called
-              //by the trigger is not correctly implemented (or old). In example: An old
-              //function that is not async and retruns and Observable.of instead of a promise
-              //and then throws an error. In this case the error is not caught by chained
-              //.then().catch() and propagates to the front end and this has to be prevented
-              try {
-                const hookResponse = postSaveCreateHookFunction(oid, record, options, user);
-                this.resolveHookResponse(hookResponse)
-                  .then((_result: unknown) => {
-                    sails.log.debug(`post-save trigger ${postSaveCreateHookFunctionString} completed for ${oid}`);
-                  })
-                  .catch((error: unknown) => {
-                    sails.log.error(`post-save trigger ${postSaveCreateHookFunctionString} failed to complete`);
-                    sails.log.error(error);
-                  });
-              } catch (err) {
-                sails.log.error(
-                  `post-save trigger external catch ${postSaveCreateHookFunctionString} failed to complete`
-                );
-                sails.log.error(err);
-              }
-            }
-          } else {
-            sails.log.error(`Invalid post-save trigger configuration for ${mode}; skipping fire-and-forget hook`);
-          }
-        });
+      const execution =
+        operation ??
+        this.createHookExecutionOperation(mode as ActionExecutionOperation['mode'], undefined, oid ?? undefined);
+      try {
+        this.hookCoordinator(execution).dispatchPost(oid, record, recordType, mode, user);
+        if (operation === undefined) {
+          this.completeHookOperation(execution);
+        }
+      } catch (error) {
+        sails.log.error(`Invalid post-save trigger configuration for ${mode}; skipping fire-and-forget hook`, error);
       }
-    }
-
-    private resolveHookResponse(hookResponse: unknown): Promise<unknown> {
-      if (isObservable(hookResponse)) {
-        return firstValueFrom(hookResponse);
-      }
-      return Promise.resolve(hookResponse);
     }
 
     public async exists(oid: string) {

--- a/packages/redbox-core/src/services/RecordsService.ts
+++ b/packages/redbox-core/src/services/RecordsService.ts
@@ -145,8 +145,6 @@ export namespace Services {
           error: (message, fields) => sails.log.error(`${this.logHeader}${message}`, fields),
         },
         supervisor: this.hookExecutionSupervisor,
-        schedule: (durationMs, task) => setTimeout(task, durationMs),
-        cancelSchedule: handle => clearTimeout(handle as ReturnType<typeof setTimeout>),
       };
     }
 
@@ -383,6 +381,7 @@ export namespace Services {
             sails.log.error(`${this.logHeader} index submission failed`, error);
           });
       }
+      let auditTimer: ReturnType<typeof setTimeout> | undefined;
       const submitAudit = (detachedFinalization: DetachedAuditFinalization = 'complete'): void => {
         if (operation?.detachedAuditFinalized) {
           return;
@@ -390,10 +389,9 @@ export namespace Services {
         if (operation) {
           operation.detachedAuditFinalized = true;
           operation.onDetachedComplete = undefined;
-          if (operation.detachedAuditTimer !== undefined) {
-            operation.cancelDetachedAuditTimer?.(operation.detachedAuditTimer);
-            operation.detachedAuditTimer = undefined;
-            operation.cancelDetachedAuditTimer = undefined;
+          if (auditTimer !== undefined) {
+            clearTimeout(auditTimer);
+            auditTimer = undefined;
           }
           this.completeHookOperation(operation, detachedFinalization === 'grace-expired', detachedFinalization);
         }
@@ -418,16 +416,10 @@ export namespace Services {
       };
       if (operation && (operation.detachedPending ?? 0) > 0) {
         operation.onDetachedComplete = () => submitAudit('complete');
-        const dependencies = this.hookExecutionDependencies();
-        const schedule =
-          dependencies.schedule ?? ((durationMs: number, task: () => void) => setTimeout(task, durationMs));
-        operation.cancelDetachedAuditTimer =
-          dependencies.cancelSchedule ?? (handle => clearTimeout(handle as ReturnType<typeof setTimeout>));
-        const timer = schedule(DETACHED_AUDIT_GRACE_MS, () => submitAudit('grace-expired'));
+        auditTimer = setTimeout(() => submitAudit('grace-expired'), DETACHED_AUDIT_GRACE_MS);
         if (operation.detachedAuditFinalized) {
-          operation.cancelDetachedAuditTimer(timer);
-        } else {
-          operation.detachedAuditTimer = timer;
+          clearTimeout(auditTimer);
+          auditTimer = undefined;
         }
         // A detached action may have completed during the awaited snapshot
         // reload. Do not leave a zero-pending operation waiting on a callback.
@@ -872,8 +864,7 @@ export namespace Services {
         validateRecordHookConfiguration(
           recordType,
           modes,
-          (hook, mode, phase) => this.configuredHookFunction(hook, mode, phase),
-          ['pre']
+          (hook, mode, phase) => this.configuredHookFunction(hook, mode, phase)
         );
       } catch (error) {
         if (RBValidationError.isRBValidationError(error)) {

--- a/packages/redbox-core/src/services/record-hooks/coordinator.ts
+++ b/packages/redbox-core/src/services/record-hooks/coordinator.ts
@@ -1,0 +1,364 @@
+import { Effect } from 'effect';
+import { cloneDeep, get } from 'lodash';
+import {
+  createPhaseContext,
+  dispatchDetachedActionPlan,
+  runSequentialActionPlan,
+} from '../../action-execution/executor';
+import { legacyHookToEffect } from '../../action-execution/legacy-result';
+import { resolveActionId, validateActionExecutionPolicy } from '../../action-execution/policy';
+import type {
+  ActionExecutionAction,
+  ActionExecutionContext,
+  ActionExecutionDependencies,
+  ActionExecutionMode,
+  ActionExecutionOperation,
+  ActionExecutionPhase,
+  ActionExecutionReport,
+} from '../../action-execution/types';
+import type { RecordHookDefinition } from '../../config/recordtype.config';
+
+type AnyRecord = Record<string, unknown>;
+
+/** Resolves a configured hook definition to the callable it names. */
+export type RecordHookResolver = (hook: unknown, mode: string, phase: string) => (...args: unknown[]) => unknown;
+
+const HOOK_PHASES: readonly ActionExecutionPhase[] = ['pre', 'postSync', 'post'];
+
+export interface RecordHookCoordinatorOptions {
+  operation: ActionExecutionOperation;
+  dependencies?: ActionExecutionDependencies;
+  resolveHook: RecordHookResolver;
+}
+
+export interface RecordHookPreResult {
+  record: AnyRecord;
+  report: ActionExecutionReport;
+  terminalCause?: unknown;
+}
+
+export interface RecordHookPostSyncResult {
+  record: AnyRecord;
+  response: AnyRecord;
+  report: ActionExecutionReport;
+  terminalCause?: unknown;
+}
+
+export interface RecordHookDispatchResult {
+  report: ActionExecutionReport;
+}
+
+export class RecordHookConfigurationError extends Error {
+  readonly _tag = 'RecordHookConfigurationError';
+  readonly code = 'invalid-hook-configuration';
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = this._tag;
+  }
+}
+
+function invalidConfiguration(mode: string, phase: string): never {
+  throw new RecordHookConfigurationError(`Invalid ${phase} hook configuration for ${mode}.`);
+}
+
+function hookOptions(hook: unknown): AnyRecord {
+  const options = get(hook, 'options') as unknown;
+  return options && typeof options === 'object' && !Array.isArray(options) ? (options as AnyRecord) : {};
+}
+
+function configuredDefinitions(recordType: unknown, mode: string, phase: string): RecordHookDefinition[] {
+  const configured = get(recordType, `hooks.${mode}.${phase}`) as unknown;
+  if (configured === undefined) {
+    return [];
+  }
+  if (!Array.isArray(configured)) {
+    invalidConfiguration(mode, phase);
+  }
+  return configured as RecordHookDefinition[];
+}
+
+/**
+ * Resolve one configured phase into ordered action identities, rejecting
+ * malformed definitions, unknown policies, and duplicate identifiers. The
+ * caller decides whether to execute or merely validate the result.
+ */
+function planPhase(
+  recordType: unknown,
+  mode: string,
+  phase: ActionExecutionPhase,
+  resolveHook: RecordHookResolver
+): Array<{ hook: RecordHookDefinition; actionId: string; index: number }> {
+  const hooks = configuredDefinitions(recordType, mode, phase);
+  const seenIds = new Set<string>();
+  return hooks.map((hook, index) => {
+    if (!hook || typeof hook !== 'object' || Array.isArray(hook)) {
+      invalidConfiguration(mode, phase);
+    }
+    const expression = String(get(hook, 'function') ?? '').trim();
+    if (!expression) {
+      invalidConfiguration(mode, phase);
+    }
+    const actionId = resolveActionId(get(hook, 'id'), mode, phase, index, expression);
+    if (seenIds.has(actionId)) {
+      throw new RecordHookConfigurationError(`Duplicate ${phase} hook id '${actionId}' for ${mode}.`);
+    }
+    seenIds.add(actionId);
+    validateActionExecutionPolicy(hook.execution);
+    resolveHook(hook, mode, phase);
+    return { hook, actionId, index };
+  });
+}
+
+/**
+ * Prevalidate every selected mode before a save starts, so malformed hook
+ * configuration fails ahead of any side effect.
+ */
+export function validateRecordHookConfiguration(
+  recordType: unknown,
+  modes: readonly string[],
+  resolveHook: RecordHookResolver
+): void {
+  for (const mode of modes) {
+    for (const phase of HOOK_PHASES) {
+      planPhase(recordType, mode, phase, resolveHook);
+    }
+  }
+}
+
+export class RecordHookCoordinator {
+  private readonly options: RecordHookCoordinatorOptions;
+
+  constructor(options: RecordHookCoordinatorOptions) {
+    this.options = options;
+  }
+
+  private get dependencies(): ActionExecutionDependencies {
+    return this.options.dependencies ?? {};
+  }
+
+  private phaseContext(mode: string, phase: ActionExecutionPhase): ActionExecutionContext {
+    return createPhaseContext(this.options.operation, phase, this.dependencies, mode as ActionExecutionMode);
+  }
+
+  private append(report: ActionExecutionReport): void {
+    this.options.operation.reports.push(report);
+    if (report.context.phase === 'pre') {
+      this.options.operation.completedThrough = 'pre';
+    } else if (report.context.phase === 'postSync') {
+      this.options.operation.completedThrough = 'postSync';
+    } else if (report.context.phase === 'post') {
+      this.options.operation.completedThrough = 'post-dispatch';
+    }
+  }
+
+  /**
+   * Build the generic actions for one phase. `invoke` supplies the legacy
+   * calling convention; the mutable cancellation cell lets the adapter report
+   * whether the value it returned can actually be cancelled.
+   */
+  private actions(
+    recordType: unknown,
+    mode: string,
+    phase: ActionExecutionPhase,
+    invoke: (hook: RecordHookDefinition, index: number) => unknown
+  ): ActionExecutionAction[] {
+    return planPhase(recordType, mode, phase, this.options.resolveHook).map(({ hook, actionId, index }) => {
+      return this.action(hook, actionId, mode, phase, index, invoke);
+    });
+  }
+
+  private action(
+    hook: RecordHookDefinition,
+    actionId: string,
+    mode: string,
+    phase: ActionExecutionPhase,
+    index: number,
+    invoke: (hook: RecordHookDefinition, index: number) => unknown
+  ): ActionExecutionAction {
+    const cancellation = { value: true };
+    return {
+      actionId,
+      mode: mode as ActionExecutionMode,
+      phase,
+      index,
+      policy: hook.execution,
+      cooperativeCancellation: () => cancellation.value,
+      invoke: () => legacyHookToEffect(() => invoke(hook, index), cancellation),
+    };
+  }
+
+  /**
+   * Detached hooks historically skipped a malformed entry and continued with
+   * later entries. Save-time prevalidation still blocks malformed configuration
+   * before persistence; this path preserves the public fire-and-forget method's
+   * per-entry compatibility behaviour.
+   */
+  private detachedActions(
+    recordType: unknown,
+    mode: string,
+    invoke: (hook: RecordHookDefinition, index: number) => unknown
+  ): ActionExecutionAction[] {
+    const configured = get(recordType, `hooks.${mode}.post`) as unknown;
+    if (!Array.isArray(configured)) {
+      return [];
+    }
+    const seenIds = new Set<string>();
+    const actions: ActionExecutionAction[] = [];
+    configured.forEach((hook, index) => {
+      try {
+        if (!hook || typeof hook !== 'object' || Array.isArray(hook)) {
+          throw new RecordHookConfigurationError('Invalid post hook configuration.');
+        }
+        const expression = String(get(hook, 'function') ?? '').trim();
+        if (!expression) {
+          throw new RecordHookConfigurationError('Invalid post hook configuration.');
+        }
+        const actionId = resolveActionId(get(hook, 'id'), mode, 'post', index, expression);
+        if (seenIds.has(actionId)) {
+          throw new RecordHookConfigurationError('Duplicate post hook id.');
+        }
+        validateActionExecutionPolicy(get(hook, 'execution'));
+        this.options.resolveHook(hook, mode, 'post');
+        seenIds.add(actionId);
+        actions.push(this.action(hook as RecordHookDefinition, actionId, mode, 'post', index, invoke));
+      } catch (_error) {
+        const fields: Record<string, unknown> = {
+          execution_id: this.options.operation.executionId,
+          hook_mode: mode,
+          hook_phase: 'post',
+          action_index: index,
+          failure_kind: 'configuration',
+          failure_code: 'invalid-hook-configuration',
+        };
+        if (this.options.operation.requestId) {
+          fields.request_id = this.options.operation.requestId;
+        }
+        if (this.options.operation.recordOid) {
+          fields.record_oid = this.options.operation.recordOid;
+        }
+        this.dependencies.logger?.warn?.('record_hook_detached_action_skipped', fields);
+      }
+    });
+    return actions;
+  }
+
+  async runPre(
+    oid: string | null,
+    record: AnyRecord,
+    recordType: unknown,
+    mode: string,
+    user: unknown
+  ): Promise<RecordHookPreResult> {
+    // Each hook receives the record produced by the previous one.
+    let currentRecord = record;
+    const actions = this.actions(recordType, mode, 'pre', hook => {
+      const fn = this.options.resolveHook(hook, mode, 'pre');
+      return fn(oid, currentRecord, hookOptions(hook), user);
+    });
+    const context = this.phaseContext(mode, 'pre');
+    const outcome = await Effect.runPromise(
+      runSequentialActionPlan(actions, context, this.dependencies, value => {
+        currentRecord = value as AnyRecord;
+      })
+    );
+    this.append(outcome.report);
+    return { record: currentRecord, report: outcome.report, terminalCause: outcome.terminalCause };
+  }
+
+  async runPostSync(
+    oid: string | null,
+    record: AnyRecord,
+    recordType: unknown,
+    mode: string,
+    user: unknown,
+    initialResponse: AnyRecord
+  ): Promise<RecordHookPostSyncResult> {
+    let currentRecord = record;
+    let response = initialResponse;
+    // Each hook is handed its own clone of the response so far, and keeps that
+    // same clone across retries. Hooks are allowed to mutate it in place.
+    const hookInputs = new Map<number, AnyRecord>();
+    const actions = this.actions(recordType, mode, 'postSync', (hook, index) => {
+      const fn = this.options.resolveHook(hook, mode, 'postSync');
+      let hookInput = hookInputs.get(index);
+      if (hookInput === undefined) {
+        hookInput = cloneDeep(response) as AnyRecord;
+        hookInputs.set(index, hookInput);
+      }
+      return fn(oid, currentRecord, hookOptions(hook), user, hookInput);
+    });
+
+    const hooks = configuredDefinitions(recordType, mode, 'postSync');
+    // A hook that returns the wrong shape fails its own action, so the phase
+    // stops here and the partial report is still reported to the caller.
+    const applyResult = (value: unknown, index: number): void => {
+      const options = hookOptions(hooks[index]);
+      const returnType = options.returnType === undefined ? 'record' : options.returnType;
+      if (returnType === 'record') {
+        if (!value || typeof value !== 'object') {
+          throw new Error('Post-save record hook did not return a record');
+        }
+        currentRecord = value as AnyRecord;
+      } else if (value && typeof value === 'object') {
+        response = mergeLegacyHookResponse(response, value as AnyRecord);
+      }
+      response = mergeWorkspaceFields(response, hookInputs.get(index));
+    };
+
+    const context = this.phaseContext(mode, 'postSync');
+    const outcome = await Effect.runPromise(runSequentialActionPlan(actions, context, this.dependencies, applyResult));
+    this.append(outcome.report);
+    return { record: currentRecord, response, report: outcome.report, terminalCause: outcome.terminalCause };
+  }
+
+  dispatchPost(
+    oid: string | null,
+    record: AnyRecord,
+    recordType: unknown,
+    mode: string,
+    user: unknown
+  ): RecordHookDispatchResult {
+    const actions = this.detachedActions(recordType, mode, hook => {
+      const fn = this.options.resolveHook(hook, mode, 'post');
+      return fn(oid, record, hookOptions(hook), user);
+    });
+    const context = this.phaseContext(mode, 'post');
+    const outcome = dispatchDetachedActionPlan(actions, context, this.dependencies);
+    this.append(outcome.report);
+    return { report: outcome.report };
+  }
+}
+
+/** Only the legacy response-field whitelist is merged back into the response. */
+function mergeLegacyHookResponse(response: AnyRecord, returned: AnyRecord): AnyRecord {
+  const merged: AnyRecord = { ...response };
+  if (typeof returned.success === 'boolean') {
+    merged.success = returned.success;
+  }
+  if (typeof returned.message === 'string') {
+    merged.message = returned.message;
+  }
+  if (Object.hasOwn(returned, 'data')) {
+    merged.data = returned.data;
+  }
+  if (Object.hasOwn(returned, 'metadata')) {
+    merged.metadata = returned.metadata;
+  }
+  return merged;
+}
+
+/** Workspace fields are read back from the response clone the hook mutated. */
+function mergeWorkspaceFields(response: AnyRecord, hookInput: AnyRecord | undefined): AnyRecord {
+  if (!hookInput) {
+    return response;
+  }
+  const merged: AnyRecord = { ...response };
+  if (typeof hookInput.workspaceOid === 'string' && hookInput.workspaceOid.trim()) {
+    merged.workspaceOid = hookInput.workspaceOid;
+  }
+  if (Object.hasOwn(hookInput, 'workspaceData')) {
+    merged.workspaceData = hookInput.workspaceData;
+  }
+  return merged;
+}

--- a/packages/redbox-core/src/services/record-hooks/coordinator.ts
+++ b/packages/redbox-core/src/services/record-hooks/coordinator.ts
@@ -23,8 +23,6 @@ type AnyRecord = Record<string, unknown>;
 /** Resolves a configured hook definition to the callable it names. */
 export type RecordHookResolver = (hook: unknown, mode: string, phase: string) => (...args: unknown[]) => unknown;
 
-const HOOK_PHASES: readonly ActionExecutionPhase[] = ['pre', 'postSync', 'post'];
-
 export interface RecordHookCoordinatorOptions {
   operation: ActionExecutionOperation;
   dependencies?: ActionExecutionDependencies;
@@ -78,6 +76,31 @@ function configuredDefinitions(recordType: unknown, mode: string, phase: string)
   return configured as RecordHookDefinition[];
 }
 
+function parseHookDefinition(
+  hook: RecordHookDefinition,
+  mode: string,
+  phase: ActionExecutionPhase,
+  index: number,
+  seenIds: Set<string>,
+  resolveHook: RecordHookResolver
+): { hook: RecordHookDefinition; actionId: string; index: number } {
+  if (!hook || typeof hook !== 'object' || Array.isArray(hook)) {
+    invalidConfiguration(mode, phase);
+  }
+  const expression = String(get(hook, 'function') ?? '').trim();
+  if (!expression) {
+    invalidConfiguration(mode, phase);
+  }
+  const actionId = resolveActionId(get(hook, 'id'), mode, phase, index, expression);
+  if (seenIds.has(actionId)) {
+    throw new RecordHookConfigurationError(`Duplicate ${phase} hook id '${actionId}' for ${mode}.`);
+  }
+  validateActionExecutionPolicy(hook.execution);
+  resolveHook(hook, mode, phase);
+  seenIds.add(actionId);
+  return { hook, actionId, index };
+}
+
 /**
  * Resolve one configured phase into ordered action identities, rejecting
  * malformed definitions, unknown policies, and duplicate identifiers. The
@@ -91,23 +114,7 @@ function planPhase(
 ): Array<{ hook: RecordHookDefinition; actionId: string; index: number }> {
   const hooks = configuredDefinitions(recordType, mode, phase);
   const seenIds = new Set<string>();
-  return hooks.map((hook, index) => {
-    if (!hook || typeof hook !== 'object' || Array.isArray(hook)) {
-      invalidConfiguration(mode, phase);
-    }
-    const expression = String(get(hook, 'function') ?? '').trim();
-    if (!expression) {
-      invalidConfiguration(mode, phase);
-    }
-    const actionId = resolveActionId(get(hook, 'id'), mode, phase, index, expression);
-    if (seenIds.has(actionId)) {
-      throw new RecordHookConfigurationError(`Duplicate ${phase} hook id '${actionId}' for ${mode}.`);
-    }
-    seenIds.add(actionId);
-    validateActionExecutionPolicy(hook.execution);
-    resolveHook(hook, mode, phase);
-    return { hook, actionId, index };
-  });
+  return hooks.map((hook, index) => parseHookDefinition(hook, mode, phase, index, seenIds, resolveHook));
 }
 
 /**
@@ -117,13 +124,10 @@ function planPhase(
 export function validateRecordHookConfiguration(
   recordType: unknown,
   modes: readonly string[],
-  resolveHook: RecordHookResolver,
-  phases: readonly ActionExecutionPhase[] = HOOK_PHASES
+  resolveHook: RecordHookResolver
 ): void {
   for (const mode of modes) {
-    for (const phase of phases) {
-      planPhase(recordType, mode, phase, resolveHook);
-    }
+    planPhase(recordType, mode, 'pre', resolveHook);
   }
 }
 
@@ -208,21 +212,15 @@ export class RecordHookCoordinator {
     const actions: ActionExecutionAction[] = [];
     configured.forEach((hook, index) => {
       try {
-        if (!hook || typeof hook !== 'object' || Array.isArray(hook)) {
-          throw new RecordHookConfigurationError('Invalid post hook configuration.');
-        }
-        const expression = String(get(hook, 'function') ?? '').trim();
-        if (!expression) {
-          throw new RecordHookConfigurationError('Invalid post hook configuration.');
-        }
-        const actionId = resolveActionId(get(hook, 'id'), mode, 'post', index, expression);
-        if (seenIds.has(actionId)) {
-          throw new RecordHookConfigurationError('Duplicate post hook id.');
-        }
-        validateActionExecutionPolicy(get(hook, 'execution'));
-        this.options.resolveHook(hook, mode, 'post');
-        seenIds.add(actionId);
-        actions.push(this.action(hook as RecordHookDefinition, actionId, mode, 'post', index, invoke));
+        const parsed = parseHookDefinition(
+          hook as RecordHookDefinition,
+          mode,
+          'post',
+          index,
+          seenIds,
+          this.options.resolveHook
+        );
+        actions.push(this.action(parsed.hook, parsed.actionId, mode, 'post', parsed.index, invoke));
       } catch (_error) {
         const fields: Record<string, unknown> = {
           execution_id: this.options.operation.executionId,

--- a/packages/redbox-core/src/services/record-hooks/coordinator.ts
+++ b/packages/redbox-core/src/services/record-hooks/coordinator.ts
@@ -117,10 +117,11 @@ function planPhase(
 export function validateRecordHookConfiguration(
   recordType: unknown,
   modes: readonly string[],
-  resolveHook: RecordHookResolver
+  resolveHook: RecordHookResolver,
+  phases: readonly ActionExecutionPhase[] = HOOK_PHASES
 ): void {
   for (const mode of modes) {
-    for (const phase of HOOK_PHASES) {
+    for (const phase of phases) {
       planPhase(recordType, mode, phase, resolveHook);
     }
   }
@@ -324,7 +325,25 @@ export class RecordHookCoordinator {
       return fn(oid, record, hookOptions(hook), user);
     });
     const context = this.phaseContext(mode, 'post');
-    const outcome = dispatchDetachedActionPlan(actions, context, this.dependencies);
+    const operation = this.options.operation;
+    operation.detachedPending = (operation.detachedPending ?? 0) + actions.length;
+    operation.detachedResults ??= [];
+    const existingCompletion = this.dependencies.onDetachedActionComplete;
+    const dispatchDependencies: ActionExecutionDependencies = {
+      ...this.dependencies,
+      onDetachedActionComplete: (completedContext, result) => {
+        existingCompletion?.(completedContext, result);
+        operation.detachedResults?.push(result);
+        operation.detachedPending = Math.max(0, (operation.detachedPending ?? 1) - 1);
+        operation.detachedCompletedAt = result.completedAt;
+        if (operation.detachedPending === 0) {
+          const onDetachedComplete = operation.onDetachedComplete;
+          operation.onDetachedComplete = undefined;
+          onDetachedComplete?.();
+        }
+      },
+    };
+    const outcome = dispatchDetachedActionPlan(actions, context, dispatchDependencies);
     this.append(outcome.report);
     return { report: outcome.report };
   }

--- a/packages/redbox-core/test/action-execution/executor.test.ts
+++ b/packages/redbox-core/test/action-execution/executor.test.ts
@@ -143,6 +143,37 @@ describe('Effect action execution', function () {
     expect(outcome.report.actions[0].failure?.cancellationCooperative).to.equal(false);
   });
 
+  it('does not retry a non-cooperative timeout into an overlapping invocation', async function () {
+    let invocations = 0;
+    const operation = createActionExecutionOperation('onCreate');
+    const cancellation = { value: true };
+    const outcome = await runActionPlan(
+      [
+        {
+          actionId: 'promise-timeout-retry',
+          mode: 'onCreate',
+          phase: 'pre',
+          index: 0,
+          policy: {
+            timeoutMs: 5,
+            retry: { maxAttempts: 2, retryOn: ['timeout'], idempotent: true },
+          },
+          cooperativeCancellation: () => cancellation.value,
+          invoke: () =>
+            legacyHookToEffect(() => {
+              invocations += 1;
+              return new Promise(() => undefined);
+            }, cancellation),
+        },
+      ],
+      createPhaseContext(operation, 'pre')
+    );
+
+    expect(invocations).to.equal(1);
+    expect(outcome.report.actions[0].attempts).to.equal(1);
+    expect(outcome.report.actions[0].failure?.cancellationCooperative).to.equal(false);
+  });
+
   it('dispatches detached actions without waiting for completion', function () {
     const operation = createActionExecutionOperation('onCreate');
     const events: string[] = [];
@@ -360,6 +391,35 @@ describe('Effect action execution', function () {
         entry => entry.name === 'record_hook_detached_action_failed' && entry.fields?.failure_kind === 'interrupted'
       )
     ).to.equal(true);
+  });
+
+  it('unregisters detached fibers after they complete', async function () {
+    const registered: unknown[] = [];
+    const unregistered: unknown[] = [];
+    const operation = createActionExecutionOperation('onCreate');
+    dispatchDetachedActionPlan(
+      [
+        {
+          actionId: 'completes',
+          mode: 'onCreate',
+          phase: 'post',
+          index: 0,
+          invoke: () => Effect.succeed(undefined),
+        },
+      ],
+      createPhaseContext(operation, 'post'),
+      {
+        supervisor: {
+          register: fiber => registered.push(fiber),
+          unregister: fiber => unregistered.push(fiber),
+        },
+      }
+    );
+
+    await new Promise(resolve => setImmediate(resolve));
+    await new Promise(resolve => setImmediate(resolve));
+    expect(registered).to.have.length(1);
+    expect(unregistered).to.deep.equal(registered);
   });
 
   it('fails the action when a post-sync hook returns the wrong shape and still reports the phase', async function () {

--- a/packages/redbox-core/test/action-execution/executor.test.ts
+++ b/packages/redbox-core/test/action-execution/executor.test.ts
@@ -10,12 +10,49 @@ import {
   dispatchDetachedActionPlan,
   legacyHookToEffect,
   projectRecordHookExecutionAuditSummary,
-  runActionPlan,
   runSequentialActionPlan,
   retryDelayMs,
+  type ActionExecutionOperation,
+  type ActionExecutionReport,
+  type ActionExecutionResult,
   validateActionExecutionPolicy,
 } from '../../src/action-execution/index';
 import { RecordHookCoordinator } from '../../src/services/record-hooks/coordinator';
+
+const timestamp = '2026-01-01T00:00:00.000Z';
+
+function dispatchedAction(index: number): ActionExecutionResult {
+  return {
+    actionId: `post-${index}`,
+    mode: 'onCreate',
+    phase: 'post',
+    index,
+    status: 'dispatched',
+    attempts: 0,
+    startedAt: timestamp,
+    completedAt: timestamp,
+    durationMs: 0,
+  };
+}
+
+function dispatchedReport(
+  operation: ActionExecutionOperation,
+  actions: ActionExecutionResult[]
+): ActionExecutionReport {
+  return {
+    context: {
+      executionId: operation.executionId,
+      phaseExecutionId: 'phase-post',
+      mode: 'onCreate',
+      phase: 'post',
+    },
+    status: 'dispatched',
+    startedAt: timestamp,
+    completedAt: timestamp,
+    durationMs: 0,
+    actions,
+  };
+}
 
 describe('Effect action execution', function () {
   it('derives stable bounded IDs without including the function expression', function () {
@@ -35,9 +72,10 @@ describe('Effect action execution', function () {
 
   it('threads sequential values, retries transient failures, and skips later actions after exhaustion', async function () {
     let attempts = 0;
+    const values: unknown[] = [];
     const operation = createActionExecutionOperation('onCreate', 'request-1');
     const context = createPhaseContext(operation, 'pre');
-    const outcome = await runActionPlan(
+    const outcome = await Effect.runPromise(runSequentialActionPlan(
       [
         {
           actionId: 'first',
@@ -67,11 +105,13 @@ describe('Effect action execution', function () {
           invoke: () => Effect.succeed({ value: 3 }),
         },
       ],
-      context
-    );
+      context,
+      {},
+      value => values.push(value)
+    ));
 
     expect(attempts).to.equal(2);
-    expect(outcome.values).to.deep.equal([{ value: 1 }]);
+    expect(values).to.deep.equal([{ value: 1 }]);
     expect(outcome.report.actions.map(action => action.status)).to.deep.equal(['succeeded', 'failed', 'skipped']);
     expect(outcome.report.actions[2].skippedReason).to.equal('prior_action_failed');
     expect(outcome.report.actions[0].attempts).to.equal(2);
@@ -125,7 +165,7 @@ describe('Effect action execution', function () {
   it('reports an opaque Promise timeout as non-cooperative', async function () {
     const operation = createActionExecutionOperation('onCreate');
     const cancellation = { value: true };
-    const outcome = await runActionPlan(
+    const outcome = await Effect.runPromise(runSequentialActionPlan(
       [
         {
           actionId: 'promise-timeout',
@@ -138,7 +178,7 @@ describe('Effect action execution', function () {
         },
       ],
       createPhaseContext(operation, 'pre')
-    );
+    ));
     expect(outcome.report.actions[0].status).to.equal('timed_out');
     expect(outcome.report.actions[0].failure?.cancellationCooperative).to.equal(false);
   });
@@ -147,7 +187,7 @@ describe('Effect action execution', function () {
     let invocations = 0;
     const operation = createActionExecutionOperation('onCreate');
     const cancellation = { value: true };
-    const outcome = await runActionPlan(
+    const outcome = await Effect.runPromise(runSequentialActionPlan(
       [
         {
           actionId: 'promise-timeout-retry',
@@ -167,7 +207,7 @@ describe('Effect action execution', function () {
         },
       ],
       createPhaseContext(operation, 'pre')
-    );
+    ));
 
     expect(invocations).to.equal(1);
     expect(outcome.report.actions[0].attempts).to.equal(1);
@@ -209,34 +249,12 @@ describe('Effect action execution', function () {
 
   it('caps audit entries while retaining complete counts', function () {
     const operation = createActionExecutionOperation('onCreate');
-    operation.reports.push({
-      schemaVersion: 1,
-      executionId: operation.executionId,
-      phaseExecutionId: 'phase-1',
-      context: {
-        executionId: operation.executionId,
-        phaseExecutionId: 'phase-1',
-        trigger: 'record-hook',
-        mode: 'onCreate',
-        phase: 'post',
-      },
-      status: 'dispatched',
-      startedAt: '2026-01-01T00:00:00.000Z',
-      completedAt: '2026-01-01T00:00:00.000Z',
-      durationMs: 0,
-      actions: Array.from({ length: 101 }, (_, index) => ({
-        actionId: `a-${index}`,
-        mode: 'onCreate' as const,
-        phase: 'post' as const,
-        index,
-        status: 'dispatched' as const,
-        attempts: 0,
-        startedAt: '2026-01-01T00:00:00.000Z',
-        completedAt: '2026-01-01T00:00:00.000Z',
-        durationMs: 0,
-      })),
-      counts: { succeeded: 0, failed: 0, timed_out: 0, interrupted: 0, skipped: 0, dispatched: 101 },
-    });
+    operation.reports.push(
+      dispatchedReport(
+        operation,
+        Array.from({ length: 101 }, (_, index) => ({ ...dispatchedAction(index), actionId: `a-${index}` }))
+      )
+    );
     const summary = projectRecordHookExecutionAuditSummary(operation);
     expect(summary.actions).to.have.length(100);
     expect(summary.totalActions).to.equal(101);
@@ -247,47 +265,7 @@ describe('Effect action execution', function () {
   it('replaces completed detached dispatches without double-counting pending actions', function () {
     const operation = createActionExecutionOperation('onCreate');
     operation.detachedPending = 1;
-    operation.reports.push({
-      schemaVersion: 1,
-      executionId: operation.executionId,
-      phaseExecutionId: 'phase-post',
-      context: {
-        executionId: operation.executionId,
-        phaseExecutionId: 'phase-post',
-        trigger: 'record-hook',
-        mode: 'onCreate',
-        phase: 'post',
-      },
-      status: 'dispatched',
-      startedAt: '2026-01-01T00:00:00.000Z',
-      completedAt: '2026-01-01T00:00:00.000Z',
-      durationMs: 0,
-      actions: [
-        {
-          actionId: 'post-0',
-          mode: 'onCreate',
-          phase: 'post',
-          index: 0,
-          status: 'dispatched',
-          attempts: 0,
-          startedAt: '2026-01-01T00:00:00.000Z',
-          completedAt: '2026-01-01T00:00:00.000Z',
-          durationMs: 0,
-        },
-        {
-          actionId: 'post-1',
-          mode: 'onCreate',
-          phase: 'post',
-          index: 1,
-          status: 'dispatched',
-          attempts: 0,
-          startedAt: '2026-01-01T00:00:00.000Z',
-          completedAt: '2026-01-01T00:00:00.000Z',
-          durationMs: 0,
-        },
-      ],
-      counts: { succeeded: 0, failed: 0, timed_out: 0, interrupted: 0, skipped: 0, dispatched: 2 },
-    });
+    operation.reports.push(dispatchedReport(operation, [dispatchedAction(0), dispatchedAction(1)]));
     operation.detachedResults = [
       {
         actionId: 'post-0',
@@ -391,7 +369,8 @@ describe('Effect action execution', function () {
       return current.value + 1;
     }).pipe(Effect.provideService(service, { value: 4 }));
     const operation = createActionExecutionOperation('onCreate');
-    const outcome = await runActionPlan(
+    const values: unknown[] = [];
+    const outcome = await Effect.runPromise(runSequentialActionPlan(
       [
         {
           actionId: 'native-layered',
@@ -401,17 +380,19 @@ describe('Effect action execution', function () {
           invoke: () => legacyHookToEffect(() => nativeAction),
         },
       ],
-      createPhaseContext(operation, 'pre')
-    );
+      createPhaseContext(operation, 'pre'),
+      {},
+      value => values.push(value)
+    ));
 
-    expect(outcome.values).to.deep.equal([5]);
+    expect(values).to.deep.equal([5]);
     expect(outcome.report.actions[0].status).to.equal('succeeded');
   });
 
   it('logs starts at debug and keeps payloads out of info/warn fields', async function () {
     const logs: Array<{ level: string; name: string; fields?: Record<string, unknown> }> = [];
     const operation = createActionExecutionOperation('onCreate');
-    await runActionPlan(
+    await Effect.runPromise(runSequentialActionPlan(
       [
         {
           actionId: 'redacted-payload',
@@ -429,7 +410,7 @@ describe('Effect action execution', function () {
           warn: (name, fields) => logs.push({ level: 'warn', name, fields }),
         },
       }
-    );
+    ));
 
     expect(logs.some(log => log.level === 'debug' && log.name === 'record_hook_action_started')).to.equal(true);
     expect(logs.some(log => log.level === 'debug' && log.name === 'record_hook_action_attempt_succeeded')).to.equal(
@@ -475,35 +456,6 @@ describe('Effect action execution', function () {
         entry => entry.name === 'record_hook_detached_action_failed' && entry.fields?.failure_kind === 'interrupted'
       )
     ).to.equal(true);
-  });
-
-  it('unregisters detached fibers after they complete', async function () {
-    const registered: unknown[] = [];
-    const unregistered: unknown[] = [];
-    const operation = createActionExecutionOperation('onCreate');
-    dispatchDetachedActionPlan(
-      [
-        {
-          actionId: 'completes',
-          mode: 'onCreate',
-          phase: 'post',
-          index: 0,
-          invoke: () => Effect.succeed(undefined),
-        },
-      ],
-      createPhaseContext(operation, 'post'),
-      {
-        supervisor: {
-          register: fiber => registered.push(fiber),
-          unregister: fiber => unregistered.push(fiber),
-        },
-      }
-    );
-
-    await new Promise(resolve => setImmediate(resolve));
-    await new Promise(resolve => setImmediate(resolve));
-    expect(registered).to.have.length(1);
-    expect(unregistered).to.deep.equal(registered);
   });
 
   it('fails the action when a post-sync hook returns the wrong shape and still reports the phase', async function () {

--- a/packages/redbox-core/test/action-execution/executor.test.ts
+++ b/packages/redbox-core/test/action-execution/executor.test.ts
@@ -1,0 +1,426 @@
+import { Context, Effect, Fiber, TestClock, TestContext } from 'effect';
+import { expect } from 'chai';
+import { of } from 'rxjs';
+import {
+  ActionTransientFailure,
+  createActionExecutionOperation,
+  createActionExecutionSupervisor,
+  createPhaseContext,
+  deriveActionId,
+  dispatchDetachedActionPlan,
+  legacyHookToEffect,
+  projectRecordHookExecutionAuditSummary,
+  runActionPlan,
+  runSequentialActionPlan,
+  retryDelayMs,
+  validateActionExecutionPolicy,
+} from '../../src/action-execution/index';
+import { RecordHookCoordinator } from '../../src/services/record-hooks/coordinator';
+
+describe('Effect action execution', function () {
+  it('derives stable bounded IDs without including the function expression', function () {
+    const id = deriveActionId('onCreate', 'pre', 0, 'sails.services.example.run');
+    expect(id).to.match(/^onCreate\.pre\.0\.[a-f0-9]{12}$/);
+    expect(id).not.to.include('sails');
+    expect(deriveActionId('onCreate', 'pre', 0, 'sails.services.example.run')).to.equal(id);
+  });
+
+  it('validates bounded retry policies and requires idempotency acknowledgement', function () {
+    expect(() => validateActionExecutionPolicy({ retry: { maxAttempts: 2 } })).to.throw('idempotent');
+    expect(
+      validateActionExecutionPolicy({ retry: { maxAttempts: 2, idempotent: true } })?.retry?.retryOn
+    ).to.deep.equal(['transient']);
+    expect(() => validateActionExecutionPolicy({ timeoutMs: 600001 })).to.throw('timeoutMs');
+  });
+
+  it('threads sequential values, retries transient failures, and skips later actions after exhaustion', async function () {
+    let attempts = 0;
+    const operation = createActionExecutionOperation('onCreate', 'request-1');
+    const context = createPhaseContext(operation, 'pre');
+    const outcome = await runActionPlan(
+      [
+        {
+          actionId: 'first',
+          mode: 'onCreate',
+          phase: 'pre',
+          index: 0,
+          policy: { retry: { maxAttempts: 2, retryOn: ['transient'], idempotent: true } },
+          invoke: () =>
+            Effect.sync(() => {
+              attempts += 1;
+              if (attempts === 1) throw new ActionTransientFailure('temporary');
+              return { value: 1 };
+            }),
+        },
+        {
+          actionId: 'second',
+          mode: 'onCreate',
+          phase: 'pre',
+          index: 1,
+          invoke: () => Effect.fail(new Error('stop')),
+        },
+        {
+          actionId: 'never',
+          mode: 'onCreate',
+          phase: 'pre',
+          index: 2,
+          invoke: () => Effect.succeed({ value: 3 }),
+        },
+      ],
+      context
+    );
+
+    expect(attempts).to.equal(2);
+    expect(outcome.values).to.deep.equal([{ value: 1 }]);
+    expect(outcome.report.actions.map(action => action.status)).to.deep.equal(['succeeded', 'failed', 'skipped']);
+    expect(outcome.report.actions[2].skippedReason).to.equal('prior_action_failed');
+    expect(outcome.report.actions[0].attempts).to.equal(2);
+  });
+
+  it('adapts plain values, Promises, Observables, and native Effects', async function () {
+    const values = await Promise.all([
+      Effect.runPromise(legacyHookToEffect(() => 1)),
+      Effect.runPromise(legacyHookToEffect(() => Promise.resolve(2))),
+      Effect.runPromise(legacyHookToEffect(() => of(3))),
+      Effect.runPromise(legacyHookToEffect(() => Effect.succeed(4))),
+    ]);
+    expect(values).to.deep.equal([1, 2, 3, 4]);
+  });
+
+  it('threads the live record between legacy pre hooks and omits execution policy from options', async function () {
+    const seen: unknown[] = [];
+    const recordType = {
+      hooks: {
+        onCreate: {
+          pre: [
+            { id: 'first', function: 'first', options: { marker: 'legacy' } },
+            { id: 'second', function: 'second', execution: { timeoutMs: 1000 } },
+          ],
+        },
+      },
+    };
+    const operation = createActionExecutionOperation('onCreate');
+    const coordinator = new RecordHookCoordinator({
+      operation,
+      resolveHook: hook => {
+        const name = (hook as { function: string }).function;
+        return name === 'first'
+          ? (_oid, record, options) => {
+              seen.push({ record, options });
+              return { ...(record as Record<string, unknown>), first: true };
+            }
+          : (_oid, record, options) => {
+              seen.push({ record, options });
+              return { ...(record as Record<string, unknown>), second: true };
+            };
+      },
+    });
+    const result = await coordinator.runPre(null, { initial: true }, recordType, 'onCreate', { username: 'tester' });
+    expect(result.record).to.deep.equal({ initial: true, first: true, second: true });
+    expect((seen[1] as { record: unknown }).record).to.deep.equal({ initial: true, first: true });
+    expect((seen[1] as { options: unknown }).options).to.deep.equal({});
+    expect((seen[0] as { options: unknown }).options).to.deep.equal({ marker: 'legacy' });
+  });
+
+  it('reports an opaque Promise timeout as non-cooperative', async function () {
+    const operation = createActionExecutionOperation('onCreate');
+    const cancellation = { value: true };
+    const outcome = await runActionPlan(
+      [
+        {
+          actionId: 'promise-timeout',
+          mode: 'onCreate',
+          phase: 'pre',
+          index: 0,
+          policy: { timeoutMs: 5 },
+          cooperativeCancellation: () => cancellation.value,
+          invoke: () => legacyHookToEffect(() => new Promise(() => undefined), cancellation),
+        },
+      ],
+      createPhaseContext(operation, 'pre')
+    );
+    expect(outcome.report.actions[0].status).to.equal('timed_out');
+    expect(outcome.report.actions[0].failure?.cancellationCooperative).to.equal(false);
+  });
+
+  it('dispatches detached actions without waiting for completion', function () {
+    const operation = createActionExecutionOperation('onCreate');
+    const events: string[] = [];
+    const outcome = dispatchDetachedActionPlan(
+      [
+        {
+          actionId: 'one',
+          mode: 'onCreate',
+          phase: 'post',
+          index: 0,
+          invoke: () =>
+            Effect.sync(() => {
+              events.push('one');
+            }),
+        },
+        {
+          actionId: 'two',
+          mode: 'onCreate',
+          phase: 'post',
+          index: 1,
+          invoke: () =>
+            Effect.sync(() => {
+              events.push('two');
+            }),
+        },
+      ],
+      createPhaseContext(operation, 'post')
+    );
+    expect(outcome.report.status).to.equal('dispatched');
+    expect(outcome.report.actions.every(action => action.status === 'dispatched')).to.equal(true);
+    expect(events.slice(0, 2)).to.deep.equal(['one', 'two']);
+  });
+
+  it('caps audit entries while retaining complete counts', function () {
+    const operation = createActionExecutionOperation('onCreate');
+    operation.reports.push({
+      schemaVersion: 1,
+      executionId: operation.executionId,
+      phaseExecutionId: 'phase-1',
+      context: {
+        executionId: operation.executionId,
+        phaseExecutionId: 'phase-1',
+        trigger: 'record-hook',
+        mode: 'onCreate',
+        phase: 'post',
+      },
+      status: 'dispatched',
+      startedAt: '2026-01-01T00:00:00.000Z',
+      completedAt: '2026-01-01T00:00:00.000Z',
+      durationMs: 0,
+      actions: Array.from({ length: 101 }, (_, index) => ({
+        actionId: `a-${index}`,
+        mode: 'onCreate' as const,
+        phase: 'post' as const,
+        index,
+        status: 'dispatched' as const,
+        attempts: 0,
+        startedAt: '2026-01-01T00:00:00.000Z',
+        completedAt: '2026-01-01T00:00:00.000Z',
+        durationMs: 0,
+      })),
+      counts: { succeeded: 0, failed: 0, timed_out: 0, interrupted: 0, skipped: 0, dispatched: 101 },
+    });
+    const summary = projectRecordHookExecutionAuditSummary(operation);
+    expect(summary.actions).to.have.length(100);
+    expect(summary.totalActions).to.equal(101);
+    expect(summary.truncated).to.equal(true);
+    expect(summary.counts.dispatched).to.equal(101);
+  });
+  it('uses the Effect TestClock, injected time, and deterministic jitter for retry scheduling', async function () {
+    let logicalTime = 0;
+    const sleeps: number[] = [];
+    let attempts = 0;
+    const operation = createActionExecutionOperation('onCreate', undefined, undefined, {
+      now: () => new Date(logicalTime),
+    });
+    const context = createPhaseContext(operation, 'pre', {
+      now: () => new Date(logicalTime),
+    });
+    const dependencies = {
+      now: () => new Date(logicalTime),
+      random: () => 0,
+      sleep: (durationMs: number) => {
+        sleeps.push(durationMs);
+        return Effect.gen(function* () {
+          yield* TestClock.sleep(`${durationMs} millis`);
+          logicalTime += durationMs;
+        });
+      },
+    };
+    const action = {
+      actionId: 'clocked-retry',
+      mode: 'onCreate' as const,
+      phase: 'pre' as const,
+      index: 0,
+      policy: {
+        retry: {
+          maxAttempts: 2,
+          retryOn: ['transient' as const],
+          schedule: { type: 'fixed' as const, delayMs: 40, jitter: true },
+          idempotent: true as const,
+        },
+      },
+      invoke: () =>
+        Effect.sync(() => {
+          attempts += 1;
+          if (attempts === 1) throw new ActionTransientFailure('temporary');
+          return 'ok';
+        }),
+    };
+
+    const outcome = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fiber = yield* Effect.fork(runSequentialActionPlan([action], context, dependencies));
+        yield* Effect.yieldNow();
+        yield* TestClock.adjust('20 millis');
+        return yield* Fiber.join(fiber);
+      }).pipe(Effect.provide(TestContext.TestContext))
+    );
+
+    expect(outcome.report.actions[0].durationMs).to.equal(20);
+    expect(sleeps).to.deep.equal([20]);
+    expect(retryDelayMs({ type: 'fixed', delayMs: 40, jitter: true }, 1, () => 0)).to.equal(20);
+    expect(retryDelayMs({ type: 'fixed', delayMs: 40, jitter: true }, 1, () => 1)).to.equal(60);
+  });
+
+  it('executes a native Effect action with its required layer already provided', async function () {
+    const service = Context.GenericTag<{ value: number }>('test/native-action-service');
+    const nativeAction = Effect.gen(function* () {
+      const current = yield* service;
+      return current.value + 1;
+    }).pipe(Effect.provideService(service, { value: 4 }));
+    const operation = createActionExecutionOperation('onCreate');
+    const outcome = await runActionPlan(
+      [
+        {
+          actionId: 'native-layered',
+          mode: 'onCreate',
+          phase: 'pre',
+          index: 0,
+          invoke: () => legacyHookToEffect(() => nativeAction),
+        },
+      ],
+      createPhaseContext(operation, 'pre')
+    );
+
+    expect(outcome.values).to.deep.equal([5]);
+    expect(outcome.report.actions[0].status).to.equal('succeeded');
+  });
+
+  it('logs starts at debug and keeps payloads out of info/warn fields', async function () {
+    const logs: Array<{ level: string; name: string; fields?: Record<string, unknown> }> = [];
+    const operation = createActionExecutionOperation('onCreate');
+    await runActionPlan(
+      [
+        {
+          actionId: 'redacted-payload',
+          mode: 'onCreate',
+          phase: 'pre',
+          index: 0,
+          invoke: () => Effect.succeed({ token: 'secret-token', options: { password: 'secret-password' } }),
+        },
+      ],
+      createPhaseContext(operation, 'pre'),
+      {
+        logger: {
+          debug: (name, fields) => logs.push({ level: 'debug', name, fields }),
+          info: (name, fields) => logs.push({ level: 'info', name, fields }),
+          warn: (name, fields) => logs.push({ level: 'warn', name, fields }),
+        },
+      }
+    );
+
+    expect(logs.some(log => log.level === 'debug' && log.name === 'record_hook_action_started')).to.equal(true);
+    expect(logs.some(log => log.level === 'debug' && log.name === 'record_hook_action_attempt_succeeded')).to.equal(
+      true
+    );
+    const productionLogs = logs.filter(log => log.level === 'info' || log.level === 'warn');
+    expect(JSON.stringify(productionLogs)).not.to.include('secret-token');
+    expect(JSON.stringify(productionLogs)).not.to.include('secret-password');
+  });
+
+  it('interrupts supervised detached fibers during teardown', async function () {
+    const messages: Array<{ name: string; fields?: Record<string, unknown> }> = [];
+    const supervisor = createActionExecutionSupervisor();
+    const operation = createActionExecutionOperation('onCreate');
+    dispatchDetachedActionPlan(
+      [
+        {
+          actionId: 'never-completes',
+          mode: 'onCreate',
+          phase: 'post',
+          index: 0,
+          invoke: () =>
+            Effect.async((_resume, signal) => {
+              signal.addEventListener('abort', () => undefined, { once: true });
+            }),
+        },
+      ],
+      createPhaseContext(operation, 'post'),
+      {
+        supervisor,
+        logger: {
+          debug: (name, fields) => messages.push({ name, fields }),
+          warn: (name, fields) => messages.push({ name, fields }),
+        },
+      }
+    );
+    await new Promise(resolve => setImmediate(resolve));
+    supervisor?.interruptAll?.();
+    await new Promise(resolve => setTimeout(resolve, 25));
+
+    expect(
+      messages.some(
+        entry => entry.name === 'record_hook_detached_action_failed' && entry.fields?.failure_kind === 'interrupted'
+      )
+    ).to.equal(true);
+  });
+
+  it('fails the action when a post-sync hook returns the wrong shape and still reports the phase', async function () {
+    const recordType = {
+      hooks: {
+        onUpdate: {
+          postSync: [
+            { id: 'bad', function: 'bad' },
+            { id: 'never', function: 'never' },
+          ],
+        },
+      },
+    };
+    const operation = createActionExecutionOperation('onUpdate');
+    const invoked: string[] = [];
+    const coordinator = new RecordHookCoordinator({
+      operation,
+      resolveHook: hook => {
+        const name = (hook as { function: string }).function;
+        return () => {
+          invoked.push(name);
+          return name === 'bad' ? null : {};
+        };
+      },
+    });
+
+    let thrown: unknown;
+    try {
+      await coordinator.runPostSync('oid-1', {}, recordType, 'onUpdate', {}, {});
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).to.equal(undefined);
+    expect(invoked).to.deep.equal(['bad']);
+    expect(operation.reports).to.have.length(1);
+    expect(operation.reports[0].actions.map(action => action.status)).to.deep.equal(['failed', 'skipped']);
+  });
+
+  it('rejects duplicate explicit hook ids before any hook runs', async function () {
+    const recordType = {
+      hooks: {
+        onUpdate: {
+          pre: [
+            { id: 'same', function: 'a' },
+            { id: 'same', function: 'b' },
+          ],
+        },
+      },
+    };
+    const coordinator = new RecordHookCoordinator({
+      operation: createActionExecutionOperation('onUpdate'),
+      resolveHook: () => () => ({}),
+    });
+
+    let thrown: unknown;
+    try {
+      await coordinator.runPre('oid-1', {}, recordType, 'onUpdate', {});
+    } catch (error) {
+      thrown = error;
+    }
+    expect((thrown as Error | undefined)?.message).to.contain("Duplicate pre hook id 'same'");
+  });
+});

--- a/packages/redbox-core/test/action-execution/executor.test.ts
+++ b/packages/redbox-core/test/action-execution/executor.test.ts
@@ -243,6 +243,90 @@ describe('Effect action execution', function () {
     expect(summary.truncated).to.equal(true);
     expect(summary.counts.dispatched).to.equal(101);
   });
+
+  it('replaces completed detached dispatches without double-counting pending actions', function () {
+    const operation = createActionExecutionOperation('onCreate');
+    operation.detachedPending = 1;
+    operation.reports.push({
+      schemaVersion: 1,
+      executionId: operation.executionId,
+      phaseExecutionId: 'phase-post',
+      context: {
+        executionId: operation.executionId,
+        phaseExecutionId: 'phase-post',
+        trigger: 'record-hook',
+        mode: 'onCreate',
+        phase: 'post',
+      },
+      status: 'dispatched',
+      startedAt: '2026-01-01T00:00:00.000Z',
+      completedAt: '2026-01-01T00:00:00.000Z',
+      durationMs: 0,
+      actions: [
+        {
+          actionId: 'post-0',
+          mode: 'onCreate',
+          phase: 'post',
+          index: 0,
+          status: 'dispatched',
+          attempts: 0,
+          startedAt: '2026-01-01T00:00:00.000Z',
+          completedAt: '2026-01-01T00:00:00.000Z',
+          durationMs: 0,
+        },
+        {
+          actionId: 'post-1',
+          mode: 'onCreate',
+          phase: 'post',
+          index: 1,
+          status: 'dispatched',
+          attempts: 0,
+          startedAt: '2026-01-01T00:00:00.000Z',
+          completedAt: '2026-01-01T00:00:00.000Z',
+          durationMs: 0,
+        },
+      ],
+      counts: { succeeded: 0, failed: 0, timed_out: 0, interrupted: 0, skipped: 0, dispatched: 2 },
+    });
+    operation.detachedResults = [
+      {
+        actionId: 'post-0',
+        mode: 'onCreate',
+        phase: 'post',
+        index: 0,
+        status: 'succeeded',
+        attempts: 1,
+        startedAt: '2026-01-01T00:00:00.000Z',
+        completedAt: '2026-01-01T00:00:00.020Z',
+        durationMs: 20,
+      },
+    ];
+
+    const partial = projectRecordHookExecutionAuditSummary(operation);
+    expect(partial.totalActions).to.equal(2);
+    expect(partial.actions.map(action => action.status)).to.deep.equal(['succeeded', 'dispatched']);
+    expect(partial.counts.succeeded).to.equal(1);
+    expect(partial.counts.dispatched).to.equal(1);
+
+    operation.detachedPending = 0;
+    operation.detachedResults.push({
+      actionId: 'post-1',
+      mode: 'onCreate',
+      phase: 'post',
+      index: 1,
+      status: 'failed',
+      attempts: 1,
+      startedAt: '2026-01-01T00:00:00.000Z',
+      completedAt: '2026-01-01T00:00:00.030Z',
+      durationMs: 30,
+      failure: { kind: 'unexpected', code: 'hook-failed' },
+    });
+    const complete = projectRecordHookExecutionAuditSummary(operation);
+    expect(complete.totalActions).to.equal(2);
+    expect(complete.actions.map(action => action.status)).to.deep.equal(['succeeded', 'failed']);
+    expect(complete.counts.dispatched).to.equal(undefined);
+  });
+
   it('uses the Effect TestClock, injected time, and deterministic jitter for retry scheduling', async function () {
     let logicalTime = 0;
     const sleeps: number[] = [];

--- a/packages/redbox-core/test/action-execution/legacy-compatibility.test.ts
+++ b/packages/redbox-core/test/action-execution/legacy-compatibility.test.ts
@@ -7,7 +7,6 @@ import { RecordHookCoordinator } from '../../src/services/record-hooks/coordinat
 type AnyRecord = Record<string, unknown>;
 
 function coordinator(
-  recordType: AnyRecord,
   resolveHook: (hook: AnyRecord) => (...args: unknown[]) => unknown,
   logger?: {
     debug?: (...args: any[]) => void;
@@ -30,28 +29,34 @@ function tick(): Promise<void> {
 describe('record-hook legacy compatibility characterization', function () {
   it('preserves plain, Promise, Observable, and native Effect pre-hook values', async function () {
     const values = await Promise.all([
-      coordinator({ hooks: { onCreate: { pre: [{ function: 'plain' }] } } }, () => () => 'plain').runPre(
+      coordinator(() => () => 'plain').runPre(
         null,
         {},
         { hooks: { onCreate: { pre: [{ function: 'plain' }] } } },
         'onCreate',
         {}
       ),
-      coordinator(
+      coordinator(() => () => Promise.resolve('promise')).runPre(
+        null,
+        {},
         { hooks: { onCreate: { pre: [{ function: 'promise' }] } } },
-        () => () => Promise.resolve('promise')
-      ).runPre(null, {}, { hooks: { onCreate: { pre: [{ function: 'promise' }] } } }, 'onCreate', {}),
-      coordinator({ hooks: { onCreate: { pre: [{ function: 'observable' }] } } }, () => () => of('observable')).runPre(
+        'onCreate',
+        {}
+      ),
+      coordinator(() => () => of('observable')).runPre(
         null,
         {},
         { hooks: { onCreate: { pre: [{ function: 'observable' }] } } },
         'onCreate',
         {}
       ),
-      coordinator(
+      coordinator(() => () => Effect.succeed('effect')).runPre(
+        null,
+        {},
         { hooks: { onCreate: { pre: [{ function: 'effect' }] } } },
-        () => () => Effect.succeed('effect')
-      ).runPre(null, {}, { hooks: { onCreate: { pre: [{ function: 'effect' }] } } }, 'onCreate', {}),
+        'onCreate',
+        {}
+      ),
     ]);
 
     expect(values.map(result => result.record)).to.deep.equal(['plain', 'promise', 'observable', 'effect']);
@@ -66,7 +71,7 @@ describe('record-hook legacy compatibility characterization', function () {
         },
       },
     };
-    const result = await coordinator(recordType, hook => {
+    const result = await coordinator(hook => {
       const name = String(hook.function);
       return (_oid, record) => {
         invoked.push(name);
@@ -94,7 +99,7 @@ describe('record-hook legacy compatibility characterization', function () {
       },
     };
     const seen: AnyRecord[] = [];
-    const result = await coordinator(recordType, hook => {
+    const result = await coordinator(hook => {
       if (hook.function === 'record') {
         return (_oid, record, _options, _user, response) => {
           seen.push({ record: record as AnyRecord, response: response as AnyRecord });
@@ -144,7 +149,6 @@ describe('record-hook legacy compatibility characterization', function () {
       },
     };
     const result = coordinator(
-      recordType,
       hook => {
         if (hook.function === 'first') {
           return () => {
@@ -197,7 +201,6 @@ describe('record-hook legacy compatibility characterization', function () {
       },
     };
     const result = coordinator(
-      recordType,
       hook => () => {
         invoked.push(String(hook.function));
         return undefined;
@@ -221,7 +224,6 @@ describe('record-hook legacy compatibility characterization', function () {
       },
     };
     coordinator(
-      recordType,
       hook => () =>
         hook.function === 'observable'
           ? new Observable(subscriber => subscriber.error({ secret: 'do-not-log' }))

--- a/packages/redbox-core/test/action-execution/legacy-compatibility.test.ts
+++ b/packages/redbox-core/test/action-execution/legacy-compatibility.test.ts
@@ -1,0 +1,240 @@
+import { Effect } from 'effect';
+import { expect } from 'chai';
+import { Observable, of } from 'rxjs';
+import { createActionExecutionOperation } from '../../src/action-execution/index';
+import { RecordHookCoordinator } from '../../src/services/record-hooks/coordinator';
+
+type AnyRecord = Record<string, unknown>;
+
+function coordinator(
+  recordType: AnyRecord,
+  resolveHook: (hook: AnyRecord) => (...args: unknown[]) => unknown,
+  logger?: {
+    debug?: (...args: any[]) => void;
+    info?: (...args: any[]) => void;
+    warn?: (...args: any[]) => void;
+    error?: (...args: any[]) => void;
+  }
+) {
+  return new RecordHookCoordinator({
+    operation: createActionExecutionOperation('onCreate'),
+    dependencies: { logger },
+    resolveHook: hook => resolveHook(hook as AnyRecord),
+  });
+}
+
+function tick(): Promise<void> {
+  return new Promise(resolve => setImmediate(resolve));
+}
+
+describe('record-hook legacy compatibility characterization', function () {
+  it('preserves plain, Promise, Observable, and native Effect pre-hook values', async function () {
+    const values = await Promise.all([
+      coordinator({ hooks: { onCreate: { pre: [{ function: 'plain' }] } } }, () => () => 'plain').runPre(
+        null,
+        {},
+        { hooks: { onCreate: { pre: [{ function: 'plain' }] } } },
+        'onCreate',
+        {}
+      ),
+      coordinator(
+        { hooks: { onCreate: { pre: [{ function: 'promise' }] } } },
+        () => () => Promise.resolve('promise')
+      ).runPre(null, {}, { hooks: { onCreate: { pre: [{ function: 'promise' }] } } }, 'onCreate', {}),
+      coordinator({ hooks: { onCreate: { pre: [{ function: 'observable' }] } } }, () => () => of('observable')).runPre(
+        null,
+        {},
+        { hooks: { onCreate: { pre: [{ function: 'observable' }] } } },
+        'onCreate',
+        {}
+      ),
+      coordinator(
+        { hooks: { onCreate: { pre: [{ function: 'effect' }] } } },
+        () => () => Effect.succeed('effect')
+      ).runPre(null, {}, { hooks: { onCreate: { pre: [{ function: 'effect' }] } } }, 'onCreate', {}),
+    ]);
+
+    expect(values.map(result => result.record)).to.deep.equal(['plain', 'promise', 'observable', 'effect']);
+  });
+
+  it('preserves sequential record threading and fail-fast omission', async function () {
+    const invoked: string[] = [];
+    const recordType = {
+      hooks: {
+        onCreate: {
+          pre: [{ function: 'first' }, { function: 'second' }, { function: 'never' }],
+        },
+      },
+    };
+    const result = await coordinator(recordType, hook => {
+      const name = String(hook.function);
+      return (_oid, record) => {
+        invoked.push(name);
+        if (name === 'second') {
+          throw new Error('legacy stop');
+        }
+        return { ...(record as AnyRecord), first: true };
+      };
+    }).runPre('oid-1', { initial: true }, recordType, 'onCreate', { username: 'user' });
+
+    expect(invoked).to.deep.equal(['first', 'second']);
+    expect(result.record).to.deep.equal({ initial: true, first: true });
+    expect(result.report.actions.map(action => action.status)).to.deep.equal(['succeeded', 'failed', 'skipped']);
+  });
+
+  it('locks the postSync record-return and in-place response mutation quirk', async function () {
+    const recordType = {
+      hooks: {
+        onCreate: {
+          postSync: [
+            { function: 'record', options: { returnType: 'record' } },
+            { function: 'response', options: { returnType: 'response' } },
+          ],
+        },
+      },
+    };
+    const seen: AnyRecord[] = [];
+    const result = await coordinator(recordType, hook => {
+      if (hook.function === 'record') {
+        return (_oid, record, _options, _user, response) => {
+          seen.push({ record: record as AnyRecord, response: response as AnyRecord });
+          (response as AnyRecord).workspaceOid = 'workspace-1';
+          return { ...(record as AnyRecord), transformed: true };
+        };
+      }
+      return (_oid, record, _options, _user, response) => {
+        seen.push({ record: record as AnyRecord, response: response as AnyRecord });
+        (response as AnyRecord).workspaceData = { linked: true };
+        return {
+          success: false,
+          message: 'legacy response',
+          data: { accepted: true },
+          metadata: { warning: true },
+          oid: 'must-not-replace',
+          secret: 'must-not-leak',
+        };
+      };
+    }).runPostSync('oid-1', { original: true }, recordType, 'onCreate', {}, { oid: 'oid-1', success: true });
+
+    expect(result.record).to.deep.equal({ original: true, transformed: true });
+    expect(seen[1].record).to.deep.equal({ original: true, transformed: true });
+    expect(result.response).to.deep.include({
+      oid: 'oid-1',
+      success: false,
+      message: 'legacy response',
+      data: { accepted: true },
+      metadata: { warning: true },
+      workspaceOid: 'workspace-1',
+      workspaceData: { linked: true },
+    });
+    expect(result.response).not.to.have.property('secret');
+  });
+
+  it('preserves detached invocation order, overlap, ignored returns, and swallowed failures', async function () {
+    const invoked: string[] = [];
+    const completed: string[] = [];
+    const errors: unknown[] = [];
+    let resolveFirst!: () => void;
+    let resolveSecond!: () => void;
+    const recordType = {
+      hooks: {
+        onCreate: {
+          post: [{ function: 'first' }, { function: 'second' }, { function: 'failure' }],
+        },
+      },
+    };
+    const result = coordinator(
+      recordType,
+      hook => {
+        if (hook.function === 'first') {
+          return () => {
+            invoked.push('first');
+            return new Promise<void>(resolve => {
+              resolveFirst = () => {
+                completed.push('first');
+                resolve();
+              };
+            });
+          };
+        }
+        if (hook.function === 'second') {
+          return () => {
+            invoked.push('second');
+            return new Promise<void>(resolve => {
+              resolveSecond = () => {
+                completed.push('second');
+                resolve();
+              };
+            });
+          };
+        }
+        return () => {
+          invoked.push('failure');
+          throw new Error('detached failure');
+        };
+      },
+      { error: (_message, error) => errors.push(error) }
+    ).dispatchPost('oid-1', { value: true }, recordType, 'onCreate', { username: 'user' });
+
+    expect(result.report.status).to.equal('dispatched');
+    await tick();
+    expect(invoked).to.deep.equal(['first', 'second', 'failure']);
+    resolveSecond();
+    resolveFirst();
+    await tick();
+    expect(completed).to.deep.equal(['second', 'first']);
+    expect(errors).to.have.length(1);
+  });
+
+  it('skips one malformed detached definition and still dispatches later hooks', async function () {
+    const invoked: string[] = [];
+    const warnings: unknown[] = [];
+    const recordType = {
+      hooks: {
+        onCreate: {
+          post: [{ function: '' }, { function: 'valid' }],
+        },
+      },
+    };
+    const result = coordinator(
+      recordType,
+      hook => () => {
+        invoked.push(String(hook.function));
+        return undefined;
+      },
+      { warn: (_message, fields) => warnings.push(fields) }
+    ).dispatchPost('oid-1', {}, recordType, 'onCreate', {});
+
+    await tick();
+    expect(result.report.actions.map(action => action.actionId)).to.have.length(1);
+    expect(invoked).to.deep.equal(['valid']);
+    expect(warnings).to.have.length(1);
+  });
+
+  it('captures Observable failure and synchronous detached throws without leaking the cause', async function () {
+    const errors: Array<Record<string, unknown>> = [];
+    const recordType = {
+      hooks: {
+        onCreate: {
+          post: [{ function: 'observable' }, { function: 'throw' }],
+        },
+      },
+    };
+    coordinator(
+      recordType,
+      hook => () =>
+        hook.function === 'observable'
+          ? new Observable(subscriber => subscriber.error({ secret: 'do-not-log' }))
+          : (() => {
+              throw new Error('secret throw');
+            })(),
+      {
+        error: (_message, fields) => errors.push(fields as Record<string, unknown>),
+      }
+    ).dispatchPost('oid-1', {}, recordType, 'onCreate', {});
+    await tick();
+
+    expect(errors).to.have.length(2);
+    expect(JSON.stringify(errors)).not.to.include('secret');
+  });
+});

--- a/packages/redbox-core/test/services/RecordsService.test.ts
+++ b/packages/redbox-core/test/services/RecordsService.test.ts
@@ -966,7 +966,7 @@ describe('RecordsService', function () {
       (RecordsService.hasEditAccess as any).restore();
     });
 
-    it('rejects malformed delete hooks before deleting the record', async function () {
+    it('does not reject malformed detached delete hooks before deleting the record', async function () {
       const result = await RecordsService.delete(
         'record-123',
         false,
@@ -975,8 +975,8 @@ describe('RecordsService', function () {
         { username: 'admin' }
       );
 
-      expect(result.success).to.equal(false);
-      expect(mockStorageService.delete.notCalled).to.equal(true);
+      expect(result.success).to.equal(true);
+      expect(mockStorageService.delete.calledWith('record-123')).to.equal(true);
     });
 
     it('never throws malformed configuration from fire-and-forget post hooks', function () {
@@ -1459,6 +1459,10 @@ describe('RecordsService', function () {
           .find((candidate: any) => candidate !== undefined);
         expect(auditSummary.completedThrough).to.equal('post-dispatch');
         expect(auditSummary.partial).to.equal(false);
+        expect(auditSummary.counts.dispatched).to.equal(undefined);
+        expect(auditSummary.actions.some((action: any) => action.phase === 'post' && action.status === 'succeeded')).to.equal(
+          true
+        );
       } finally {
         delete (globalThis as any).__effectHookOrder;
       }
@@ -1585,6 +1589,55 @@ describe('RecordsService', function () {
       expect(result.problems).to.deep.equal([]);
       expect(mockSails.log.error.calledWithMatch('record_hook_detached_action_failed')).to.equal(true);
       expect(JSON.stringify(mockSails.log.error.args)).not.to.include('detached secret');
+    });
+
+    it('queues the terminal detached outcome instead of a dispatch-only audit result', async function () {
+      mockQueueService.now.resetHistory();
+      const result = await RecordsService.create(
+        { id: 'brand-1' },
+        { metadata: { title: 'Detached audit' } },
+        recordTypeWithHooks({
+          onCreate: { post: [{ function: '() => { throw new Error("detached audit secret"); }' }] },
+        }),
+        { username: 'user-1' }
+      );
+      await new Promise(resolve => setImmediate(resolve));
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(result.outcome).to.equal('saved');
+      const summary = mockQueueService.now.firstCall.args[1].executionSummary;
+      expect(summary.completedThrough).to.equal('post-dispatch');
+      expect(summary.counts.dispatched).to.equal(undefined);
+      expect(summary.counts.failed).to.equal(1);
+      expect(summary.actions[0].status).to.equal('failed');
+      expect(summary.actions[0].durationMs).to.be.at.least(0);
+    });
+
+    it('does not let malformed detached post configuration block persistence', async function () {
+      const calls: string[] = [];
+      (globalThis as any).__effectDetachedCompatibility = calls;
+      try {
+        const result = await RecordsService.create(
+          { id: 'brand-1' },
+          { metadata: { title: 'Malformed detached hook' } },
+          recordTypeWithHooks({
+            onCreate: {
+              post: [
+                { function: '({ invalid: true })' },
+                { function: '() => { globalThis.__effectDetachedCompatibility.push("valid"); }' },
+              ],
+            },
+          }),
+          { username: 'user-1' }
+        );
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(result.wasPersisted()).to.equal(true);
+        expect(result.outcome).to.equal('saved');
+        expect(calls).to.deep.equal(['valid']);
+      } finally {
+        delete (globalThis as any).__effectDetachedCompatibility;
+      }
     });
 
     it('preserves the trigger-flag asymmetry: disabled pre hooks do not disable post hooks', async function () {

--- a/packages/redbox-core/test/services/RecordsService.test.ts
+++ b/packages/redbox-core/test/services/RecordsService.test.ts
@@ -1,11 +1,17 @@
 let expect: Chai.ExpectStatic;
-import("chai").then(mod => expect = mod.expect);
+import('chai').then(mod => (expect = mod.expect));
 import * as sinon from 'sinon';
 import { of, firstValueFrom } from 'rxjs';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { setupServiceTestGlobals, cleanupServiceTestGlobals, createMockSails, createQueryObject, configureModelMethod } from './testHelper';
+import {
+  setupServiceTestGlobals,
+  cleanupServiceTestGlobals,
+  createMockSails,
+  createQueryObject,
+  configureModelMethod,
+} from './testHelper';
 
 describe('RecordsService', function () {
   let mockSails: any;
@@ -32,20 +38,20 @@ describe('RecordsService', function () {
       exportAllPlans: sinon.stub().returns({}),
       createRecordAudit: sinon.stub().resolves({ success: true, isSuccessful: () => true }),
       restoreRecord: sinon.stub().resolves({}),
-      destroyDeletedRecord: sinon.stub().resolves({})
+      destroyDeletedRecord: sinon.stub().resolves({}),
     };
 
     mockSearchService = {
       index: sinon.stub(),
-      remove: sinon.stub()
+      remove: sinon.stub(),
     };
 
     mockQueueService = {
-      now: sinon.stub()
+      now: sinon.stub(),
     };
 
     mockDatastreamService = {
-      listDatastreams: sinon.stub().resolves([])
+      listDatastreams: sinon.stub().resolves([]),
     };
 
     mockSails = createMockSails({
@@ -53,53 +59,53 @@ describe('RecordsService', function () {
         appPath: '/app',
         record: {
           baseUrl: {
-            redbox: 'http://localhost:9000'
+            redbox: 'http://localhost:9000',
           },
           api: {
             info: { url: '/info', method: 'GET' },
-            search: { url: '/search', method: 'GET' }
+            search: { url: '/search', method: 'GET' },
           },
           auditing: {
             enabled: true,
-            recordAuditJobName: 'RecordAudit'
+            recordAuditJobName: 'RecordAudit',
           },
-          datastreamService: 'datastreamservice'
+          datastreamService: 'datastreamservice',
         },
         storage: {
-          serviceName: 'mongostorageservice'
+          serviceName: 'mongostorageservice',
         },
         search: {
-          serviceName: 'solrsearchservice'
+          serviceName: 'solrsearchservice',
         },
         queue: {
-          serviceName: 'agendaqueueservice'
+          serviceName: 'agendaqueueservice',
         },
         redbox: {
-          apiKey: 'test-api-key'
+          apiKey: 'test-api-key',
         },
         jsonld: {
           addJsonLdContext: false,
-          contexts: {}
-        }
+          contexts: {},
+        },
       },
       log: {
         verbose: sinon.stub(),
         debug: sinon.stub(),
         info: sinon.stub(),
         warn: sinon.stub(),
-        error: sinon.stub()
+        error: sinon.stub(),
       },
       services: {
         brandingservice: {
           getDefault: sinon.stub().returns({ id: 'brand-1', name: 'default' }),
           getBrand: sinon.stub().returns({ id: 'brand-1', name: 'default' }),
-          getBrandById: sinon.stub().returns({ id: 'brand-1', name: 'default' })
+          getBrandById: sinon.stub().returns({ id: 'brand-1', name: 'default' }),
         },
         mongostorageservice: mockStorageService,
         solrsearchservice: mockSearchService,
         agendaqueueservice: mockQueueService,
-        datastreamservice: mockDatastreamService
-      }
+        datastreamservice: mockDatastreamService,
+      },
     });
 
     mockRecord = {
@@ -107,49 +113,51 @@ describe('RecordsService', function () {
       findOne: sinon.stub(),
       create: sinon.stub(),
       update: sinon.stub(),
-      destroy: sinon.stub()
+      destroy: sinon.stub(),
     };
 
     setupServiceTestGlobals(mockSails);
     (global as any).Record = mockRecord;
     (global as any).RecordType = {
-      findOne: sinon.stub().resolves({ name: 'rdmp', packageType: 'rdmp' })
+      findOne: sinon.stub().resolves({ name: 'rdmp', packageType: 'rdmp' }),
     };
     (global as any).WorkflowStep = {
-      findOne: sinon.stub().resolves({ name: 'draft', config: {} })
+      findOne: sinon.stub().resolves({ name: 'draft', config: {} }),
     };
     (global as any).BrandingService = {
       getDefault: sinon.stub().returns({ id: 'brand-1', name: 'default' }),
-      getBrand: sinon.stub().returns({ id: 'brand-1', name: 'default' })
+      getBrand: sinon.stub().returns({ id: 'brand-1', name: 'default' }),
     };
     (global as any).FormsService = {
       getForm: sinon.stub().resolves({ name: 'default-form', attachmentFields: [] }),
-      getFormByName: sinon.stub().returns(of({ name: 'default-form', attachmentFields: [] }))
+      getFormByName: sinon.stub().returns(of({ name: 'default-form', attachmentFields: [] })),
     };
     (global as any).RolesService = {
       getAdminFromBrand: sinon.stub().returns({ id: 'role-admin', name: 'Admin' }),
-      getRole: sinon.stub().returns(null)
+      getRole: sinon.stub().returns(null),
     };
     (global as any).UsersService = {
       hasRole: sinon.stub().returns(true),
-      getUserWithUsername: sinon.stub().returns(of(null))
+      getUserWithUsername: sinon.stub().returns(of(null)),
     };
     (global as any).WorkflowStepsService = {
-      getFirst: sinon.stub().returns(of({
-        name: 'draft',
-        config: {
-          form: 'default-form',
-          addJsonLdContext: false,
-          authorization: { viewRoles: [], editRoles: [] },
-        },
-      })),
-      get: sinon.stub().returns(of({ name: 'draft', config: {} }))
+      getFirst: sinon.stub().returns(
+        of({
+          name: 'draft',
+          config: {
+            form: 'default-form',
+            addJsonLdContext: false,
+            authorization: { viewRoles: [], editRoles: [] },
+          },
+        })
+      ),
+      get: sinon.stub().returns(of({ name: 'draft', config: {} })),
     };
     (global as any).RecordTypesService = {
-      get: sinon.stub().returns(of({ name: 'rdmp', hooks: {} }))
+      get: sinon.stub().returns(of({ name: 'rdmp', hooks: {} })),
     };
     (global as any).TranslationService = {
-      t: sinon.stub().callsFake((key: string) => key)
+      t: sinon.stub().callsFake((key: string) => key),
     };
     (global as any).RedboxJavaStorageService = mockStorageService;
     (global as any).SolrSearchService = mockSearchService;
@@ -183,6 +191,18 @@ describe('RecordsService', function () {
   describe('constructor', function () {
     it('should set logHeader', function () {
       expect(RecordsService.logHeader).to.equal('RecordsService::');
+    });
+
+    it('registers detached-fiber teardown on the Sails lower lifecycle', function () {
+      const supervisor = (RecordsService as any).hookExecutionSupervisor;
+      const interruptAll = sinon.spy(supervisor, 'interruptAll');
+      RecordsService.init();
+      const lowerRegistration = mockSails.on.getCalls().find((call: any) => call.args[0] === 'lower');
+
+      expect(lowerRegistration).to.not.equal(undefined);
+      lowerRegistration.args[1]();
+      expect(interruptAll.calledOnce).to.equal(true);
+      interruptAll.restore();
     });
   });
 
@@ -282,11 +302,15 @@ describe('RecordsService', function () {
           editPending: ['pending-editor'],
           viewPending: ['pending-viewer'],
           editRoles: ['Admin'],
-          viewRoles: ['Researcher']
-        }
+          viewRoles: ['Researcher'],
+        },
       });
-      (global as any).UsersService.getUserWithUsername.withArgs('editor').returns(of({ name: 'Editor', email: 'editor@example.com' }));
-      (global as any).UsersService.getUserWithUsername.withArgs('viewer').returns(of({ name: 'Viewer', email: 'viewer@example.com' }));
+      (global as any).UsersService.getUserWithUsername
+        .withArgs('editor')
+        .returns(of({ name: 'Editor', email: 'editor@example.com' }));
+      (global as any).UsersService.getUserWithUsername
+        .withArgs('viewer')
+        .returns(of({ name: 'Viewer', email: 'viewer@example.com' }));
 
       const result = await RecordsService.getResolvedPermissionsSummary('record-123');
 
@@ -296,7 +320,7 @@ describe('RecordsService', function () {
         editPending: ['pending-editor'],
         viewPending: ['pending-viewer'],
         editRoles: ['Admin'],
-        viewRoles: ['Researcher']
+        viewRoles: ['Researcher'],
       });
     });
 
@@ -309,8 +333,8 @@ describe('RecordsService', function () {
           editPending: [],
           viewPending: [],
           editRoles: [],
-          viewRoles: []
-        }
+          viewRoles: [],
+        },
       });
       (global as any).UsersService.getUserWithUsername.withArgs('missing-user').returns(of(null));
 
@@ -342,8 +366,8 @@ describe('RecordsService', function () {
       mockDatastreamService.listDatastreams.resolves([
         {
           uploadDate: new Date().toISOString(),
-          metadata: { name: 'file.pdf', mimeType: 'application/pdf' }
-        }
+          metadata: { name: 'file.pdf', mimeType: 'application/pdf' },
+        },
       ]);
 
       const result = await RecordsService.getAttachments('record-123');
@@ -360,9 +384,9 @@ describe('RecordsService', function () {
           metadata: {
             name: 'file.pdf',
             mimeType: 'application/pdf',
-            dateUpdated: '2001-01-01T00:00:00.000Z'
-          }
-        }
+            dateUpdated: '2001-01-01T00:00:00.000Z',
+          },
+        },
       ]);
 
       const result = await RecordsService.getAttachments('record-123');
@@ -375,8 +399,8 @@ describe('RecordsService', function () {
       mockDatastreamService.listDatastreams.resolves([
         {
           lastModified: '2026-05-13T07:01:32.533Z',
-          metadata: { name: 'file.pdf', mimeType: 'application/pdf' }
-        }
+          metadata: { name: 'file.pdf', mimeType: 'application/pdf' },
+        },
       ]);
 
       const result = await RecordsService.getAttachments('record-123');
@@ -388,7 +412,7 @@ describe('RecordsService', function () {
     it('should filter by label when provided', async function () {
       mockDatastreamService.listDatastreams.resolves([
         { label: 'matched-file.pdf', uploadDate: new Date().toISOString(), metadata: { name: 'matched-file.pdf' } },
-        { label: 'other-file.txt', uploadDate: new Date().toISOString(), metadata: { name: 'other-file.txt' } }
+        { label: 'other-file.txt', uploadDate: new Date().toISOString(), metadata: { name: 'other-file.txt' } },
       ]);
 
       const result = await RecordsService.getAttachments('record-123', 'matched');
@@ -404,8 +428,8 @@ describe('RecordsService', function () {
       const record = {
         authorization: {
           edit: ['testuser'],
-          view: ['testuser']
-        }
+          view: ['testuser'],
+        },
       };
 
       const result = RecordsService.hasEditAccess(brand, user, [], record);
@@ -421,8 +445,8 @@ describe('RecordsService', function () {
         authorization: {
           edit: ['otheruser'],
           view: ['otheruser'],
-          editRoles: ['Admin']
-        }
+          editRoles: ['Admin'],
+        },
       };
 
       // Mock RolesService.getRole to return the admin role
@@ -439,8 +463,8 @@ describe('RecordsService', function () {
       const record = {
         authorization: {
           edit: ['otheruser'],
-          view: ['otheruser']
-        }
+          view: ['otheruser'],
+        },
       };
 
       const result = RecordsService.hasEditAccess(brand, user, [], record);
@@ -453,7 +477,7 @@ describe('RecordsService', function () {
       const user = { username: 'testuser', roles: [] };
       const record = {
         authorization_edit: ['testuser'],
-        authorization_view: ['testuser']
+        authorization_view: ['testuser'],
       };
 
       const result = RecordsService.hasEditAccess(brand, user, [], record);
@@ -469,8 +493,8 @@ describe('RecordsService', function () {
       const record = {
         authorization: {
           edit: ['owner'],
-          view: ['owner', 'viewer']
-        }
+          view: ['owner', 'viewer'],
+        },
       };
 
       const result = RecordsService.hasViewAccess(brand, user, [], record);
@@ -484,8 +508,8 @@ describe('RecordsService', function () {
       const record = {
         authorization: {
           edit: ['editor'],
-          view: ['viewer']
-        }
+          view: ['viewer'],
+        },
       };
 
       const result = RecordsService.hasViewAccess(brand, user, [], record);
@@ -499,8 +523,8 @@ describe('RecordsService', function () {
       const record = {
         authorization: {
           edit: ['owner'],
-          view: ['viewer']
-        }
+          view: ['viewer'],
+        },
       };
 
       const result = RecordsService.hasViewAccess(brand, user, [], record);
@@ -513,7 +537,7 @@ describe('RecordsService', function () {
       const user = { username: 'viewer', roles: [] };
       const record = {
         authorization_edit: ['owner'],
-        authorization_view: ['owner', 'viewer']
+        authorization_view: ['owner', 'viewer'],
       };
 
       const result = RecordsService.hasViewAccess(brand, user, [], record);
@@ -563,8 +587,8 @@ describe('RecordsService', function () {
     it('should store audit via storage service', function () {
       const job = {
         attrs: {
-          data: { id: 'record-123', action: 'updated' }
-        }
+          data: { id: 'record-123', action: 'updated' },
+        },
       };
 
       RecordsService.storeRecordAudit(job);
@@ -578,9 +602,9 @@ describe('RecordsService', function () {
       const recordType = {
         hooks: {
           onUpdate: {
-            postSync: [{ function: 'someFunction' }]
-          }
-        }
+            postSync: [{ function: 'someFunction' }],
+          },
+        },
       };
 
       const result = RecordsService.hasPostSaveSyncHooks(recordType, 'onUpdate');
@@ -590,7 +614,7 @@ describe('RecordsService', function () {
 
     it('should return false when no hooks configured', function () {
       const recordType = {
-        hooks: {}
+        hooks: {},
       };
 
       const result = RecordsService.hasPostSaveSyncHooks(recordType, 'onUpdate');
@@ -602,9 +626,9 @@ describe('RecordsService', function () {
       const recordType = {
         hooks: {
           onUpdate: {
-            postSync: []
-          }
-        }
+            postSync: [],
+          },
+        },
       };
 
       const result = RecordsService.hasPostSaveSyncHooks(recordType, 'onUpdate');
@@ -677,19 +701,24 @@ describe('RecordsService', function () {
         name: 'rdmp',
         packageType: 'rdmp',
         packageName: 'RDMP',
-        searchCore: 'default'
+        searchCore: 'default',
       };
       const workflowStep = {
-        config: { form: 'default-form' }
+        config: { form: 'default-form' },
       };
       const form = {
         configuration: {
-          attachmentFields: ['dataLocations']
-        }
+          attachmentFields: ['dataLocations'],
+        },
       };
 
       const result = (RecordsService as any).initRecordMetaMetadata(
-        'brand-1', 'testuser', recordType, workflowStep, form, '2024-01-01T00:00:00Z'
+        'brand-1',
+        'testuser',
+        recordType,
+        workflowStep,
+        form,
+        '2024-01-01T00:00:00Z'
       );
 
       expect(result).to.have.property('brandId', 'brand-1');
@@ -705,17 +734,22 @@ describe('RecordsService', function () {
         name: 'rdmp',
         packageType: 'rdmp',
         packageName: 'RDMP',
-        searchCore: 'default'
+        searchCore: 'default',
       };
       const workflowStep = {
-        config: { form: 'default-form' }
+        config: { form: 'default-form' },
       };
       const form = {
-        attachmentFields: ['dataLocations']
+        attachmentFields: ['dataLocations'],
       };
 
       const result = (RecordsService as any).initRecordMetaMetadata(
-        'brand-1', 'testuser', recordType, workflowStep, form, '2024-01-01T00:00:00Z'
+        'brand-1',
+        'testuser',
+        recordType,
+        workflowStep,
+        form,
+        '2024-01-01T00:00:00Z'
       );
 
       expect(result).to.have.property('attachmentFields', form.attachmentFields);
@@ -725,12 +759,14 @@ describe('RecordsService', function () {
   describe('bindPendingAttachmentOids', function () {
     it('rebinds pending attachment URLs and clears the pending flag', function () {
       const metadata = {
-        attachments: [{
-          pending: true,
-          location: '/record/pending-oid/attach/file-123',
-          uploadUrl: 'http://localhost/record/pending-oid/attach/file-123',
-          fileId: 'file-123'
-        }]
+        attachments: [
+          {
+            pending: true,
+            location: '/record/pending-oid/attach/file-123',
+            uploadUrl: 'http://localhost/record/pending-oid/attach/file-123',
+            fileId: 'file-123',
+          },
+        ],
       };
 
       (RecordsService as any).bindPendingAttachmentOids(metadata, ['attachments'], 'oid-100');
@@ -738,7 +774,7 @@ describe('RecordsService', function () {
       expect(metadata.attachments[0]).to.deep.include({
         pending: false,
         location: '/record/oid-100/attach/file-123',
-        uploadUrl: 'http://localhost/record/oid-100/attach/file-123'
+        uploadUrl: 'http://localhost/record/oid-100/attach/file-123',
       });
     });
   });
@@ -867,10 +903,10 @@ describe('RecordsService', function () {
       const bootstrapPath = await fs.mkdtemp(path.join(os.tmpdir(), 'records-bootstrap-'));
       const recordsPath = path.join(bootstrapPath, 'records');
       await fs.mkdir(recordsPath, { recursive: true });
-      await fs.writeFile(path.join(recordsPath, 'party.json'), JSON.stringify([
-        { title: 'Party one' },
-        { title: 'Party two' }
-      ]));
+      await fs.writeFile(
+        path.join(recordsPath, 'party.json'),
+        JSON.stringify([{ title: 'Party one' }, { title: 'Party two' }])
+      );
       mockSails.config.bootstrap = { bootstrapDataPath: bootstrapPath };
 
       mockRecord.findOne.onFirstCall().returns(createQueryObject(null));
@@ -914,7 +950,7 @@ describe('RecordsService', function () {
       const user = { username: 'admin' };
       const record = {
         metaMetadata: { brandId: 'brand-1' },
-        metadata: {}
+        metadata: {},
       };
 
       sinon.stub(RecordsService, 'getMeta').resolves(record);
@@ -936,7 +972,7 @@ describe('RecordsService', function () {
         false,
         { metadata: {} },
         { hooks: { onDelete: { post: [{ function: '({ invalid: true })' }] } } },
-        { username: 'admin' },
+        { username: 'admin' }
       );
 
       expect(result.success).to.equal(false);
@@ -944,13 +980,15 @@ describe('RecordsService', function () {
     });
 
     it('never throws malformed configuration from fire-and-forget post hooks', function () {
-      expect(() => RecordsService.triggerPostSaveTriggers(
-        'record-123',
-        { metadata: {} },
-        { hooks: { onDelete: { post: [{ function: '({ invalid: true })' }] } } },
-        'onDelete',
-        { username: 'admin' },
-      )).not.to.throw();
+      expect(() =>
+        RecordsService.triggerPostSaveTriggers(
+          'record-123',
+          { metadata: {} },
+          { hooks: { onDelete: { post: [{ function: '({ invalid: true })' }] } } },
+          'onDelete',
+          { username: 'admin' }
+        )
+      ).not.to.throw();
     });
   });
 
@@ -969,12 +1007,14 @@ describe('RecordsService', function () {
       const recordType = {
         hooks: {
           onUpdate: {
-            pre: [{
-              function: `(() => {
+            pre: [
+              {
+                function: `(() => {
                 globalThis.hookExpressionEvaluations += 1;
                 return (_oid, record) => record;
               })()`,
-            }],
+              },
+            ],
           },
         },
       };
@@ -995,25 +1035,76 @@ describe('RecordsService', function () {
       const recordType = {
         hooks: {
           onCreate: {
-            postSync: [{
-              function: `(_oid, hookRecord, _options, _user, response) => {
+            postSync: [
+              {
+                function: `(_oid, hookRecord, _options, _user, response) => {
                 response.workspaceOid = 'workspace-1';
                 response.workspaceData = { linked: true };
                 response.oid = 'tampered';
                 return hookRecord;
               }`,
-            }],
+              },
+            ],
           },
         },
       };
 
       const result = await RecordsService.triggerPostSaveSyncTriggers(
-        'record-123', record, recordType, 'onCreate', {}, { oid: 'record-123', success: true },
+        'record-123',
+        record,
+        recordType,
+        'onCreate',
+        {},
+        { oid: 'record-123', success: true }
       );
 
       expect(result.workspaceOid).to.equal('workspace-1');
       expect(result.workspaceData).to.deep.equal({ linked: true });
       expect(result.oid).to.equal('record-123');
+    });
+
+    it('preserves standalone transition pre/postSync/post ordering and response projection', async function () {
+      const events: string[] = [];
+      (globalThis as any).__effectTransitionEvents = events;
+      const recordType = {
+        hooks: {
+          onTransitionWorkflow: {
+            pre: [
+              { function: '(_oid, record) => { globalThis.__effectTransitionEvents.push("pre"); return record; }' },
+            ],
+            postSync: [
+              {
+                function: '(_oid, record) => { globalThis.__effectTransitionEvents.push("postSync"); return record; }',
+              },
+            ],
+            post: [{ function: '() => { globalThis.__effectTransitionEvents.push("post"); }' }],
+          },
+        },
+      };
+
+      try {
+        const transitioned = await RecordsService.triggerPreSaveTransitionWorkflowTriggers(
+          'record-123',
+          { metadata: {} },
+          recordType,
+          { name: 'published' },
+          { username: 'user-1' }
+        );
+        const response = await RecordsService.triggerPostSaveTransitionWorkflowTriggers(
+          'record-123',
+          transitioned,
+          recordType,
+          { name: 'published' },
+          { username: 'user-1' },
+          { oid: 'record-123', success: true }
+        );
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(response.oid).to.equal('record-123');
+        expect(events).to.deep.equal(['pre', 'postSync', 'post']);
+      } finally {
+        delete (globalThis as any).__effectTransitionEvents;
+      }
     });
   });
 
@@ -1038,10 +1129,12 @@ describe('RecordsService', function () {
         metaMetadata: { type: 'rdmp', form: 'default-form', brandId: 'brand-1' },
         metadata: { attachments: [{ attachmentId: 'attachment-1', fileId: 'file-1', pending: false }] },
       });
-      (global as any).FormsService.getFormByName.returns(of({
-        name: 'default-form',
-        configuration: { attachmentFields: ['attachments'] },
-      }));
+      (global as any).FormsService.getFormByName.returns(
+        of({
+          name: 'default-form',
+          configuration: { attachmentFields: ['attachments'] },
+        })
+      );
       (global as any).RecordTypesService.get.returns(of({ name: 'rdmp', hooks: {}, searchable: false }));
 
       const result = await RecordsService.updateMeta(
@@ -1056,7 +1149,7 @@ describe('RecordsService', function () {
         true,
         true,
         {},
-        { attachments: [{ attachmentId: 'attachment-1', fileId: 'file-1', pending: true }] },
+        { attachments: [{ attachmentId: 'attachment-1', fileId: 'file-1', pending: true }] }
       );
 
       expect(result.wasPersisted()).to.equal(true);
@@ -1153,7 +1246,7 @@ describe('RecordsService', function () {
         { id: 'brand-1' },
         { metadata: { attachments: [{ attachmentId: 'attachment-1', fileId: 'file-1', pending: true }] } },
         { name: 'rdmp', hooks: {}, searchable: false },
-        { username: 'user-1' },
+        { username: 'user-1' }
       );
 
       expect(result.wasPersisted()).to.equal(true);
@@ -1321,6 +1414,274 @@ describe('RecordsService', function () {
     });
   });
 
+  describe('Effect hook lifecycle integration', function () {
+    function recordTypeWithHooks(hooks: any): any {
+      return { name: 'rdmp', searchable: false, hooks };
+    }
+
+    it('preserves create ordering and keeps execution metadata out of the business record', async function () {
+      const order: string[] = [];
+      (globalThis as any).__effectHookOrder = order;
+      mockStorageService.create.callsFake(async () => {
+        order.push('persistence');
+        return { success: true, oid: 'created-1', applicationState: 'applied' };
+      });
+      mockStorageService.updateMeta.callsFake(async () => {
+        order.push('postSync-persistence');
+        return { success: true, oid: 'created-1', applicationState: 'applied' };
+      });
+      const recordType = recordTypeWithHooks({
+        onCreate: {
+          pre: [{ function: '(_oid, record) => { globalThis.__effectHookOrder.push("pre"); return record; }' }],
+          postSync: [
+            { function: '(_oid, record) => { globalThis.__effectHookOrder.push("postSync"); return record; }' },
+          ],
+          post: [{ function: '() => { globalThis.__effectHookOrder.push("post"); }' }],
+        },
+      });
+
+      try {
+        const result = await RecordsService.create({ id: 'brand-1' }, { metadata: { title: 'Created' } }, recordType, {
+          username: 'user-1',
+        });
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(result.wasPersisted()).to.equal(true);
+        expect(order).to.deep.equal(['pre', 'persistence', 'postSync', 'postSync-persistence', 'post']);
+        const storedRecord = mockStorageService.create.firstCall.args[1];
+        expect(storedRecord).not.to.have.property('executionSummary');
+        expect(JSON.stringify(storedRecord)).not.to.include('executionId');
+        expect(Object.keys(result)).not.to.include('executionSummary');
+
+        const auditSummary = mockQueueService.now
+          .getCalls()
+          .map((call: any) => call.args[1]?.executionSummary)
+          .find((candidate: any) => candidate !== undefined);
+        expect(auditSummary.completedThrough).to.equal('post-dispatch');
+        expect(auditSummary.partial).to.equal(false);
+      } finally {
+        delete (globalThis as any).__effectHookOrder;
+      }
+    });
+
+    it('does not persist after a pre-hook failure', async function () {
+      mockStorageService.create.resetHistory();
+      const result = await RecordsService.create(
+        { id: 'brand-1' },
+        { metadata: { title: 'Rejected' } },
+        recordTypeWithHooks({
+          onCreate: { pre: [{ function: '() => { throw new Error("secret pre failure"); }' }] },
+        }),
+        { username: 'user-1' }
+      );
+
+      expect(mockStorageService.create.notCalled).to.equal(true);
+      expect(result.wasPersisted()).to.equal(false);
+      expect(result.outcome).to.equal('not-saved');
+      expect(JSON.stringify(result)).not.to.include('secret pre failure');
+    });
+
+    it('keeps a postSync failure persisted with warnings and queues its summary', async function () {
+      mockStorageService.create.resetHistory();
+      mockQueueService.now.resetHistory();
+      const result = await RecordsService.create(
+        { id: 'brand-1' },
+        { metadata: { title: 'Warning' } },
+        recordTypeWithHooks({
+          onCreate: { postSync: [{ function: '() => null' }] },
+        }),
+        { username: 'user-1' }
+      );
+      await Promise.resolve();
+
+      expect(mockStorageService.create.calledOnce).to.equal(true);
+      expect(result.wasPersisted()).to.equal(true);
+      expect(result.outcome).to.equal('saved-with-warnings');
+      expect(result.problems[0].phase).to.equal('post-save');
+      expect(mockQueueService.now.calledOnce).to.equal(true);
+      const summary = mockQueueService.now.firstCall.args[1].executionSummary;
+      expect(summary.completedThrough).to.equal('postSync');
+      expect(summary.partial).to.equal(false);
+      expect(summary.actions[0].status).to.equal('failed');
+    });
+
+    it('recovers a transient pre-hook retry without a user-facing warning', async function () {
+      mockStorageService.create.resetHistory();
+      const result = await RecordsService.create(
+        { id: 'brand-1' },
+        { metadata: { title: 'Retry' } },
+        recordTypeWithHooks({
+          onCreate: {
+            pre: [
+              {
+                function: `(() => {
+                globalThis.__effectRetryAttempts = 0;
+                return (_oid, record) => {
+                  globalThis.__effectRetryAttempts += 1;
+                  if (globalThis.__effectRetryAttempts === 1) {
+                    throw Object.assign(new Error('transient secret'), { _tag: 'ActionTransientFailure', code: 'temporary' });
+                  }
+                  return record;
+                };
+              })()`,
+                execution: {
+                  retry: { maxAttempts: 2, retryOn: ['transient'], idempotent: true },
+                },
+              },
+            ],
+          },
+        }),
+        { username: 'user-1' }
+      );
+
+      try {
+        expect((globalThis as any).__effectRetryAttempts).to.equal(2);
+        expect(mockStorageService.create.calledOnce).to.equal(true);
+        expect(result.outcome).to.equal('saved');
+        expect(result.problems).to.deep.equal([]);
+      } finally {
+        delete (globalThis as any).__effectRetryAttempts;
+      }
+    });
+
+    it('maps pre and postSync timeouts to their existing save boundaries', async function () {
+      mockStorageService.create.resetHistory();
+      const preResult = await RecordsService.create(
+        { id: 'brand-1' },
+        { metadata: { title: 'Pre timeout' } },
+        recordTypeWithHooks({
+          onCreate: { pre: [{ function: '() => new Promise(() => undefined)', execution: { timeoutMs: 10 } }] },
+        }),
+        { username: 'user-1' }
+      );
+      expect(preResult.wasPersisted()).to.equal(false);
+      expect(mockStorageService.create.notCalled).to.equal(true);
+
+      const postResult = await RecordsService.create(
+        { id: 'brand-1' },
+        { metadata: { title: 'Post timeout' } },
+        recordTypeWithHooks({
+          onCreate: { postSync: [{ function: '() => new Promise(() => undefined)', execution: { timeoutMs: 10 } }] },
+        }),
+        { username: 'user-1' }
+      );
+      expect(postResult.wasPersisted()).to.equal(true);
+      expect(postResult.outcome).to.equal('saved-with-warnings');
+    });
+
+    it('does not alter a successful response when a detached hook fails afterward', async function () {
+      mockSails.log.error.resetHistory();
+      const result = await RecordsService.create(
+        { id: 'brand-1' },
+        { metadata: { title: 'Detached' } },
+        recordTypeWithHooks({
+          onCreate: { post: [{ function: '() => { throw new Error("detached secret"); }' }] },
+        }),
+        { username: 'user-1' }
+      );
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(result.outcome).to.equal('saved');
+      expect(result.problems).to.deep.equal([]);
+      expect(mockSails.log.error.calledWithMatch('record_hook_detached_action_failed')).to.equal(true);
+      expect(JSON.stringify(mockSails.log.error.args)).not.to.include('detached secret');
+    });
+
+    it('preserves the trigger-flag asymmetry: disabled pre hooks do not disable post hooks', async function () {
+      const calls: string[] = [];
+      (globalThis as any).__effectFlagCalls = calls;
+      const recordType = recordTypeWithHooks({
+        onUpdate: {
+          pre: [{ function: '(_oid, record) => { globalThis.__effectFlagCalls.push("pre"); return record; }' }],
+          post: [{ function: '() => { globalThis.__effectFlagCalls.push("post"); }' }],
+        },
+      });
+      (globalThis as any).RecordTypesService.get.returns(of(recordType));
+      try {
+        const result = await RecordsService.updateMeta(
+          { id: 'brand-1' },
+          'record-123',
+          { metaMetadata: { type: 'rdmp', brandId: 'brand-1', form: 'default-form' }, metadata: {} },
+          { username: 'user-1' },
+          false,
+          true
+        );
+        await new Promise(resolve => setImmediate(resolve));
+        expect(result.wasPersisted()).to.equal(true);
+        expect(calls).to.deep.equal(['post']);
+      } finally {
+        delete (globalThis as any).__effectFlagCalls;
+      }
+    });
+
+    it('passes execution summaries through the existing audit queue payload', async function () {
+      mockQueueService.now.resetHistory();
+      const summary = {
+        schemaVersion: 1,
+        executionId: 'execution-1',
+        trigger: 'record-hook' as const,
+        operation: 'update' as const,
+        partial: false,
+        durationMs: 3,
+        totalActions: 1,
+        counts: { succeeded: 1 },
+        actions: [],
+        truncated: false,
+      };
+      await RecordsService.auditRecord(
+        'record-123',
+        { metadata: { title: 'Audit' } },
+        { username: 'user-1' },
+        'updated',
+        summary
+      );
+
+      expect(mockQueueService.now.firstCall.args[1].executionSummary).to.deep.equal(summary);
+      expect(mockQueueService.now.firstCall.args[1].record).not.to.have.property('executionSummary');
+    });
+
+    it('lets a custom RecordsService subclass inherit the core hook coordinator', async function () {
+      const CoreRecords = RecordsService.constructor as any;
+      class ExtendedRecords extends CoreRecords {
+        public extensionMarker = true;
+      }
+      const extended = new ExtendedRecords();
+      const recordType = recordTypeWithHooks({
+        onCreate: { pre: [{ function: '(_oid, record) => ({ ...record, extended: true })' }] },
+      });
+      const result = await extended.triggerPreSaveTriggers('record-123', {}, recordType, 'onCreate', {});
+
+      expect(extended.extensionMarker).to.equal(true);
+      expect(result).to.deep.equal({ extended: true });
+    });
+  });
+
+  describe('delete hook audit boundary', function () {
+    it('writes a partial audit before detached post work starts', async function () {
+      mockQueueService.now.resetHistory();
+      const recordType = {
+        name: 'rdmp',
+        searchable: false,
+        hooks: {
+          onDelete: {
+            pre: [{ function: '(_oid, record) => record' }],
+            post: [{ function: '() => undefined' }],
+          },
+        },
+      };
+      const result = await RecordsService.delete('record-123', false, { metadata: {} }, recordType, {
+        username: 'user-1',
+      });
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(result.success).to.equal(true);
+      const summary = mockQueueService.now.firstCall.args[1].executionSummary;
+      expect(summary.partial).to.equal(true);
+      expect(summary.completedThrough).to.equal('persistence');
+      expect(summary.actions.every((action: any) => action.phase !== 'post')).to.equal(true);
+    });
+  });
+
   describe('finishSave operational handoff', function () {
     function persistedTracker() {
       const { RecordSaveResponse, createRecordSaveContext } = require('../../src/RecordSaveResponse');
@@ -1333,12 +1694,7 @@ describe('RecordsService', function () {
       mockStorageService.getMeta.rejects(new Error('snapshot unavailable'));
       const audit = sinon.stub(RecordsService, 'auditRecord');
 
-      const result = await (RecordsService as any).finishSave(
-        persistedTracker(),
-        {},
-        'updated',
-        true,
-      );
+      const result = await (RecordsService as any).finishSave(persistedTracker(), {}, 'updated', true);
 
       expect(result.oid).to.equal('tracker-oid');
       expect(mockSearchService.index.notCalled).to.equal(true);
@@ -1350,17 +1706,14 @@ describe('RecordsService', function () {
       mockSearchService.index.callsFake(() => new Promise(() => undefined));
       sinon.stub(RecordsService, 'auditRecord').callsFake(() => new Promise(() => undefined));
 
-      const result = await (RecordsService as any).finishSave(
-        persistedTracker(),
-        {},
-        'updated',
-        true,
-      );
+      const result = await (RecordsService as any).finishSave(persistedTracker(), {}, 'updated', true);
       await Promise.resolve();
 
       expect(result.oid).to.equal('tracker-oid');
       expect(mockStorageService.getMeta.calledWith('tracker-oid')).to.equal(true);
-      expect(mockSearchService.index.calledWith('tracker-oid', sinon.match({ metadata: { committed: true } }))).to.equal(true);
+      expect(
+        mockSearchService.index.calledWith('tracker-oid', sinon.match({ metadata: { committed: true } }))
+      ).to.equal(true);
     });
   });
 

--- a/packages/redbox-core/test/services/RecordsService.test.ts
+++ b/packages/redbox-core/test/services/RecordsService.test.ts
@@ -1460,9 +1460,9 @@ describe('RecordsService', function () {
         expect(auditSummary.completedThrough).to.equal('post-dispatch');
         expect(auditSummary.partial).to.equal(false);
         expect(auditSummary.counts.dispatched).to.equal(undefined);
-        expect(auditSummary.actions.some((action: any) => action.phase === 'post' && action.status === 'succeeded')).to.equal(
-          true
-        );
+        expect(
+          auditSummary.actions.some((action: any) => action.phase === 'post' && action.status === 'succeeded')
+        ).to.equal(true);
       } finally {
         delete (globalThis as any).__effectHookOrder;
       }
@@ -1611,6 +1611,70 @@ describe('RecordsService', function () {
       expect(summary.counts.failed).to.equal(1);
       expect(summary.actions[0].status).to.equal('failed');
       expect(summary.actions[0].durationMs).to.be.at.least(0);
+    });
+
+    it('finalizes a detached audit after a bounded grace period and does so exactly once', async function () {
+      const clock = sinon.useFakeTimers();
+      mockQueueService.now.resetHistory();
+      mockSails.log.info.resetHistory();
+      (globalThis as any).__resolvePendingDetached = undefined;
+      try {
+        const result = await RecordsService.create(
+          { id: 'brand-1' },
+          { metadata: { title: 'Pending detached audit' } },
+          recordTypeWithHooks({
+            onCreate: {
+              post: [
+                { function: '() => undefined' },
+                {
+                  function: '() => new Promise(resolve => { globalThis.__resolvePendingDetached = resolve; })',
+                },
+              ],
+            },
+          }),
+          { username: 'user-1' }
+        );
+        await Promise.resolve();
+
+        // The response and indexing path do not wait for the detached grace
+        // period, and the unresolved Promise has not prevented submission yet.
+        expect(result.outcome).to.equal('saved');
+        expect(mockQueueService.now.notCalled).to.equal(true);
+
+        await clock.tickAsync(1000);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(mockQueueService.now.calledOnce).to.equal(true);
+        const summary = mockQueueService.now.firstCall.args[1].executionSummary;
+        expect(summary.partial).to.equal(true);
+        expect(summary.detachedFinalization).to.equal('grace-expired');
+        expect(summary.detachedPending).to.equal(1);
+        expect(summary.totalActions).to.equal(2);
+        expect(summary.counts.succeeded).to.equal(1);
+        expect(summary.counts.dispatched).to.equal(1);
+        expect(summary.actions.map((action: any) => action.status)).to.deep.equal(['succeeded', 'dispatched']);
+
+        const completedEvents = mockSails.log.info
+          .getCalls()
+          .filter((call: any) => String(call.args[0]).includes('record_hook_operation_completed'));
+        const dispatchedEvents = mockSails.log.info
+          .getCalls()
+          .filter((call: any) => String(call.args[0]).includes('record_hook_operation_dispatched'));
+        expect(dispatchedEvents).to.have.length(1);
+        expect(completedEvents).to.have.length(1);
+
+        // A terminal result arriving after finalization remains observable at
+        // action level but cannot enqueue a second audit document.
+        (globalThis as any).__resolvePendingDetached?.();
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(mockQueueService.now.calledOnce).to.equal(true);
+        expect(completedEvents).to.have.length(1);
+      } finally {
+        delete (globalThis as any).__resolvePendingDetached;
+        clock.restore();
+      }
     });
 
     it('does not let malformed detached post configuration block persistence', async function () {

--- a/packages/sails-hook-redbox-storage-mongo/src/models/RecordAudit.ts
+++ b/packages/sails-hook-redbox-storage-mongo/src/models/RecordAudit.ts
@@ -17,6 +17,9 @@ export class RecordAuditClass {
 
   @Attr({ type: 'string' })
   public action?: string;
+
+  @Attr({ type: 'json' })
+  public executionSummary?: Record<string, unknown>;
 }
 
 export const RecordAuditWLDef = toWaterlineModelDef(RecordAuditClass);

--- a/packages/sails-hook-redbox-storage-mongo/src/services/MongoStorageService.ts
+++ b/packages/sails-hook-redbox-storage-mongo/src/services/MongoStorageService.ts
@@ -145,9 +145,8 @@ export namespace Services {
     private getErrorMessage(err: unknown): string {
       if (err instanceof Error) {
         const messageParts = [err.message];
-        const causeMessage = err.cause instanceof Error
-          ? err.cause.message
-          : (typeof err.cause === 'string' ? err.cause : undefined);
+        const causeMessage =
+          err.cause instanceof Error ? err.cause.message : typeof err.cause === 'string' ? err.cause : undefined;
         if (causeMessage != null && causeMessage !== '' && causeMessage !== err.message) {
           messageParts.push(`Cause: ${causeMessage}`);
         }
@@ -184,10 +183,7 @@ export namespace Services {
       }
 
       try {
-        const collectionInfo = this.db.collection(
-          collectionName,
-          { strict: true } as mongodb.CollectionOptions
-        );
+        const collectionInfo = this.db.collection(collectionName, { strict: true } as mongodb.CollectionOptions);
         sails.log.verbose(`${this.logHeader} Collection '${collectionName}' info:`);
         sails.log.verbose(JSON.stringify(collectionInfo));
         return true;
@@ -392,7 +388,11 @@ export namespace Services {
       batchFn();
     }
 
-    public async getRelatedRecords(oid: string, brand: BrandingModel, options: RecordRelationshipExpandOptions = {}): Promise<RecordRelationshipGraph> {
+    public async getRelatedRecords(
+      oid: string,
+      brand: BrandingModel,
+      options: RecordRelationshipExpandOptions = {}
+    ): Promise<RecordRelationshipGraph> {
       const mappingContext = await this.walkRelatedRecords(String(oid ?? ''), brand, options);
       return {
         rootOid: mappingContext.rootOid,
@@ -417,9 +417,14 @@ export namespace Services {
 
       const record = (await this.getMeta(normalizedOid)) as JsonMap;
       const currentRecordTypeName = String(recordTypeName ?? _.get(record, 'metaMetadata.type', '')).trim();
-      const maxDepth = typeof options.depth === 'number' && options.depth >= 0 ? options.depth : Number.POSITIVE_INFINITY;
-      const includeRecordTypes = new Set((options.includeRecordTypes ?? []).map((value) => String(value ?? '').trim()).filter(Boolean));
-      const includeRelationIds = new Set((options.includeRelationIds ?? []).map((value) => String(value ?? '').trim()).filter(Boolean));
+      const maxDepth =
+        typeof options.depth === 'number' && options.depth >= 0 ? options.depth : Number.POSITIVE_INFINITY;
+      const includeRecordTypes = new Set(
+        (options.includeRecordTypes ?? []).map(value => String(value ?? '').trim()).filter(Boolean)
+      );
+      const includeRelationIds = new Set(
+        (options.includeRelationIds ?? []).map(value => String(value ?? '').trim()).filter(Boolean)
+      );
 
       if (_.isEmpty(mappingContext)) {
         mappingContext = {
@@ -518,7 +523,11 @@ export namespace Services {
       return mappingContext;
     }
 
-    private addRelatedObject(mappingContext: RelatedRecordsContext, recordTypeName: string, record: MongoRecordDocument) {
+    private addRelatedObject(
+      mappingContext: RelatedRecordsContext,
+      recordTypeName: string,
+      record: MongoRecordDocument
+    ) {
       const normalizedRecordTypeName = String(recordTypeName ?? '').trim();
       const recordOid = String((record as JsonMap).redboxOid ?? '').trim();
       if (!normalizedRecordTypeName || !recordOid) {
@@ -538,11 +547,13 @@ export namespace Services {
     }
 
     private extractRelationshipLocalValues(record: JsonMap, relationship: NormalizedRecordRelation): string[] {
-      const rawValue = _.get(record, relationship.localField, relationship.localField === 'redboxOid' ? record.redboxOid : undefined);
+      const rawValue = _.get(
+        record,
+        relationship.localField,
+        relationship.localField === 'redboxOid' ? record.redboxOid : undefined
+      );
       const values = Array.isArray(rawValue) ? rawValue : [rawValue];
-      return values
-        .map((value) => String(value ?? '').trim())
-        .filter((value) => value !== '');
+      return values.map(value => String(value ?? '').trim()).filter(value => value !== '');
     }
 
     private buildRelationshipCriteria(relationship: NormalizedRecordRelation, localValues: string[]): JsonMap {
@@ -550,9 +561,7 @@ export namespace Services {
         'metaMetadata.type': relationship.recordType,
       };
 
-      criteria[relationship.foreignField] = localValues.length === 1
-        ? localValues[0]
-        : { in: localValues };
+      criteria[relationship.foreignField] = localValues.length === 1 ? localValues[0] : { in: localValues };
 
       return criteria;
     }
@@ -570,8 +579,9 @@ export namespace Services {
           meta: (value: JsonMap) => Promise<JsonMap[]>;
         };
         if (typeof chainedQuery.limit === 'function') {
-          return await (chainedQuery.limit(1) as { meta: (value: JsonMap) => Promise<JsonMap[]> })
-            .meta({ enableExperimentalDeepTargets: true });
+          return await (chainedQuery.limit(1) as { meta: (value: JsonMap) => Promise<JsonMap[]> }).meta({
+            enableExperimentalDeepTargets: true,
+          });
         }
       }
 
@@ -581,7 +591,9 @@ export namespace Services {
       }
 
       return [...relatedRecords]
-        .sort((left, right) => String(_.get(left, 'redboxOid', '')).localeCompare(String(_.get(right, 'redboxOid', ''))))
+        .sort((left, right) =>
+          String(_.get(left, 'redboxOid', '')).localeCompare(String(_.get(right, 'redboxOid', '')))
+        )
         .slice(0, 1);
     }
 
@@ -1016,10 +1028,15 @@ export namespace Services {
               objectMode: true,
               transform(record: Record<string, unknown>, _encoding, callback) {
                 callback(null, sanitizeCsvRecord(record));
-              }
+              },
             });
             const json2csv = new Transform({ fields, transforms: [flatten()] }, { objectMode: true });
-            await pipeline(stream.Readable.from(this.fetchAllRecords(query, { ...options })), sanitize, json2csv, passThrough);
+            await pipeline(
+              stream.Readable.from(this.fetchAllRecords(query, { ...options })),
+              sanitize,
+              json2csv,
+              passThrough
+            );
           } catch (err) {
             sails.log.error(`${this.logHeader} Failed to export records as CSV:`);
             sails.log.error(err);
@@ -1260,12 +1277,100 @@ export namespace Services {
       }
     }
 
+    private sanitizeRecordHookExecutionSummary(value: unknown): Record<string, unknown> | undefined {
+      if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return undefined;
+      }
+      const source = value as Record<string, unknown>;
+      if (source.schemaVersion !== 1 || source.trigger !== 'record-hook') {
+        return undefined;
+      }
+      const safeStatuses = new Set(['succeeded', 'failed', 'timed_out', 'interrupted', 'skipped', 'dispatched']);
+      const safeKinds = new Set([
+        'configuration',
+        'validation',
+        'domain',
+        'transient',
+        'timeout',
+        'interrupted',
+        'unexpected',
+      ]);
+      const safeReasons = new Set([
+        'prior_action_failed',
+        'phase_not_reached',
+        'save_not_persisted',
+        'trigger_disabled',
+      ]);
+      const actions = Array.isArray(source.actions)
+        ? source.actions.slice(0, 100).flatMap(item => {
+            if (!item || typeof item !== 'object' || Array.isArray(item)) return [];
+            const action = item as Record<string, unknown>;
+            if (
+              typeof action.actionId !== 'string' ||
+              typeof action.mode !== 'string' ||
+              typeof action.phase !== 'string' ||
+              typeof action.status !== 'string' ||
+              !safeStatuses.has(action.status)
+            )
+              return [];
+            const result: Record<string, unknown> = {
+              actionId: action.actionId.slice(0, 128),
+              mode: action.mode,
+              phase: action.phase,
+              status: action.status,
+              attempts: Number.isInteger(action.attempts) && Number(action.attempts) >= 0 ? Number(action.attempts) : 0,
+              durationMs:
+                Number.isInteger(action.durationMs) && Number(action.durationMs) >= 0 ? Number(action.durationMs) : 0,
+            };
+            if (typeof action.failureKind === 'string' && safeKinds.has(action.failureKind))
+              result.failureKind = action.failureKind;
+            if (typeof action.failureCode === 'string' && action.failureCode.length <= 128)
+              result.failureCode = action.failureCode;
+            if (typeof action.skippedReason === 'string' && safeReasons.has(action.skippedReason))
+              result.skippedReason = action.skippedReason;
+            return [result];
+          })
+        : [];
+      const counts: Record<string, number> = {};
+      if (source.counts && typeof source.counts === 'object' && !Array.isArray(source.counts)) {
+        for (const [key, count] of Object.entries(source.counts as Record<string, unknown>)) {
+          if (safeStatuses.has(key) && Number.isInteger(count) && Number(count) >= 0) counts[key] = Number(count);
+        }
+      }
+      const summary: Record<string, unknown> = {
+        schemaVersion: 1,
+        executionId: typeof source.executionId === 'string' ? source.executionId.slice(0, 128) : '',
+        trigger: 'record-hook',
+        operation: ['create', 'update', 'delete', 'transition'].includes(String(source.operation))
+          ? source.operation
+          : 'update',
+        partial: source.partial === true,
+        durationMs:
+          Number.isInteger(source.durationMs) && Number(source.durationMs) >= 0 ? Number(source.durationMs) : 0,
+        totalActions:
+          Number.isInteger(source.totalActions) && Number(source.totalActions) >= 0
+            ? Number(source.totalActions)
+            : actions.length,
+        counts,
+        actions,
+        truncated: source.truncated === true,
+      };
+      if (typeof source.requestId === 'string' && source.requestId.length <= 128) summary.requestId = source.requestId;
+      if (['pre', 'persistence', 'postSync', 'post-dispatch'].includes(String(source.completedThrough))) {
+        summary.completedThrough = source.completedThrough;
+      }
+      return summary;
+    }
+
     private sanitizeRecordAudit(recordAudit: RecordAuditModel): RecordAuditModel {
       const payload: RecordAuditModel = {
         redboxOid: recordAudit.redboxOid,
         action: recordAudit.action,
         user: this.toJsonSafe(recordAudit.user) as Record<string, unknown> | undefined,
         record: this.toJsonSafe(recordAudit.record) as Record<string, unknown> | undefined,
+        executionSummary: this.sanitizeRecordHookExecutionSummary(
+          recordAudit.executionSummary
+        ) as unknown as RecordAuditModel['executionSummary'],
       };
 
       if (_.isUndefined(payload.user)) {
@@ -1274,6 +1379,10 @@ export namespace Services {
 
       if (_.isUndefined(payload.record)) {
         delete payload.record;
+      }
+
+      if (_.isUndefined(payload.executionSummary)) {
+        delete payload.executionSummary;
       }
 
       return payload;
@@ -1406,7 +1515,9 @@ export namespace Services {
       return response;
     }
 
-    private buildIntegrationAuditStartedAtCriteria(params: IntegrationAuditParams): Record<string, unknown> | undefined {
+    private buildIntegrationAuditStartedAtCriteria(
+      params: IntegrationAuditParams
+    ): Record<string, unknown> | undefined {
       const criteria: Record<string, unknown> = {};
       if (_.isDate(params.dateFrom)) {
         criteria['>='] = params.dateFrom.toISOString();

--- a/packages/sails-hook-redbox-storage-mongo/src/services/MongoStorageService.ts
+++ b/packages/sails-hook-redbox-storage-mongo/src/services/MongoStorageService.ts
@@ -1359,6 +1359,12 @@ export namespace Services {
       if (['pre', 'persistence', 'postSync', 'post-dispatch'].includes(String(source.completedThrough))) {
         summary.completedThrough = source.completedThrough;
       }
+      if (['complete', 'grace-expired'].includes(String(source.detachedFinalization))) {
+        summary.detachedFinalization = source.detachedFinalization;
+      }
+      if (Number.isInteger(source.detachedPending) && Number(source.detachedPending) > 0) {
+        summary.detachedPending = Number(source.detachedPending);
+      }
       return summary;
     }
 

--- a/packages/sails-hook-redbox-storage-mongo/src/services/MongoStorageService.ts
+++ b/packages/sails-hook-redbox-storage-mongo/src/services/MongoStorageService.ts
@@ -29,6 +29,9 @@ import {
   RoleModel,
   RecordRelationshipExpandOptions,
   RecordRelationshipGraph,
+  ACTION_EXECUTION_STATUSES,
+  ACTION_FAILURE_KINDS,
+  ACTION_SKIPPED_REASONS,
 } from '@researchdatabox/redbox-core';
 import { ExportJSONTransformer } from '@researchdatabox/redbox-core';
 import { normalizeRecordRelations, NormalizedRecordRelation } from '@researchdatabox/redbox-core';
@@ -1285,22 +1288,9 @@ export namespace Services {
       if (source.schemaVersion !== 1 || source.trigger !== 'record-hook') {
         return undefined;
       }
-      const safeStatuses = new Set(['succeeded', 'failed', 'timed_out', 'interrupted', 'skipped', 'dispatched']);
-      const safeKinds = new Set([
-        'configuration',
-        'validation',
-        'domain',
-        'transient',
-        'timeout',
-        'interrupted',
-        'unexpected',
-      ]);
-      const safeReasons = new Set([
-        'prior_action_failed',
-        'phase_not_reached',
-        'save_not_persisted',
-        'trigger_disabled',
-      ]);
+      const safeStatuses = new Set<string>(ACTION_EXECUTION_STATUSES);
+      const safeKinds = new Set<string>(ACTION_FAILURE_KINDS);
+      const safeReasons = new Set<string>(ACTION_SKIPPED_REASONS);
       const actions = Array.isArray(source.actions)
         ? source.actions.slice(0, 100).flatMap(item => {
             if (!item || typeof item !== 'object' || Array.isArray(item)) return [];

--- a/packages/sails-hook-redbox-storage-mongo/test/services/MongoStorageService.test.ts
+++ b/packages/sails-hook-redbox-storage-mongo/test/services/MongoStorageService.test.ts
@@ -309,7 +309,10 @@ describe('MongoStorageService', function () {
 
   it('prepares batch items before dispatching create calls', async function () {
     const createStub = sandbox.stub(service, 'create').resolves({ success: true });
-    const data = [{ externalId: 'ext-1', metaMetadata: {} }, { externalId: 'ext-2', metaMetadata: {} }];
+    const data = [
+      { externalId: 'ext-1', metaMetadata: {} },
+      { externalId: 'ext-2', metaMetadata: {} },
+    ];
 
     const response = await service.createBatch('rdmp', data, 'externalId');
 
@@ -336,7 +339,11 @@ describe('MongoStorageService', function () {
     getMetaStub.onFirstCall().resolves({ redboxOid: 'oid-1', metaMetadata: { type: 'parent' } });
     getMetaStub.onSecondCall().resolves({ redboxOid: 'child-1', metaMetadata: { type: 'child' } });
     (global as any).RecordTypesService.get.callsFake((brand: any, recordTypeName: string) =>
-      of(recordTypeName === 'parent' ? { relatedTo: [{ recordType: 'child', foreignField: 'parentId' }] } : { relatedTo: [] })
+      of(
+        recordTypeName === 'parent'
+          ? { relatedTo: [{ recordType: 'child', foreignField: 'parentId' }] }
+          : { relatedTo: [] }
+      )
     );
     const metaQuery = { meta: sandbox.stub().resolves([{ redboxOid: 'child-1', parentId: 'oid-1' }]) };
     Record.find.returns(metaQuery);
@@ -350,8 +357,8 @@ describe('MongoStorageService', function () {
         label: undefined,
         sourceOid: 'oid-1',
         targetOid: 'child-1',
-        targetRecordType: 'child'
-      }
+        targetRecordType: 'child',
+      },
     ]);
     expect(result.relatedObjects.parent).to.have.length(1);
     expect(result.relatedObjects.child).to.have.length(1);
@@ -364,9 +371,13 @@ describe('MongoStorageService', function () {
     getMetaStub.onFirstCall().resolves({ redboxOid: 'oid-1', metaMetadata: { type: 'parent' } });
     getMetaStub.onSecondCall().resolves({ redboxOid: 'child-1', metaMetadata: { type: 'child' } });
     (global as any).RecordTypesService.get.callsFake((brand: any, recordTypeName: string) =>
-      of(recordTypeName === 'parent'
-        ? { relatedTo: [{ recordType: 'child', foreignField: 'parentId', direction: 'inbound', cardinality: 'many' }] }
-        : { relatedTo: [] })
+      of(
+        recordTypeName === 'parent'
+          ? {
+              relatedTo: [{ recordType: 'child', foreignField: 'parentId', direction: 'inbound', cardinality: 'many' }],
+            }
+          : { relatedTo: [] }
+      )
     );
     const metaQuery = { meta: sandbox.stub().resolves([{ redboxOid: 'child-1', parentId: 'oid-1' }]) };
     Record.find.returns(metaQuery);
@@ -380,8 +391,8 @@ describe('MongoStorageService', function () {
         label: undefined,
         sourceOid: 'child-1',
         targetOid: 'oid-1',
-        targetRecordType: 'parent'
-      }
+        targetRecordType: 'parent',
+      },
     ]);
     expect(result.relatedObjects.parent).to.have.length(1);
     expect(result.relatedObjects.child).to.have.length(1);
@@ -393,15 +404,17 @@ describe('MongoStorageService', function () {
     getMetaStub.onFirstCall().resolves({ redboxOid: 'oid-1', metaMetadata: { type: 'parent' } });
     getMetaStub.onSecondCall().resolves({ redboxOid: 'child-1', metaMetadata: { type: 'child' } });
     (global as any).RecordTypesService.get.callsFake((brand: any, recordTypeName: string) =>
-      of(recordTypeName === 'parent'
-        ? { relatedTo: [{ recordType: 'child', foreignField: 'parentId', cardinality: 'one' }] }
-        : { relatedTo: [] })
+      of(
+        recordTypeName === 'parent'
+          ? { relatedTo: [{ recordType: 'child', foreignField: 'parentId', cardinality: 'one' }] }
+          : { relatedTo: [] }
+      )
     );
     const metaQuery = {
       meta: sandbox.stub().resolves([
         { redboxOid: 'child-2', parentId: 'oid-1' },
-        { redboxOid: 'child-1', parentId: 'oid-1' }
-      ])
+        { redboxOid: 'child-1', parentId: 'oid-1' },
+      ]),
     };
     Record.find.returns(metaQuery);
 
@@ -414,8 +427,8 @@ describe('MongoStorageService', function () {
         label: undefined,
         sourceOid: 'oid-1',
         targetOid: 'child-1',
-        targetRecordType: 'child'
-      }
+        targetRecordType: 'child',
+      },
     ]);
     expect(result.relatedObjects.child).to.deep.equal([{ redboxOid: 'child-1', parentId: 'oid-1' }]);
     expect(metaQuery.meta.calledOnce).to.be.true;
@@ -631,17 +644,7 @@ describe('MongoStorageService', function () {
   it('applies single-item record and package type filters', async function () {
     const runStub = sandbox.stub(service, 'runRecordQuery').resolves({ items: [], totalItems: 0 });
 
-    await service.getRecords(
-      '',
-      ['rdmp'],
-      0,
-      5,
-      'user',
-      [],
-      { id: 'brand-1' },
-      undefined,
-      ['package-a']
-    );
+    await service.getRecords('', ['rdmp'], 0, 5, 'user', [], { id: 'brand-1' }, undefined, ['package-a']);
 
     const query = runStub.firstCall.args[1];
     expect(query['metaMetadata.type']).to.equal('rdmp');
@@ -699,13 +702,15 @@ describe('MongoStorageService', function () {
 
   it('sanitizes formula-prefixed values after nested records are flattened', async function () {
     service.recordCol = {
-      find: pagedFind([{
-        redboxOid: '1',
-        metadata: {
-          title: '=HYPERLINK("https://example.invalid")',
-          contributors: [{ name: '+malicious' }],
+      find: pagedFind([
+        {
+          redboxOid: '1',
+          metadata: {
+            title: '=HYPERLINK("https://example.invalid")',
+            contributors: [{ name: '+malicious' }],
+          },
         },
-      }]),
+      ]),
     };
 
     const exportStream = service.exportAllPlans('user', [], { id: 'brand-1' }, 'csv', null, null, 'rdmp');
@@ -769,8 +774,12 @@ describe('MongoStorageService', function () {
   it('stops collecting csv fields once the export has been cancelled', async function () {
     // Each page holds one record; cancellation is signalled after the first record is seen.
     const findStub = sandbox.stub();
-    findStub.onFirstCall().returns({ toArray: sandbox.stub().resolves([{ redboxOid: '1', metadata: { title: 'One' } }]) });
-    findStub.onSecondCall().returns({ toArray: sandbox.stub().resolves([{ redboxOid: '2', metadata: { extraField: 'present' } }]) });
+    findStub
+      .onFirstCall()
+      .returns({ toArray: sandbox.stub().resolves([{ redboxOid: '1', metadata: { title: 'One' } }]) });
+    findStub
+      .onSecondCall()
+      .returns({ toArray: sandbox.stub().resolves([{ redboxOid: '2', metadata: { extraField: 'present' } }]) });
     // A third page is never requested; if it were, this unstubbed call would throw and fail the test.
     service.recordCol = { find: findStub };
 
@@ -805,7 +814,15 @@ describe('MongoStorageService', function () {
     findStub.onThirdCall().returns({ toArray: sandbox.stub().resolves([]) });
     service.recordCol = { find: findStub };
 
-    const exportStream = service.exportAllPlans('user', [{ name: 'Admin', branding: 'brand-1' }], { id: 'brand-1' }, 'json', '2025-01-10', '2025-01-01', 'rdmp');
+    const exportStream = service.exportAllPlans(
+      'user',
+      [{ name: 'Admin', branding: 'brand-1' }],
+      { id: 'brand-1' },
+      'json',
+      '2025-01-10',
+      '2025-01-01',
+      'rdmp'
+    );
     const chunks: Buffer[] = [];
     for await (const chunk of exportStream) {
       chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
@@ -854,8 +871,9 @@ describe('MongoStorageService', function () {
     await promise;
 
     expect(stagingDisk.getStream.calledOnceWith('file-1')).to.be.true;
-    expect(mockBucket.openUploadStream.calledOnceWith('oid-1/file-1', { metadata: { name: 'doc', redboxOid: 'oid-1' } }))
-      .to.be.true;
+    expect(
+      mockBucket.openUploadStream.calledOnceWith('oid-1/file-1', { metadata: { name: 'doc', redboxOid: 'oid-1' } })
+    ).to.be.true;
   });
 
   it('uses a named disk and computes attachment add/remove requests in updateDatastream', async function () {
@@ -907,7 +925,9 @@ describe('MongoStorageService', function () {
     const addStub = sandbox.stub(service, 'addDatastream').resolves(undefined);
     const removeStub = sandbox.stub(service, 'removeDatastream').resolves(undefined);
 
-    await service.addAndRemoveDatastreams('oid-1', [{ fileId: 'new' }], [{ fileId: 'old' }], { getStream: sandbox.stub() });
+    await service.addAndRemoveDatastreams('oid-1', [{ fileId: 'new' }], [{ fileId: 'old' }], {
+      getStream: sandbox.stub(),
+    });
 
     expect(addStub.calledOnce).to.be.true;
     expect(removeStub.calledOnce).to.be.true;
@@ -1021,6 +1041,44 @@ describe('MongoStorageService', function () {
     expect(response.success).to.equal(false);
     expect(response.message).to.equal('audit failed');
     expect(RecordAudit.create.calledOnceWith({ redboxOid: 'oid-1', action: 'save' })).to.be.true;
+  });
+
+  it('persists only the bounded execution-summary audit whitelist', async function () {
+    const actions = Array.from({ length: 101 }, (_, index) => ({
+      actionId: `hook-${index}`,
+      mode: 'onCreate',
+      phase: 'post',
+      status: 'dispatched',
+      attempts: 0,
+      durationMs: 0,
+      secret: 'must-not-persist',
+    }));
+    await service.createRecordAudit({
+      redboxOid: 'oid-1',
+      action: 'save',
+      user: undefined,
+      record: { safe: true },
+      executionSummary: {
+        schemaVersion: 1,
+        executionId: 'execution-1',
+        trigger: 'record-hook',
+        operation: 'create',
+        partial: false,
+        durationMs: 4,
+        totalActions: 101,
+        counts: { dispatched: 101 },
+        actions,
+        truncated: true,
+        unsafe: 'must-not-persist',
+      } as any,
+    });
+
+    const saved = RecordAudit.create.firstCall.args[0].executionSummary;
+    expect(saved.actions).to.have.length(100);
+    expect(saved.totalActions).to.equal(101);
+    expect(saved.truncated).to.equal(true);
+    expect(saved.unsafe).to.equal(undefined);
+    expect(saved.actions[0].secret).to.equal(undefined);
   });
 
   it('builds record-audit queries from oid and dates', async function () {

--- a/packages/sails-hook-redbox-storage-mongo/test/services/MongoStorageService.test.ts
+++ b/packages/sails-hook-redbox-storage-mongo/test/services/MongoStorageService.test.ts
@@ -1069,6 +1069,8 @@ describe('MongoStorageService', function () {
         counts: { dispatched: 101 },
         actions,
         truncated: true,
+        detachedFinalization: 'grace-expired',
+        detachedPending: 1,
         unsafe: 'must-not-persist',
       } as any,
     });
@@ -1077,6 +1079,8 @@ describe('MongoStorageService', function () {
     expect(saved.actions).to.have.length(100);
     expect(saved.totalActions).to.equal(101);
     expect(saved.truncated).to.equal(true);
+    expect(saved.detachedFinalization).to.equal('grace-expired');
+    expect(saved.detachedPending).to.equal(1);
     expect(saved.unsafe).to.equal(undefined);
     expect(saved.actions[0].secret).to.equal(undefined);
   });

--- a/support/wiki/Configuring-Record-Type-Hooks.md
+++ b/support/wiki/Configuring-Record-Type-Hooks.md
@@ -157,10 +157,14 @@ dispatch. This keeps detached-post configuration from blocking persistence.
 
 The application logger emits concise events such as
 `record_hook_action_completed`, `record_hook_action_retry_scheduled`,
-`record_hook_action_timed_out`, `record_hook_detached_action_failed`, and
-`record_hook_operation_completed`. Filter on `execution_id` to reconstruct one
-record operation. Record bodies, hook options, users, function expressions,
-returned payloads, and raw errors are excluded from production-level events.
+`record_hook_action_timed_out`, `record_hook_detached_action_failed`,
+`record_hook_operation_dispatched`, and `record_hook_operation_completed`.
+The save-boundary `record_hook_operation_dispatched` event is emitted when
+detached work is launched; exactly one
+`record_hook_operation_completed` event follows when the audit reaches its
+finalization state. Filter on `execution_id` to reconstruct one record
+operation. Record bodies, hook options, users, function expressions, returned
+payloads, and raw errors are excluded from production-level events.
 
 For record create/update endpoints, callers should inspect the typed save
 `outcome` rather than the legacy boolean `success`: `saved-with-warnings`
@@ -177,11 +181,14 @@ for the response and request-correlation contract.
 Create and update audits include a versioned, bounded `executionSummary` with
 aggregate counts and at most the first 100 action entries. Delete audits are
 truthfully marked `partial` at the existing audit-before-post boundary. Create
-and update audit submission waits asynchronously for detached actions to reach
-terminal results, so their persisted summaries contain actual post outcomes
-(`succeeded`, `failed`, `timed_out`, or `interrupted`) rather than `dispatched`
-placeholders. The summary is audit metadata and is never embedded in the
-business-record snapshot.
+and update audit submission gives detached actions a bounded asynchronous grace
+period. Actions that finish within it are persisted with terminal outcomes
+(`succeeded`, `failed`, `timed_out`, or `interrupted`); if the grace period
+expires, the audit is still written with completed results plus truthful
+`dispatched` entries, `detachedPending`, and `detachedFinalization:
+"grace-expired"`. A late detached completion only emits its structured action
+logs and never creates a second audit. The summary is audit metadata and is
+never embedded in the business-record snapshot.
 
 Create/update summaries also expose `completedThrough` (`pre`, `persistence`,
 `postSync`, or `post-dispatch`) so early exits are distinguishable from a fully

--- a/support/wiki/Configuring-Record-Type-Hooks.md
+++ b/support/wiki/Configuring-Record-Type-Hooks.md
@@ -27,6 +27,41 @@ Typical record-type hook configuration (JSON/YAML) looks like:
 - `options` is a free-form object used by your hook code. For `postSync` hooks the `options.returnType` value controls what is expected from the function:
   - `returnType: "record"` (default) — the hook should return/resolve to the updated record object.
   - Any other value — the hook should return/resolve to a storage service response object and that response will be used by the caller.
+- `id` is an optional stable identifier used in logs and audit summaries. If it is omitted, ReDBox derives a deterministic identifier from the mode, phase, array index, and a short digest of the function expression.
+- `execution` is optional policy metadata. It is consumed by the runner and is never added to the legacy `options` object passed to hooks.
+
+## Retry and timeout policy
+
+The default policy is one attempt with no timeout. Policy values are validated before any selected hook phase starts:
+
+```json
+{
+  "id": "mint-after-save",
+  "function": "sails.services.mintservice.afterSave",
+  "options": { "returnType": "response" },
+  "execution": {
+    "timeoutMs": 30000,
+    "retry": {
+      "maxAttempts": 3,
+      "retryOn": ["transient"],
+      "schedule": { "type": "exponential", "delayMs": 250, "maxDelayMs": 2000, "jitter": true },
+      "idempotent": true
+    }
+  }
+}
+```
+
+`maxAttempts` includes the first invocation and is limited to 5. `timeoutMs` is a
+per-attempt timeout from 1 ms through 10 minutes. Retry is opt-in, requires the
+literal `idempotent: true`, and defaults to the `transient` failure kind when
+`retryOn` is omitted. Fixed or exponential delays are limited to 60 seconds;
+values outside these limits are configuration errors rather than being clamped.
+Retries receive the same live argument objects. They do not roll back partial
+in-memory mutations, so only enable them for idempotent work.
+
+Timeouts interrupt native Effect actions and unsubscribe Observables. An already
+started legacy Promise cannot be cancelled; a timed-out Promise may continue its
+side effect after the save response has returned.
 
 ## How hooks are executed (summary)
 
@@ -106,6 +141,24 @@ Common use-cases:
 
 The app supports hooks that return Observables, Promises, or plain values. Observables are converted to Promises internally.
 
+Every awaited phase is executed through a normalized Effect runner. Reports remain
+internal: they are not added to HTTP save responses. A phase report can contain
+`succeeded`, `failed`, `timed_out`, `interrupted`, or `skipped` actions. Detached
+`post` actions are reported as `dispatched` at the save boundary and complete or
+fail later under the same correlation ID.
+
+Save-time validation still rejects malformed hook configuration before any
+primary mutation. For a direct public fire-and-forget call, malformed `post`
+entries retain the legacy per-entry behaviour: they are logged and skipped while
+later valid entries continue to dispatch.
+
+The application logger emits concise events such as
+`record_hook_action_completed`, `record_hook_action_retry_scheduled`,
+`record_hook_action_timed_out`, `record_hook_detached_action_failed`, and
+`record_hook_operation_completed`. Filter on `execution_id` to reconstruct one
+record operation. Record bodies, hook options, users, function expressions,
+returned payloads, and raw errors are excluded from production-level events.
+
 For record create/update endpoints, callers should inspect the typed save
 `outcome` rather than the legacy boolean `success`: `saved-with-warnings`
 means primary metadata committed but an awaited hook or attachment phase needs
@@ -117,6 +170,25 @@ for the response and request-correlation contract.
 - If a pre-hook throws an error, the operation (create/update/delete/transition) is aborted and the error is propagated. If the thrown error has `name === 'RBValidationError'` RecordsService treats it as a validation error and surfaces the message.
 - If a postSync hook throws, the primary metadata commit remains authoritative and the typed result is `saved-with-warnings`; indexing and persistence audit are still submitted. A pre-save hook failure or invalid hook configuration returns `not-saved` and no attachment work is started.
 - post (async) hooks have their errors caught and logged; they won't block the user operation.
+
+Create and update audits include a versioned, bounded `executionSummary` with
+aggregate counts and at most the first 100 action entries. Delete audits are
+truthfully marked `partial` at the existing audit-before-post boundary; detached
+completion is available in correlated logs rather than through a second audit
+update. The summary is audit metadata and is never embedded in the business
+record snapshot.
+
+Create/update summaries also expose `completedThrough` (`pre`, `persistence`,
+`postSync`, or `post-dispatch`) so early exits are distinguishable from a fully
+dispatched operation.
+
+### Service extension boundary
+
+A custom service that subclasses the core `RecordsService` inherits the
+Effect-backed hook coordinator and its lifecycle guarantees. A full replacement
+service registered in place of the core service does not automatically receive
+these guarantees; it must call the coordinator or implement equivalent
+execution, logging, supervision, and audit integration itself.
 
 ## Security and best practices
 

--- a/support/wiki/Configuring-Record-Type-Hooks.md
+++ b/support/wiki/Configuring-Record-Type-Hooks.md
@@ -27,7 +27,7 @@ Typical record-type hook configuration (JSON/YAML) looks like:
 - `options` is a free-form object used by your hook code. For `postSync` hooks the `options.returnType` value controls what is expected from the function:
   - `returnType: "record"` (default) — the hook should return/resolve to the updated record object.
   - Any other value — the hook should return/resolve to a storage service response object and that response will be used by the caller.
-- `id` is an optional stable identifier used in logs and audit summaries. If it is omitted, ReDBox derives a deterministic identifier from the mode, phase, array index, and a short digest of the function expression.
+- `id` is an optional stable identifier used in logs and audit summaries. For durable identity across hook reordering, configure it explicitly. If it is omitted, ReDBox derives a deterministic identifier from the mode, phase, array index, and a short digest of the function expression; moving the hook in the array changes that generated identity.
 - `execution` is optional policy metadata. It is consumed by the runner and is never added to the legacy `options` object passed to hooks.
 
 ## Retry and timeout policy
@@ -61,7 +61,9 @@ in-memory mutations, so only enable them for idempotent work.
 
 Timeouts interrupt native Effect actions and unsubscribe Observables. An already
 started legacy Promise cannot be cancelled; a timed-out Promise may continue its
-side effect after the save response has returned.
+side effect after the save response has returned. ReDBox therefore does not retry
+non-cooperative timeout or interruption failures, even when `idempotent: true`,
+because doing so could overlap the still-running legacy side effect.
 
 ## How hooks are executed (summary)
 
@@ -147,10 +149,11 @@ internal: they are not added to HTTP save responses. A phase report can contain
 `post` actions are reported as `dispatched` at the save boundary and complete or
 fail later under the same correlation ID.
 
-Save-time validation still rejects malformed hook configuration before any
-primary mutation. For a direct public fire-and-forget call, malformed `post`
-entries retain the legacy per-entry behaviour: they are logged and skipped while
-later valid entries continue to dispatch.
+Save-time validation rejects malformed `pre` configuration before any primary
+mutation. `postSync` configuration is validated at its awaited post-persistence
+phase boundary, while malformed `post` entries retain the legacy per-entry
+behaviour: they are logged and skipped while later valid entries continue to
+dispatch. This keeps detached-post configuration from blocking persistence.
 
 The application logger emits concise events such as
 `record_hook_action_completed`, `record_hook_action_retry_scheduled`,
@@ -173,14 +176,21 @@ for the response and request-correlation contract.
 
 Create and update audits include a versioned, bounded `executionSummary` with
 aggregate counts and at most the first 100 action entries. Delete audits are
-truthfully marked `partial` at the existing audit-before-post boundary; detached
-completion is available in correlated logs rather than through a second audit
-update. The summary is audit metadata and is never embedded in the business
-record snapshot.
+truthfully marked `partial` at the existing audit-before-post boundary. Create
+and update audit submission waits asynchronously for detached actions to reach
+terminal results, so their persisted summaries contain actual post outcomes
+(`succeeded`, `failed`, `timed_out`, or `interrupted`) rather than `dispatched`
+placeholders. The summary is audit metadata and is never embedded in the
+business-record snapshot.
 
 Create/update summaries also expose `completedThrough` (`pre`, `persistence`,
 `postSync`, or `post-dispatch`) so early exits are distinguishable from a fully
 dispatched operation.
+
+The current observability surface is structured correlation logging rather than
+native Effect spans. Operation, phase, action, and attempt identifiers are
+available for log aggregation; Effect/OpenTelemetry span integration remains a
+follow-up.
 
 ### Service extension boundary
 

--- a/support/wiki/Effect-Hook-Execution-Verification.md
+++ b/support/wiki/Effect-Hook-Execution-Verification.md
@@ -64,13 +64,3 @@ ReDBox page. Container logs should include structured
 `record_hook_operation_completed` event per execution;
 raw hook arguments and execution summaries must not appear in business-record
 payloads.
-
-## Recorded handoff
-
-The verification run for this change used host Node `v24.19.0` with npm
-`11.17.0`, and the running container reported Node `v26.7.0`. The full core
-`redbox-core` suite completed with 2189 passing tests and 14 pending; the Mongo storage suite
-completed with 71 passing tests. `npm run compile:core`, the Mongo TypeScript
-compile, Oxlint, and `git diff --check` passed. The Tailscale smoke request
-returned `302` from `/` followed by `200 OK` for the rendered page containing
-`Welcome to ReDBox`.

--- a/support/wiki/Effect-Hook-Execution-Verification.md
+++ b/support/wiki/Effect-Hook-Execution-Verification.md
@@ -43,7 +43,8 @@ and look for errors in the files this change touches.
 
 The action-execution and RecordsService suites cover legacy characterization,
 deterministic retry scheduling, native Effect actions, supervised teardown,
-cross-layer save boundaries, audit queue payloads, and public response safety.
+cross-layer save boundaries, terminal detached audit outcomes, non-overlapping
+timeout retry policy, audit queue payloads, and public response safety.
 The Mongo suite covers bounded summary sanitization and persistence.
 
 ## Container smoke check
@@ -63,8 +64,8 @@ payloads.
 ## Recorded handoff
 
 The verification run for this change used host Node `v24.19.0` with npm
-`11.17.0`, and the running container reported Node `v26.7.0`. The focused core
-`redbox-core` suite completed with 2183 passing tests; the Mongo storage suite
+`11.17.0`, and the running container reported Node `v26.7.0`. The full core
+`redbox-core` suite completed with 2187 passing tests and 14 pending; the Mongo storage suite
 completed with 71 passing tests. `npm run compile:core`, the Mongo TypeScript
 compile, Oxlint, and `git diff --check` passed. The Tailscale smoke request
 returned `302` from `/` followed by `200 OK` for the rendered page containing

--- a/support/wiki/Effect-Hook-Execution-Verification.md
+++ b/support/wiki/Effect-Hook-Execution-Verification.md
@@ -43,8 +43,11 @@ and look for errors in the files this change touches.
 
 The action-execution and RecordsService suites cover legacy characterization,
 deterministic retry scheduling, native Effect actions, supervised teardown,
-cross-layer save boundaries, terminal detached audit outcomes, non-overlapping
-timeout retry policy, audit queue payloads, and public response safety.
+cross-layer save boundaries, bounded detached audit finalization, replacement
+projection for partially completed detached work, non-overlapping timeout retry
+policy, audit queue payloads, and public response safety. Operation logs emit a
+single final `record_hook_operation_completed` event per execution; the
+save-boundary event is `record_hook_operation_dispatched`.
 The Mongo suite covers bounded summary sanitization and persistence.
 
 ## Container smoke check
@@ -57,7 +60,8 @@ curl -fsS -D - -o /tmp/redbox-home.html http://<tailscale-ip>:1500/
 The compose interpolation maps `APP_URL` to `sails_appUrl`. A healthy stack
 redirects `/` to the branded home route and returns `200 OK` for the rendered
 ReDBox page. Container logs should include structured
-`record_hook_action_completed` and `record_hook_operation_completed` events;
+`record_hook_action_completed`, `record_hook_operation_dispatched`, and one
+`record_hook_operation_completed` event per execution;
 raw hook arguments and execution summaries must not appear in business-record
 payloads.
 
@@ -65,7 +69,7 @@ payloads.
 
 The verification run for this change used host Node `v24.19.0` with npm
 `11.17.0`, and the running container reported Node `v26.7.0`. The full core
-`redbox-core` suite completed with 2187 passing tests and 14 pending; the Mongo storage suite
+`redbox-core` suite completed with 2189 passing tests and 14 pending; the Mongo storage suite
 completed with 71 passing tests. `npm run compile:core`, the Mongo TypeScript
 compile, Oxlint, and `git diff --check` passed. The Tailscale smoke request
 returned `302` from `/` followed by `200 OK` for the rendered page containing

--- a/support/wiki/Effect-Hook-Execution-Verification.md
+++ b/support/wiki/Effect-Hook-Execution-Verification.md
@@ -1,0 +1,71 @@
+# Effect Hook Execution Verification Handoff
+
+This page records reproducible checks for the Effect-based record-hook
+execution change. Commands are run from the repository root.
+
+## Toolchains
+
+- Host smoke toolchain: Node 24 (`node --version`), npm, and the repository's
+  exact-pinned dependencies.
+- Container smoke toolchain: the development image's Node 26 runtime. Confirm
+  with `sudo -n docker exec development-rbportal-mount-1 node --version` while
+  `npm run dev:run` is running.
+
+## Focused checks
+
+Run the packages' own test scripts. Do not substitute a narrowed
+`--no-config` / `TS_NODE_TRANSPILE_ONLY=true` invocation: transpile-only skips
+type checking, and `--no-config` bypasses `.mocharc.js`, so a focused run can
+report passing tests while `npm test` cannot load the suite at all.
+
+```sh
+npm run compile:core
+cd packages/sails-hook-redbox-storage-mongo
+node_modules/.bin/tsc -p tsconfig.json
+cd ../..
+
+# Type-checks src only. Test files are covered by test/tsconfig.json, which
+# ts-node applies per loaded file during the run below.
+cd packages/redbox-core
+npm test
+cd ../..
+
+cd packages/sails-hook-redbox-storage-mongo
+npm test
+cd ../..
+```
+
+A type error in any loaded test file makes ts-node fail to compile it; mocha
+then retries the file as ESM and the run aborts with a misleading
+`ERR_MODULE_NOT_FOUND` naming an imported module rather than the real type
+error. If that appears, run `node_modules/.bin/tsc --noEmit -p test/tsconfig.json`
+and look for errors in the files this change touches.
+
+The action-execution and RecordsService suites cover legacy characterization,
+deterministic retry scheduling, native Effect actions, supervised teardown,
+cross-layer save boundaries, audit queue payloads, and public response safety.
+The Mongo suite covers bounded summary sanitization and persistence.
+
+## Container smoke check
+
+```sh
+APP_URL=http://<tailscale-ip>:1500 npm run dev:run
+curl -fsS -D - -o /tmp/redbox-home.html http://<tailscale-ip>:1500/
+```
+
+The compose interpolation maps `APP_URL` to `sails_appUrl`. A healthy stack
+redirects `/` to the branded home route and returns `200 OK` for the rendered
+ReDBox page. Container logs should include structured
+`record_hook_action_completed` and `record_hook_operation_completed` events;
+raw hook arguments and execution summaries must not appear in business-record
+payloads.
+
+## Recorded handoff
+
+The verification run for this change used host Node `v24.19.0` with npm
+`11.17.0`, and the running container reported Node `v26.7.0`. The focused core
+`redbox-core` suite completed with 2183 passing tests; the Mongo storage suite
+completed with 71 passing tests. `npm run compile:core`, the Mongo TypeScript
+compile, Oxlint, and `git diff --check` passed. The Tailscale smoke request
+returned `302` from `/` followed by `200 OK` for the rendered page containing
+`Welcome to ReDBox`.


### PR DESCRIPTION
## Summary

Introduces a normalized, Effect-based execution runner for all record-type hooks (`pre`, `postSync`, and `post` phases across create, update, delete, and workflow-transition operations). The runner layers opt-in timeout and retry policies, typed save outcomes, versioned audit execution summaries, and correlation-based structured logging on top of the existing hook contract, while keeping detached `post` hooks fire-and-forget for the save caller.

---

## Context / Motivation

Record hooks previously ran as ad-hoc awaited calls with no uniform treatment of timeouts, retries, failure classification, or observability. Failures in awaited phases were hard to attribute, async `post` work left no durable trace once the save response had returned, and audits did not distinguish fully dispatched operations from partial executions. This change gives every hook invocation a single supervised execution path with deterministic identifiers, validated policies, and an auditable, privacy-conscious reporting surface.

---

## Key Features

### Normalized effect execution engine

- Adds an `action-execution` module to `redbox-core` providing a sequential plan executor, policy validation, failure-kind taxonomy (`configuration`, `validation`, `domain`, `transient`, `timeout`, `interrupted`, `unexpected`), and adapters that wrap legacy Promise, Observable, and plain-value hooks into Effects.
- Every awaited hook phase runs through the same runner with execution, phase, action, and attempt identifiers, enabling end-to-end correlation via `execution_id`.

### Per-hook timeout and retry policy

- Hook definitions accept an optional `execution` block with `timeoutMs` and opt-in retry settings (`maxAttempts` capped at 5, fixed/exponential schedules up to 60 s, jitter, and explicit `idempotent: true` requirement). Invalid values are configuration errors rather than silently clamped values.
- Policy metadata is consumed by the runner and never leaked into the legacy `options` object passed to hooks. Timeouts interrupt native Effect actions and unsubscribe Observables; non-cooperative Promise timeouts are never retried so still-running side effects cannot overlap.
- Optional stable `id` on each hook definition provides durable identity across reordering; otherwise a deterministic identifier is derived from mode, phase, index, and function digest.

### Save-boundary semantics and typed outcomes

- Malformed `pre` configuration is rejected before any primary mutation (`not-saved`); `postSync` configuration is validated at its awaited post-persistence boundary where failures degrade the result to `saved-with-warnings` while indexing and audit submission continue.
- Detached `post` entries remain fire-and-forget: malformed entries are logged and skipped without blocking persistence or later valid dispatches.
- Callers inspect the typed save `outcome` rather than the legacy boolean `success`, distinguishing `saved-with-warnings` from authoritative commits.

### Auditable execution summaries with bounded detached finalization

- Create and update audits carry a versioned, size-bounded `executionSummary` (aggregate counts plus at most the first 100 action entries) that is never embedded in the business-record snapshot; delete audits are truthfully marked `partial`.
- Detached actions get a bounded asynchronous grace period before audit submission: completions within it persist terminal outcomes, while expiry persists completed results alongside truthful `dispatched` entries, `detachedPending`, and `detachedFinalization: "grace-expired"`. A late completion only emits structured logs and never creates a second audit.
- Summaries expose `completedThrough` (`pre`, `persistence`, `postSync`, `post-dispatch`) so early exits are distinguishable from fully dispatched operations.

### Production-safe structured logging

- Emits concise lifecycle events (`record_hook_action_completed`, `record_hook_action_retry_scheduled`, `record_hook_action_timed_out`, `record_hook_detached_action_failed`, `record_hook_operation_dispatched`, exactly one `record_hook_operation_completed`) filterable by `execution_id`.
- Record bodies, hook options, user identities, function expressions, returned payloads, and raw errors are excluded from production-level events; only safe failure kinds, codes, and short summaries appear.

---

## Testing

- Added focused suites for the executor (`executor.test.ts`) and legacy hook compatibility (`legacy-compatibility.test.ts`) covering characterization, retry scheduling, native Effect actions, supervised teardown, and public response safety.
- Substantially extended `RecordsService` tests for cross-layer save boundaries, bounded detached audit finalization, replacement projections for partially completed detached work, non-overlapping timeout retry policy, and audit queue payloads.
- Extended Mongo storage tests for bounded summary sanitization and persistence.
- Full verification run recorded in the wiki handoff: `redbox-core` suite passing (2189 passing, 14 pending), Mongo storage suite passing (71 passing), Oxlint clean.

---

## Architectural / Operational Impact

### Architecture

- Hook execution is centralized in a coordinator layer between `RecordsService` and the storage service, decoupling save orchestration from individual hook implementations and making phase boundaries explicit.
- The `RecordHooksConfig` type now uniformly supports `postSync` across all trigger modes and adds `onDelete` and `onTransitionWorkflow` declarations.

### Operations

- Structured, correlation-keyed logs replace implicit failure modes, enabling reconstruction of a single record operation from log filters alone.
- The bounded grace period keeps save latency predictable: detached audit finalization never extends beyond the configured window, and late work remains observable without duplicating audits.

### Security and privacy

- Audit summaries and operational logs are sanitized at both the service and storage layers, ensuring raw arguments, payloads, and error details do not reach business records or production logs.

---

## Backwards Compatibility

- Existing hooks without `execution` blocks retain current behavior under the default policy of a single untimed attempt; the legacy `options` object is unchanged.
- The legacy boolean `success` response shape remains available; the typed `outcome` is additive.
- Generated hook identifiers are deterministic but change when hooks are reordered; deployments relying on identity stability should configure explicit `id` values.

---

## Deployment Notes

- No database migration is required; the audit collection tolerates records with and without `executionSummary`.
- Institutions configuring hooks should review the updated record-type hooks documentation, particularly if hooks perform non-idempotent work where retry enablement would be unsafe.
- Timeout interruption does not cancel already-started legacy Promises; operators should be aware such side effects may complete after the save response returns.

---

## Impact

Provides uniform, policy-driven, observable execution for all record hooks while preserving existing hook contracts and save latency characteristics, giving operators reliable audits and correlation-based tracing without exposing sensitive payload data.
