### PR TITLE
Fix repeated and mixed Figshare file synchronization

### DIFF
--- a/packages/redbox-core/src/services/figshare-v2/README.md
+++ b/packages/redbox-core/src/services/figshare-v2/README.md
@@ -16,3 +16,12 @@ successful upload by default, or retained on success when `cleanupPolicy` is
 
 The fs-era `tempDir` and `diskSpaceThresholdBytes` settings have been removed from the
 config model; capacity failures now surface from the configured StorageManager disk.
+
+Linked-file sync matches selected URLs against existing linked files' `download_url`
+values. An unchanged link is reused and excluded from deletion, so pre-save,
+post-save and subsequent saves do not try to create the same link again. Duplicate
+selected rows with the same URL also reuse one result. Matching is exact: a changed
+query string or path is a different link. If a new link cannot be created, existing
+links are preserved and the sync reports failure. This does not add support for
+mixing hosted attachments and linked files or change the replacement strategy for
+an edited URL.

--- a/packages/redbox-core/src/services/figshare-v2/README.md
+++ b/packages/redbox-core/src/services/figshare-v2/README.md
@@ -22,6 +22,11 @@ values. An unchanged link is reused and excluded from deletion, so pre-save,
 post-save and subsequent saves do not try to create the same link again. Duplicate
 selected rows with the same URL also reuse one result. Matching is exact: a changed
 query string or path is a different link. If a new link cannot be created, existing
-links are preserved and the sync reports failure. This does not add support for
-mixing hosted attachments and linked files or change the replacement strategy for
-an edited URL.
+links are preserved and the sync reports failure. This does not change the
+replacement strategy for an edited URL.
+
+When selected data locations contain both hosted attachments and URLs, hosted
+attachments take precedence, matching the 4.x integration. The URL entries remain
+in the record for metadata bindings such as `Full Text URL`, but are not also sent
+to Figshare as linked files. URL entries become linked files when there are no
+hosted attachments, or when hosted-file publishing is disabled.

--- a/packages/redbox-core/src/services/figshare-v2/assets.ts
+++ b/packages/redbox-core/src/services/figshare-v2/assets.ts
@@ -276,11 +276,24 @@ async function syncLinkOnlyFiles(
   currentFiles: FigshareFile[]
 ): Promise<FigshareFile[]> {
   const existingLinkFiles = currentFiles.filter(entry => entry.is_link_only === true);
+  const retainedLinkIds = new Set<string>();
 
   const uploadedUrls: FigshareFile[] = [];
   const creationErrors: Error[] = [];
   for (const entry of selectedUrls) {
     if (entry.ignore === true) {
+      continue;
+    }
+    const link = entry.location ?? '';
+    // Both save phases (and later retries) can sync the same URL. Figshare
+    // rejects creating another linked file when the article already has one.
+    if (uploadedUrls.some(file => file.download_url === link)) {
+      continue;
+    }
+    const existingLink = existingLinkFiles.find(file => file.download_url === link);
+    if (existingLink != null) {
+      retainedLinkIds.add(String(existingLink.id));
+      uploadedUrls.push(existingLink);
       continue;
     }
     let responseLocation: { location: string } | null = null;
@@ -289,7 +302,7 @@ async function syncLinkOnlyFiles(
       attempt += 1;
       try {
         responseLocation = await client.createArticleFile(articleId, {
-          link: entry.location ?? '',
+          link,
         });
         break;
       } catch (error) {
@@ -322,6 +335,9 @@ async function syncLinkOnlyFiles(
   }
 
   for (const file of existingLinkFiles) {
+    if (retainedLinkIds.has(String(file.id))) {
+      continue;
+    }
     await client.deleteArticleFile(articleId, String(file.id));
   }
   return uploadedUrls;

--- a/packages/redbox-core/src/services/figshare-v2/assets.ts
+++ b/packages/redbox-core/src/services/figshare-v2/assets.ts
@@ -343,6 +343,21 @@ async function syncLinkOnlyFiles(
   return uploadedUrls;
 }
 
+function getPublishableUrlEntries(selectedUrls: DataLocationEntry[]): DataLocationEntry[] {
+  const seenUrls = new Set<string>();
+  return selectedUrls.filter(entry => {
+    if (entry.ignore === true) {
+      return false;
+    }
+    const url = entry.location ?? '';
+    if (seenUrls.has(url)) {
+      return false;
+    }
+    seenUrls.add(url);
+    return true;
+  });
+}
+
 function toFixtureFigshareFile(
   entry: DataLocationEntry,
   articleId: string,
@@ -381,6 +396,7 @@ export async function syncAssetsPhase(
   // Preserve the 4.x behaviour: hosted attachments take precedence over
   // linked files. URL data locations remain available to metadata mappings.
   const syncLinkedFiles = config.assets.enableLinkFiles && !(config.assets.enableHostedFiles && attachmentCount > 0);
+  const publishableUrls = syncLinkedFiles ? getPublishableUrlEntries(selectedUrls) : [];
   const currentFiles = await listArticleFiles(client, articleId);
 
   if (hasPendingUploads(currentFiles)) {
@@ -399,7 +415,7 @@ export async function syncAssetsPhase(
       urlCount,
       uploadsComplete,
       uploadedAttachmentCount: attachmentCount,
-      uploadedUrlCount: syncLinkedFiles ? urlCount : 0,
+      uploadedUrlCount: publishableUrls.length,
     };
     setSyncState(config, record, syncState);
     return {
@@ -410,9 +426,7 @@ export async function syncAssetsPhase(
       uploadedAttachments: selectedAttachments.map((entry, index) =>
         toFixtureFigshareFile(entry, articleId, index, false)
       ),
-      uploadedUrls: syncLinkedFiles
-        ? selectedUrls.map((entry, index) => toFixtureFigshareFile(entry, articleId, index, true))
-        : [],
+      uploadedUrls: publishableUrls.map((entry, index) => toFixtureFigshareFile(entry, articleId, index, true)),
       dataLocations: selectedDataLocations,
     };
   }
@@ -434,7 +448,7 @@ export async function syncAssetsPhase(
     }
   }
 
-  const uploadedUrls = syncLinkedFiles ? await syncLinkOnlyFiles(client, articleId, selectedUrls, currentFiles) : [];
+  const uploadedUrls = syncLinkedFiles ? await syncLinkOnlyFiles(client, articleId, publishableUrls, currentFiles) : [];
 
   const refreshedFiles = attachmentCount > 0 ? await listArticleFiles(client, articleId) : currentFiles;
   const uploadsComplete =

--- a/packages/redbox-core/src/services/figshare-v2/assets.ts
+++ b/packages/redbox-core/src/services/figshare-v2/assets.ts
@@ -378,6 +378,9 @@ export async function syncAssetsPhase(
 
   const attachmentCount = selectedAttachments.length;
   const urlCount = selectedUrls.length;
+  // Preserve the 4.x behaviour: hosted attachments take precedence over
+  // linked files. URL data locations remain available to metadata mappings.
+  const syncLinkedFiles = config.assets.enableLinkFiles && !(config.assets.enableHostedFiles && attachmentCount > 0);
   const currentFiles = await listArticleFiles(client, articleId);
 
   if (hasPendingUploads(currentFiles)) {
@@ -396,7 +399,7 @@ export async function syncAssetsPhase(
       urlCount,
       uploadsComplete,
       uploadedAttachmentCount: attachmentCount,
-      uploadedUrlCount: urlCount,
+      uploadedUrlCount: syncLinkedFiles ? urlCount : 0,
     };
     setSyncState(config, record, syncState);
     return {
@@ -407,7 +410,9 @@ export async function syncAssetsPhase(
       uploadedAttachments: selectedAttachments.map((entry, index) =>
         toFixtureFigshareFile(entry, articleId, index, false)
       ),
-      uploadedUrls: selectedUrls.map((entry, index) => toFixtureFigshareFile(entry, articleId, index, true)),
+      uploadedUrls: syncLinkedFiles
+        ? selectedUrls.map((entry, index) => toFixtureFigshareFile(entry, articleId, index, true))
+        : [],
       dataLocations: selectedDataLocations,
     };
   }
@@ -429,9 +434,7 @@ export async function syncAssetsPhase(
     }
   }
 
-  const uploadedUrls = config.assets.enableLinkFiles
-    ? await syncLinkOnlyFiles(client, articleId, selectedUrls, currentFiles)
-    : [];
+  const uploadedUrls = syncLinkedFiles ? await syncLinkOnlyFiles(client, articleId, selectedUrls, currentFiles) : [];
 
   const refreshedFiles = attachmentCount > 0 ? await listArticleFiles(client, articleId) : currentFiles;
   const uploadsComplete =

--- a/packages/redbox-core/test/services/FigshareService.test.ts
+++ b/packages/redbox-core/test/services/FigshareService.test.ts
@@ -2121,6 +2121,79 @@ describe('FigshareService', function () {
     });
   });
 
+  describe('syncAssetsPhase (mixed hosted attachments and URLs)', function () {
+    const locations = [
+      { type: 'attachment', fileId: 'file-1', name: 'file.txt', selected: true },
+      { type: 'url', location: 'https://example.org/dataset', selected: true },
+    ];
+
+    it('gives hosted attachments precedence and keeps the URL as record metadata', async function () {
+      installDatastreamStub(Buffer.from('existing attachment'), 19);
+      const client = buildAssetClient([]);
+      client.listArticleFiles = sinon
+        .stub()
+        .resolves([{ id: 'hosted-file-1', name: 'file.txt', size: 19, status: 'available', is_link_only: false }]);
+      const record = buildAssetRecord(locations);
+      const state: FigshareSyncState = { status: 'syncing' };
+
+      const result = await syncAssetsPhase(client, buildLiveAssetConfig(), record, { id: 'article-1' }, state);
+
+      expect(result.uploadedAttachments.map((file: FigshareFile) => file.id)).to.deep.equal(['hosted-file-1']);
+      expect(result.uploadedUrls).to.deep.equal([]);
+      expect(result.dataLocations).to.deep.equal(locations);
+      expect(state.partialProgress).to.include({
+        attachmentCount: 1,
+        uploadedAttachmentCount: 1,
+        urlCount: 1,
+        uploadedUrlCount: 0,
+        uploadsComplete: true,
+      });
+      expect((client.createArticleFile as sinon.SinonStub).called).to.equal(false);
+      expect((client.deleteArticleFile as sinon.SinonStub).called).to.equal(false);
+    });
+
+    it('uses the same attachment precedence in fixture mode', async function () {
+      const client = buildAssetClient([]);
+      const config = {
+        ...buildLiveAssetConfig(),
+        runtime: { mode: 'fixture' },
+      } as any;
+      const record = buildAssetRecord(locations);
+      const state: FigshareSyncState = { status: 'syncing' };
+
+      const result = await syncAssetsPhase(client, config, record, { id: 'article-1' }, state);
+
+      expect(result.uploadedAttachments).to.have.length(1);
+      expect(result.uploadedUrls).to.deep.equal([]);
+      expect(result.dataLocations).to.deep.equal(locations);
+      expect(state.partialProgress).to.include({ urlCount: 1, uploadedUrlCount: 0 });
+    });
+
+    it('still creates a linked file when hosted-file publishing is disabled', async function () {
+      const client = buildAssetClient([]);
+      client.getLocation = sinon.stub().resolves({
+        id: 'linked-file-1',
+        name: '',
+        status: 'available',
+        download_url: 'https://example.org/dataset',
+        is_link_only: true,
+      });
+      const config = buildLiveAssetConfig();
+      config.assets.enableHostedFiles = false;
+      const record = buildAssetRecord(locations);
+
+      const result = await syncAssetsPhase(client, config, record, { id: 'article-1' }, {});
+
+      expect(result.uploadedAttachments).to.deep.equal([]);
+      expect(result.uploadedUrls.map((file: FigshareFile) => file.id)).to.deep.equal(['linked-file-1']);
+      expect(
+        (client.createArticleFile as sinon.SinonStub).calledOnceWithExactly('article-1', {
+          link: 'https://example.org/dataset',
+        })
+      ).to.equal(true);
+    });
+  });
+
   describe('syncAssetsPhase (live upload)', function () {
     // Staging keys carry a per-attempt random UUID segment, e.g.
     // `figshare/article-1-oid-1-file-1-<uuid>/file.txt`.

--- a/packages/redbox-core/test/services/FigshareService.test.ts
+++ b/packages/redbox-core/test/services/FigshareService.test.ts
@@ -1,7 +1,7 @@
 import * as sinon from 'sinon';
 import { Readable } from 'node:stream';
 import { createRequire } from 'node:module';
-import type { RecordModel } from '../../src/services/figshare-v2/types';
+import type { FigshareFile, FigshareSyncState, RecordModel } from '../../src/services/figshare-v2/types';
 import type { FigshareClient } from '../../src/services/figshare-v2/http';
 import type { FigsharePublishingConfigData } from '../../src/configmodels/FigsharePublishing';
 
@@ -2033,6 +2033,92 @@ describe('FigshareService', function () {
     expect((global as any).IntegrationAuditService.completeAudit.called).to.equal(false);
     expect((global as any).IntegrationAuditService.failAudit.calledOnce).to.equal(true);
     expect((global as any).IntegrationAuditService.failAudit.firstCall.args[1].message).to.equal('transition failed');
+  });
+
+  describe('syncAssetsPhase (URL-only repeat sync)', function () {
+    const url = 'https://example.org/dataset?version=1';
+    const existingLink: FigshareFile = {
+      id: 123,
+      name: '', // Figshare returns an empty name for linked files.
+      download_url: url,
+      is_link_only: true,
+      status: 'available',
+    };
+
+    it('creates once across pre-save, post-save and a subsequent save', async function () {
+      const client = buildAssetClient([]);
+      const files: FigshareFile[] = [];
+      client.listArticleFiles = sinon.stub().callsFake(async () => [...files]);
+      const create = sinon.stub().callsFake(async () => {
+        if (files.length > 0) throw new Error('Cannot add a linked file to an article that already has file(s).');
+        files.push(existingLink);
+        return { location: 'https://api.figshare.test/file-123' };
+      });
+      client.createArticleFile = create;
+      client.getLocation = sinon.stub().resolves(existingLink);
+      const config = buildLiveAssetConfig();
+      const record = buildAssetRecord([{ type: 'url', location: url, selected: true }]);
+
+      for (const phase of ['pre', 'post', 'next-save']) {
+        const state: FigshareSyncState = { status: 'syncing', correlationId: phase };
+        const result = await syncAssetsPhase(client, config, record, { id: 'article-1' }, state);
+        expect(result.uploadedUrls.map((file: FigshareFile) => file.id)).to.deep.equal([123]);
+        expect(result.uploadsComplete).to.equal(true);
+        expect(state.partialProgress?.uploadedUrlCount).to.equal(1);
+      }
+      expect(create.calledOnceWithExactly('article-1', { link: url })).to.equal(true);
+      expect((client.deleteArticleFile as sinon.SinonStub).called).to.equal(false);
+    });
+
+    it('recovers using the remote link after local sync progress has been lost', async function () {
+      const client = buildAssetClient([]);
+      client.listArticleFiles = sinon.stub().resolves([existingLink]);
+      const record = buildAssetRecord([{ type: 'url', location: url, selected: true }]);
+      const result = await syncAssetsPhase(client, buildLiveAssetConfig(), record, { id: 'article-1' }, {});
+      expect(result.uploadedUrls).to.deep.equal([existingLink]);
+      expect((client.createArticleFile as sinon.SinonStub).called).to.equal(false);
+      expect((client.deleteArticleFile as sinon.SinonStub).called).to.equal(false);
+    });
+
+    it('creates only one link for duplicate selected URL rows', async function () {
+      const client = buildAssetClient([]);
+      client.getLocation = sinon.stub().resolves(existingLink);
+      const record = buildAssetRecord([
+        { type: 'url', location: url, selected: true },
+        { type: 'url', location: url, selected: true },
+      ]);
+      const result = await syncAssetsPhase(client, buildLiveAssetConfig(), record, { id: 'article-1' }, {});
+      expect(result.uploadedUrls).to.have.length(1);
+      expect((client.createArticleFile as sinon.SinonStub).calledOnce).to.equal(true);
+    });
+
+    it('does not mistake a changed query for an unchanged link or delete the old link on failure', async function () {
+      const client = buildAssetClient([]);
+      client.listArticleFiles = sinon.stub().resolves([existingLink]);
+      client.createArticleFile = sinon.stub().rejects(new Error('Figshare rejected replacement'));
+      const record = buildAssetRecord([{ type: 'url', location: url.replace('version=1', 'version=2'), selected: true }]);
+      let error: unknown;
+      try {
+        await syncAssetsPhase(client, buildLiveAssetConfig(), record, { id: 'article-1' }, {});
+      } catch (caught) {
+        error = caught;
+      }
+      expect(error).to.be.instanceOf(RBValidationError);
+      expect((client.createArticleFile as sinon.SinonStub).called).to.equal(true);
+      expect((client.deleteArticleFile as sinon.SinonStub).called).to.equal(false);
+    });
+
+    it('deletes only deselected links and retains the selected existing link', async function () {
+      const client = buildAssetClient([]);
+      client.listArticleFiles = sinon.stub().resolves([
+        existingLink,
+        { ...existingLink, id: 456, download_url: 'https://example.org/removed' },
+      ]);
+      const record = buildAssetRecord([{ type: 'url', location: url, selected: true }]);
+      await syncAssetsPhase(client, buildLiveAssetConfig(), record, { id: 'article-1' }, {});
+      expect((client.createArticleFile as sinon.SinonStub).called).to.equal(false);
+      expect((client.deleteArticleFile as sinon.SinonStub).calledOnceWithExactly('article-1', '456')).to.equal(true);
+    });
   });
 
   describe('syncAssetsPhase (live upload)', function () {

--- a/packages/redbox-core/test/services/FigshareService.test.ts
+++ b/packages/redbox-core/test/services/FigshareService.test.ts
@@ -2092,6 +2092,46 @@ describe('FigshareService', function () {
       expect((client.createArticleFile as sinon.SinonStub).calledOnce).to.equal(true);
     });
 
+    it('omits ignored URLs from fixture results and progress', async function () {
+      const client = buildAssetClient([]);
+      const config = {
+        ...buildLiveAssetConfig(),
+        runtime: { mode: 'fixture' },
+      } as any;
+      const record = buildAssetRecord([
+        { type: 'url', location: url, selected: true, ignore: true },
+        { type: 'url', location: 'https://example.org/published', selected: true },
+      ]);
+      const state: FigshareSyncState = { status: 'syncing' };
+
+      const result = await syncAssetsPhase(client, config, record, { id: 'article-1' }, state);
+
+      expect(result.urlCount).to.equal(2);
+      expect(result.uploadedUrls.map((file: FigshareFile) => file.download_url)).to.deep.equal([
+        'https://example.org/published',
+      ]);
+      expect(state.partialProgress).to.include({ urlCount: 2, uploadedUrlCount: 1 });
+    });
+
+    it('deduplicates exact URLs in fixture results and progress', async function () {
+      const client = buildAssetClient([]);
+      const config = {
+        ...buildLiveAssetConfig(),
+        runtime: { mode: 'fixture' },
+      } as any;
+      const record = buildAssetRecord([
+        { type: 'url', location: url, selected: true },
+        { type: 'url', location: url, selected: true },
+      ]);
+      const state: FigshareSyncState = { status: 'syncing' };
+
+      const result = await syncAssetsPhase(client, config, record, { id: 'article-1' }, state);
+
+      expect(result.urlCount).to.equal(2);
+      expect(result.uploadedUrls.map((file: FigshareFile) => file.download_url)).to.deep.equal([url]);
+      expect(state.partialProgress).to.include({ urlCount: 2, uploadedUrlCount: 1 });
+    });
+
     it('does not mistake a changed query for an unchanged link or delete the old link on failure', async function () {
       const client = buildAssetClient([]);
       client.listArticleFiles = sinon.stub().resolves([existingLink]);


### PR DESCRIPTION
## Summary

Fix Figshare asset synchronization for repeated URL-only saves and records that contain both hosted attachments and URLs.

The change prevents duplicate linked-file creation during pre-save, post-save and later syncs, and restores the ReDBox 4.x rule that hosted attachments take precedence over linked files in mixed records.

---

## Context / Motivation

CQU staging verification exposed two runtime failures in the Figshare v2 integration:

- URL-only Dataset records created a linked file during pre-save, then attempted to create the same link again during post-save. Figshare rejected the duplicate and ReDBox recorded a failed sync even though the original link existed.
- Records containing both hosted attachments and a URL uploaded the attachments and then attempted to add the URL as a linked file. Figshare rejects that combination.

The 4.x integration avoided the mixed-file failure by uploading eligible attachments and treating URLs as metadata rather than linked files whenever attachments were present.

---

## Key Features

### Repeat-safe linked-file synchronization

- Matches selected URLs against existing Figshare linked files using `download_url`.
- Reuses unchanged links across pre-save, post-save and subsequent saves.
- Deduplicates repeated selected URL rows.
- Excludes retained links from deletion.
- Preserves existing links if creation of a changed link fails.

### Attachment precedence for mixed records

- Gives hosted attachments precedence when both attachment and URL locations are selected, matching 4.x behavior.
- Keeps URL entries in the ReDBox record for metadata mappings such as Full Text URL.
- Suppresses linked-file creation only while hosted-file publishing is active and attachments are present.
- Continues creating linked files for URL-only records and when hosted-file publishing is disabled.
- Reports mixed-location progress accurately with the URL counted but not marked as uploaded.

---

## Testing

- Added five URL-only regression cases covering repeated phases, lost local progress, duplicate URL rows, changed URLs and deselected links.
- Added three mixed-location cases covering live mode, fixture mode and hosted-file publishing disabled.
- Core TypeScript compilation passed.
- All 73 Figshare service/runtime tests passed.
- CQU staging E2E passed through the restarted portal:
  - two hosted files uploaded and read back as available with `is_link_only=false`;
  - the selected URL remained in Full Text URL metadata;
  - request logs showed two hosted-file creates, zero linked-file creates and zero file deletes;
  - ReDBox completed post-save with `published` sync state, empty errors and `uploadsComplete=true`.

---

## Architectural / Operational Impact

### Figshare asset reconciliation

The asset phase now treats the remote file list as reconciliation state for linked URLs. This makes sync idempotent across the multiple lifecycle phases that can process the same record.

### Mixed-location compatibility

Attachment precedence is decided once per asset sync. URL metadata is preserved, while incompatible linked-file writes are skipped before any request is made to Figshare.

---

## Backwards Compatibility

The mixed-location behavior restores the established 4.x precedence rule. URL-only publishing and attachment-only publishing remain supported. Existing unchanged linked files are retained instead of recreated.

Edited URLs continue to use the current replacement strategy; this PR does not introduce in-place linked-file updates.

---

## Deployment Notes

No database migration or configuration update is required. The portal must be rebuilt or restarted so the updated `@researchdatabox/redbox-core` service code is loaded.

---

## Impact

Dataset publication no longer reports false failures when the same URL is synchronized repeatedly, and mixed attachment/URL records follow the compatible 4.x behavior without leaving partially synchronized Figshare articles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved Figshare synchronization for linked files, avoiding duplicate links during repeated or duplicate URL selections.
  * Existing linked files are preserved when synchronization encounters an error.
  * Hosted attachments now take precedence over URL-based linked files when both are available.
  * URL metadata remains available for record bindings even when it is not published as a linked file.
  * URL-based linked files continue to be created when hosted attachments are unavailable or disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->