### PR TITLE
Bugfix: Apply branded hook layouts to error pages and attachments

### DIFF
--- a/packages/redbox-core/src/CoreController.ts
+++ b/packages/redbox-core/src/CoreController.ts
@@ -329,6 +329,42 @@ export namespace Controllers.Core {
       return path.resolve(this.getCoreViewRoot(), path.dirname(resolvedFile.relativePath));
     }
 
+    private addRequestBrandingAndPortal(req: Sails.Req, locals: Record<string, unknown>): void {
+      const stringValue = (value: unknown): string | undefined => {
+        return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+      };
+      const requestParam = (name: string): string | undefined => {
+        if (typeof req.param === 'function') {
+          return stringValue(req.param(name));
+        }
+        return stringValue(req.params?.[name]);
+      };
+
+      let branding = stringValue(locals.branding) ?? requestParam('branding');
+      let portal = stringValue(locals.portal) ?? requestParam('portal');
+
+      // A route-level 404 has already run brandingAndPortal, but an unmatched
+      // branded URL has no route parameters or policies. Recover its context
+      // from the first two path segments so it receives the same theme.
+      if (!branding || !portal) {
+        const requestPath = stringValue(req.originalUrl) ?? stringValue(req.url);
+        const segments = requestPath?.split('?')[0].split('/').filter(Boolean) ?? [];
+        const rootContext = stringValue(sails.config.http?.rootContext);
+        if (rootContext && segments[0] === rootContext) {
+          segments.shift();
+        }
+        if (segments.length >= 2) {
+          branding ??= segments[0];
+          portal ??= segments[1];
+        }
+      }
+
+      branding ??= stringValue(req.session?.branding) ?? stringValue(sails.config.auth?.defaultBrand) ?? 'default';
+      portal ??= stringValue(req.session?.portal) ?? stringValue(sails.config.auth?.defaultPortal) ?? 'default';
+      locals.branding = branding;
+      locals.portal = portal;
+    }
+
     public _getResolvedView(branding: string, portal: string, view: string): string | null {
       const resolvedView = this.resolveViewFile(branding, portal, view);
       return resolvedView ? this.getSailsViewPath(resolvedView) : null;
@@ -348,6 +384,7 @@ export namespace Controllers.Core {
         req.options.locals = {};
       }
       const mergedLocal: Record<string, unknown> = Object.assign({}, req.options.locals as Record<string, unknown>, locals);
+      this.addRequestBrandingAndPortal(req, mergedLocal);
 
       const branding = mergedLocal['branding'] as string;
       const portal = mergedLocal['portal'] as string;

--- a/packages/redbox-core/src/CoreController.ts
+++ b/packages/redbox-core/src/CoreController.ts
@@ -276,6 +276,7 @@ export namespace Controllers.Core {
         `${branding}/${portal}/${view}`,
         `default/${portal}/${view}`,
         `default/default/${view}`,
+        view,
       ];
 
       for (const candidate of candidates) {

--- a/packages/redbox-core/src/CoreController.ts
+++ b/packages/redbox-core/src/CoreController.ts
@@ -3,6 +3,7 @@ import * as _ from 'lodash';
 import path from 'path';
 import { ILogger } from './Logger';
 import { resolveSiteTitle, resolveTranslation } from './responses/siteTitle';
+import { sendTerminalErrorFallback } from './responses/terminalErrorFallback';
 import { resolveHookViewFile } from './hooks/hookResources';
 import type { ResolvedHookFile } from './hooks/hookResources';
 import {
@@ -392,9 +393,10 @@ export namespace Controllers.Core {
       const resolvedView = this.resolveViewFile(branding, portal, view);
       const resolvedLayout = this.resolveLayoutFile(branding, portal);
 
-      // View still doesn't exist so return a 404
+      // Do not re-enter res.notFound here: the missing view may itself be the
+      // 404 template. Preserve an existing error status and terminate safely.
       if (resolvedView === null) {
-        res.notFound(mergedLocal, "404");
+        sendTerminalErrorFallback(res);
         return;
       }
 

--- a/packages/redbox-core/src/config/dompurify.config.ts
+++ b/packages/redbox-core/src/config/dompurify.config.ts
@@ -151,7 +151,8 @@ export const dompurify: DomPurifyConfig = {
             ],
             ALLOW_DATA_ATTR: false,
             ALLOW_UNKNOWN_PROTOCOLS: false,
-            ALLOWED_URI_REGEXP: /^(?:#|(?:\.{1,2}\/|\/(?!\/)))/i,
+            // href values are restricted by DomSanitizerService. DOMPurify also applies
+            // ALLOWED_URI_REGEXP to path geometry (`d`), which would erase SVG drawings.
             SANITIZE_DOM: true,
             KEEP_CONTENT: false,
             IN_PLACE: false

--- a/packages/redbox-core/src/config/dompurify.config.ts
+++ b/packages/redbox-core/src/config/dompurify.config.ts
@@ -86,6 +86,7 @@ export interface DomPurifyConfig {
 }
 
 export const safeHtmlUriRegexp = /^(?:(?:https?|ftps?|mailto|tel):|(?:[^a-z:]|[a-z][a-z0-9.+-]*(?:[^a-z0-9.+-:]|$)))/i;
+export const safeSvgUriRegexp = /^(?:#|\.{1,2}\/|\/(?!\/))/i;
 
 export const dompurify: DomPurifyConfig = {
     /**
@@ -151,8 +152,9 @@ export const dompurify: DomPurifyConfig = {
             ],
             ALLOW_DATA_ATTR: false,
             ALLOW_UNKNOWN_PROTOCOLS: false,
-            // href values are restricted by DomSanitizerService. DOMPurify also applies
-            // ALLOWED_URI_REGEXP to path geometry (`d`), which would erase SVG drawings.
+            // DomSanitizerService applies safeSvgUriRegexp specifically to href and
+            // xlink:href. DOMPurify also applies ALLOWED_URI_REGEXP to path geometry
+            // (`d`), so setting it here would erase SVG drawings.
             SANITIZE_DOM: true,
             KEEP_CONTENT: false,
             IN_PLACE: false

--- a/packages/redbox-core/src/config/dompurify.config.ts
+++ b/packages/redbox-core/src/config/dompurify.config.ts
@@ -86,7 +86,7 @@ export interface DomPurifyConfig {
 }
 
 export const safeHtmlUriRegexp = /^(?:(?:https?|ftps?|mailto|tel):|(?:[^a-z:]|[a-z][a-z0-9.+-]*(?:[^a-z0-9.+-:]|$)))/i;
-export const safeSvgUriRegexp = /^(?:#|\.{1,2}\/|\/(?!\/))/i;
+export const safeSvgUriRegexp = /^(?:#[^\s]*|(?:\.{1,2}\/|\/(?!\/))?[^\\/:?#\s]+(?:\/[^\\/:?#\s]+)*(?:[?#][^\s]*)?)$/i;
 
 export const dompurify: DomPurifyConfig = {
     /**

--- a/packages/redbox-core/src/controllers/RecordController.ts
+++ b/packages/redbox-core/src/controllers/RecordController.ts
@@ -1402,8 +1402,7 @@ export namespace Controllers {
         if (!found) {
           sails.log.verbose("Error: Attachment not found in do attachment.");
           if (!this.isAjax(req)) {
-            res.status(404);
-            return this.sendView(req, res, '404');
+            return res.notFound();
           }
           return this.sendResp(req, res, {
             status: 404,
@@ -1442,8 +1441,7 @@ export namespace Controllers {
             return this.sendResp(req, res, { status: 403, errors: [this.asError(error)], displayErrors: [{ code: 'edit-error-no-permissions' }] });
           } else if (errorMessage == TranslationService.t('attachment-not-found')) {
             if (!this.isAjax(req)) {
-              res.status(404);
-              return this.sendView(req, res, '404');
+              return res.notFound();
             }
             return this.sendResp(req, res, { status: 404, errors: [this.asError(error)], displayErrors: [{ code: 'attachment-not-found' }] });
           } else {

--- a/packages/redbox-core/src/controllers/RecordController.ts
+++ b/packages/redbox-core/src/controllers/RecordController.ts
@@ -1402,7 +1402,8 @@ export namespace Controllers {
         if (!found) {
           sails.log.verbose("Error: Attachment not found in do attachment.");
           if (!this.isAjax(req)) {
-            return res.notFound();
+            res.status(404);
+            return this.sendView(req, res, '404');
           }
           return this.sendResp(req, res, {
             status: 404,
@@ -1441,7 +1442,8 @@ export namespace Controllers {
             return this.sendResp(req, res, { status: 403, errors: [this.asError(error)], displayErrors: [{ code: 'edit-error-no-permissions' }] });
           } else if (errorMessage == TranslationService.t('attachment-not-found')) {
             if (!this.isAjax(req)) {
-              return res.notFound();
+              res.status(404);
+              return this.sendView(req, res, '404');
             }
             return this.sendResp(req, res, { status: 404, errors: [this.asError(error)], displayErrors: [{ code: 'attachment-not-found' }] });
           } else {

--- a/packages/redbox-core/src/responses/badRequest.ts
+++ b/packages/redbox-core/src/responses/badRequest.ts
@@ -1,5 +1,6 @@
 import { resolveSiteTitle } from './siteTitle';
 import { inspect } from 'node:util';
+import { renderErrorView } from './renderErrorView';
 
 declare module 'express-serve-static-core' {
     interface Response {
@@ -60,20 +61,6 @@ export function badRequest(this: { req: Sails.Req, res: Sails.Res }, data?: unkn
         }
     }
 
-    // If a view was provided in options, serve it.
-    // Otherwise try to guess an appropriate view, or if that doesn't
-    // work, just send JSON.
-    // If a view was provided in options, serve it.
-    // Otherwise try to guess an appropriate view, or if that doesn't
-    // work, just send JSON.
-    if (options.view) {
-        return res.view(options.view, { data: viewData, title: siteTitle });
-    }
-
-    // If no second argument provided, try to serve the implied view,
-    // but fall back to sending JSON(P) if no view can be inferred.
-    else return res.guessView({ data: viewData, title: siteTitle }, function couldNotGuessView() {
-        return res.json(data);
-    });
+    return renderErrorView(req, res, options.view || '400', { data: viewData, title: siteTitle });
 
 };

--- a/packages/redbox-core/src/responses/forbidden.ts
+++ b/packages/redbox-core/src/responses/forbidden.ts
@@ -1,5 +1,6 @@
 import { resolveSiteTitle } from './siteTitle';
 import { inspect } from 'node:util';
+import { renderErrorView } from './renderErrorView';
 
 declare module 'express-serve-static-core' {
     interface Response {
@@ -60,20 +61,6 @@ export function forbidden(this: { req: Sails.Req, res: Sails.Res }, data?: unkno
         }
     }
 
-    // If a view was provided in options, serve it.
-    // Otherwise try to guess an appropriate view, or if that doesn't
-    // work, just send JSON.
-    // If a view was provided in options, serve it.
-    // Otherwise try to guess an appropriate view, or if that doesn't
-    // work, just send JSON.
-    if (options.view) {
-        return res.view(options.view, { data: viewData, title: siteTitle });
-    }
-
-    // If no second argument provided, try to serve the implied view,
-    // but fall back to sending JSON(P) if no view can be inferred.
-    else return res.guessView({ data: viewData, title: siteTitle }, function couldNotGuessView() {
-        return res.json(data);
-    });
+    return renderErrorView(req, res, options.view || '403', { data: viewData, title: siteTitle });
 
 };

--- a/packages/redbox-core/src/responses/index.ts
+++ b/packages/redbox-core/src/responses/index.ts
@@ -2,4 +2,5 @@ export * from './ok';
 export * from './badRequest';
 export * from './created';
 export * from './forbidden';
+export * from './notFound';
 export * from './serverError';

--- a/packages/redbox-core/src/responses/notFound.ts
+++ b/packages/redbox-core/src/responses/notFound.ts
@@ -1,0 +1,57 @@
+import { inspect } from 'node:util';
+import { renderErrorView } from './renderErrorView';
+import { resolveSiteTitle } from './siteTitle';
+
+declare module 'express-serve-static-core' {
+  interface Response {
+    notFound(data?: unknown, options?: string | { view?: string }): Response;
+  }
+}
+
+/**
+ * 404 (Not Found) Handler
+ *
+ * Usage:
+ * return res.notFound();
+ * return res.notFound(data);
+ * return res.notFound(data, 'some/specific/notFound/view');
+ */
+export function notFound(
+  this: { req: Sails.Req; res: Sails.Res },
+  data?: unknown,
+  options?: string | { view?: string }
+): Sails.Res {
+  const req = this.req;
+  const res = this.res;
+  const sails = req._sails as Sails.Application;
+  const siteTitle = resolveSiteTitle('Site', req.options?.locals as Record<string, unknown> | undefined);
+
+  res.status(404);
+
+  if (data !== undefined) {
+    sails.log.verbose('Sending 404 ("Not Found") response: \n', data);
+  } else {
+    sails.log.verbose('Sending 404 ("Not Found") response');
+  }
+
+  if (sails.config.environment === 'production' && sails.config.keepResponseErrors !== true) {
+    data = undefined;
+  }
+
+  if (req.wantsJSON || sails.config.hooks.views === false) {
+    return res.json(data) as Sails.Res;
+  }
+
+  options = typeof options === 'string' ? { view: options } : options || {};
+
+  let viewData = data;
+  if (!(viewData instanceof Error) && typeof viewData === 'object') {
+    try {
+      viewData = inspect(data, { depth: null });
+    } catch (_error) {
+      viewData = undefined;
+    }
+  }
+
+  return renderErrorView(req, res, options.view || '404', { data: viewData, title: siteTitle });
+}

--- a/packages/redbox-core/src/responses/renderErrorView.ts
+++ b/packages/redbox-core/src/responses/renderErrorView.ts
@@ -1,0 +1,18 @@
+import { Controllers } from '../CoreController';
+
+const errorViewController = new Controllers.Core.Controller();
+
+/**
+ * Render an error view through the same hook-aware view and layout resolver used
+ * by controllers. Sails' built-in response rendering only searches the app view
+ * root, so it cannot apply layouts supplied by a Redbox hook.
+ */
+export function renderErrorView(
+  req: Sails.Req,
+  res: Sails.Res,
+  view: string,
+  locals: Record<string, unknown>
+): Sails.Res {
+  errorViewController.sendView(req, res, view, locals);
+  return res;
+}

--- a/packages/redbox-core/src/responses/serverError.ts
+++ b/packages/redbox-core/src/responses/serverError.ts
@@ -1,5 +1,6 @@
 import { resolveSiteTitle } from './siteTitle';
 import { inspect } from 'node:util';
+import { renderErrorView } from './renderErrorView';
 
 declare module 'express-serve-static-core' {
     interface Response {
@@ -60,20 +61,6 @@ export function serverError(this: { req: Sails.Req, res: Sails.Res }, data?: unk
         }
     }
 
-    // If a view was provided in options, serve it.
-    // Otherwise try to guess an appropriate view, or if that doesn't
-    // work, just send JSON.
-    // If a view was provided in options, serve it.
-    // Otherwise try to guess an appropriate view, or if that doesn't
-    // work, just send JSON.
-    if (options.view) {
-        return res.view(options.view, { data: viewData, title: siteTitle });
-    }
-
-    // If no second argument provided, try to serve the implied view,
-    // but fall back to sending JSON(P) if no view can be inferred.
-    else return res.guessView({ data: viewData, title: siteTitle }, function couldNotGuessView() {
-        return res.json(data);
-    });
+    return renderErrorView(req, res, options.view || '500', { data: viewData, title: siteTitle });
 
 };

--- a/packages/redbox-core/src/responses/terminalErrorFallback.ts
+++ b/packages/redbox-core/src/responses/terminalErrorFallback.ts
@@ -1,0 +1,14 @@
+import { STATUS_CODES } from 'node:http';
+
+/**
+ * End an error response without invoking view resolution again. This is the
+ * final fallback when no requested or default error template can be found.
+ */
+export function sendTerminalErrorFallback(res: Sails.Res): Sails.Res {
+  const currentStatus = Number(res.statusCode);
+  const status = Number.isInteger(currentStatus) && currentStatus >= 400 ? currentStatus : 404;
+  const message = STATUS_CODES[status] || 'Error';
+
+  res.status(status);
+  return res.type('text/plain').send(`${status} ${message}`) as Sails.Res;
+}

--- a/packages/redbox-core/src/services/DomSanitizerService.ts
+++ b/packages/redbox-core/src/services/DomSanitizerService.ts
@@ -1,6 +1,6 @@
 import { PopulateExportedMethods } from '../decorator/PopulateExportedMethods.decorator';
 import { Services as coreServices } from '../CoreService';
-import type { DomPurifyConfig } from '../config/dompurify.config';
+import { safeSvgUriRegexp, type DomPurifyConfig } from '../config/dompurify.config';
 
 import domPurify = require('dompurify');
 import { Buffer } from 'buffer';
@@ -28,6 +28,17 @@ type SanitizerNode = {
   remove: () => void;
   removeAttribute: (name: string) => void;
   getAttribute: (name: string) => string | null;
+};
+
+const getUnsafeSvgReferenceError = (value: string): string | null => {
+  const reference = value.toLowerCase().trim();
+  if (reference.startsWith('javascript:')) return 'javascript-protocol';
+  if (reference.startsWith('vbscript:')) return 'vbscript-protocol';
+  if (reference.startsWith('data:')) return 'data-url-embed';
+  if (reference.startsWith('http:') || reference.startsWith('https:') || reference.startsWith('//')) {
+    return 'external-ref';
+  }
+  return safeSvgUriRegexp.test(reference) ? null : 'unsafe-uri-reference';
 };
 
 const isDomPurifyInstance = (candidate: unknown): candidate is DomPurifyInstance => {
@@ -303,16 +314,6 @@ export namespace Services {
     private validateHrefAttributes(svg: string): { valid: boolean; errors: string[] } {
       const errors: string[] = [];
 
-      // Check for dangerous protocols in href attributes
-      const dangerousProtocols = [
-        'javascript:', 'vbscript:', 'data:', 'file:', 'ftp:', 'ftps:',
-        'chrome:', 'resource:', 'moz-extension:', 'chrome-extension:',
-        'ms-appx:', 'ms-appx-web:', 'about:', 'blob:', 'filesystem:'
-      ];
-
-      // Check for external references (http/https/protocol-relative)
-      const externalProtocols = ['http:', 'https:', '//'];
-
       // Match href attributes with both quoted and unquoted values
       // Group 1: quoted value (single or double quotes)
       // Group 2: unquoted value (non-whitespace, non->)
@@ -321,31 +322,9 @@ export namespace Services {
 
       while ((match = hrefPattern.exec(svg)) !== null) {
         // Use whichever capture group matched (quoted = group 1, unquoted = group 2)
-        const url = (match[1] !== undefined ? match[1] : match[2]).toLowerCase().trim();
-
-        // Check for dangerous protocols
-        for (const protocol of dangerousProtocols) {
-          if (url.startsWith(protocol)) {
-            if (protocol === 'javascript:') {
-              errors.push('javascript-protocol');
-            } else if (protocol === 'vbscript:') {
-              errors.push('vbscript-protocol');
-            } else if (protocol === 'data:') {
-              errors.push('data-url-embed');
-            } else {
-              errors.push('dangerous-protocol');
-            }
-            break;
-          }
-        }
-
-        // Check for external references
-        for (const protocol of externalProtocols) {
-          if (url.startsWith(protocol)) {
-            errors.push('external-ref');
-            break;
-          }
-        }
+        const url = match[1] !== undefined ? match[1] : match[2];
+        const error = getUnsafeSvgReferenceError(url);
+        if (error && !errors.includes(error)) errors.push(error);
       }
 
       return { valid: errors.length === 0, errors };
@@ -423,8 +402,7 @@ export namespace Services {
       // Pre-validation: Check for dangerous patterns before sanitization
       const hrefValidation = this.validateHrefAttributes(svg);
       if (!hrefValidation.valid) {
-        // Filter out 'external-ref' as it will be caught by hooks
-        errors.push(...hrefValidation.errors.filter(e => e !== 'external-ref'));
+        errors.push(...hrefValidation.errors);
       }
 
       // Check for script elements
@@ -469,34 +447,9 @@ export namespace Services {
             return;
           }
 
-          const lowerHref = href.toLowerCase().trim();
-          const dangerousProtocols = [
-            'javascript:', 'vbscript:', 'data:', 'file:', 'chrome:',
-            'resource:', 'moz-extension:', 'chrome-extension:', 'ms-appx:',
-            'about:', 'blob:', 'filesystem:'
-          ];
-          const externalProtocols = ['http:', 'https:', '//'];
-
-          let shouldRemove = false;
-
-          for (const protocol of dangerousProtocols) {
-            if (lowerHref.startsWith(protocol)) {
-              shouldRemove = true;
-              break;
-            }
-          }
-
-          if (!shouldRemove) {
-            for (const protocol of externalProtocols) {
-              if (lowerHref.startsWith(protocol)) {
-                shouldRemove = true;
-                errors.push('external-ref');
-                break;
-              }
-            }
-          }
-
-          if (shouldRemove) {
+          const hrefError = getUnsafeSvgReferenceError(href);
+          if (hrefError) {
+            if (!errors.includes(hrefError)) errors.push(hrefError);
             node.removeAttribute('href');
             node.removeAttribute('xlink:href');
           }

--- a/packages/redbox-core/test/controllers/CoreControllerViewResolution.test.ts
+++ b/packages/redbox-core/test/controllers/CoreControllerViewResolution.test.ts
@@ -198,4 +198,24 @@ describe('CoreController hook view resolution', function () {
     expect(res.view.firstCall.args[0]).to.equal('404');
     expect(path.resolve(path.dirname(coreErrorView), res.view.firstCall.args[1]._layoutFile)).to.equal(hookLayout);
   });
+
+  it('recovers branding and portal from an unmatched branded URL', function () {
+    const hookRoot = createHook();
+    const coreErrorView = path.join(appPath, 'views', '404.ejs');
+    const hookLayout = path.join(hookRoot, 'views', 'brand', 'portal', 'layout', 'layout.ejs');
+    writeFile(coreErrorView, 'not found');
+    writeFile(hookLayout, '<%- body %>');
+
+    const req = {
+      originalUrl: '/brand/portal/page-that-does-not-exist',
+      options: { locals: {} },
+    };
+    const res = createRes();
+    controller.sendView(req as unknown as Sails.Req, res as unknown as Sails.Res, '404');
+
+    const locals = res.view.firstCall.args[1];
+    expect(locals.branding).to.equal('brand');
+    expect(locals.portal).to.equal('portal');
+    expect(path.resolve(path.dirname(coreErrorView), locals._layoutFile)).to.equal(hookLayout);
+  });
 });

--- a/packages/redbox-core/test/controllers/CoreControllerViewResolution.test.ts
+++ b/packages/redbox-core/test/controllers/CoreControllerViewResolution.test.ts
@@ -183,4 +183,19 @@ describe('CoreController hook view resolution', function () {
 
     expect(res.view.firstCall.args[1].layoutDirectoryLocation).to.equal(`${path.dirname(coreLayout)}${path.sep}`);
   });
+
+  it('renders a root error view with the hook layout', function () {
+    const hookRoot = createHook();
+    const coreErrorView = path.join(appPath, 'views', '404.ejs');
+    const hookLayout = path.join(hookRoot, 'views', 'default', 'default', 'layout.ejs');
+    writeFile(coreErrorView, 'not found');
+    writeFile(hookLayout, '<%- body %>');
+
+    const res = createRes();
+    controller.sendView(createReq() as unknown as Sails.Req, res as unknown as Sails.Res, '404');
+
+    expect(res.notFound.called).to.equal(false);
+    expect(res.view.firstCall.args[0]).to.equal('404');
+    expect(path.resolve(path.dirname(coreErrorView), res.view.firstCall.args[1]._layoutFile)).to.equal(hookLayout);
+  });
 });

--- a/packages/redbox-core/test/controllers/CoreControllerViewResolution.test.ts
+++ b/packages/redbox-core/test/controllers/CoreControllerViewResolution.test.ts
@@ -49,6 +49,13 @@ describe('CoreController hook view resolution', function () {
     return {
       locals: {},
       notFound: sinon.stub(),
+      statusCode: 200,
+      status: sinon.stub().callsFake(function (this: { statusCode: number }, status: number) {
+        this.statusCode = status;
+        return this;
+      }),
+      type: sinon.stub().returnsThis(),
+      send: sinon.stub(),
       view: sinon.stub(),
     };
   }
@@ -217,5 +224,27 @@ describe('CoreController hook view resolution', function () {
     expect(locals.branding).to.equal('brand');
     expect(locals.portal).to.equal('portal');
     expect(path.resolve(path.dirname(coreErrorView), locals._layoutFile)).to.equal(hookLayout);
+  });
+
+  it('terminates with a 404 when the requested view and 404 template are unavailable', function () {
+    const res = createRes();
+
+    controller.sendView(createReq() as unknown as Sails.Req, res as unknown as Sails.Res, 'missing-view');
+
+    expect(res.notFound.called).to.equal(false);
+    expect(res.status.calledOnceWithExactly(404)).to.equal(true);
+    expect(res.type.calledOnceWithExactly('text/plain')).to.equal(true);
+    expect(res.send.calledOnceWithExactly('404 Not Found')).to.equal(true);
+  });
+
+  it('preserves an assigned error status when the error view is unavailable', function () {
+    const res = createRes();
+    res.statusCode = 500;
+
+    controller.sendView(createReq() as unknown as Sails.Req, res as unknown as Sails.Res, '500');
+
+    expect(res.notFound.called).to.equal(false);
+    expect(res.status.calledOnceWithExactly(500)).to.equal(true);
+    expect(res.send.calledOnceWithExactly('500 Internal Server Error')).to.equal(true);
   });
 });

--- a/packages/redbox-core/test/controllers/RecordController.test.ts
+++ b/packages/redbox-core/test/controllers/RecordController.test.ts
@@ -730,12 +730,14 @@ describe('RecordController TUS URL generation', () => {
       headers: { host: 'localhost:1500' },
       param: sinon.stub().callsFake((name: string) => ({ oid: 'oid-1', attachId: 'file-missing' }[name])),
     } as unknown as Sails.Req;
-    const res = { notFound: sinon.stub() } as unknown as Sails.Res;
+    const res = { status: sinon.stub() } as unknown as Sails.Res;
     const sendRespStub = sinon.stub(controller as any, 'sendResp');
+    const sendViewStub = sinon.stub(controller, 'sendView');
 
     await controller.doAttachment(req, res);
 
-    expect((res.notFound as any).calledOnce).to.equal(true);
+    expect((res.status as any).calledOnceWithExactly(404)).to.equal(true);
+    expect(sendViewStub.calledOnceWithExactly(req, res, '404')).to.equal(true);
     expect(sendRespStub.called).to.equal(false);
   });
 
@@ -790,13 +792,15 @@ describe('RecordController TUS URL generation', () => {
     const res = {
       set: sinon.stub(),
       attachment: sinon.stub(),
-      notFound: sinon.stub(),
+      status: sinon.stub(),
     } as unknown as Sails.Res;
     const sendRespStub = sinon.stub(controller as any, 'sendResp');
+    const sendViewStub = sinon.stub(controller, 'sendView');
 
     await controller.doAttachment(req, res);
 
-    expect((res.notFound as any).calledOnce).to.equal(true);
+    expect((res.status as any).calledOnceWithExactly(404)).to.equal(true);
+    expect(sendViewStub.calledOnceWithExactly(req, res, '404')).to.equal(true);
     expect((res.set as any).called).to.equal(false);
     expect((res.attachment as any).called).to.equal(false);
     expect(sendRespStub.called).to.equal(false);

--- a/packages/redbox-core/test/controllers/RecordController.test.ts
+++ b/packages/redbox-core/test/controllers/RecordController.test.ts
@@ -713,7 +713,7 @@ describe('RecordController TUS URL generation', () => {
     expect(checkDiskSpaceStub.firstCall.args[0]).to.not.equal('/legacy/mongodb-disk');
   });
 
-  it('renders the browser 404 page when an attachment is not in the record', async () => {
+  it('uses the shared browser 404 response when an attachment is not in the record', async () => {
     (controller as any).tusServer = { handle: sinon.stub() };
     sinon.stub(controller as any, 'getRecord').returns(of({
       metaMetadata: { attachmentFields: [] },
@@ -730,14 +730,12 @@ describe('RecordController TUS URL generation', () => {
       headers: { host: 'localhost:1500' },
       param: sinon.stub().callsFake((name: string) => ({ oid: 'oid-1', attachId: 'file-missing' }[name])),
     } as unknown as Sails.Req;
-    const res = { status: sinon.stub() } as unknown as Sails.Res;
+    const res = { notFound: sinon.stub() } as unknown as Sails.Res;
     const sendRespStub = sinon.stub(controller as any, 'sendResp');
-    const sendViewStub = sinon.stub(controller, 'sendView');
 
     await controller.doAttachment(req, res);
 
-    expect((res.status as any).calledOnceWithExactly(404)).to.equal(true);
-    expect(sendViewStub.calledOnceWithExactly(req, res, '404')).to.equal(true);
+    expect((res.notFound as any).calledOnce).to.equal(true);
     expect(sendRespStub.called).to.equal(false);
   });
 
@@ -767,7 +765,7 @@ describe('RecordController TUS URL generation', () => {
     expect(sendRespStub.firstCall.args[2]).to.deep.include({ status: 404 });
   });
 
-  it('renders the browser 404 page when the attachment stream is missing', async () => {
+  it('uses the shared browser 404 response when the attachment stream is missing', async () => {
     (controller as any).tusServer = { handle: sinon.stub() };
     sinon.stub(controller as any, 'getRecord').returns(of({
       metaMetadata: { attachmentFields: ['attachments'] },
@@ -792,15 +790,13 @@ describe('RecordController TUS URL generation', () => {
     const res = {
       set: sinon.stub(),
       attachment: sinon.stub(),
-      status: sinon.stub(),
+      notFound: sinon.stub(),
     } as unknown as Sails.Res;
     const sendRespStub = sinon.stub(controller as any, 'sendResp');
-    const sendViewStub = sinon.stub(controller, 'sendView');
 
     await controller.doAttachment(req, res);
 
-    expect((res.status as any).calledOnceWithExactly(404)).to.equal(true);
-    expect(sendViewStub.calledOnceWithExactly(req, res, '404')).to.equal(true);
+    expect((res.notFound as any).calledOnce).to.equal(true);
     expect((res.set as any).called).to.equal(false);
     expect((res.attachment as any).called).to.equal(false);
     expect(sendRespStub.called).to.equal(false);

--- a/packages/redbox-core/test/responses/Responses.test.ts
+++ b/packages/redbox-core/test/responses/Responses.test.ts
@@ -1,9 +1,11 @@
 let expect: Chai.ExpectStatic;
 import * as sinon from 'sinon';
+import { Controllers } from '../../src/CoreController';
 import { ok } from '../../src/responses/ok';
 import { badRequest } from '../../src/responses/badRequest';
 import { created } from '../../src/responses/created';
 import { forbidden } from '../../src/responses/forbidden';
+import { notFound } from '../../src/responses/notFound';
 import { serverError } from '../../src/responses/serverError';
 
 before(async () => {
@@ -47,10 +49,15 @@ describe('Responses', function () {
     (global as any).TranslationService = {
       t: sinon.stub().callsFake((key: string) => key === 'default-title' ? 'Site' : key)
     };
+
+    sinon.stub(Controllers.Core.Controller.prototype, 'sendView').callsFake((_req, response, view, locals) => {
+      response.view(view, locals);
+    });
   });
 
   afterEach(function () {
     (global as any).TranslationService = originalTranslationService;
+    sinon.restore();
   });
 
   describe('ok', function () {
@@ -126,6 +133,14 @@ describe('Responses', function () {
 
       expect(res.view.calledWith('bad-view', { data: 'error', title: 'Site' })).to.be.true;
     });
+
+    it('should render the branded 400 view by default for HTML requests', function () {
+      req.wantsJSON = false;
+
+      badRequest.call({ req, res }, 'error');
+
+      expect(res.view.calledWith('400', { data: 'error', title: 'Site' })).to.be.true;
+    });
   });
 
   describe('created', function () {
@@ -164,6 +179,31 @@ describe('Responses', function () {
 
       expect(res.view.calledWith('forbidden-view', { data: 'denied', title: 'Site' })).to.be.true;
     });
+
+    it('should render the branded 403 view by default for HTML requests', function () {
+      req.wantsJSON = false;
+
+      forbidden.call({ req, res }, 'denied');
+
+      expect(res.view.calledWith('403', { data: 'denied', title: 'Site' })).to.be.true;
+    });
+  });
+
+  describe('notFound', function () {
+    it('should preserve the JSON 404 response', function () {
+      notFound.call({ req, res }, 'missing');
+
+      expect(res.status.calledWith(404)).to.be.true;
+      expect(res.json.calledWith('missing')).to.be.true;
+    });
+
+    it('should render the branded 404 view by default for HTML requests', function () {
+      req.wantsJSON = false;
+
+      notFound.call({ req, res }, 'missing');
+
+      expect(res.view.calledWith('404', { data: 'missing', title: 'Site' })).to.be.true;
+    });
   });
 
   describe('serverError', function () {
@@ -182,6 +222,14 @@ describe('Responses', function () {
       serverError.call(context, 'oops', 'error-view');
 
       expect(res.view.calledWith('error-view', { data: 'oops', title: 'Site' })).to.be.true;
+    });
+
+    it('should render the branded 500 view by default for HTML requests', function () {
+      req.wantsJSON = false;
+
+      serverError.call({ req, res }, 'oops');
+
+      expect(res.view.calledWith('500', { data: 'oops', title: 'Site' })).to.be.true;
     });
   });
 });

--- a/packages/redbox-core/test/services/DomSanitizerService.test.ts
+++ b/packages/redbox-core/test/services/DomSanitizerService.test.ts
@@ -90,6 +90,34 @@ describe('DomSanitizerService', function() {
       expect(result.sanitized).to.include('d="m 0,0 100,0 0,100 z"');
     });
 
+    it('should preserve fragment and relative SVG references', function() {
+      mockSails.config.dompurify = dompurifyConfig;
+      const svg = '<svg><image href="#mark"/><image href="./images/logo.svg"/><image href="../logo.svg"/><image href="/logo.svg"/></svg>';
+
+      const result = DomSanitizerService.sanitize(svg);
+
+      expect(result.safe).to.be.true;
+      expect(result.sanitized).to.include('href="#mark"');
+      expect(result.sanitized).to.include('href="./images/logo.svg"');
+      expect(result.sanitized).to.include('href="../logo.svg"');
+      expect(result.sanitized).to.include('href="/logo.svg"');
+    });
+
+    ['mailto:', 'tel:', 'callto:', 'sms:', 'cid:', 'xmpp:', 'matrix:'].forEach((scheme, index) => {
+      it(`should reject ${scheme} SVG references`, function() {
+        mockSails.config.dompurify = dompurifyConfig;
+        const attribute = index % 2 === 0 ? 'href' : 'xlink:href';
+        const svg = `<svg><a ${attribute}="${scheme}attacker"><path d="m 0,0 1,1"/></a></svg>`;
+
+        const result = DomSanitizerService.sanitize(svg);
+
+        expect(result.safe).to.be.false;
+        expect(result.errors).to.include('unsafe-uri-reference');
+        expect(result.sanitized).not.to.include(`${scheme}attacker`);
+        expect(result.sanitized).to.include('d="m 0,0 1,1"');
+      });
+    });
+
     it('should reject non-string input', function() {
       const result = DomSanitizerService.sanitize(null as any);
       

--- a/packages/redbox-core/test/services/DomSanitizerService.test.ts
+++ b/packages/redbox-core/test/services/DomSanitizerService.test.ts
@@ -2,7 +2,7 @@ let expect: Chai.ExpectStatic;
 import("chai").then(mod => expect = mod.expect);
 import * as sinon from 'sinon';
 import { setupServiceTestGlobals, cleanupServiceTestGlobals, createMockSails } from './testHelper';
-import { dompurify as dompurifyConfig, safeHtmlUriRegexp } from '../../src/config/dompurify.config';
+import { dompurify as dompurifyConfig, safeHtmlUriRegexp, safeSvgUriRegexp } from '../../src/config/dompurify.config';
 
 describe('DomSanitizerService', function() {
   let mockSails: any;
@@ -92,12 +92,13 @@ describe('DomSanitizerService', function() {
 
     it('should preserve fragment and relative SVG references', function() {
       mockSails.config.dompurify = dompurifyConfig;
-      const svg = '<svg><image href="#mark"/><image href="./images/logo.svg"/><image href="../logo.svg"/><image href="/logo.svg"/></svg>';
+      const svg = '<svg><image href="#mark"/><image href="images/logo.svg"/><image href="./images/logo.svg"/><image href="../logo.svg"/><image href="/logo.svg"/></svg>';
 
       const result = DomSanitizerService.sanitize(svg);
 
       expect(result.safe).to.be.true;
       expect(result.sanitized).to.include('href="#mark"');
+      expect(result.sanitized).to.include('href="images/logo.svg"');
       expect(result.sanitized).to.include('href="./images/logo.svg"');
       expect(result.sanitized).to.include('href="../logo.svg"');
       expect(result.sanitized).to.include('href="/logo.svg"');
@@ -301,6 +302,23 @@ describe('DomSanitizerService', function() {
     it('should block scriptable or embedded-data protocols', function() {
       expect(safeHtmlUriRegexp.test('javascript:alert(1)')).to.equal(false);
       expect(safeHtmlUriRegexp.test('data:text/html,<script>alert(1)</script>')).to.equal(false);
+    });
+  });
+
+  describe('safeSvgUriRegexp', function() {
+    it('should allow complete fragment and relative references', function() {
+      expect(safeSvgUriRegexp.test('#mark')).to.equal(true);
+      expect(safeSvgUriRegexp.test('images/logo.svg')).to.equal(true);
+      expect(safeSvgUriRegexp.test('images/logo.svg?version=1#mark')).to.equal(true);
+      expect(safeSvgUriRegexp.test('./images/logo.svg')).to.equal(true);
+      expect(safeSvgUriRegexp.test('../images/logo.svg')).to.equal(true);
+      expect(safeSvgUriRegexp.test('/images/logo.svg')).to.equal(true);
+    });
+
+    it('should reject absolute schemes and protocol-relative references without partial matches', function() {
+      ['mailto:user@example.org', 'https://example.org/logo.svg', '//example.org/logo.svg'].forEach((reference) => {
+        expect(safeSvgUriRegexp.test(reference)).to.equal(false);
+      });
     });
   });
 });

--- a/packages/redbox-core/test/services/DomSanitizerService.test.ts
+++ b/packages/redbox-core/test/services/DomSanitizerService.test.ts
@@ -2,7 +2,7 @@ let expect: Chai.ExpectStatic;
 import("chai").then(mod => expect = mod.expect);
 import * as sinon from 'sinon';
 import { setupServiceTestGlobals, cleanupServiceTestGlobals, createMockSails } from './testHelper';
-import { safeHtmlUriRegexp } from '../../src/config/dompurify.config';
+import { dompurify as dompurifyConfig, safeHtmlUriRegexp } from '../../src/config/dompurify.config';
 
 describe('DomSanitizerService', function() {
   let mockSails: any;
@@ -77,6 +77,17 @@ describe('DomSanitizerService', function() {
       expect(result.sanitized).to.include('svg');
       expect(result.sanitized).to.include('circle');
       expect(result.errors).to.be.an('array').that.is.empty;
+    });
+
+    it('should preserve SVG path geometry and viewBox attributes', function() {
+      mockSails.config.dompurify = dompurifyConfig;
+      const svg = '<svg viewBox="0 0 100 100"><path d="m 0,0 100,0 0,100 z" fill="#fff"/></svg>';
+
+      const result = DomSanitizerService.sanitize(svg);
+
+      expect(result.safe).to.be.true;
+      expect(result.sanitized).to.include('viewBox="0 0 100 100"');
+      expect(result.sanitized).to.include('d="m 0,0 100,0 0,100 z"');
     });
 
     it('should reject non-string input', function() {

--- a/views/400.ejs
+++ b/views/400.ejs
@@ -1,0 +1,16 @@
+<div class="container">
+  <div class="row">
+    <div class="col-xs-2"></div>
+    <div class="col-xs-8">
+      <div class="panel panel-danger">
+        <div class="panel-heading">
+          <h3 class="panel-title">Bad Request</h3>
+        </div>
+        <div class="panel-body">
+          <%= typeof data === 'undefined' ? 'The request could not be processed.' : data %>
+        </div>
+      </div>
+    </div>
+    <div class="col-xs-2"></div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary

Fixes branded error pages (400/403/404/500) not inheriting the theme and layout supplied by a Redbox hook, and addresses branded attachment 404 pages being served unthemed or with SVG paths stripped.

---

## Context / Motivation

When a hook provides branded views and layouts, Sails' built-in response rendering only searches the app view root, so error pages were rendered without the hook-provided layout. Additionally, branded 404 pages for missing attachments lost their branding because the request had no route parameters or policies to recover branding/portal context. The DOMPurify `ALLOWED_URI_REGEXP` also applied to SVG path geometry (`d` attribute), which erased vector drawings on error pages.

---

## Key Features

### Hook-aware error view rendering

- Added a shared `renderErrorView` helper that routes error views through the same hook-aware view and layout resolver used by controllers.
- Routed the `badRequest`, `forbidden`, and `serverError` responses through the shared resolver with sensible default views (`400`, `403`, `500`).
- Added a new `notFound` response that renders the branded `404` view for HTML requests while preserving the JSON response where appropriate.

### Branding recovery on unmatched URLs

- Added request-level branding/portal recovery to the core controller so an unmatched branded URL (e.g. a missing attachment) can reconstruct its branding and portal context from the URL path segments, falling back to session and default config values.
- Added the root view to the view resolution candidates so error views resolve correctly when no branded/portal override exists.

### SVG preservation in sanitization

- Restricted DOMPurify `ALLOWED_URI_REGEXP` handling so href validation (handled by `DomSanitizerService`) no longer also strips SVG path geometry (`d`) and `viewBox` attributes.

---

## Testing

- Added unit tests in `CoreControllerViewResolution.test.ts` covering hook layout application to root error views and branding/portal recovery from unmatched branded URLs.
- Extended `Responses.test.ts` to assert branded default views for `400`, `403`, `404`, and `500` HTML responses while preserving JSON behavior.
- Added a `DomSanitizerService` test confirming SVG path geometry and `viewBox` attributes are preserved.
- Updated `RecordController.test.ts` descriptions to reflect use of the shared 404 response for missing attachments.

---

## Architectural / Operational Impact

### Response rendering

Consolidates error view rendering across the core error responses onto a single hook-aware path, so future branding/layout changes to error pages apply consistently.

### Sanitization

Narrows the scope of DOMPurify's URI regexp to avoid unintended side effects on SVG markup, without weakening href-based sanitization, which remains enforced by `DomSanitizerService`.

---

## Backwards Compatibility

JSON error responses are preserved. Existing custom error view options remain supported. The default HTML view names match the existing `400`/`403`/`500`/`404` conventions.

---

## Deployment Notes

No data migrations or configuration changes are required. New error view files (`views/400.ejs`) and the `notFound` response are additive.

---

## Impact

Restores consistent, branded theming to all core error pages and prevents branded attachment 404 pages from losing their layout or SVG content.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated “Bad Request” (400) error page with helpful fallback messaging.
  - Added standardized 404 handling for HTML and JSON requests.
  - Error pages now support branded and portal-specific views and layouts, including root-level views.

- **Bug Fixes**
  - Improved branded error-page resolution when branding details appear in the URL.
  - SVG sanitization now preserves valid `viewBox` and path geometry.

- **Consistency**
  - Bad request, forbidden, not found, and server error responses now use consistent error-view rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->