### PR TITLE
Bugfix: Return proper browser 404 page for missing attachments

### DIFF
--- a/packages/redbox-core/src/controllers/RecordController.ts
+++ b/packages/redbox-core/src/controllers/RecordController.ts
@@ -1415,18 +1415,16 @@ export namespace Controllers {
           // Set octet stream as a default
           mimeType = 'application/octet-stream'
         }
-        res.set('Content-Type', mimeType);
-
         const size = found['size'] as string;
-        if (!_.isEmpty(size)) {
-          res.set('Content-Length', size);
-        }
-
         sails.log.verbose("found.name " + found['name']);
-        res.attachment(found['name'] as string);
         sails.log.verbose(`Returning datastream observable of ${oid}: ${found['name']}, attachId: ${attachId}`);
         try {
           const response = await that.datastreamService.getDatastream(oid, attachId, { username: String(req.user?.username ?? '') || undefined });
+          res.set('Content-Type', mimeType);
+          if (!_.isEmpty(size)) {
+            res.set('Content-Length', size);
+          }
+          res.attachment(found['name'] as string);
           if (response.readstream) {
             response.readstream.pipe(res);
           } else {

--- a/packages/redbox-core/src/controllers/RecordController.ts
+++ b/packages/redbox-core/src/controllers/RecordController.ts
@@ -1401,6 +1401,9 @@ export namespace Controllers {
         });
         if (!found) {
           sails.log.verbose("Error: Attachment not found in do attachment.");
+          if (!this.isAjax(req)) {
+            return res.notFound();
+          }
           return this.sendResp(req, res, {
             status: 404,
             errors: [this.asError(new Error(TranslationService.t('attachment-not-found')))],
@@ -1439,6 +1442,9 @@ export namespace Controllers {
           } else if (errorMessage == TranslationService.t('edit-error-no-permissions')) {
             return this.sendResp(req, res, { status: 403, errors: [this.asError(error)], displayErrors: [{ code: 'edit-error-no-permissions' }] });
           } else if (errorMessage == TranslationService.t('attachment-not-found')) {
+            if (!this.isAjax(req)) {
+              return res.notFound();
+            }
             return this.sendResp(req, res, { status: 404, errors: [this.asError(error)], displayErrors: [{ code: 'attachment-not-found' }] });
           } else {
             return this.sendResp(req, res, { status: 500, errors: [this.asError(error)] });

--- a/packages/redbox-core/test/controllers/RecordController.test.ts
+++ b/packages/redbox-core/test/controllers/RecordController.test.ts
@@ -712,6 +712,93 @@ describe('RecordController TUS URL generation', () => {
 
     expect(checkDiskSpaceStub.firstCall.args[0]).to.not.equal('/legacy/mongodb-disk');
   });
+
+  it('renders the browser 404 page when an attachment is not in the record', async () => {
+    (controller as any).tusServer = { handle: sinon.stub() };
+    sinon.stub(controller as any, 'getRecord').returns(of({
+      metaMetadata: { attachmentFields: [] },
+      metadata: {},
+    }));
+    sinon.stub(controller as any, 'hasViewAccess').returns(of(true));
+
+    const req = {
+      method: 'GET',
+      session: { branding: 'default' },
+      user: { username: 'user' },
+      url: '/default/rdmp/record/oid-1/attach/file-missing',
+      path: '/default/rdmp/record/oid-1/attach/file-missing',
+      headers: { host: 'localhost:1500' },
+      param: sinon.stub().callsFake((name: string) => ({ oid: 'oid-1', attachId: 'file-missing' }[name])),
+    } as unknown as Sails.Req;
+    const res = { notFound: sinon.stub() } as unknown as Sails.Res;
+    const sendRespStub = sinon.stub(controller as any, 'sendResp');
+
+    await controller.doAttachment(req, res);
+
+    expect((res.notFound as any).calledOnce).to.equal(true);
+    expect(sendRespStub.called).to.equal(false);
+  });
+
+  it('keeps the JSON 404 response for attachment API requests', async () => {
+    (controller as any).tusServer = { handle: sinon.stub() };
+    sinon.stub(controller as any, 'getRecord').returns(of({
+      metaMetadata: { attachmentFields: [] },
+      metadata: {},
+    }));
+    sinon.stub(controller as any, 'hasViewAccess').returns(of(true));
+
+    const req = {
+      method: 'GET',
+      session: { branding: 'default' },
+      user: { username: 'user' },
+      url: '/default/rdmp/record/oid-1/attach/file-missing',
+      path: '/default/rdmp/record/oid-1/attach/file-missing',
+      headers: { host: 'localhost:1500', 'x-source': 'jsclient' },
+      param: sinon.stub().callsFake((name: string) => ({ oid: 'oid-1', attachId: 'file-missing' }[name])),
+    } as unknown as Sails.Req;
+    const res = {} as Sails.Res;
+    const sendRespStub = sinon.stub(controller as any, 'sendResp');
+
+    await controller.doAttachment(req, res);
+
+    expect(sendRespStub.calledOnce).to.equal(true);
+    expect(sendRespStub.firstCall.args[2]).to.deep.include({ status: 404 });
+  });
+
+  it('renders the browser 404 page when the attachment stream is missing', async () => {
+    (controller as any).tusServer = { handle: sinon.stub() };
+    sinon.stub(controller as any, 'getRecord').returns(of({
+      metaMetadata: { attachmentFields: ['attachments'] },
+      metadata: {
+        attachments: [{ fileId: 'file-missing', name: 'missing.txt', mimeType: 'text/plain', size: '1' }],
+      },
+    }));
+    sinon.stub(controller as any, 'hasViewAccess').returns(of(true));
+    controller.datastreamService = {
+      getDatastream: sinon.stub().rejects(new Error('attachment-not-found')),
+    } as any;
+
+    const req = {
+      method: 'GET',
+      session: { branding: 'default' },
+      user: { username: 'user' },
+      url: '/default/rdmp/record/oid-1/attach/file-missing',
+      path: '/default/rdmp/record/oid-1/attach/file-missing',
+      headers: { host: 'localhost:1500' },
+      param: sinon.stub().callsFake((name: string) => ({ oid: 'oid-1', attachId: 'file-missing' }[name])),
+    } as unknown as Sails.Req;
+    const res = {
+      set: sinon.stub(),
+      attachment: sinon.stub(),
+      notFound: sinon.stub(),
+    } as unknown as Sails.Res;
+    const sendRespStub = sinon.stub(controller as any, 'sendResp');
+
+    await controller.doAttachment(req, res);
+
+    expect((res.notFound as any).calledOnce).to.equal(true);
+    expect(sendRespStub.called).to.equal(false);
+  });
 });
 
 describe('AsynchController authorization', () => {

--- a/packages/redbox-core/test/controllers/RecordController.test.ts
+++ b/packages/redbox-core/test/controllers/RecordController.test.ts
@@ -797,6 +797,8 @@ describe('RecordController TUS URL generation', () => {
     await controller.doAttachment(req, res);
 
     expect((res.notFound as any).calledOnce).to.equal(true);
+    expect((res.set as any).called).to.equal(false);
+    expect((res.attachment as any).called).to.equal(false);
     expect(sendRespStub.called).to.equal(false);
   });
 });


### PR DESCRIPTION
## Summary

Fix missing attachments to return a proper browser 404 page instead of a raw JSON response when accessed via a browser request.

---

## Context / Motivation

When a user navigates to an attachment URL in the browser for an attachment that no longer exists, the controller was returning a JSON error response (`{ status: 404, errors: [...] }`). This is appropriate for AJAX/API clients but results in a poor user experience for browser users who see raw JSON instead of a meaningful 404 page.

---

## Key Features

### Browser 404 handling for missing attachments

- When a browser request (non-AJAX) hits a missing attachment, the controller now returns `res.notFound()` instead of a JSON payload
- The `isAjax` check distinguishes between browser navigation and API/AJAX calls
- Two code paths are covered: attachment not found in the record metadata, and attachment stream fetch failure

### API response preservation

- AJAX/API requests (`x-source: jsclient` header) continue to receive the existing JSON 404 response with error details
- No breaking change for existing API consumers

---

## Testing

- Added test: renders the browser 404 page when an attachment is not in the record
- Added test: keeps the JSON 404 response for attachment API requests
- Added test: renders the browser 404 page when the attachment stream is missing

---

## Architectural / Operational Impact

### Controller behavior

The `doAttachment` method in `RecordController` now branches on request type (browser vs AJAX) before returning error responses. This is a minimal, targeted change with no broader architectural implications.

---

## Backwards Compatibility

Fully backwards compatible. API/AJAX clients receive the same JSON response as before. Only browser requests see the new behavior.

---

## Deployment Notes

No migration or configuration changes required. Deploy as normal.

---

## Impact

Browser users navigating to deleted or non-existent attachments will now see a proper 404 page instead of a raw JSON error blob.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Browser requests now receive a standard 404 page when an attachment or its content cannot be found.
  * JavaScript requests continue to receive structured JSON 404 responses for missing attachments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->