### PR TITLE
Bugfix: Sort deleted records by stored fields

### DIFF
--- a/angular/projects/researchdatabox/deleted-records/src/app/deleted-records.component.spec.ts
+++ b/angular/projects/researchdatabox/deleted-records/src/app/deleted-records.component.spec.ts
@@ -159,6 +159,43 @@ describe('DeletedRecordsComponent', () => {
     expect(app.deletedRecordsResult.total).toEqual(1);
   });
 
+  it('should sort each column using its deleted-record storage path', async function () {
+    const fixture = TestBed.createComponent(DeletedRecordsComponent);
+    const app = fixture.componentInstance;
+
+    fixture.autoDetectChanges(true);
+    await app.waitForInit();
+    await fixture.whenStable();
+
+    const requestedSorts: string[] = [];
+    recordService.getDeletedRecords = async function(
+      recordType: string,
+      state: string,
+      pageNumber: number,
+      packageType: string = '',
+      sort: string = ''
+    ) {
+      requestedSorts.push(sort);
+      return mockData.deletedRecords;
+    };
+
+    for (const header of app.tableHeaders) {
+      await app.headerSortChanged({ sort: 'asc' }, header);
+      await app.headerSortChanged({ sort: 'desc' }, header);
+    }
+
+    expect(requestedSorts).toEqual([
+      'deletedRecordMetadata.metadata.title:1',
+      'deletedRecordMetadata.metadata.title:-1',
+      'deletedRecordMetadata.dateCreated:1',
+      'deletedRecordMetadata.dateCreated:-1',
+      'deletedRecordMetadata.lastSaveDate:1',
+      'deletedRecordMetadata.lastSaveDate:-1',
+      'dateDeleted:1',
+      'dateDeleted:-1',
+    ]);
+  });
+
   it('should restore a deleted record', async function () {
     // create app
     const fixture = TestBed.createComponent(DeletedRecordsComponent);

--- a/angular/projects/researchdatabox/deleted-records/src/app/deleted-records.component.ts
+++ b/angular/projects/researchdatabox/deleted-records/src/app/deleted-records.component.ts
@@ -24,6 +24,10 @@ import { isEmpty as _isEmpty, set as _set, get as _get, isUndefined as _isUndefi
 import { ModalDirective } from "ngx-bootstrap/modal";
 import { DateTime } from 'luxon';
 
+interface DeletedRecordTableHeader extends RecordPropViewMetaDto {
+  sortProperty: string;
+}
+
 /**
  * Restore deleted records Component
  */
@@ -70,10 +74,11 @@ export class DeletedRecordsComponent extends BaseComponent implements RecordSour
   filterParams: any = {};
 
   // Record table properties
-  tableHeaders: RecordPropViewMetaDto[] = [
+  tableHeaders: DeletedRecordTableHeader[] = [
     {
       label: "deleted-records-results-table-header-title",
       property: "title",
+      sortProperty: "deletedRecordMetadata.metadata.title",
       template: "",
       hide: false,
       multivalue: false
@@ -81,6 +86,7 @@ export class DeletedRecordsComponent extends BaseComponent implements RecordSour
     {
       label: "deleted-records-results-table-header-created-date",
       property: "dateCreatedDisplay",
+      sortProperty: "deletedRecordMetadata.dateCreated",
       template: "",
       hide: false,
       multivalue: false
@@ -88,6 +94,7 @@ export class DeletedRecordsComponent extends BaseComponent implements RecordSour
     {
       label: "deleted-records-results-table-header-modified-date",
       property: "dateModifiedDisplay",
+      sortProperty: "deletedRecordMetadata.lastSaveDate",
       template: "",
       hide: false,
       multivalue: false
@@ -95,6 +102,7 @@ export class DeletedRecordsComponent extends BaseComponent implements RecordSour
     {
       label: "deleted-records-results-table-header-deleted-date",
       property: "dateDeletedDisplay",
+      sortProperty: "dateDeleted",
       template: "",
       hide: false,
       multivalue: false
@@ -156,8 +164,8 @@ export class DeletedRecordsComponent extends BaseComponent implements RecordSour
     await this.gotoPage(1);
   }
 
-  public async headerSortChanged(event: any, data: any) {
-    this.sort = `${event.variable}:${event.sort === 'desc' ? '-1' : '1'}`;
+  public async headerSortChanged(event: any, data: DeletedRecordTableHeader) {
+    this.sort = `${data.sortProperty}:${event.sort === 'desc' ? '-1' : '1'}`;
     await this.gotoPage(1);
   }
 


### PR DESCRIPTION
## Summary

Makes every sortable column on the Deleted Records admin page use the corresponding persisted tombstone field. Ascending and descending sorting now changes the displayed record order for titles and all three date columns.

Fixes #4568.

---

## Context / Motivation

The table previously reused its display properties as server-side sort keys. Deleted-record responses expose flattened display values such as `title` and formatted date fields, while MongoDB stores those values under `deletedRecordMetadata` or on the tombstone itself. The UI therefore requested valid but non-existent storage fields, so the sort indicator changed without changing row order.

---

## Key Features

### Deleted-record sorting

- Separates each column's display property from its persisted sort property.
- Maps titles to the nested deleted-record metadata title.
- Maps created and modified dates to the original record snapshot and deleted dates to the tombstone date.
- Preserves the existing ascending/descending interaction and resets pagination to the first page after sorting.

### Regression coverage

- Exercises ascending and descending requests for all four sortable columns.
- Verifies the exact storage paths sent through the existing deleted-record query service.

---

## Testing

- Passed the deleted-records Angular test suite: 5 tests passing.
- Passed the deleted-records Angular development build.
- Passed oxlint and Git whitespace validation for the changed component and test.
- Reproduced the failure with three deterministic deleted records: requests used `title:1` and `title:-1`, while rows remained unchanged.
- Visually verified ascending and descending sorting for title, date created, date modified, and date deleted; each column reversed the expected live rows.
- No Bruno test was added because this PR does not change an API contract or backend behavior; it corrects the sort keys supplied by the Angular client to the existing endpoint.

---

## Architectural / Operational Impact

### Client data mapping

Deleted-record table headers now carry an explicit storage sort property alongside their response display property. The generic record table and deleted-record API remain unchanged.

### Runtime behavior

Sorting still uses the existing paginated server-side query path. Only the requested field names change, so result size, filtering, permissions, and lifecycle actions are unaffected.

---

## Backwards Compatibility

The Deleted Records route, response shape, filters, and action controls remain compatible. There are no persisted data or public API changes.

---

## Deployment Notes

No migrations, dependency updates, or configuration changes are required. Deploy the rebuilt deleted-records Angular bundle with the normal portal release.

---

## Impact

Administrators can reliably sort deleted records in either direction using every visible sortable column.
