### PR TITLE
Bugfix: Preserve unconstrained object array metadata

### DIFF
--- a/packages/redbox-core/src/services/FormRecordConsistencyService.ts
+++ b/packages/redbox-core/src/services/FormRecordConsistencyService.ts
@@ -206,6 +206,9 @@ export namespace Services {
             const originalRecord = original as Record<string | number, unknown>;
             const changedRecord = changed as Record<string | number, unknown>;
             const permittedChangesObj = permittedChanges as Record<string | number, unknown>;
+            if (permittedChangesObj?.type === 'object') {
+                return changedRecord;
+            }
             // if (!('properties' in permittedChangesObj)) {
             //     throw new Error(`Permitted changes must have an object, a 'properties' property, at the top level ${JSON.stringify(permittedChanges)}`)
             // }
@@ -234,10 +237,11 @@ export namespace Services {
                 // pre-calculate aspects of the permitted changes
                 const isKeyInPermittedChange = key in permittedChangesProps;
                 const permittedChangesValue = permittedChangesProps?.[key] as Record<string, unknown> | undefined;
-                const isPermittedChangeObject = isKeyInPermittedChange && !!permittedChangesValue && 'properties' in permittedChangesValue;
-                const isPermittedChangeArray = isKeyInPermittedChange && !!permittedChangesValue && 'elements' in permittedChangesValue;
-                const isPermittedChangeType = isKeyInPermittedChange && !!permittedChangesValue && 'type' in permittedChangesValue;
-                const isPermittedChangeEmpty = isKeyInPermittedChange && !!permittedChangesValue && Object.keys(permittedChangesValue).length === 0;
+                const isPermittedChangesValueObject = typeof permittedChangesValue === 'object' && permittedChangesValue !== null;
+                const isPermittedChangeObject = isKeyInPermittedChange && isPermittedChangesValueObject && 'properties' in permittedChangesValue;
+                const isPermittedChangeArray = isKeyInPermittedChange && isPermittedChangesValueObject && 'elements' in permittedChangesValue;
+                const isPermittedChangeType = isKeyInPermittedChange && isPermittedChangesValueObject && 'type' in permittedChangesValue;
+                const isPermittedChangeEmpty = isKeyInPermittedChange && isPermittedChangesValueObject && Object.keys(permittedChangesValue).length === 0;
                 const originalValueForMerge = isKeyInOriginal
                   ? originalValue
                   : isPermittedChangeArray
@@ -272,6 +276,9 @@ export namespace Services {
                     //       Replacing the whole array prevents use of constraints in components in the array elements.
                     const newPermittedChanges = permittedChangesValue['elements'] as Record<string, unknown>;
                     result[key] = (changedValue as unknown[]).map((changedElement: unknown, index: number) => {
+                        if (newPermittedChanges?.type === 'object' || Object.keys(newPermittedChanges ?? {}).length === 0) {
+                            return changedElement;
+                        }
                         // Evaluate the element in the array.
                         const guessedType = guessType(changedElement);
                         if (guessedType === "object") {

--- a/packages/redbox-core/src/services/FormRecordConsistencyService.ts
+++ b/packages/redbox-core/src/services/FormRecordConsistencyService.ts
@@ -35,6 +35,16 @@ import { ClientFormConfigVisitor } from '../visitor/client.visitor';
 import { VocabInlineFormConfigVisitor } from '../visitor/vocab-inline.visitor';
 import { ContextVariablesFormConfigVisitor } from '../visitor/context-variables.visitor';
 
+const isPermittedChangesSchemaObject = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const requirePermittedChangesSchemaObject = (value: unknown): Record<string, unknown> => {
+    if (!isPermittedChangesSchemaObject(value)) {
+        throw new Error(`Invalid permittedChanges object, schema definitions must be objects: ${JSON.stringify(value)}`);
+    }
+    return value;
+};
+
 
 
 
@@ -236,12 +246,14 @@ export namespace Services {
 
                 // pre-calculate aspects of the permitted changes
                 const isKeyInPermittedChange = key in permittedChangesProps;
-                const permittedChangesValue = permittedChangesProps?.[key] as Record<string, unknown> | undefined;
-                const isPermittedChangesValueObject = typeof permittedChangesValue === 'object' && permittedChangesValue !== null;
-                const isPermittedChangeObject = isKeyInPermittedChange && isPermittedChangesValueObject && 'properties' in permittedChangesValue;
-                const isPermittedChangeArray = isKeyInPermittedChange && isPermittedChangesValueObject && 'elements' in permittedChangesValue;
-                const isPermittedChangeType = isKeyInPermittedChange && isPermittedChangesValueObject && 'type' in permittedChangesValue;
-                const isPermittedChangeEmpty = isKeyInPermittedChange && isPermittedChangesValueObject && Object.keys(permittedChangesValue).length === 0;
+                const permittedChangesValue = permittedChangesProps?.[key];
+                const permittedChangesValueObj = isKeyInPermittedChange
+                  ? requirePermittedChangesSchemaObject(permittedChangesValue)
+                  : undefined;
+                const isPermittedChangeObject = isKeyInPermittedChange && !!permittedChangesValueObj && 'properties' in permittedChangesValueObj;
+                const isPermittedChangeArray = isKeyInPermittedChange && !!permittedChangesValueObj && 'elements' in permittedChangesValueObj;
+                const isPermittedChangeType = isKeyInPermittedChange && !!permittedChangesValueObj && 'type' in permittedChangesValueObj;
+                const isPermittedChangeEmpty = isKeyInPermittedChange && !!permittedChangesValueObj && Object.keys(permittedChangesValueObj).length === 0;
                 const originalValueForMerge = isKeyInOriginal
                   ? originalValue
                   : isPermittedChangeArray
@@ -274,9 +286,9 @@ export namespace Services {
                     // The whole array is replaced because there is no current way to distinguish what from the original should be kept.
                     // TODO: Consider how to replace each element in the array instead of the whole array.
                     //       Replacing the whole array prevents use of constraints in components in the array elements.
-                    const newPermittedChanges = permittedChangesValue['elements'] as Record<string, unknown>;
+                    const newPermittedChanges = requirePermittedChangesSchemaObject(permittedChangesValueObj?.['elements']);
                     result[key] = (changedValue as unknown[]).map((changedElement: unknown, index: number) => {
-                        if (newPermittedChanges?.type === 'object' || Object.keys(newPermittedChanges ?? {}).length === 0) {
+                        if (newPermittedChanges.type === 'object' || Object.keys(newPermittedChanges).length === 0) {
                             return changedElement;
                         }
                         // Evaluate the element in the array.

--- a/packages/redbox-core/test/services/FormRecordConsistencyService.test.ts
+++ b/packages/redbox-core/test/services/FormRecordConsistencyService.test.ts
@@ -246,6 +246,19 @@ describe('FormRecordConsistencyService', function () {
 
       expect(merge).to.throw(Error, 'Invalid permittedChanges object');
     });
+
+    it('reports malformed primitive array element schemas as validation errors', function () {
+      for (const elementSchema of [123, false, 'string']) {
+        const merge = () => FormRecordConsistencyService.mergeRecordMetadataPermitted(
+          {},
+          { dataLocations: [{ type: 'url', location: 'https://example.com/dataset' }] },
+          { properties: { dataLocations: { elements: elementSchema } } },
+          []
+        );
+
+        expect(merge).to.throw(Error, 'Invalid permittedChanges object');
+      }
+    });
   });
 
   describe('compareRecords', function () {

--- a/packages/redbox-core/test/services/FormRecordConsistencyService.test.ts
+++ b/packages/redbox-core/test/services/FormRecordConsistencyService.test.ts
@@ -166,6 +166,88 @@ describe('FormRecordConsistencyService', function () {
     });
   });
 
+  describe('mergeRecordMetadataPermitted', function () {
+    it('preserves every property of array elements permitted as unconstrained objects', function () {
+      const changed = {
+        dataLocations: [
+          {
+            type: 'url',
+            location: 'https://example.com/dataset',
+            notes: 'test notes',
+            selected: true,
+          },
+        ],
+      };
+      const permittedChanges = {
+        properties: {
+          dataLocations: {
+            elements: {
+              type: 'object',
+            },
+          },
+        },
+      };
+
+      const result = FormRecordConsistencyService.mergeRecordMetadataPermitted(
+        {},
+        changed,
+        permittedChanges,
+        []
+      );
+
+      expect(result).to.deep.equal(changed);
+    });
+
+    it('preserves array elements permitted by an empty schema', function () {
+      const changed = {
+        attachments: [
+          {
+            attachmentId: 'attachment-1',
+            name: 'dataset.pdf',
+          },
+        ],
+      };
+      const permittedChanges = {
+        properties: {
+          attachments: {
+            elements: {},
+          },
+        },
+      };
+
+      const result = FormRecordConsistencyService.mergeRecordMetadataPermitted(
+        {},
+        changed,
+        permittedChanges,
+        []
+      );
+
+      expect(result).to.deep.equal(changed);
+    });
+
+    it('continues to filter metadata when a form has no permitted fields', function () {
+      const result = FormRecordConsistencyService.mergeRecordMetadataPermitted(
+        {},
+        { serverOnly: 'hidden' },
+        {},
+        []
+      );
+
+      expect(result).to.deep.equal({});
+    });
+
+    it('reports malformed primitive property schemas as validation errors', function () {
+      const merge = () => FormRecordConsistencyService.mergeRecordMetadataPermitted(
+        {},
+        { title: 'Dataset' },
+        { properties: { title: 'string' } },
+        []
+      );
+
+      expect(merge).to.throw(Error, 'Invalid permittedChanges object');
+    });
+  });
+
   describe('compareRecords', function () {
     it('should detect changes in simple objects', function () {
       const original = { a: 1 };


### PR DESCRIPTION
## Summary

Fix metadata projection and merge failures for form fields represented as arrays of unconstrained objects.

---

## Context / Motivation

The JSON Type Definition visitor emits array element schemas such as `{ type: 'object' }` for data locations, uploaded files, and PDF lists. The consistency service previously treated that schema as a property map. When an element itself contained a `type` field, the service evaluated the `in` operator against the primitive schema value and threw a `TypeError`, causing record metadata requests to return HTTP 500 responses.

---

## Key Features

### Unconstrained object handling

- Preserve all fields when the active schema explicitly permits an unconstrained object.
- Preserve unconstrained array elements without recursively interpreting their values as schema definitions.
- Retain fail-closed behavior for an empty top-level form schema so server-only metadata is not projected.

### Defensive schema validation

- Validate property and array-element schema definitions through the same object assertion before applying object-only operations.
- Reject malformed primitive, null, or array schema definitions with a controlled validation error instead of exposing metadata or throwing an incidental runtime `TypeError`.

---

## Testing

- Added unit coverage for array elements declared with `{ type: 'object' }`.
- Added coverage for empty array-element schemas, empty top-level form schemas, malformed primitive property schemas, and malformed primitive array-element schemas.
- `npm run build` passes in `packages/redbox-core`.
- `npm run lint` passes in `packages/redbox-core`.
- Focused `mergeRecordMetadataPermitted` tests pass (6 passing).
- Full `packages/redbox-core` suite: 3,024 passing, 14 pending, with one unrelated existing CSP-policy failure that also reproduces in isolation.

---

## Architectural / Operational Impact

### Metadata projection

Record viewing and editing can project data-location and attachment-style metadata without crashing or stripping fields from unconstrained object elements.

### Security boundary

The change remains scoped to schemas that explicitly permit unconstrained objects or array elements. Malformed schema definitions fail closed, and a form schema with no permitted fields continues to project no metadata.

---

## Backwards Compatibility

No API or configuration changes are required. Existing constrained object schemas retain their filtering behavior; invalid schema definitions now fail consistently.

---

## Deployment Notes

No deployment steps or data migrations are required.

---

## Impact

Records containing uploaded files, data locations, or PDF attachments can be viewed and edited without metadata filtering failures, while malformed array-element schemas cannot bypass filtering.
