### PR TITLE
Bugfix: Fix save request UUID generation in HTTP development

### DIFF
--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/record.service.spec.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/record.service.spec.ts
@@ -57,12 +57,17 @@ describe('RecordService', () => {
     );
   });
 
-  it('creates a UUID save request header in development when crypto.randomUUID is unavailable', async () => {
+  it('creates a UUID save request header in production mode when crypto.randomUUID is unavailable', async () => {
+    const runtimeGlobals = globalThis as typeof globalThis & { ngDevMode?: unknown };
+    const hadNgDevMode = Object.prototype.hasOwnProperty.call(runtimeGlobals, 'ngDevMode');
+    const nativeNgDevMode = runtimeGlobals.ngDevMode;
     const nativeRandomUUID = globalThis.crypto.randomUUID;
+    runtimeGlobals.ngDevMode = false;
     Object.defineProperty(globalThis.crypto, 'randomUUID', { configurable: true, value: undefined });
 
     try {
       const createPromise = recordService.create({ title: 'Test record' }, 'rdmp');
+      runtimeGlobals.ngDevMode = nativeNgDevMode;
       const request = httpTestingController.expectOne(`${recordService.brandingAndPortalUrl}/recordmeta/rdmp`);
       const requestId = request.request.headers.get('X-ReDBox-Save-Request-Id');
 
@@ -76,6 +81,11 @@ describe('RecordService', () => {
         })
       );
     } finally {
+      if (hadNgDevMode) {
+        runtimeGlobals.ngDevMode = nativeNgDevMode;
+      } else {
+        delete runtimeGlobals.ngDevMode;
+      }
       Object.defineProperty(globalThis.crypto, 'randomUUID', { configurable: true, value: nativeRandomUUID });
     }
   });

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/record.service.spec.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/record.service.spec.ts
@@ -57,17 +57,12 @@ describe('RecordService', () => {
     );
   });
 
-  it('creates a UUID save request header in production mode when crypto.randomUUID is unavailable', async () => {
-    const runtimeGlobals = globalThis as typeof globalThis & { ngDevMode?: unknown };
-    const hadNgDevMode = Object.prototype.hasOwnProperty.call(runtimeGlobals, 'ngDevMode');
-    const nativeNgDevMode = runtimeGlobals.ngDevMode;
-    const nativeRandomUUID = globalThis.crypto.randomUUID;
-    runtimeGlobals.ngDevMode = false;
+  it('creates a UUID save request header when crypto.randomUUID is unavailable', async () => {
+    const nativeRandomUUIDDescriptor = Object.getOwnPropertyDescriptor(globalThis.crypto, 'randomUUID');
     Object.defineProperty(globalThis.crypto, 'randomUUID', { configurable: true, value: undefined });
 
     try {
       const createPromise = recordService.create({ title: 'Test record' }, 'rdmp');
-      runtimeGlobals.ngDevMode = nativeNgDevMode;
       const request = httpTestingController.expectOne(`${recordService.brandingAndPortalUrl}/recordmeta/rdmp`);
       const requestId = request.request.headers.get('X-ReDBox-Save-Request-Id');
 
@@ -81,12 +76,11 @@ describe('RecordService', () => {
         })
       );
     } finally {
-      if (hadNgDevMode) {
-        runtimeGlobals.ngDevMode = nativeNgDevMode;
+      if (nativeRandomUUIDDescriptor) {
+        Object.defineProperty(globalThis.crypto, 'randomUUID', nativeRandomUUIDDescriptor);
       } else {
-        delete runtimeGlobals.ngDevMode;
+        Reflect.deleteProperty(globalThis.crypto, 'randomUUID');
       }
-      Object.defineProperty(globalThis.crypto, 'randomUUID', { configurable: true, value: nativeRandomUUID });
     }
   });
 

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/record.service.spec.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/record.service.spec.ts
@@ -57,6 +57,29 @@ describe('RecordService', () => {
     );
   });
 
+  it('creates a UUID save request header in development when crypto.randomUUID is unavailable', async () => {
+    const nativeRandomUUID = globalThis.crypto.randomUUID;
+    Object.defineProperty(globalThis.crypto, 'randomUUID', { configurable: true, value: undefined });
+
+    try {
+      const createPromise = recordService.create({ title: 'Test record' }, 'rdmp');
+      const request = httpTestingController.expectOne(`${recordService.brandingAndPortalUrl}/recordmeta/rdmp`);
+      const requestId = request.request.headers.get('X-ReDBox-Save-Request-Id');
+
+      expect(requestId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+
+      request.flush({ meta: { outcome: 'saved', success: true, oid: 'oid-123' } });
+      await expectAsync(createPromise).toBeResolvedTo(
+        jasmine.objectContaining({
+          outcome: 'saved',
+          oid: 'oid-123',
+        })
+      );
+    } finally {
+      Object.defineProperty(globalThis.crypto, 'randomUUID', { configurable: true, value: nativeRandomUUID });
+    }
+  });
+
   it('requests API v2 and keeps the CSRF context on saves', async () => {
     const updatePromise = recordService.update('oid-123', { title: 'Test record' }, '', undefined, {
       entityTag: entityTag(4),

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/record.service.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/record.service.ts
@@ -18,7 +18,7 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import { map, firstValueFrom } from 'rxjs';
-import { Injectable, Inject, isDevMode } from '@angular/core';
+import { Injectable, Inject } from '@angular/core';
 import { APP_BASE_HREF } from '@angular/common';
 import {
   HttpClient,
@@ -114,11 +114,10 @@ function createSaveRequestId(): string {
   if (globalThis.crypto?.randomUUID) {
     return globalThis.crypto.randomUUID();
   }
-  // crypto.randomUUID() may be unavailable when running the portal over HTTP in
-  // development because it requires a secure context. Fall back to
-  // crypto.getRandomValues() for local development, while keeping production
-  // behaviour strict so unexpected crypto API availability issues are surfaced.
-  if (!isDevMode() || !globalThis.crypto?.getRandomValues) {
+  // crypto.randomUUID() may be unavailable when the portal is served over HTTP
+  // because it requires a secure context. getRandomValues() is still suitable
+  // for generating a cryptographically random UUID in that environment.
+  if (!globalThis.crypto?.getRandomValues) {
     throw new Error('Unable to generate save request id: crypto.randomUUID() is unavailable');
   }
   return '10000000-1000-4000-8000-100000000000'.replace(/[018]/g, character =>

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/record.service.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/record.service.ts
@@ -114,6 +114,10 @@ function createSaveRequestId(): string {
   if (globalThis.crypto?.randomUUID) {
     return globalThis.crypto.randomUUID();
   }
+  // crypto.randomUUID() may be unavailable when running the portal over HTTP in
+  // development because it requires a secure context. Fall back to
+  // crypto.getRandomValues() for local development, while keeping production
+  // behaviour strict so unexpected crypto API availability issues are surfaced.
   if (!isDevMode() || !globalThis.crypto?.getRandomValues) {
     throw new Error('Unable to generate save request id: crypto.randomUUID() is unavailable');
   }

--- a/angular/projects/researchdatabox/portal-ng-common/src/lib/record.service.ts
+++ b/angular/projects/researchdatabox/portal-ng-common/src/lib/record.service.ts
@@ -18,7 +18,7 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import { map, firstValueFrom } from 'rxjs';
-import { Injectable, Inject } from '@angular/core';
+import { Injectable, Inject, isDevMode } from '@angular/core';
 import { APP_BASE_HREF } from '@angular/common';
 import {
   HttpClient,
@@ -111,7 +111,18 @@ const recordSaveLifecyclePhases: ReadonlySet<RecordSaveLifecyclePhase> = new Set
 ]);
 
 function createSaveRequestId(): string {
-  return globalThis.crypto.randomUUID();
+  if (globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID();
+  }
+  if (!isDevMode() || !globalThis.crypto?.getRandomValues) {
+    throw new Error('Unable to generate save request id: crypto.randomUUID() is unavailable');
+  }
+  return '10000000-1000-4000-8000-100000000000'.replace(/[018]/g, character =>
+    (
+      Number(character) ^
+      (globalThis.crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (Number(character) / 4)))
+    ).toString(16)
+  );
 }
 
 export interface RecordTypeConf {


### PR DESCRIPTION
## Summary

Fixes save request header generation when the browser does not expose `crypto.randomUUID()`. The portal now prefers the native API and falls back to a standards-compliant UUID v4 generated with `crypto.getRandomValues()`.

The motivating case is an HTTP development environment, but the decision is intentionally capability-based rather than tied to the Angular build mode. The fallback therefore works whenever the browser lacks `randomUUID()`, regardless of whether Angular was compiled in development or production mode.

---

## Context / Motivation

The `X-ReDBox-Save-Request-Id` header correlates record save lifecycle events. The previous implementation called `crypto.randomUUID()` unconditionally. Browsers may omit that API on HTTP origins because it requires a secure context, causing record saves to fail during local development.

`crypto.getRandomValues()` remains available in those environments and provides cryptographically secure random values suitable for constructing a UUID v4.

---

## Key Changes

- Prefer `crypto.randomUUID()` when the browser provides it.
- Fall back to a UUID v4 generated with `crypto.getRandomValues()` based solely on browser capability.
- Throw a clear error only when neither cryptographic API is available.
- Add coverage that removes `crypto.randomUUID()`, verifies the generated request header is a valid UUID v4, and restores the original property descriptor after the test.

---

## Testing

- `@researchdatabox/portal-ng-common` Angular unit suite: 113 tests passed.
- Production library build passed for the implementation at the reviewed head.

---

## Backwards Compatibility

When `crypto.randomUUID()` is available, behavior is unchanged. There are no schema, configuration, or migration changes; this is client-side only.

---

## Impact

Restores reliable record save request correlation for HTTP development environments while keeping the behavior correct in any browser context where the native UUID helper is unavailable.