### PR TITLE
Chore: group peer-coupled Vitest Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,10 +41,16 @@ updates:
       - '/packages/sails-hook-redbox-storage-mongo'
       - '/packages/sails-ng-common'
       - '/packages/redbox-hook-dev'
-      - '/packages/agdenda-sqs-backend'
+      - '/packages/agenda-sqs-backend'
     schedule:
       interval: 'daily'
     target-branch: 'develop'
+    groups:
+      vitest:
+        applies-to: 'version-updates'
+        patterns:
+          - 'vitest'
+          - '@vitest/*'
     cooldown:
       default-days: 7
 


### PR DESCRIPTION
## Summary

- group `vitest` and `@vitest/*` version updates so exact peer dependencies stay aligned
- correct the agenda-sqs-backend Dependabot directory typo

## Context

The separate `vitest` and `@vitest/coverage-v8` Dependabot PRs currently make strict npm lock refreshes fail with ERESOLVE.

## Testing

- validated `.github/dependabot.yml` as YAML
- `git diff --check`