### PR TITLE
Bugfix: preserve create form fingerprints across workflow transitions

### DIFF
--- a/packages/redbox-core/src/RecordsService.ts
+++ b/packages/redbox-core/src/RecordsService.ts
@@ -245,7 +245,6 @@ export interface RecordsService {
   getRecordFormFingerprint(
     record: RecordInput,
     recordType: Record<string, unknown>,
-    targetStep?: unknown,
     sourceForm?: FormAttributes
   ): Promise<string | undefined>;
   getResolvedPermissionsSummary(oid: string): Promise<ResolvedRecordPermissions>;

--- a/packages/redbox-core/src/controllers/RecordController.ts
+++ b/packages/redbox-core/src/controllers/RecordController.ts
@@ -233,8 +233,9 @@ export namespace Controllers {
     /**
      * Fingerprint the form contract this response delivers, through the same
      * authoritative service routine a save recomputes. A create has no stored
-     * record, so its contract is described by the workflow step the save will
-     * apply: the requested target when present, otherwise the starting step.
+     * record, so its contract is described by the starting workflow step. A
+     * target transition is a save intent and does not change the form that
+     * was delivered to the browser.
      */
     private async generatedFormFingerprint(
       req: Sails.Req,
@@ -260,8 +261,7 @@ export namespace Controllers {
       if (currentRec) {
         fingerprintRecord = currentRec as unknown as AnyRecord;
       } else {
-        const effectiveStep =
-          targetStep ?? ((await firstValueFrom(WorkflowStepsService.getFirst(recordType))) as unknown as AnyRecord);
+        const effectiveStep = (await firstValueFrom(WorkflowStepsService.getFirst(recordType))) as unknown as AnyRecord;
         fingerprintRecord = {
           metaMetadata: {
             brandId: String(brand?.id ?? ''),
@@ -275,7 +275,7 @@ export namespace Controllers {
       const fingerprint = await this.recordsService.getRecordFormFingerprint(
         fingerprintRecord,
         recordType,
-        targetStep ?? undefined,
+        currentRec ? targetStep ?? undefined : undefined,
         sourceForm
       );
       if (!fingerprint) {

--- a/packages/redbox-core/src/controllers/RecordController.ts
+++ b/packages/redbox-core/src/controllers/RecordController.ts
@@ -238,7 +238,6 @@ export namespace Controllers {
      * was delivered to the browser.
      */
     private async generatedFormFingerprint(
-      req: Sails.Req,
       brand: BrandingModel,
       currentRec: RecordModel | null,
       requestedRecordType: string | undefined,
@@ -252,10 +251,6 @@ export namespace Controllers {
         currentRec?.metaMetadata?.type ?? requestedRecordType ?? formConfig.type ?? ''
       ).trim();
       const recordType = (await firstValueFrom(RecordTypesService.get(brand, recordTypeName))) as unknown as AnyRecord;
-      const targetStepName = this.requestString(req.query, 'targetStep');
-      const targetStep = targetStepName
-        ? ((await firstValueFrom(WorkflowStepsService.get(recordType, targetStepName))) as unknown as AnyRecord | null)
-        : null;
 
       let fingerprintRecord: AnyRecord;
       if (currentRec) {
@@ -272,12 +267,7 @@ export namespace Controllers {
         };
       }
 
-      const fingerprint = await this.recordsService.getRecordFormFingerprint(
-        fingerprintRecord,
-        recordType,
-        currentRec ? targetStep ?? undefined : undefined,
-        sourceForm
-      );
+      const fingerprint = await this.recordsService.getRecordFormFingerprint(fingerprintRecord, recordType, sourceForm);
       if (!fingerprint) {
         throw new Error('The current form concurrency fingerprint could not be generated.');
       }
@@ -1118,7 +1108,7 @@ export namespace Controllers {
           formConfig: mergedForm,
         });
 
-        const formFingerprint = await this.generatedFormFingerprint(req, brand, currentRec, recordType, form);
+        const formFingerprint = await this.generatedFormFingerprint(brand, currentRec, recordType, form);
         const representation = currentRec ? recordRepresentationConcurrency(currentRec) : undefined;
 
         // return the form config

--- a/packages/redbox-core/src/services/RecordsService.ts
+++ b/packages/redbox-core/src/services/RecordsService.ts
@@ -3396,7 +3396,7 @@ export namespace Services {
       const createFormFingerprintRecord: AnyRecord = {
         metaMetadata: {
           brandId: String(brandObj?.id ?? ''),
-          type: String(recordTypeObj?.name ?? recordTypeName),
+          type: recordTypeName,
           form: String(_.get(startingWfStep, 'config.form', '')),
         },
         workflow: { stage: this.workflowStepName(startingWfStep) },

--- a/packages/redbox-core/src/services/RecordsService.ts
+++ b/packages/redbox-core/src/services/RecordsService.ts
@@ -3388,6 +3388,19 @@ export namespace Services {
           return tracker.toResponse();
         }
       }
+
+      // A create form is delivered from the starting workflow step. The
+      // target step is selected by the save button and is not part of the
+      // form contract the browser received, so retain a server-owned copy of
+      // that starting contract for the concurrency check below.
+      const createFormFingerprintRecord: AnyRecord = {
+        metaMetadata: {
+          brandId: String(brandObj?.id ?? ''),
+          type: String(recordTypeObj?.name ?? recordTypeName),
+          form: String(_.get(startingWfStep, 'config.form', '')),
+        },
+        workflow: { stage: this.workflowStepName(startingWfStep) },
+      };
       this.transitionWorkflowStepMetadata(recordObj, startingWfStep);
       if (targetStepName) this.transitionWorkflowStepMetadata(recordObj, wfStep);
       const formName = String(_.get(wfStep, 'config.form', ''));
@@ -3434,9 +3447,8 @@ export namespace Services {
       if (suppliedFormFingerprint || formFingerprintRequired) {
         try {
           currentFormFingerprint = await this.getRecordFormFingerprint(
-            recordObj,
+            createFormFingerprintRecord,
             recordTypeObj,
-            targetStepName ? wfStep : undefined
           );
         } catch (error) {
           tracker.recordPrimaryNotApplied(

--- a/packages/redbox-core/src/services/RecordsService.ts
+++ b/packages/redbox-core/src/services/RecordsService.ts
@@ -1161,7 +1161,6 @@ export namespace Services {
     public async getRecordFormFingerprint(
       record: AnyRecord,
       recordType: RecordTypeLike,
-      _targetStep?: WorkflowStepLike,
       sourceForm?: FormAttributes
     ): Promise<string | undefined> {
       const metaMetadata = this.recordObject(record.metaMetadata);
@@ -3389,16 +3388,9 @@ export namespace Services {
         }
       }
 
-      // A create form is delivered from the starting workflow step. The
-      // target step is selected by the save button and is not part of the
-      // form contract the browser received, so retain a server-owned copy of
-      // that starting contract for the concurrency check below.
+      // Preserve the starting-form contract before applying target-step metadata.
       const createFormFingerprintRecord: AnyRecord = {
-        metaMetadata: {
-          brandId: String(brandObj?.id ?? ''),
-          type: recordTypeName,
-          form: String(_.get(startingWfStep, 'config.form', '')),
-        },
+        metaMetadata: { brandId: String(brandObj.id ?? ''), form: String(_.get(startingWfStep, 'config.form', '')) },
         workflow: { stage: this.workflowStepName(startingWfStep) },
       };
       this.transitionWorkflowStepMetadata(recordObj, startingWfStep);
@@ -3446,10 +3438,7 @@ export namespace Services {
       const formFingerprintRequired = tracker.context.routeFamily === 'browser' && concurrencyMode === 'strict';
       if (suppliedFormFingerprint || formFingerprintRequired) {
         try {
-          currentFormFingerprint = await this.getRecordFormFingerprint(
-            createFormFingerprintRecord,
-            recordTypeObj,
-          );
+          currentFormFingerprint = await this.getRecordFormFingerprint(createFormFingerprintRecord, recordTypeObj);
         } catch (error) {
           tracker.recordPrimaryNotApplied(
             this.concurrencyProblem('pre-save', 'record-concurrency-capability-unavailable')
@@ -4427,8 +4416,7 @@ export namespace Services {
         try {
           currentFormFingerprint = await this.getRecordFormFingerprint(
             originalRecord as AnyRecord,
-            recordType as RecordTypeLike,
-            transitionRequested && requestedTargetName && !targetDiagnostic ? nextStepObj : undefined
+            recordType as RecordTypeLike
           );
         } catch (error) {
           tracker.recordPrimaryNotApplied(

--- a/packages/redbox-core/test/controllers/RecordController.test.ts
+++ b/packages/redbox-core/test/controllers/RecordController.test.ts
@@ -707,11 +707,10 @@ describe('RecordController getWorkflowSteps', () => {
       workflow: { stage: 'draft' },
     });
     expect(createArgs[1]).to.deep.equal({ name: 'dataset' });
-    expect(createArgs[2]).to.equal(undefined);
-    expect(createArgs[3]).to.equal(form);
+    expect(createArgs[2]).to.equal(form);
   });
 
-  it('fingerprints the authoritative delivered form and preserves target intent', async function () {
+  it('fingerprints the authoritative delivered form independently of target intent', async function () {
     const currentRec = {
       redboxOid: 'oid-1',
       revision: 3,
@@ -720,7 +719,6 @@ describe('RecordController getWorkflowSteps', () => {
       workflow: { stage: 'draft' },
     };
     const recordType = { name: 'dataset' };
-    const targetStep = { name: 'published', config: { form: 'dataset-published' } };
     (global as any).sails.config = { reusableFormDefinitions: {}, validators: { definitions: [] } };
     (global as any).sails.services = {
       formpayloadprehydrateservice: { build: sinon.stub().resolves({}) },
@@ -733,7 +731,6 @@ describe('RecordController getWorkflowSteps', () => {
     (global as any).FormsService.buildClientFormConfig.resolves({ type: 'dataset' });
     (global as any).FormsService.discoverValidationOperations.resolves([]);
     (global as any).RecordTypesService.get.returns(of(recordType));
-    (global as any).WorkflowStepsService.get = sinon.stub().returns(of(targetStep));
     (controller.recordsService as any).getRecordFormFingerprint = sinon.stub().resolves('form-fingerprint-2');
     const req = {
       param: sinon
@@ -752,8 +749,7 @@ describe('RecordController getWorkflowSteps', () => {
     const args = (controller.recordsService as any).getRecordFormFingerprint.firstCall.args;
     expect(args[0]).to.equal(currentRec);
     expect(args[1]).to.deep.equal(recordType);
-    expect(args[2]).to.deep.equal(targetStep);
-    expect(args[3]).to.deep.include({ id: 'form-1', name: 'dataset-draft', branding: 'brand-1' });
+    expect(args[2]).to.deep.include({ id: 'form-1', name: 'dataset-draft', branding: 'brand-1' });
     expect(sendResp.firstCall.args[2].meta).to.deep.include({
       formFingerprint: 'form-fingerprint-2',
       revision: 3,

--- a/packages/redbox-core/test/services/RecordsService.test.ts
+++ b/packages/redbox-core/test/services/RecordsService.test.ts
@@ -3147,6 +3147,46 @@ describe('RecordsService', function () {
       expect(mockStorageService.create.calledOnce).to.equal(true);
     });
 
+    it('normalizes a missing brand id in the starting form fingerprint contract', async function () {
+      mockStorageService.getCapabilities = sinon.stub().returns({
+        recordConcurrency: FULL_RECORD_STORAGE_CONCURRENCY_CAPABILITIES,
+      });
+      const recordType = {
+        name: 'rdmp',
+        hooks: {},
+        searchable: false,
+        concurrentModification: { mode: 'strict' },
+      };
+      const getFingerprint = sinon.stub(RecordsService, 'getRecordFormFingerprint').resolves('issued-fingerprint');
+      const context = createRecordSaveContext({
+        routeFamily: 'browser',
+        operation: 'create',
+        targetStep: 'published',
+        concurrency: { entityTagSupplied: false, formFingerprint: 'issued-fingerprint' },
+      });
+
+      const result = await RecordsService.create(
+        {},
+        {
+          metadata: { title: 'Create without brand id' },
+          authorization: { edit: ['user-1'], view: ['user-1'], editRoles: [], viewRoles: [] },
+        },
+        recordType,
+        { username: 'user-1' },
+        true,
+        false,
+        'published',
+        context
+      );
+
+      expect(result.wasPersisted()).to.equal(true);
+      expect(getFingerprint.calledOnce).to.equal(true);
+      expect(getFingerprint.firstCall.args[0]).to.deep.include({
+        metaMetadata: { brandId: '', type: 'rdmp', form: 'default-form' },
+        workflow: { stage: 'draft' },
+      });
+    });
+
     it('generates a historical hyphenless OID for a configured create before storage', async function () {
       mockStorageService.create.resolves({
         success: true,

--- a/packages/redbox-core/test/services/RecordsService.test.ts
+++ b/packages/redbox-core/test/services/RecordsService.test.ts
@@ -3100,6 +3100,53 @@ describe('RecordsService', function () {
   });
 
   describe('create save pipeline', function () {
+    it('accepts the starting form fingerprint when a create transitions to its target step', async function () {
+      mockStorageService.getCapabilities = sinon.stub().returns({
+        recordConcurrency: FULL_RECORD_STORAGE_CONCURRENCY_CAPABILITIES,
+      });
+      const recordType = {
+        name: 'rdmp',
+        hooks: {},
+        searchable: false,
+        concurrentModification: { mode: 'strict' },
+      };
+      const issued = await RecordsService.getRecordFormFingerprint(
+        {
+          metaMetadata: { brandId: 'brand-1', type: 'rdmp', form: 'default-form' },
+          workflow: { stage: 'draft' },
+        },
+        recordType
+      );
+      const context = createRecordSaveContext({
+        routeFamily: 'browser',
+        operation: 'create',
+        targetStep: 'published',
+        concurrency: { entityTagSupplied: false, formFingerprint: issued },
+      });
+
+      const result = await RecordsService.create(
+        { id: 'brand-1' },
+        {
+          metadata: { title: 'Create with transition' },
+          authorization: { edit: ['user-1'], view: ['user-1'], editRoles: [], viewRoles: [] },
+        },
+        recordType,
+        { username: 'user-1' },
+        true,
+        false,
+        'published',
+        context
+      );
+
+      expect(result.wasPersisted()).to.equal(true);
+      expect(result.outcome).to.be.oneOf(['saved', 'saved-with-warnings']);
+      expect(result.problems.flatMap((problem: any) => problem.issues).map((issue: any) => issue.code)).not.to.include(
+        'form-definition-changed'
+      );
+      expect(result.concurrency?.formFingerprint).to.equal(issued);
+      expect(mockStorageService.create.calledOnce).to.equal(true);
+    });
+
     it('generates a historical hyphenless OID for a configured create before storage', async function () {
       mockStorageService.create.resolves({
         success: true,

--- a/packages/redbox-core/test/services/RecordsService.test.ts
+++ b/packages/redbox-core/test/services/RecordsService.test.ts
@@ -2389,7 +2389,7 @@ describe('RecordsService', function () {
         configuration: { componentDefinitions: [] },
       };
       (global as any).FormsService.getFormByName.returns(of(deliveredForm));
-      const issued = await RecordsService.getRecordFormFingerprint(stored, recordType, undefined, deliveredForm);
+      const issued = await RecordsService.getRecordFormFingerprint(stored, recordType, deliveredForm);
       expect(issued).to.match(/^sha256:[0-9a-f]{64}$/);
 
       // Save recomputation resolves the same authoritative form identity and
@@ -2411,7 +2411,7 @@ describe('RecordsService', function () {
 
     it('refuses to fingerprint a delivered form outside the authoritative stored form identity', async function () {
       const stored = record();
-      const fingerprint = await RecordsService.getRecordFormFingerprint(stored, { name: 'rdmp' }, undefined, {
+      const fingerprint = await RecordsService.getRecordFormFingerprint(stored, { name: 'rdmp' }, {
         id: 'other-id',
         name: 'other-form',
         branding: 'brand-1',
@@ -2422,7 +2422,7 @@ describe('RecordsService', function () {
       expect((global as any).FormsService.getFormByName.notCalled).to.equal(true);
     });
 
-    it('binds target workflow mappings while keeping one fingerprint stable across a transition', async function () {
+    it('binds workflow mappings into a stable fingerprint', async function () {
       installMode('strict');
       const stored = record();
       const recordType = { name: 'rdmp', hooks: {}, searchable: false };
@@ -2431,13 +2431,8 @@ describe('RecordsService', function () {
       );
 
       const current = await RecordsService.getRecordFormFingerprint(stored, recordType);
-      const target = await RecordsService.getRecordFormFingerprint(stored, recordType, {
-        name: 'published',
-        config: { form: 'published-form' },
-      });
 
       expect(current).to.match(/^sha256:[0-9a-f]{64}$/);
-      expect(target).to.equal(current);
       expect((global as any).FormsService.getFormByName.alwaysCalledWith('default-form', true, 'brand-1')).to.equal(
         true
       );
@@ -3102,7 +3097,7 @@ describe('RecordsService', function () {
   describe('create save pipeline', function () {
     it('accepts the starting form fingerprint when a create transitions to its target step', async function () {
       mockStorageService.getCapabilities = sinon.stub().returns({
-        recordConcurrency: FULL_RECORD_STORAGE_CONCURRENCY_CAPABILITIES,
+        recordConcurrency: RECORD_STORAGE_CONCURRENCY_CAPABILITY_VERSION,
       });
       const recordType = {
         name: 'rdmp',
@@ -3139,52 +3134,11 @@ describe('RecordsService', function () {
       );
 
       expect(result.wasPersisted()).to.equal(true);
-      expect(result.outcome).to.be.oneOf(['saved', 'saved-with-warnings']);
       expect(result.problems.flatMap((problem: any) => problem.issues).map((issue: any) => issue.code)).not.to.include(
         'form-definition-changed'
       );
       expect(result.concurrency?.formFingerprint).to.equal(issued);
       expect(mockStorageService.create.calledOnce).to.equal(true);
-    });
-
-    it('normalizes a missing brand id in the starting form fingerprint contract', async function () {
-      mockStorageService.getCapabilities = sinon.stub().returns({
-        recordConcurrency: FULL_RECORD_STORAGE_CONCURRENCY_CAPABILITIES,
-      });
-      const recordType = {
-        name: 'rdmp',
-        hooks: {},
-        searchable: false,
-        concurrentModification: { mode: 'strict' },
-      };
-      const getFingerprint = sinon.stub(RecordsService, 'getRecordFormFingerprint').resolves('issued-fingerprint');
-      const context = createRecordSaveContext({
-        routeFamily: 'browser',
-        operation: 'create',
-        targetStep: 'published',
-        concurrency: { entityTagSupplied: false, formFingerprint: 'issued-fingerprint' },
-      });
-
-      const result = await RecordsService.create(
-        {},
-        {
-          metadata: { title: 'Create without brand id' },
-          authorization: { edit: ['user-1'], view: ['user-1'], editRoles: [], viewRoles: [] },
-        },
-        recordType,
-        { username: 'user-1' },
-        true,
-        false,
-        'published',
-        context
-      );
-
-      expect(result.wasPersisted()).to.equal(true);
-      expect(getFingerprint.calledOnce).to.equal(true);
-      expect(getFingerprint.firstCall.args[0]).to.deep.include({
-        metaMetadata: { brandId: '', type: 'rdmp', form: 'default-form' },
-        workflow: { stage: 'draft' },
-      });
     });
 
     it('generates a historical hyphenless OID for a configured create before storage', async function () {


### PR DESCRIPTION
## Summary

Corrects form fingerprint validation for browser-created records that transition to another workflow step during save.

Changes made:

* Validates a create against the form contract that was delivered to the browser.
* Keeps the requested target workflow step as save intent rather than treating it as a different submitted form.
* Prevents valid strict-concurrency creates from being rejected with a misleading `form-definition-changed` problem.

## Context / related work

* Builds on the HTTP optimistic concurrency and form fingerprint handling introduced in the stacked concurrency work.
* Complements the existing create and workflow-transition save contracts without changing update validation.

## Technical implementation details

* `RecordController` now fingerprints a new record from its starting workflow step, while retaining target-step fingerprinting for existing records.
* `RecordsService` keeps a server-owned representation of the starting create form for the concurrency comparison after workflow metadata is advanced to the target step.
* The response continues to return the issued form fingerprint for subsequent client requests.

## Testing

* Added focused `RecordsService` coverage for a strict-concurrency create that transitions from the starting step to a target step.
* The test verifies persistence succeeds, storage is called once, and the result does not contain `form-definition-changed`.

## Backwards Compatibility

Existing update and transition fingerprint checks retain their current behaviour. The change only corrects the create path, where no stored record exists yet and the target transition is not the form contract submitted by the browser.

## Impact

Browser-created records can now complete an authorised workflow transition under strict concurrency without a false form-definition conflict.

Replacement for the no-op merge of #4548 during stack branch recovery. The original implementation commits remain on this branch.