### PR TITLE
Bugfix: Export DOM sanitizer service methods via decorator

### DIFF
--- a/packages/redbox-core/src/services/DomSanitizerService.ts
+++ b/packages/redbox-core/src/services/DomSanitizerService.ts
@@ -237,6 +237,7 @@ export namespace Services {
    * - Consider additional application-specific validation
    * - Keep DOMPurify updated for latest security patches
    */
+  @PopulateExportedMethods
   export class DomSanitizer extends coreServices.Core.Service {
 
     constructor() {
@@ -604,7 +605,6 @@ export namespace Services {
 
 
 export default Services;
-PopulateExportedMethods(Services.DomSanitizer);
 
 declare global {
   let DomSanitizerService: Services.DomSanitizer;

--- a/packages/redbox-core/test/services/DomSanitizerService.test.ts
+++ b/packages/redbox-core/test/services/DomSanitizerService.test.ts
@@ -57,6 +57,15 @@ describe('DomSanitizerService', function() {
     sinon.restore();
   });
 
+  describe('service exports', function() {
+    it('should expose public sanitizer methods through the Sails service shim', function() {
+      const exportedMethods = DomSanitizerService.exports();
+
+      expect(exportedMethods.sanitize).to.be.a('function');
+      expect(exportedMethods.sanitizeWithProfile).to.be.a('function');
+    });
+  });
+
   describe('sanitize', function() {
     it('should sanitize a valid simple SVG', function() {
       const svg = '<svg viewBox="0 0 100 100"><circle cx="50" cy="50" r="40" fill="red"/></svg>';


### PR DESCRIPTION
## Summary

Fixes the branding logo upload sanitizer by ensuring the `DomSanitizer` service methods are correctly exported through the Sails service shim.

The service previously relied on a manual `PopulateExportedMethods(Services.DomSanitizer)` invocation placed after the class declaration, which meant the sanitizer methods were not reliably surfaced on the runtime Sails service object used by controllers and hooks. This change moves the export wiring onto the class via the `@PopulateExportedMethods` decorator, matching the convention used across the rest of the core services, and adds a regression test covering the exported method surface.

Fixes bug where the branding logo upload path could not resolve the DOM sanitizer service methods.

## Context / related work

* Builds on the standard Sails service export convention used throughout `@researchdatabox/redbox-core-types`.
* Related to the branding logo upload feature, which relies on `DomSanitizerService` to validate and sanitize uploaded SVG assets.

## Technical implementation details

* Replaced the trailing `PopulateExportedMethods(Services.DomSanitizer)` call with the `@PopulateExportedMethods` class decorator on `DomSanitizer` in `DomSanitizerService.ts`.
* Added a regression test in `DomSanitizerService.test.ts` verifying that `sanitize` and `sanitizeWithProfile` are exposed through `DomSanitizerService.exports()`.

## Testing

* Added unit test coverage in `DomSanitizerService.test.ts` to assert the public sanitizer methods are present on the Sails service shim.
* Existing sanitizer behaviour tests continue to cover `sanitize`, `sanitizeWithProfile`, and related input handling.

## Future work

* Omitted; this change contains no known outstanding follow-ups beyond the existing sanitizer roadmap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying that the DOM sanitization service exposes its supported sanitization methods through the service interface.
* **Refactor**
  * Internal method registration was streamlined without changing the service’s public behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->