### PR TITLE
Bugfix: exclude development hook from runtime Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,7 @@ RUN cp -a node_modules /tmp/test-node_modules \
 RUN npm prune --omit=dev \
  && npm cache clean --force \
  && rm -rf \
+    node_modules/redbox-hook-dev \
     packages/redbox-core/node_modules \
     packages/sails-ng-common/node_modules \
     packages/raido/node_modules \

--- a/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
@@ -2,7 +2,6 @@ import {fakeAsync, flushMicrotasks, TestBed, tick} from '@angular/core/testing';
 import { Location } from '@angular/common';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { FormComponent } from './form.component';
-import { FormDebugStateService } from './form-debug/form-debug-state.service';
 import { FormConfigFrame } from '@researchdatabox/sails-ng-common';
 import { RecordActionResult } from '@researchdatabox/portal-ng-common';
 import { SimpleInputComponent } from './component/simple-input.component';
@@ -2598,8 +2597,6 @@ describe('FormComponent', () => {
 
   it('does not enable debug UI for invalid formDebug query param values', async () => {
     setFormDebugUrl('off');
-    const debugState = TestBed.inject(FormDebugStateService);
-    debugState.refreshFromUrl();
     const formConfig: FormConfigFrame = {
       name: 'debug-query-disabled',
       componentDefinitions: [

--- a/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
@@ -2596,7 +2596,6 @@ describe('FormComponent', () => {
   });
 
   it('does not enable debug UI for invalid formDebug query param values', async () => {
-    setFormDebugUrl('off');
     const formConfig: FormConfigFrame = {
       name: 'debug-query-disabled',
       componentDefinitions: [

--- a/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/form.component.spec.ts
@@ -2,6 +2,7 @@ import {fakeAsync, flushMicrotasks, TestBed, tick} from '@angular/core/testing';
 import { Location } from '@angular/common';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { FormComponent } from './form.component';
+import { FormDebugStateService } from './form-debug/form-debug-state.service';
 import { FormConfigFrame } from '@researchdatabox/sails-ng-common';
 import { RecordActionResult } from '@researchdatabox/portal-ng-common';
 import { SimpleInputComponent } from './component/simple-input.component';
@@ -2596,6 +2597,9 @@ describe('FormComponent', () => {
   });
 
   it('does not enable debug UI for invalid formDebug query param values', async () => {
+    setFormDebugUrl('off');
+    const debugState = TestBed.inject(FormDebugStateService);
+    debugState.refreshFromUrl();
     const formConfig: FormConfigFrame = {
       name: 'debug-query-disabled',
       componentDefinitions: [

--- a/packages/redbox-core/src/visitor/data-value.visitor.ts
+++ b/packages/redbox-core/src/visitor/data-value.visitor.ts
@@ -11,6 +11,10 @@ import {
   ContentFormComponentDefinitionOutline,
 } from '@researchdatabox/sails-ng-common';
 import {
+  RelatedObjectDataFieldComponentDefinitionOutline,
+  RelatedObjectDataFormComponentDefinitionOutline,
+} from '@researchdatabox/sails-ng-common';
+import {
   RepeatableElementFieldLayoutDefinitionOutline,
   RepeatableFieldComponentDefinitionOutline,
   RepeatableFieldModelDefinitionOutline,
@@ -236,6 +240,18 @@ export class DataValueFormConfigVisitor extends FormConfigVisitor {
   async visitContentFieldComponentDefinition(_item: ContentFieldComponentDefinitionOutline): Promise<void> {}
 
   async visitContentFormComponentDefinition(item: ContentFormComponentDefinitionOutline): Promise<void> {
+    await this.acceptFormComponentDefinition(item);
+  }
+
+  /* Related object data */
+
+  async visitRelatedObjectDataFieldComponentDefinition(
+    _item: RelatedObjectDataFieldComponentDefinitionOutline
+  ): Promise<void> {}
+
+  async visitRelatedObjectDataFormComponentDefinition(
+    item: RelatedObjectDataFormComponentDefinitionOutline
+  ): Promise<void> {
     await this.acceptFormComponentDefinition(item);
   }
 

--- a/packages/redbox-core/src/visitor/json-type-def.visitor.ts
+++ b/packages/redbox-core/src/visitor/json-type-def.visitor.ts
@@ -11,6 +11,10 @@ import {
   ContentFormComponentDefinitionOutline,
 } from '@researchdatabox/sails-ng-common';
 import {
+  RelatedObjectDataFieldComponentDefinitionOutline,
+  RelatedObjectDataFormComponentDefinitionOutline,
+} from '@researchdatabox/sails-ng-common';
+import {
   RepeatableElementFieldLayoutDefinitionOutline,
   RepeatableFieldComponentDefinitionOutline,
   RepeatableFieldModelDefinitionOutline,
@@ -238,6 +242,18 @@ export class JsonTypeDefSchemaFormConfigVisitor extends FormConfigVisitor {
   async visitContentFieldComponentDefinition(_item: ContentFieldComponentDefinitionOutline): Promise<void> {}
 
   async visitContentFormComponentDefinition(item: ContentFormComponentDefinitionOutline): Promise<void> {
+    await this.acceptFormComponentDefinition(item);
+  }
+
+  /* Related object data */
+
+  async visitRelatedObjectDataFieldComponentDefinition(
+    _item: RelatedObjectDataFieldComponentDefinitionOutline
+  ): Promise<void> {}
+
+  async visitRelatedObjectDataFormComponentDefinition(
+    item: RelatedObjectDataFormComponentDefinitionOutline
+  ): Promise<void> {
     await this.acceptFormComponentDefinition(item);
   }
 

--- a/packages/redbox-core/src/visitor/validator.visitor.ts
+++ b/packages/redbox-core/src/visitor/validator.visitor.ts
@@ -15,6 +15,8 @@ import {
   ValidatorsSupport,
   ContentFieldComponentDefinitionOutline,
   ContentFormComponentDefinitionOutline,
+  RelatedObjectDataFieldComponentDefinitionOutline,
+  RelatedObjectDataFormComponentDefinitionOutline,
   RepeatableFieldComponentDefinitionOutline,
   RepeatableFieldModelDefinitionOutline,
   RepeatableElementFieldLayoutDefinitionOutline,
@@ -283,6 +285,18 @@ export class ValidatorFormConfigVisitor extends FormConfigVisitor {
   async visitContentFieldComponentDefinition(_item: ContentFieldComponentDefinitionOutline): Promise<void> {}
 
   async visitContentFormComponentDefinition(item: ContentFormComponentDefinitionOutline): Promise<void> {
+    await this.acceptFormComponentDefinition(item);
+  }
+
+  /* Related object data */
+
+  async visitRelatedObjectDataFieldComponentDefinition(
+    _item: RelatedObjectDataFieldComponentDefinitionOutline
+  ): Promise<void> {}
+
+  async visitRelatedObjectDataFormComponentDefinition(
+    item: RelatedObjectDataFormComponentDefinitionOutline
+  ): Promise<void> {
     await this.acceptFormComponentDefinition(item);
   }
 

--- a/packages/redbox-core/test/unit/json-type-def.visitor.test.ts
+++ b/packages/redbox-core/test/unit/json-type-def.visitor.test.ts
@@ -385,6 +385,27 @@ describe("JSON Type Def Schema Visitor", async () => {
                     }
                 }
             }
+        },
+        {
+            title: "ignore related object data components",
+            args: {
+                name: "related-object-data-form",
+                componentDefinitions: [
+                    {
+                        name: "workspaces",
+                        component: {
+                            class: "RelatedObjectDataComponent",
+                            config: {
+                                dataPath: "metadata.workspaces",
+                                oidProperty: "id",
+                                relatedFields: ["title"]
+                            }
+                        },
+                        layout: {class: "DefaultLayout", config: {}}
+                    }
+                ]
+            },
+            expected: {}
         }
     ];
     cases.forEach(({title, args, expected}) => {

--- a/packages/redbox-core/test/unit/validator.visitor.test.ts
+++ b/packages/redbox-core/test/unit/validator.visitor.test.ts
@@ -85,6 +85,37 @@ describe("Validator Visitor", async () => {
             layoutJsonPointer: '/contributors-layout/1/name-layout',
         });
     });
+    it('ignores related object data components during server validation', async function () {
+        const formConfig: FormConfigFrame = {
+            name: 'related-object-data-server-validation',
+            componentDefinitions: [
+                {
+                    name: 'workspaces',
+                    component: {
+                        class: 'RelatedObjectDataComponent',
+                        config: {
+                            dataPath: 'metadata.workspaces',
+                            oidProperty: 'id',
+                            relatedFields: ['title'],
+                        },
+                    },
+                    layout: { class: 'DefaultLayout', config: {} },
+                },
+            ],
+        };
+        const constructed = await new ConstructFormConfigVisitor(logger).start({
+            data: formConfig,
+            formMode: 'edit',
+            record: { metadata: { workspaces: [] } },
+        });
+
+        const actual = await new ValidatorFormConfigVisitor(logger).start({
+            form: constructed,
+            validatorDefinitions: formValidatorsSharedDefinitions,
+        });
+
+        expect(actual).to.deep.equal([]);
+    });
     it('checks the shared deadline around every repeatable row', async function () {
         const formConfig: FormConfigFrame = {
             name: 'repeatable-deadline',


### PR DESCRIPTION
## Summary

Exclude the development-only `redbox-hook-dev` package from the production Docker runtime image by removing its `node_modules` directory during the build prune step.

---

## Context / Motivation

The `redbox-hook-dev` package is intended only for local development workflows. Its `node_modules` directory was not being cleaned during the production prune, meaning it was unnecessarily included in the final runtime image. This adds unused dependencies to the production image, increasing image size and surface area.

---

## Key Features

### Docker image hygiene

- Adds `node_modules/redbox-hook-dev` to the list of directories removed after `npm prune --omit=dev`, ensuring the development hook is fully excluded from the runtime stage.

---

## Testing

- No new tests required; this is a build-time change. Existing CI builds will confirm the runtime image builds correctly.

---

## Architectural / Operational Impact

### Image size and security

Removing unused development `node_modules` from the runtime image reduces image size and removes any potential attack surface from unnecessary packages.

---

## Backwards Compatibility

No functional change to the portal runtime. The `redbox-hook-dev` package was already only used during local development and is not required at runtime.

---

## Deployment Notes

No special deployment steps required. This change applies automatically when the Docker image is rebuilt.

---

## Impact

A straightforward build hygiene improvement that ensures the production Docker image does not carry unnecessary development dependencies.

Replacement for the no-op merge of #4539 during stack branch recovery. The original implementation commits remain on this branch.