### PR TITLE
Bugfix: support per-form SaveStatus messages

### DIFF
--- a/angular/projects/researchdatabox/form/src/app/component/save-status.component.spec.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/save-status.component.spec.ts
@@ -26,6 +26,7 @@ describe('SaveStatusComponent', () => {
       '@dmpt-form-save-error': 'Error while saving: ',
       '@dmpt-form-save-warning-create': 'The record was saved, but some follow-up processing could not be completed.',
       '@dmpt-form-save-unknown-update': 'We couldn’t confirm whether your changes were saved. Reference: {{requestId}}.',
+      '@storage-workspace-save-warning': 'The storage request could not be completed. Request ID: {{requestId}}. Please contact support for help.',
       '@record-save-save-not-applied': 'The changes were not saved.',
     });
     formConfig = {
@@ -154,6 +155,31 @@ describe('SaveStatusComponent', () => {
     const el = fixture.nativeElement.querySelector('.rb-form-save-status.alert-warning');
     expect(el?.textContent).toContain('couldn’t confirm');
     expect(el?.textContent).toContain('99999999-9999-4999-8999-999999999999');
+  });
+
+  it('should use a configured warning translation code', async () => {
+    const saveStatus = formConfig.componentDefinitions.find(component => component.name === 'save_status');
+    (saveStatus?.component?.config as Record<string, unknown>)['warningMessageCreate'] = '@storage-workspace-save-warning';
+    const { fixture, formComponent } = await createFormAndWaitForReady(formConfig);
+    const store = TestBed.inject(Store);
+    const eventBus = TestBed.inject(FormComponentEventBus);
+    spyOn(formComponent, 'saveForm').and.returnValue(new Promise(() => {}));
+    store.dispatch(FormActions.submitForm({ force: true }));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    eventBus.publish(createFormSaveSuccessEvent({
+      operation: 'create',
+      requestId: '77777777-7777-4777-8777-777777777777',
+      response: { outcome: 'saved-with-warnings' },
+    }));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const el = fixture.nativeElement.querySelector('.rb-form-save-status.alert-warning');
+    expect(el?.textContent).toContain('The storage request could not be completed');
+    expect(el?.textContent).toContain('77777777-7777-4777-8777-777777777777');
+    expect(el?.textContent).not.toContain('follow-up processing');
   });
 
   it('should ignore a scoped save event when no save operation is pending', async () => {

--- a/angular/projects/researchdatabox/form/src/app/component/save-status.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/save-status.component.ts
@@ -1,9 +1,19 @@
 import { Component, computed, effect, inject, signal } from '@angular/core';
 import { FormFieldBaseComponent } from '@researchdatabox/portal-ng-common';
-import { isRecordSaveOutcome, RecordSaveOutcome, SaveStatusComponentName } from '@researchdatabox/sails-ng-common';
+import {
+  isRecordSaveOutcome,
+  RecordSaveOutcome,
+  SaveStatusComponentName,
+  SaveStatusFieldComponentConfigOutline
+} from '@researchdatabox/sails-ng-common';
 import { FormComponentEventBus, FormComponentEventType, FormStateFacade } from '../form-state';
 
 type SaveStatusMessageType = 'saving' | 'deleting' | 'error' | 'warning' | 'unknown' | 'success' | null;
+type SaveStatusMessageConfigProperty =
+  | 'warningMessageCreate'
+  | 'warningMessageUpdate'
+  | 'unknownMessageCreate'
+  | 'unknownMessageUpdate';
 
 @Component({
   selector: 'redbox-form-save-status',
@@ -165,16 +175,29 @@ export class SaveStatusComponent extends FormFieldBaseComponent<undefined> {
   protected readonly messageType = computed<SaveStatusMessageType>(() => this.messageState());
   protected readonly errorPrefix = computed(() => this.lastOperation() === 'delete' ? '@dmpt-form-delete-error' : '@dmpt-form-save-error');
   protected readonly successMessage = computed(() => this.lastOperation() === 'delete' ? '@dmpt-form-delete-success' : '@dmpt-form-save-success');
-  protected readonly warningMessage = computed(() => this.isCreateSave()
-    ? '@dmpt-form-save-warning-create'
-    : '@dmpt-form-save-warning-update');
-  protected readonly unknownMessage = computed(() => this.isCreateSave()
-    ? '@dmpt-form-save-unknown-create'
-    : '@dmpt-form-save-unknown-update');
+  protected readonly warningMessage = computed(() => {
+    const isCreate = this.isCreateSave();
+    return this.configuredMessage(
+      isCreate ? 'warningMessageCreate' : 'warningMessageUpdate',
+      isCreate ? '@dmpt-form-save-warning-create' : '@dmpt-form-save-warning-update'
+    );
+  });
+  protected readonly unknownMessage = computed(() => {
+    const isCreate = this.isCreateSave();
+    return this.configuredMessage(
+      isCreate ? 'unknownMessageCreate' : 'unknownMessageUpdate',
+      isCreate ? '@dmpt-form-save-unknown-create' : '@dmpt-form-save-unknown-update'
+    );
+  });
 
   private isCreateSave(): boolean {
     const operation = this.saveOperation();
     return operation === 'create' || (operation === null && !this.formComponent?.trimmedParams.oid());
+  }
+
+  private configuredMessage(property: SaveStatusMessageConfigProperty, fallback: string): string {
+    const configured = (this.componentDefinition?.config as SaveStatusFieldComponentConfigOutline | undefined)?.[property];
+    return typeof configured === 'string' && configured.trim() ? configured.trim() : fallback;
   }
 
   private saveOutcome(response: { outcome?: unknown } | null | undefined): RecordSaveOutcome | undefined {

--- a/angular/projects/researchdatabox/form/src/app/component/save-status.component.ts
+++ b/angular/projects/researchdatabox/form/src/app/component/save-status.component.ts
@@ -1,11 +1,6 @@
 import { Component, computed, effect, inject, signal } from '@angular/core';
 import { FormFieldBaseComponent } from '@researchdatabox/portal-ng-common';
-import {
-  isRecordSaveOutcome,
-  RecordSaveOutcome,
-  SaveStatusComponentName,
-  SaveStatusFieldComponentConfigOutline
-} from '@researchdatabox/sails-ng-common';
+import { isRecordSaveOutcome, RecordSaveOutcome, SaveStatusComponentName } from '@researchdatabox/sails-ng-common';
 import { FormComponentEventBus, FormComponentEventType, FormStateFacade } from '../form-state';
 
 type SaveStatusMessageType = 'saving' | 'deleting' | 'error' | 'warning' | 'unknown' | 'success' | null;
@@ -196,7 +191,7 @@ export class SaveStatusComponent extends FormFieldBaseComponent<undefined> {
   }
 
   private configuredMessage(property: SaveStatusMessageConfigProperty, fallback: string): string {
-    const configured = (this.componentDefinition?.config as SaveStatusFieldComponentConfigOutline | undefined)?.[property];
+    const configured = this.getStringProperty(property);
     return typeof configured === 'string' && configured.trim() ? configured.trim() : fallback;
   }
 

--- a/packages/redbox-core/src/visitor/construct.visitor.ts
+++ b/packages/redbox-core/src/visitor/construct.visitor.ts
@@ -833,6 +833,11 @@ export class ConstructFormConfigVisitor extends FormConfigVisitor {
     item.config = new SaveStatusFieldComponentConfig();
 
     this.sharedProps.sharedPopulateFieldComponentConfig(item.config, config);
+    this.sharedProps.setPropOverride('successDisplayDurationMs', item.config, config);
+    this.sharedProps.setPropOverride('warningMessageCreate', item.config, config);
+    this.sharedProps.setPropOverride('warningMessageUpdate', item.config, config);
+    this.sharedProps.setPropOverride('unknownMessageCreate', item.config, config);
+    this.sharedProps.setPropOverride('unknownMessageUpdate', item.config, config);
   }
 
   async visitSaveStatusFormComponentDefinition(item: SaveStatusFormComponentDefinitionOutline): Promise<void> {

--- a/packages/redbox-core/test/unit/construct.visitor.test.ts
+++ b/packages/redbox-core/test/unit/construct.visitor.test.ts
@@ -666,6 +666,40 @@ describe("Construct Visitor", async () => {
               hideWhenInactive: true,
             });
         });
+
+        it("should include save status message properties", async function () {
+            const visitor = new ConstructFormConfigVisitor(logger);
+            const actual = await visitor.start({
+                formMode: "edit",
+                data: {
+                    name: "test",
+                    componentDefinitions: [
+                      {
+                        name: "save_status",
+                        component: {
+                          class: "SaveStatusComponent",
+                          config: {
+                            successDisplayDurationMs: 5000,
+                            warningMessageCreate: "@storage-workspace-save-warning",
+                            warningMessageUpdate: "@storage-workspace-save-warning",
+                            unknownMessageCreate: "@storage-workspace-save-unknown",
+                            unknownMessageUpdate: "@storage-workspace-save-unknown",
+                          }
+                        }
+                      }
+                    ]
+                }
+            });
+
+            expect(actual.componentDefinitions?.[0]?.component?.class).to.equal("SaveStatusComponent");
+            expect(actual.componentDefinitions?.[0]?.component?.config).to.containSubset({
+              successDisplayDurationMs: 5000,
+              warningMessageCreate: "@storage-workspace-save-warning",
+              warningMessageUpdate: "@storage-workspace-save-warning",
+              unknownMessageCreate: "@storage-workspace-save-unknown",
+              unknownMessageUpdate: "@storage-workspace-save-unknown",
+            });
+        });
     });
 
     describe("record metadata retriever", async () => {

--- a/packages/redbox-core/test/unit/construct.visitor.test.ts
+++ b/packages/redbox-core/test/unit/construct.visitor.test.ts
@@ -669,6 +669,13 @@ describe("Construct Visitor", async () => {
 
         it("should include save status message properties", async function () {
             const visitor = new ConstructFormConfigVisitor(logger);
+            const expectedConfig = {
+              successDisplayDurationMs: 5000,
+              warningMessageCreate: "@storage-workspace-save-warning",
+              warningMessageUpdate: "@storage-workspace-save-warning",
+              unknownMessageCreate: "@storage-workspace-save-unknown",
+              unknownMessageUpdate: "@storage-workspace-save-unknown",
+            };
             const actual = await visitor.start({
                 formMode: "edit",
                 data: {
@@ -678,13 +685,7 @@ describe("Construct Visitor", async () => {
                         name: "save_status",
                         component: {
                           class: "SaveStatusComponent",
-                          config: {
-                            successDisplayDurationMs: 5000,
-                            warningMessageCreate: "@storage-workspace-save-warning",
-                            warningMessageUpdate: "@storage-workspace-save-warning",
-                            unknownMessageCreate: "@storage-workspace-save-unknown",
-                            unknownMessageUpdate: "@storage-workspace-save-unknown",
-                          }
+                          config: { ...expectedConfig }
                         }
                       }
                     ]
@@ -692,13 +693,7 @@ describe("Construct Visitor", async () => {
             });
 
             expect(actual.componentDefinitions?.[0]?.component?.class).to.equal("SaveStatusComponent");
-            expect(actual.componentDefinitions?.[0]?.component?.config).to.containSubset({
-              successDisplayDurationMs: 5000,
-              warningMessageCreate: "@storage-workspace-save-warning",
-              warningMessageUpdate: "@storage-workspace-save-warning",
-              unknownMessageCreate: "@storage-workspace-save-unknown",
-              unknownMessageUpdate: "@storage-workspace-save-unknown",
-            });
+            expect(actual.componentDefinitions?.[0]?.component?.config).to.containSubset(expectedConfig);
         });
     });
 

--- a/packages/sails-ng-common/src/config/component/save-status.model.ts
+++ b/packages/sails-ng-common/src/config/component/save-status.model.ts
@@ -14,6 +14,10 @@ import {AvailableFieldLayoutDefinitionOutlines} from "../dictionary.outline";
 
 export class SaveStatusFieldComponentConfig extends FieldComponentConfig implements SaveStatusFieldComponentConfigOutline {
     successDisplayDurationMs = 3000;
+    warningMessageCreate?: string;
+    warningMessageUpdate?: string;
+    unknownMessageCreate?: string;
+    unknownMessageUpdate?: string;
 
     constructor() {
         super();

--- a/packages/sails-ng-common/src/config/component/save-status.outline.ts
+++ b/packages/sails-ng-common/src/config/component/save-status.outline.ts
@@ -23,6 +23,26 @@ export interface SaveStatusFieldComponentConfigFrame extends FieldComponentConfi
      * Defaults to 3000 milliseconds.
      */
     successDisplayDurationMs?: number;
+    /**
+     * Translation code for a persisted warning after creating a record.
+     * Falls back to the global save warning when not provided.
+     */
+    warningMessageCreate?: string;
+    /**
+     * Translation code for a persisted warning after updating a record.
+     * Falls back to the global save warning when not provided.
+     */
+    warningMessageUpdate?: string;
+    /**
+     * Translation code when the result of creating a record cannot be confirmed.
+     * Falls back to the global unknown-save message when not provided.
+     */
+    unknownMessageCreate?: string;
+    /**
+     * Translation code when the result of updating a record cannot be confirmed.
+     * Falls back to the global unknown-save message when not provided.
+     */
+    unknownMessageUpdate?: string;
 }
 
 export interface SaveStatusFieldComponentConfigOutline extends SaveStatusFieldComponentConfigFrame, FieldComponentConfigOutline {


### PR DESCRIPTION
## Summary

Allows each form to customise the SaveStatus translations used for warning and unknown save outcomes while preserving the existing global defaults.

Changes made:

* Adds per-form translation-code configuration for create and update warning states.
* Adds per-form translation-code configuration for create and update unknown states.
* Configures ServiceNow storage forms to show the storage request ID and direct users to contact support when the request cannot be completed or confirmed.

## Context / related work

* Builds on the typed save outcomes and request ID messaging introduced by the informative record save outcomes work.
* The global save-status messages remain the fallback for forms that do not provide overrides.

## Technical implementation details

* Extends the shared SaveStatus component model and outline with `warningMessageCreate`, `warningMessageUpdate`, `unknownMessageCreate`, and `unknownMessageUpdate`.
* Copies the component-specific properties through form construction and selects the configured translation code in the Angular SaveStatus component.
* Retains the existing global create/update keys when an override is absent or blank.
* Adds the storage-request warning and unknown translations and applies them to all six ServiceNow storage workflows.

## Testing

* Added form-construction coverage confirming all four message overrides survive the core visitor.
* Added Angular SaveStatus coverage confirming a configured warning translation renders with the request ID.
* Verified the focused SaveStatus suite, core and hook compilation, and the Angular form build.

## Backwards Compatibility

Forms without custom message codes continue to use the existing generic global translations. No save outcome or request-processing semantics are changed.

## Impact

ServiceNow storage failures now provide an actionable, request-specific message and discourage users from repeatedly editing a record whose downstream storage request needs support intervention.

Replacement for the no-op merge of #4549 during stack branch recovery. The original implementation commits remain on this branch.