### PR TITLE
Bugfix: Retry timed out RVA bootstrap imports

### DIFF
--- a/packages/redbox-core/src/services/VocabularyService.ts
+++ b/packages/redbox-core/src/services/VocabularyService.ts
@@ -20,6 +20,7 @@ export namespace Services {
   const FIGSHARE_IMPORTS_FILE = 'figshare-imports.json';
   const DEFAULT_BOOTSTRAP_DATA_PATH = 'bootstrap-data';
   const RVA_IMPORT_TIMEOUT_MS = 30_000;
+  const RVA_IMPORT_SETTLEMENT_TIMEOUT_MS = 30_000;
   const RVA_IMPORT_MAX_ATTEMPTS = 3;
   const RVA_IMPORT_RETRY_DELAY_MS = 1_000;
 
@@ -1200,9 +1201,21 @@ export namespace Services {
             return imported;
           }
 
-          const settled = await importPromise.then(
+          // Retrying while the original import is still pending could create a
+          // duplicate vocabulary. Fail this bootstrap item instead of overlapping it
+          // if it does not settle within the bounded reconciliation window.
+          const settled = await promiseWithTimeout(
+            importPromise,
+            RVA_IMPORT_SETTLEMENT_TIMEOUT_MS,
+            `RVA import ${sourceKey} settlement`
+          ).then(
             value => ({ status: 'fulfilled' as const, value }),
-            reason => ({ status: 'rejected' as const, reason })
+            reason => {
+              if (reason instanceof Error && reason.message.includes('settlement timed out')) {
+                throw reason;
+              }
+              return { status: 'rejected' as const, reason };
+            }
           );
           if (settled.status === 'fulfilled') {
             return settled.value;

--- a/packages/redbox-core/src/services/VocabularyService.ts
+++ b/packages/redbox-core/src/services/VocabularyService.ts
@@ -22,7 +22,6 @@ export namespace Services {
   const RVA_IMPORT_TIMEOUT_MS = 30_000;
   const RVA_IMPORT_MAX_ATTEMPTS = 3;
   const RVA_IMPORT_RETRY_DELAY_MS = 1_000;
-  const RVA_IMPORT_SETTLE_TIMEOUT_MS = 30_000;
 
   export type VocabularyEntryInput =
     Pick<VocabularyEntryAttributes, 'id' | 'label' | 'value' | 'identifier' | 'order' | 'historical'> & {
@@ -1192,7 +1191,7 @@ export namespace Services {
           }
 
           // A timeout does not cancel the import. Wait for the in-flight operation to
-          // finish before retrying, so it cannot complete during a second import.
+          // settle before retrying, so it cannot overlap a second import.
           await new Promise<void>((resolve) => setTimeout(resolve, RVA_IMPORT_RETRY_DELAY_MS));
 
           const imported = await Vocabulary.findOne({ rvaSourceKey: sourceKey }) as VocabularyAttributes | null;
@@ -1201,12 +1200,12 @@ export namespace Services {
             return imported;
           }
 
-          const settled = await this.waitForRvaImportSettlement(importPromise);
+          const settled = await importPromise.then(
+            value => ({ status: 'fulfilled' as const, value }),
+            reason => ({ status: 'rejected' as const, reason })
+          );
           if (settled.status === 'fulfilled') {
             return settled.value;
-          }
-          if (settled.status === 'pending') {
-            throw error;
           }
           lastError = settled.reason;
 
@@ -1227,24 +1226,6 @@ export namespace Services {
       }
 
       throw lastError;
-    }
-
-    private async waitForRvaImportSettlement<T>(importPromise: Promise<T>): Promise<
-      { status: 'fulfilled'; value: T } | { status: 'rejected'; reason: unknown } | { status: 'pending' }
-    > {
-      return await new Promise(resolve => {
-        const timeout = setTimeout(() => resolve({ status: 'pending' }), RVA_IMPORT_SETTLE_TIMEOUT_MS);
-        importPromise.then(
-          value => {
-            clearTimeout(timeout);
-            resolve({ status: 'fulfilled', value });
-          },
-          reason => {
-            clearTimeout(timeout);
-            resolve({ status: 'rejected', reason });
-          }
-        );
-      });
     }
 
     private isRetryableRvaImportError(error: unknown): boolean {

--- a/packages/redbox-core/src/services/VocabularyService.ts
+++ b/packages/redbox-core/src/services/VocabularyService.ts
@@ -20,6 +20,9 @@ export namespace Services {
   const FIGSHARE_IMPORTS_FILE = 'figshare-imports.json';
   const DEFAULT_BOOTSTRAP_DATA_PATH = 'bootstrap-data';
   const RVA_IMPORT_TIMEOUT_MS = 30_000;
+  const RVA_IMPORT_MAX_ATTEMPTS = 3;
+  const RVA_IMPORT_RETRY_DELAY_MS = 1_000;
+  const RVA_IMPORT_SETTLE_TIMEOUT_MS = 30_000;
 
   export type VocabularyEntryInput =
     Pick<VocabularyEntryAttributes, 'id' | 'label' | 'value' | 'identifier' | 'order' | 'historical'> & {
@@ -1153,16 +1156,100 @@ export namespace Services {
         const versionId = typeof item?.versionId === 'string' ? item.versionId.trim() : undefined;
 
         try {
-          await promiseWithTimeout(
-            rvaImportService.importRvaVocabulary(rvaId, versionId, defaultBranding),
-            RVA_IMPORT_TIMEOUT_MS,
-            `RVA import ${sourceKey}`
-          );
+          await this.importRvaBootstrapVocabulary(rvaImportService, rvaId, versionId, defaultBranding, sourceKey);
           sails.log.verbose(`Imported RVA bootstrap vocabulary: ${sourceKey}`);
         } catch (error) {
           sails.log.error(`Failed RVA bootstrap import: ${sourceKey}`, error);
         }
       }
+    }
+
+    private async importRvaBootstrapVocabulary(
+      rvaImportService: { importRvaVocabulary: (rvaId: string, versionId?: string, branding?: string) => Promise<VocabularyAttributes> },
+      rvaId: string,
+      versionId: string | undefined,
+      branding: string,
+      sourceKey: string
+    ): Promise<VocabularyAttributes> {
+      let lastError: unknown;
+
+      for (let attempt = 1; attempt <= RVA_IMPORT_MAX_ATTEMPTS; attempt++) {
+        let importPromise: Promise<VocabularyAttributes> | undefined;
+        try {
+          importPromise = rvaImportService.importRvaVocabulary(rvaId, versionId, branding);
+          return await promiseWithTimeout(
+            importPromise,
+            RVA_IMPORT_TIMEOUT_MS,
+            `RVA import ${sourceKey}`
+          );
+        } catch (error) {
+          lastError = error;
+          if (!this.isRetryableRvaImportError(error)) {
+            throw error;
+          }
+          if (!importPromise) {
+            throw error;
+          }
+
+          // A timeout does not cancel the import. Wait for the in-flight operation to
+          // finish before retrying, so it cannot complete during a second import.
+          await new Promise<void>((resolve) => setTimeout(resolve, RVA_IMPORT_RETRY_DELAY_MS));
+
+          const imported = await Vocabulary.findOne({ rvaSourceKey: sourceKey }) as VocabularyAttributes | null;
+          if (imported) {
+            sails.log.verbose(`RVA bootstrap import completed after timeout: ${sourceKey}`);
+            return imported;
+          }
+
+          const settled = await this.waitForRvaImportSettlement(importPromise);
+          if (settled.status === 'fulfilled') {
+            return settled.value;
+          }
+          if (settled.status === 'pending') {
+            throw error;
+          }
+          lastError = settled.reason;
+
+          // The original operation has settled, so this reconciliation cannot race with
+          // its database write before a retry is launched.
+          const settledImport = await Vocabulary.findOne({ rvaSourceKey: sourceKey }) as VocabularyAttributes | null;
+          if (settledImport) {
+            sails.log.verbose(`RVA bootstrap import completed after timeout: ${sourceKey}`);
+            return settledImport;
+          }
+
+          if (attempt === RVA_IMPORT_MAX_ATTEMPTS) {
+            throw lastError;
+          }
+
+          sails.log.verbose(`Retrying RVA bootstrap import ${sourceKey} (attempt ${attempt + 1}/${RVA_IMPORT_MAX_ATTEMPTS})`);
+        }
+      }
+
+      throw lastError;
+    }
+
+    private async waitForRvaImportSettlement<T>(importPromise: Promise<T>): Promise<
+      { status: 'fulfilled'; value: T } | { status: 'rejected'; reason: unknown } | { status: 'pending' }
+    > {
+      return await new Promise(resolve => {
+        const timeout = setTimeout(() => resolve({ status: 'pending' }), RVA_IMPORT_SETTLE_TIMEOUT_MS);
+        importPromise.then(
+          value => {
+            clearTimeout(timeout);
+            resolve({ status: 'fulfilled', value });
+          },
+          reason => {
+            clearTimeout(timeout);
+            resolve({ status: 'rejected', reason });
+          }
+        );
+      });
+    }
+
+    private isRetryableRvaImportError(error: unknown): boolean {
+      const message = error instanceof Error ? error.message : String(error ?? '');
+      return /timed out|timeout|ETIMEDOUT|ECONNABORTED|ECONNRESET|ECONNREFUSED|EAI_AGAIN/i.test(message);
     }
 
     private async readJsonFile<T>(filePath: string): Promise<T | null> {

--- a/packages/redbox-core/test/services/VocabularyService.test.ts
+++ b/packages/redbox-core/test/services/VocabularyService.test.ts
@@ -567,6 +567,59 @@ describe('VocabularyService', () => {
       expect((g.sails.log.error as sinon.SinonStub).called).to.equal(false);
     });
 
+    it('stops retrying when a timed-out RVA import is reconciled', async () => {
+      const clock = sinon.useFakeTimers();
+      try {
+        const { readdirStub, readFileStub } = stubBootstrapFileOps();
+        readdirStub.resolves([{ isFile: () => true, name: 'rva-imports.json' }] as unknown as ReaddirResult);
+        readFileStub.resolves(JSON.stringify({ imports: [{ rvaId: '316' }] }));
+        const findOneStub = sinon.stub();
+        findOneStub.onFirstCall().resolves(null);
+        findOneStub.onSecondCall().resolves({ id: 'rva-316' });
+        g.Vocabulary.findOne = findOneStub as unknown as VocabularyModelStub['findOne'];
+        const importStub = (g.sails.services.rvaimportservice as { importRvaVocabulary: sinon.SinonStub }).importRvaVocabulary;
+        importStub.returns(new Promise(() => undefined));
+
+        const bootstrap = service.bootstrapData();
+        await clock.tickAsync(30_001);
+        await clock.tickAsync(1_000);
+        await bootstrap;
+
+        expect(importStub.calledOnce).to.equal(true);
+        expect((g.sails.log.error as sinon.SinonStub).called).to.equal(false);
+      } finally {
+        clock.restore();
+      }
+    });
+
+    it('logs a non-transient RVA bootstrap failure without retrying', async () => {
+      const { readdirStub, readFileStub } = stubBootstrapFileOps();
+      readdirStub.resolves([{ isFile: () => true, name: 'rva-imports.json' }] as unknown as ReaddirResult);
+      readFileStub.resolves(JSON.stringify({ imports: [{ rvaId: '316' }] }));
+      g.Vocabulary.findOne = sinon.stub().resolves(null) as unknown as VocabularyModelStub['findOne'];
+      const importStub = (g.sails.services.rvaimportservice as { importRvaVocabulary: sinon.SinonStub }).importRvaVocabulary;
+      importStub.rejects(new Error('RVA metadata is invalid'));
+
+      await service.bootstrapData();
+
+      expect(importStub.calledOnce).to.equal(true);
+      expect((g.sails.log.error as sinon.SinonStub).calledOnce).to.equal(true);
+    });
+
+    it('stops after three transient RVA bootstrap failures', async () => {
+      const { readdirStub, readFileStub } = stubBootstrapFileOps();
+      readdirStub.resolves([{ isFile: () => true, name: 'rva-imports.json' }] as unknown as ReaddirResult);
+      readFileStub.resolves(JSON.stringify({ imports: [{ rvaId: '316' }] }));
+      g.Vocabulary.findOne = sinon.stub().resolves(null) as unknown as VocabularyModelStub['findOne'];
+      const importStub = (g.sails.services.rvaimportservice as { importRvaVocabulary: sinon.SinonStub }).importRvaVocabulary;
+      importStub.rejects(new Error('RVA import timed out'));
+
+      await service.bootstrapData();
+
+      expect(importStub.callCount).to.equal(3);
+      expect((g.sails.log.error as sinon.SinonStub).calledOnce).to.equal(true);
+    });
+
     it('accepts an RVA import that appears after the timeout', async () => {
       const clock = sinon.useFakeTimers();
       try {
@@ -595,6 +648,33 @@ describe('VocabularyService', () => {
 
         expect(importStub.calledOnce).to.equal(true);
         expect((g.sails.log.error as sinon.SinonStub).called).to.equal(false);
+      } finally {
+        clock.restore();
+      }
+    });
+
+    it('fails a still-pending RVA import after the settlement timeout', async () => {
+      const clock = sinon.useFakeTimers();
+      try {
+        g.Vocabulary.findOne = sinon.stub().resolves(null) as unknown as VocabularyModelStub['findOne'];
+        const importStub = (g.sails.services.rvaimportservice as { importRvaVocabulary: sinon.SinonStub }).importRvaVocabulary;
+        importStub.returns(new Promise(() => undefined));
+        const importBootstrap = Reflect.get(service, 'importRvaBootstrapVocabulary').bind(service) as (
+          importService: typeof g.sails.services.rvaimportservice,
+          rvaId: string,
+          versionId: string | undefined,
+          branding: string,
+          sourceKey: string
+        ) => Promise<VocabularyAttributes>;
+
+        const importResult = importBootstrap(g.sails.services.rvaimportservice, '316', undefined, 'default', 'rva:316');
+        let error: unknown;
+        importResult.catch((caughtError) => { error = caughtError; });
+        await clock.runAllAsync();
+
+        expect(error).to.be.instanceOf(Error);
+        expect((error as Error).message).to.contain('settlement timed out');
+        expect(importStub.calledOnce).to.equal(true);
       } finally {
         clock.restore();
       }

--- a/packages/redbox-core/test/services/VocabularyService.test.ts
+++ b/packages/redbox-core/test/services/VocabularyService.test.ts
@@ -552,6 +552,54 @@ describe('VocabularyService', () => {
       expect(importStub.firstCall.args[0]).to.equal('316');
     });
 
+    it('retries a transient RVA bootstrap failure without logging an error when it succeeds', async () => {
+      const { readdirStub, readFileStub } = stubBootstrapFileOps();
+      readdirStub.resolves([{ isFile: () => true, name: 'rva-imports.json' }] as unknown as ReaddirResult);
+      readFileStub.resolves(JSON.stringify({ imports: [{ rvaId: '316' }] }));
+      g.Vocabulary.findOne = sinon.stub().resolves(null) as unknown as VocabularyModelStub['findOne'];
+      const importStub = (g.sails.services.rvaimportservice as { importRvaVocabulary: sinon.SinonStub }).importRvaVocabulary;
+      importStub.onFirstCall().rejects(new Error('RVA import timed out'));
+      importStub.onSecondCall().resolves({ id: 'rva-316' });
+
+      await service.bootstrapData();
+
+      expect(importStub.callCount).to.equal(2);
+      expect((g.sails.log.error as sinon.SinonStub).called).to.equal(false);
+    });
+
+    it('accepts an RVA import that appears after the timeout', async () => {
+      const clock = sinon.useFakeTimers();
+      try {
+        const { readdirStub, readFileStub } = stubBootstrapFileOps();
+        readdirStub.resolves([{ isFile: () => true, name: 'rva-imports.json' }] as unknown as ReaddirResult);
+        readFileStub.resolves(JSON.stringify({ imports: [{ rvaId: '316' }] }));
+        const findOneStub = sinon.stub();
+        findOneStub.onFirstCall().resolves(null);
+        // The original import finishes after reconciliation sees no row.
+        let resolveImport!: (value: { id: string }) => void;
+        const originalImport = new Promise<{ id: string }>(resolve => {
+          resolveImport = resolve;
+        });
+        findOneStub.onSecondCall().callsFake(async () => {
+          resolveImport({ id: 'rva-316' });
+          return null;
+        });
+        g.Vocabulary.findOne = findOneStub as unknown as VocabularyModelStub['findOne'];
+        const importStub = (g.sails.services.rvaimportservice as { importRvaVocabulary: sinon.SinonStub }).importRvaVocabulary;
+        importStub.returns(originalImport);
+
+        const bootstrap = service.bootstrapData();
+        await clock.tickAsync(30_001);
+        await clock.tickAsync(1_000);
+        await bootstrap;
+
+        expect(importStub.calledOnce).to.equal(true);
+        expect((g.sails.log.error as sinon.SinonStub).called).to.equal(false);
+      } finally {
+        clock.restore();
+      }
+    });
+
     it('does not import rva vocabularies when disabled in config', async () => {
       g.sails.config.vocab = { bootstrapRvaImports: false };
       const { readdirStub, readFileStub } = stubBootstrapFileOps();


### PR DESCRIPTION
## Summary

Adds retry-on-timeout handling for Research Vocabularies Australia (RVA) bootstrap imports in the `VocabularyService`. Transient network failures and timeouts no longer abandon an import; the bootstrap retries up to three times and gracefully accepts imports that complete after the timeout window.

---

## Context / Motivation

RVA bootstrap imports occasionally time out during the initial data load, which caused the import to fail permanently and left the vocabulary missing. In many cases the upstream has actually completed the work, but the client gave up because the response did not arrive within the fixed timeout.

---

## Key Features

### Retry with backoff

- RVA bootstrap imports now retry up to three attempts with a short delay between them.
- Only transient, retryable failures (timeout, connection reset/refused, DNS errors) trigger a retry; genuine errors are re-thrown immediately.

### Post-timeout reconciliation

- Because a timeout does not cancel the import, each retry first checks whether the vocabulary was already written to the database before starting a new attempt.
- If the import completed after the timeout, it is accepted and logged as a success rather than reported as a failure.

### Refactored import path

- Extracted the retryable import logic into a dedicated private method to keep the bootstrap loop readable.
- Failure detection is centralised in a small predicate that matches known transient error signatures.

---

## Testing

- Added unit tests covering a transient failure followed by a successful retry (verifying no error is logged).
- Added a unit test simulating a timed-out import whose output appears after the timeout, confirming it is accepted and not logged as an error.
- Existing RVA bootstrap tests continue to pass.

---

## Architectural / Operational Impact

### Vocabulary bootstrap reliability

The RVA bootstrap no longer becomes permanently stuck on a single transient failure, improving first-run reliability.

### Logging

Successful post-timeout imports are now logged at verbose level instead of being reported as failures, reducing noisy false error logs during bootstrap.

---

## Backwards Compatibility

No public API or configuration changes. Retry behaviour is internal to the service and applies consistently to all RVA bootstrap imports.

---

## Deployment Notes

No migration or environment configuration required. Deploys cleanly as part of the standard build.

---

## Impact

Makes first-run RVA bootstrap imports resilient to transient network timeouts while preserving existing behaviour for genuine failures.
