### PR TITLE
Fix agenda backend Vitest tsconfig resolution

### DIFF
--- a/packages/agenda-sqs-backend/vitest.config.ts
+++ b/packages/agenda-sqs-backend/vitest.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+	// Oxc resolves the nested test tsconfig from the repository root, while
+	// this package's CI job installs dependencies in the package directory.
+	oxc: { tsconfig: false } as any,
 	test: {
 		environment: 'node',
 		include: ['test/**/*.test.ts']


### PR DESCRIPTION
## What\n\nFix the agenda SQS backend test configuration so Vitest 4.1.10 can transform TypeScript when the package CI job installs dependencies in the package directory. Oxc otherwise looks for the nested test tsconfig base from the repository root and fails before running any tests.\n\n## Validation\n\n- `npm ci --include=dev --ignore-scripts --strict-peer-deps`\n- `npm run build`\n- `npm run test:coverage`\n- Codecov report preparation\n\nAll six agenda backend tests pass locally.