### PR TITLE
Feature: Add denyRoles form authorization support

### DIFF
--- a/packages/redbox-core/src/visitor/client.visitor.ts
+++ b/packages/redbox-core/src/visitor/client.visitor.ts
@@ -1209,6 +1209,16 @@ export class ClientFormConfigVisitor extends FormConfigVisitor {
     const requiredRoles = Array.from(
       new Set(constraints?.map(b => b?.authorization?.allowRoles ?? [])?.filter(i => i.length > 0) ?? [])
     );
+    const deniedRoles = Array.from(
+      new Set(constraints?.map(b => b?.authorization?.denyRoles ?? [])?.filter(i => i.length > 0) ?? [])
+    );
+
+    const isDenied = deniedRoles?.some(roles => {
+      return Array.isArray(roles) && roles.length > 0 && currentUserRoles.some(c => roles.includes(c));
+    });
+    if (isDenied) {
+      return false;
+    }
 
     // The current user must have at least one of the roles required by each component.
     return requiredRoles?.every(i => {

--- a/packages/redbox-core/test/unit/client.visitor.test.ts
+++ b/packages/redbox-core/test/unit/client.visitor.test.ts
@@ -1895,6 +1895,26 @@ describe("Client Visitor", async () => {
           }
         },
         {
+          name: 'deny_only_field',
+          layout: {
+            class: 'DefaultLayout',
+            config: { label: 'Denied for Admin' }
+          },
+          model: {
+            class: 'SimpleInputModel',
+            config: { defaultValue: 'deny-only' }
+          },
+          component: {
+            class: 'SimpleInputComponent',
+            config: { readonly: false }
+          },
+          constraints: {
+            authorization: {
+              denyRoles: ['Admin']
+            }
+          }
+        },
+        {
           name: 'admin_edit_field',
           layout: {
             class: 'DefaultLayout',
@@ -1917,13 +1937,13 @@ describe("Client Visitor", async () => {
       ]
     };
 
-    // 1. User with only Researcher role: should see researcher_only_field, but not admin_edit_field
+    // 1. User with only Researcher role: should see both non-Admin fields, but not admin_edit_field
     const constructor1 = new ConstructFormConfigVisitor(logger);
     const constructed1 = await constructor1.start({ data: structuredClone(formConfig), formMode: 'edit' });
     const visitor1 = new ClientFormConfigVisitor(logger);
     const actual1 = await visitor1.start({ form: constructed1, formMode: 'edit', userRoles: ['Researcher'] });
     const fieldNames1 = actual1.componentDefinitions?.map((c: any) => c.name) ?? [];
-    expect(fieldNames1).to.deep.equal(['researcher_only_field']);
+    expect(fieldNames1).to.deep.equal(['researcher_only_field', 'deny_only_field']);
 
     // 2. User with Admin (has all roles including Researcher): should see admin_edit_field, but NOT researcher_only_field
     const constructor2 = new ConstructFormConfigVisitor(logger);
@@ -1933,13 +1953,73 @@ describe("Client Visitor", async () => {
     const fieldNames2 = actual2.componentDefinitions?.map((c: any) => c.name) ?? [];
     expect(fieldNames2).to.deep.equal(['admin_edit_field']);
 
-    // 3. User with Librarians + Researcher: should see admin_edit_field, but NOT researcher_only_field
+    // 3. User with Librarians + Researcher: should see the deny-only and admin fields, but NOT researcher_only_field
     const constructor3 = new ConstructFormConfigVisitor(logger);
     const constructed3 = await constructor3.start({ data: structuredClone(formConfig), formMode: 'edit' });
     const visitor3 = new ClientFormConfigVisitor(logger);
     const actual3 = await visitor3.start({ form: constructed3, formMode: 'edit', userRoles: ['Librarians', 'Researcher'] });
     const fieldNames3 = actual3.componentDefinitions?.map((c: any) => c.name) ?? [];
-    expect(fieldNames3).to.deep.equal(['admin_edit_field']);
+    expect(fieldNames3).to.deep.equal(['deny_only_field', 'admin_edit_field']);
+  });
+
+  it('should inherit denyRoles from nested group components', async function () {
+    const formConfig = {
+      name: 'nested-role-test-form',
+      componentDefinitions: [
+        {
+          name: 'restricted_group',
+          layout: {
+            class: 'DefaultLayout',
+            config: { label: 'Restricted group' }
+          },
+          model: {
+            class: 'GroupModel',
+            config: {}
+          },
+          component: {
+            class: 'GroupComponent',
+            config: {
+              componentDefinitions: [
+                {
+                  name: 'nested_field',
+                  layout: {
+                    class: 'DefaultLayout',
+                    config: { label: 'Nested field' }
+                  },
+                  model: {
+                    class: 'SimpleInputModel',
+                    config: { defaultValue: 'nested' }
+                  },
+                  component: {
+                    class: 'SimpleInputComponent',
+                    config: {}
+                  }
+                }
+              ]
+            }
+          },
+          constraints: {
+            authorization: {
+              denyRoles: ['Admin']
+            }
+          }
+        }
+      ]
+    };
+
+    const constructor1 = new ConstructFormConfigVisitor(logger);
+    const constructed1 = await constructor1.start({ data: structuredClone(formConfig), formMode: 'edit' });
+    const visitor1 = new ClientFormConfigVisitor(logger);
+    const actual1 = await visitor1.start({ form: constructed1, formMode: 'edit', userRoles: ['Researcher'] });
+    const group = actual1.componentDefinitions?.[0] as any;
+    expect(group?.name).to.equal('restricted_group');
+    expect(group?.component?.config?.componentDefinitions?.map((c: any) => c.name)).to.deep.equal(['nested_field']);
+
+    const constructor2 = new ConstructFormConfigVisitor(logger);
+    const constructed2 = await constructor2.start({ data: structuredClone(formConfig), formMode: 'edit' });
+    const visitor2 = new ClientFormConfigVisitor(logger);
+    const actual2 = await visitor2.start({ form: constructed2, formMode: 'edit', userRoles: ['Admin'] });
+    expect(actual2).to.eql({});
   });
 
   it(`should keep transformed accordion in view mode`, async function () {

--- a/packages/redbox-core/test/unit/client.visitor.test.ts
+++ b/packages/redbox-core/test/unit/client.visitor.test.ts
@@ -1869,6 +1869,79 @@ describe("Client Visitor", async () => {
     expect(actual).to.eql({});
   });
 
+  it('should support denyRoles to hide fields from users with denied roles', async function () {
+    const formConfig = {
+      name: 'role-test-form',
+      componentDefinitions: [
+        {
+          name: 'researcher_only_field',
+          layout: {
+            class: 'DefaultLayout',
+            config: { label: 'Researcher Only' }
+          },
+          model: {
+            class: 'SimpleInputModel',
+            config: { defaultValue: 'res' }
+          },
+          component: {
+            class: 'SimpleInputComponent',
+            config: { readonly: true }
+          },
+          constraints: {
+            authorization: {
+              allowRoles: ['Researcher'],
+              denyRoles: ['Admin', 'Librarians']
+            }
+          }
+        },
+        {
+          name: 'admin_edit_field',
+          layout: {
+            class: 'DefaultLayout',
+            config: { label: 'Admin Edit' }
+          },
+          model: {
+            class: 'SimpleInputModel',
+            config: { defaultValue: 'admin' }
+          },
+          component: {
+            class: 'SimpleInputComponent',
+            config: { readonly: false }
+          },
+          constraints: {
+            authorization: {
+              allowRoles: ['Admin', 'Librarians']
+            }
+          }
+        }
+      ]
+    };
+
+    // 1. User with only Researcher role: should see researcher_only_field, but not admin_edit_field
+    const constructor1 = new ConstructFormConfigVisitor(logger);
+    const constructed1 = await constructor1.start({ data: structuredClone(formConfig), formMode: 'edit' });
+    const visitor1 = new ClientFormConfigVisitor(logger);
+    const actual1 = await visitor1.start({ form: constructed1, formMode: 'edit', userRoles: ['Researcher'] });
+    const fieldNames1 = actual1.componentDefinitions?.map((c: any) => c.name) ?? [];
+    expect(fieldNames1).to.deep.equal(['researcher_only_field']);
+
+    // 2. User with Admin (has all roles including Researcher): should see admin_edit_field, but NOT researcher_only_field
+    const constructor2 = new ConstructFormConfigVisitor(logger);
+    const constructed2 = await constructor2.start({ data: structuredClone(formConfig), formMode: 'edit' });
+    const visitor2 = new ClientFormConfigVisitor(logger);
+    const actual2 = await visitor2.start({ form: constructed2, formMode: 'edit', userRoles: ['Admin', 'Librarians', 'Researcher'] });
+    const fieldNames2 = actual2.componentDefinitions?.map((c: any) => c.name) ?? [];
+    expect(fieldNames2).to.deep.equal(['admin_edit_field']);
+
+    // 3. User with Librarians + Researcher: should see admin_edit_field, but NOT researcher_only_field
+    const constructor3 = new ConstructFormConfigVisitor(logger);
+    const constructed3 = await constructor3.start({ data: structuredClone(formConfig), formMode: 'edit' });
+    const visitor3 = new ClientFormConfigVisitor(logger);
+    const actual3 = await visitor3.start({ form: constructed3, formMode: 'edit', userRoles: ['Librarians', 'Researcher'] });
+    const fieldNames3 = actual3.componentDefinitions?.map((c: any) => c.name) ?? [];
+    expect(fieldNames3).to.deep.equal(['admin_edit_field']);
+  });
+
   it(`should keep transformed accordion in view mode`, async function () {
     const constructor = new ConstructFormConfigVisitor(logger);
     const constructed = await constructor.start({

--- a/packages/redbox-core/test/unit/migrate-config-v4-v5.visitor.test.ts
+++ b/packages/redbox-core/test/unit/migrate-config-v4-v5.visitor.test.ts
@@ -141,7 +141,7 @@ describe('Migrate v4 to v5 Visitor', async () => {
     expect(migrated.componentDefinitions[saveStatusIndex].component.class).to.equal('SaveStatusComponent');
     expect(migrated.componentDefinitions[validationSummaryIndex].component.class).to.equal('ValidationSummaryComponent');
     expect(migrated.componentDefinitions[validationSummaryIndex].constraints).to.deep.equal({
-      authorization: { allowRoles: [] },
+      authorization: { allowRoles: [], denyRoles: [] },
       allowModes: [],
     });
   });

--- a/packages/sails-ng-common/src/config/form-component.model.ts
+++ b/packages/sails-ng-common/src/config/form-component.model.ts
@@ -30,6 +30,7 @@ export class FormConstraintConfig implements FormConstraintConfigOutline {
  */
 export class FormConstraintAuthorizationConfig implements FormConstraintAuthorizationConfigOutline {
     allowRoles?: string[];
+    declare denyRoles?: string[];
 }
 
 

--- a/packages/sails-ng-common/src/config/form-component.model.ts
+++ b/packages/sails-ng-common/src/config/form-component.model.ts
@@ -30,7 +30,7 @@ export class FormConstraintConfig implements FormConstraintConfigOutline {
  */
 export class FormConstraintAuthorizationConfig implements FormConstraintAuthorizationConfigOutline {
     allowRoles?: string[];
-    declare denyRoles?: string[];
+    denyRoles?: string[];
 }
 
 

--- a/packages/sails-ng-common/src/config/form-component.outline.ts
+++ b/packages/sails-ng-common/src/config/form-component.outline.ts
@@ -298,6 +298,12 @@ export interface FormConstraintAuthorizationConfigFrame {
      * e.g. allowRoles: ['Admin', 'Librarians'],
      */
     allowRoles?: string[];
+    /**
+     * The form field will be excluded if the current user has any of these roles.
+     *
+     * e.g. denyRoles: ['Admin', 'Librarians'],
+     */
+    denyRoles?: string[];
 }
 
 export interface FormConstraintAuthorizationConfigOutline extends FormConstraintAuthorizationConfigFrame {

--- a/packages/sails-ng-common/src/config/visitor/common.model.ts
+++ b/packages/sails-ng-common/src/config/visitor/common.model.ts
@@ -82,9 +82,7 @@ export class PropertiesHelper {
 
     item.constraints.authorization = new FormConstraintAuthorizationConfig();
     item.constraints.authorization.allowRoles = currentData?.constraints?.authorization?.allowRoles ?? [];
-    if (currentData?.constraints?.authorization?.denyRoles !== undefined) {
-      item.constraints.authorization.denyRoles = currentData.constraints.authorization.denyRoles;
-    }
+    item.constraints.authorization.denyRoles = currentData?.constraints?.authorization?.denyRoles ?? [];
 
     // TODO: Commented out below while we decide on how to handle 'form-level' expressions
     // Set the expressions

--- a/packages/sails-ng-common/src/config/visitor/common.model.ts
+++ b/packages/sails-ng-common/src/config/visitor/common.model.ts
@@ -82,6 +82,9 @@ export class PropertiesHelper {
 
     item.constraints.authorization = new FormConstraintAuthorizationConfig();
     item.constraints.authorization.allowRoles = currentData?.constraints?.authorization?.allowRoles ?? [];
+    if (currentData?.constraints?.authorization?.denyRoles !== undefined) {
+      item.constraints.authorization.denyRoles = currentData.constraints.authorization.denyRoles;
+    }
 
     // TODO: Commented out below while we decide on how to handle 'form-level' expressions
     // Set the expressions


### PR DESCRIPTION
## Summary

Adds first-class `denyRoles` support to client-side form authorization so fields can be excluded when a user has a denied role. This enables role-specific field variants to remain unambiguous when users carry overlapping roles.

---

## Context / Motivation

Some ReDBox deployments need to render different versions of the same logical field for different roles. Allow-role checks alone cannot distinguish those versions when an administrator or librarian also carries the Researcher role, which can result in both variants being rendered. A deny-role constraint provides the missing exclusion rule.

---

## Key Features

### Form authorization configuration

- Adds optional `denyRoles` typing to `sails-ng-common` form authorization configuration and models.
- Preserves `denyRoles` while form configuration is transformed into the client model.
- Excludes a component when the current user has any denied role before evaluating its existing `allowRoles` constraint.

### Role-specific field rendering

- Supports mutually exclusive readonly and editable field variants for deployments with overlapping role membership.
- Keeps the existing allow-role behavior unchanged for configurations that do not specify `denyRoles`.

---

## Testing

- `npm run compile:all` passed in the develop portal worktree.
- Focused core visitor test for `denyRoles`: 1 passing.
- WSU hook compile passed.
- WSU unit suite passed: 52 passing.
- T3 Browser verification confirmed one editable RDMP ID field for Local Admin and one readonly RDMP ID field for Test Researcher.

---

## Architectural / Operational Impact

### Configuration and runtime behavior

This is an optional, backward-compatible extension to the existing client form authorization model. No new runtime dependency, API route, database migration, or persistence change is introduced.

### Authorization semantics

`denyRoles` narrows client-side field visibility in combination with the existing allow-role checks. It follows the established form rendering authorization model and does not replace server-side record or API authorization.

---

## Backwards Compatibility

Existing form configurations without `denyRoles` retain their current behavior. Existing `allowRoles` constraints continue to be evaluated as before when no denied role matches.

---

## Deployment Notes

No migration or environment change is required. The portal packages should be compiled and deployed together with any hook configuration that consumes `denyRoles`.

---

## Impact

Downstream ReDBox hooks can now express mutually exclusive role-specific fields cleanly, preventing overlapping role memberships from producing duplicate or incorrect field variants.
