### PR TITLE
Bugfix: Restore Playwright and lint checks for dependency updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "zone.js": "0.16.2"
       },
       "devDependencies": {
-        "@playwright/test": "1.62.1",
+        "@playwright/test": "1.63.0",
         "@types/chai": "5.2.3",
         "@types/jquery": "4.0.1",
         "@types/lodash-es": "4.17.12",
@@ -3162,13 +3162,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
-      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+      "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.62.1"
+        "playwright": "1.63.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -12309,28 +12309,25 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
-      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.62.1"
+        "playwright-core": "1.63.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
         "node": ">=20"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
-      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -213,7 +213,7 @@
     "ro-crate-modes": "git+https://github.com/Language-Research-Technology/ro-crate-modes.git#3d80adab4cf94c5e3df4756d0160a342b5e3d74e"
   },
   "devDependencies": {
-    "@playwright/test": "1.62.1",
+    "@playwright/test": "1.63.0",
     "@types/chai": "5.2.3",
     "@types/jquery": "4.0.1",
     "@types/lodash-es": "4.17.12",

--- a/support/security/explicit-type-node-baseline.json
+++ b/support/security/explicit-type-node-baseline.json
@@ -3823,8 +3823,8 @@
       "scope": "source",
       "path": "packages/redbox-core/src/services/FormRecordConsistencyService.ts",
       "anyCount": 0,
-      "unknownCount": 43,
-      "fingerprint": "sha256:58e529a5fa27ac720d7c72a4b7c345408d4f3ac5e872b4910fca0d9ef4402da0"
+      "unknownCount": 46,
+      "fingerprint": "sha256:9ea3f6d36c7489345e9a74932be32d999b9b8c1fa9e8b4b898839ddbb7699581"
     },
     {
       "scope": "source",


### PR DESCRIPTION
## Summary

Restore CI for the pending Dependabot updates by matching Playwright's npm package to its Docker image and reconciling the type baseline after the develop merge.

---

## Context / Motivation

The Playwright image was upgraded to 1.63.0 in #4644 while npm still installed 1.62.1. Browser startup consequently failed before tests ran. Separately, merge a581ea2bb restored existing schema validation code in FormRecordConsistencyService after the explicit-type baseline had been generated, causing lint to fail with 46 unknown nodes against an expected 43.

---

## Key Features

### CI compatibility

- Pin @playwright/test and its locked dependencies to 1.63.0, matching the existing Docker image.
- Reconcile only the affected service's existing baseline count and fingerprint with the merged source.

---

## Testing

- Reproduced the missing-browser executable failure with npm Playwright 1.62.1 in the 1.63.0 image.
- Browser launch and a page-content assertion pass with npm Playwright 1.63.0 in that image.
- `npm run lint:explicit-type-nodes` passes, including all seven guard tests.
- Full CircleCI validation will run before merging.

---

## Architectural / Operational Impact

Only test dependencies and the inventory of existing type debt change. Service runtime code is unchanged.

---

## Backwards Compatibility

No application API or record-data changes.

---

## Deployment Notes

No migration required. Install dependencies from the updated lockfile.

---

## Impact

Allows dependency PRs to reach the browser test suite and complete lint again.
